### PR TITLE
build: remove SSL dependency for `git2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,8 +453,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -656,24 +654,8 @@ checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -790,25 +772,6 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "3.0.14", features = ["cargo"] }
 clap_complete = "3.0.6"
 config = "0.11.0"
 criterion = "0.3.5"
-git2 = "0.13.25"
+git2 = { version = "0.13.25", default-features = false }
 hex = "0.4.3"
 indoc = "1.0.3"
 itertools = "0.10.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = "1.4.3"
 chrono = "0.4.19"
 config = "0.11.0"
 dirs = "4.0.0"
-git2 = "0.13.25"
+git2 = { version = "0.13.25", default-features = false }
 hex = "0.4.3"
 itertools = "0.10.3"
 maplit = "1.0.2"


### PR DESCRIPTION
Fixes #75.
