### PR TITLE
debug: add mangen + nix: add completion/manpages to output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_mangen"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0649fb4156bbd7306896025005596033879a2051f9a3aa7416ab915df1f8fdac"
+dependencies = [
+ "clap 3.1.2",
+ "roff",
+]
+
+[[package]]
 name = "config"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +581,7 @@ dependencies = [
  "chrono",
  "clap 3.1.2",
  "clap_complete",
+ "clap_mangen",
  "config",
  "criterion",
  "criterion_bencher_compat",
@@ -1069,6 +1080,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rust-ini"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ atty = "0.2.14"
 chrono = "0.4.19"
 clap = { version = "3.1.0", features = ["cargo"] }
 clap_complete = "3.1.0"
+clap_mangen = "0.1"
 config = "0.11.0"
 criterion = "0.3.5"
 git2 = "0.13.25"

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
             , Security
             , SystemConfiguration
             , libiconv
+            , installShellFiles
             }:
 
             rustPlatform.buildRustPackage rec {
@@ -42,13 +43,27 @@
               cargoLock = {
                 lockFile = "${self}/Cargo.lock";
               };
-              nativeBuildInputs = [ pkgconfig gzip makeWrapper ];
+              nativeBuildInputs = [
+                pkgconfig gzip makeWrapper
+                installShellFiles
+              ];
               buildInputs = [ openssl dbus sqlite ]
               ++ lib.optionals stdenv.isDarwin [
                 Security
                 SystemConfiguration
                 libiconv
               ];
+              postInstall = ''
+                $out/bin/jj debug mangen > ./jj.1
+                installManPage ./jj.1
+
+                $out/bin/jj debug completion --bash > ./completions.bash
+                installShellCompletion --bash --name ${pname}.bash ./completions.bash
+                $out/bin/jj debug completion --fish > ./completions.fish
+                installShellCompletion --fish --name ${pname}.fish ./completions.fish
+                $out/bin/jj debug completion --zsh > ./completions.zsh
+                installShellCompletion --zsh --name _${pname} ./completions.zsh
+              '';
             }
 
           )


### PR DESCRIPTION
Sorry, I didn't open an issue for this one. It started with a quick Nix fix and evolved. Let me know if you'd prefer it split, etc.

This:
1. adds `clap_mangen` to cargo
2. adds `jj debug mangen` subcommand
3. uses the debug subcommands in the nix expression to enrich the package outputs

`clap_mangen` suggest possibly using in a build task, but I prefer, and wanted to match, the internal debug command pattern already used for completions.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR 

To be honest, I don't know what is normally done to install manpages, hence the lack of README change. Mine just works via nixos/home-manager.

demo: https://asciinema.org/a/zyx09Y2SWz6FuEihbUupl5TP1

- first the nix config for a to-be-upstreamed [home-manager](https://github.com/nix-community/home-manager) module
- `man jj` showing the manpage
- `jj <tab>` showing completions
- `jj status <tab>` showing arg completions

(demo created by utilizing my existing configuration, then `sudo nixos-rebuild ~/code/nixcfg#porty --override-input jj ~/code/jj`, and then just ran zellij in asciinema)