### PR TITLE
Fix unstable name collision lint warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,23 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-  clippy:
+  clippy-stable:
+    name: Clippy check (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --workspace
+
+  clippy-nightly:
     name: Clippy check (nightly)
     runs-on: ubuntu-latest
     steps:

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -815,16 +815,20 @@ impl<'a> CompositeIndex<'a> {
 
         let mut result = BTreeSet::new();
         while !(items1.is_empty() || items2.is_empty()) {
+            #[allow(unstable_name_collisions)]
             let entry1 = items1.last().unwrap();
+            #[allow(unstable_name_collisions)]
             let entry2 = items2.last().unwrap();
             match entry1.cmp(entry2) {
                 Ordering::Greater => {
+                    #[allow(unstable_name_collisions)]
                     let entry1 = items1.pop_last().unwrap();
                     for parent_entry in entry1.0.parents() {
                         items1.insert(IndexEntryByGeneration(parent_entry));
                     }
                 }
                 Ordering::Less => {
+                    #[allow(unstable_name_collisions)]
                     let entry2 = items2.pop_last().unwrap();
                     for parent_entry in entry2.0.parents() {
                         items2.insert(IndexEntryByGeneration(parent_entry));
@@ -832,7 +836,9 @@ impl<'a> CompositeIndex<'a> {
                 }
                 Ordering::Equal => {
                     result.insert(entry1.0.pos);
+                    #[allow(unstable_name_collisions)]
                     items1.pop_last();
+                    #[allow(unstable_name_collisions)]
                     items2.pop_last();
                 }
             }

--- a/lib/src/nightly_shims.rs
+++ b/lib/src/nightly_shims.rs
@@ -85,6 +85,7 @@ impl<K: Ord + Clone> BTreeSetExt<K> for std::collections::BTreeSet<K> {
     }
 
     fn pop_last(&mut self) -> Option<K> {
+        #[allow(unstable_name_collisions)]
         let key = self.last()?;
         let key = key.clone(); // ownership hack
         self.take(&key)


### PR DESCRIPTION
Running `cargo clippy` on main exposes some lint warnings. This stack fixes those warnings and updates the CI job.

If we think that running Clippy twice is too much overhead, we could remove one of them.
