### PR TITLE
docs: use stable Rust toolchain for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,7 @@ $ export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@3/lib/pkgconfig"
 
 Now run this (regardless of platform):
 ```shell script
-# We need the "nightly" Rust toolchain. This command installs that without
-# changing your default.
-$ rustup install nightly
-$ cargo +nightly install --git https://github.com/martinvonz/jj.git
+$ cargo install --git https://github.com/martinvonz/jj.git
 ```
 
 To set up command-line completion, source the output of 


### PR DESCRIPTION
We don't need the nightly toolchain anymore since #70 (thanks,
@arxanas!).

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
