### PR TITLE
cli: expand `~` in `core.excludesFile`, don't crash when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed bugs
+
+ - (#131) Fixed crash when `core.excludesFile` pointed to non-existent file, and
+   made leading `~/` in that config expand to `$HOME/`
+
 ## [0.3.0] - 2022-03-12
 
 Last release before this changelog started.

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -31,6 +31,7 @@ impl Default for TestEnvironment {
         let tmp_dir = TempDir::new().unwrap();
         let env_root = tmp_dir.path().canonicalize().unwrap();
         let home_dir = env_root.join("home");
+        std::fs::create_dir(&home_dir).unwrap();
         Self {
             _temp_dir: tmp_dir,
             env_root,

--- a/tests/test_gitignores.rs
+++ b/tests/test_gitignores.rs
@@ -31,24 +31,15 @@ fn test_gitignores() {
         .append(true)
         .open(workspace_root.join(".git").join("config"))
         .unwrap();
-    let excludes_file_path = test_env
-        .env_root()
-        .join("my-ignores")
-        .to_str()
-        .unwrap()
-        .to_string();
-    file.write_all(
-        format!(
-            "[core]\nexcludesFile=\"{}\"",
-            excludes_file_path
-                .replace('\\', "\\\\")
-                .replace('\"', "\\\"")
-        )
-        .as_bytes(),
+    // Put the file in "~/my-ignores" so we also test that "~" expands to "$HOME"
+    file.write_all(b"[core]\nexcludesFile=~/my-ignores\n")
+        .unwrap();
+    drop(file);
+    std::fs::write(
+        test_env.home_dir().join("my-ignores"),
+        "file1\nfile2\nfile3",
     )
     .unwrap();
-    drop(file);
-    std::fs::write(excludes_file_path, "file1\nfile2\nfile3").unwrap();
 
     // Say in .git/info/exclude that we actually do want file2 and file3
     let mut file = std::fs::OpenOptions::new()


### PR DESCRIPTION
I thought that `std::fs::canonicalize()` expanded "~", but it doesn't
seem to do that, which caused #131. Git seems to do the expansion
itself, so we probably also should. More importantly
`std::fs::canonicalize()` crashes when the file doesn't exist. The
manual expansion we do now does not.

Closes #131.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
