### PR TITLE
github: make CI check formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          profile: minimal
           components: clippy
           override: true
-      - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -54,9 +54,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          profile: minimal
           components: clippy
           override: true
-      - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,22 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+  rustfmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          components: rustfmt
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
   clippy-stable:
     name: Clippy check (stable)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,15 @@ jobs:
         override: true
         profile: minimal
     - name: Build
-      run: |
-        cargo build --workspace --verbose
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --workspace --verbose
     - name: Test
-      run: |
-        cargo test --workspace --verbose
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --verbose
       env:
         RUST_BACKTRACE: 1
 

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -24,10 +24,7 @@ fn smoke_test() {
 
     let repo_path = test_env.env_root().join("repo");
     // Check the output of `jj status` right after initializing repo
-    let assert = test_env
-        .jj_cmd(&repo_path, &["status"])
-        .assert()
-        .success();
+    let assert = test_env.jj_cmd(&repo_path, &["status"]).assert().success();
     insta::assert_snapshot!(get_stdout_string(&assert), @r###"
     Parent commit: 000000000000 
     Working copy : 1d1984a23811 
@@ -40,10 +37,7 @@ fn smoke_test() {
     std::fs::write(repo_path.join("file3"), "file3").unwrap();
 
     // The working copy's ID should have changed
-    let assert = test_env
-        .jj_cmd(&repo_path, &["status"])
-        .assert()
-        .success();
+    let assert = test_env.jj_cmd(&repo_path, &["status"]).assert().success();
     let stdout_string = get_stdout_string(&assert);
     insta::assert_snapshot!(stdout_string, @r###"
     Parent commit: 000000000000 
@@ -70,10 +64,7 @@ fn smoke_test() {
 ");
 
     // Close the commit
-    let assert = test_env
-        .jj_cmd(&repo_path, &["close"])
-        .assert()
-        .success();
+    let assert = test_env.jj_cmd(&repo_path, &["close"]).assert().success();
     insta::assert_snapshot!(get_stdout_string(&assert), @"Working copy now at: 6ff8a22d8ce1 
 ");
 }

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -35,7 +35,6 @@ fn test_no_commit_working_copy() {
     o 0000000000000000000000000000000000000000
     "###);
 
-
     // Modify the file. With --no-commit-working-copy, we still get the same commit
     // ID.
     std::fs::write(repo_path.join("file"), "modified").unwrap();


### PR DESCRIPTION
I've forgotten to run `rustfmt` many times (most recently in
572143655866), so let's have CI check for it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
