### PR TITLE
docs: mention user-specific config path on different platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ $ source <(jj debug completion)  # --bash is the default
 ```
 
 You may also want to configure your name and email so commits are made in your
-name. Create a file at `${XDG_CONFIG_HOME}/jj/config.toml` or `~/.jjconfig` and
-make it look something like this:
+name. Create a file at `<config dir>/jj/config.toml` (where `<config dir>` is
+`${XDG_CONFIG_HOME}` or `~/.config/` on Linux, `~/Library/Application Support/`
+on macOS, and `~\AppData\Roaming\` on Windows) or `~/.jjconfig` and make it
+look something like this:
 ```shell script
 $ cat ~/.jjconfig
 [user]


### PR DESCRIPTION
Since #85, we load the user's config from a path under
`dirs::config_dir()`. It's probably not obvious to all users where to
put the file, so let's describe that. (I didn't know where to put the
file on my Mac until I looked at the function's documentation.)