### PR TITLE
github: include version number in issue template again

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,3 +20,4 @@ Feel free to remove any of the sections below if they don't seem useful. -->
 ## Specifications
 
 - Platform:
+- Version:


### PR DESCRIPTION
Now that we have a changelog and I plan to do releases once in a
while, it makes sense again to have the version number in the issue
template.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
