### PR TITLE
cli: when pushing all branches (the default), skip open commit

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4364,6 +4364,18 @@ fn cmd_git_push(
                 BranchPushAction::LocalConflicted => {}
                 BranchPushAction::RemoteConflicted => {}
                 BranchPushAction::Update(update) => {
+                    if let Some(new_target) = &update.new_target {
+                        let new_target_commit = repo.store().get_commit(new_target)?;
+                        // TODO: Should we also skip branches that have open commits as ancestors?
+                        if new_target_commit.is_open() {
+                            writeln!(
+                                ui,
+                                "Skipping branch '{}' since it points to an open commit.",
+                                branch_name
+                            )?;
+                            continue;
+                        }
+                    }
                     branch_updates.insert(branch_name, update);
                 }
             }


### PR DESCRIPTION
Open commits are work-in-progress and `jj git push --branch <name>`
therefore errors out if the branch points to an open commit. However,
we don't do the same check if you run `jj git push` to push all
branches. This patch introduces such a check. Rather than error out,
we skip such branches instead.

I didn't make it check for open commits in ancestors. It's quite
unusual (at least in my workflow) to have a closed commit on top of an
open one. We can revisit if users get surprised by it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
