### PR TITLE
cargo: use libgit2 with vendored OpenSSL (#73)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -732,9 +732,9 @@ checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",
@@ -892,6 +892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.17.0+1.1.1m"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +909,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap_complete = "3.1.0"
 clap_mangen = "0.1"
 config = "0.11.0"
 criterion = "0.3.5"
-git2 = "0.13.25"
+git2 = "0.14.2"
 hex = "0.4.3"
 indoc = "1.0.3"
 insta = "1.13.0"
@@ -54,3 +54,7 @@ regex = "1.5.4"
 criterion = "0.3.5"
 criterion_bencher_compat = "0.3.4"
 predicates = "2.1.1"
+
+[features]
+default = ["vendored-openssl"]
+vendored-openssl = ["git2/vendored-openssl", "jujutsu-lib/vendored-openssl"]

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
             rustPlatform.buildRustPackage rec {
               pname = "jujutsu";
               version = "unstable-${self.shortRev or "dirty"}";
+              buildNoDefaultFeatures = true;
 
               src = self;
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = "1.4.3"
 chrono = "0.4.19"
 config = "0.11.0"
 dirs = "4.0.0"
-git2 = "0.13.25"
+git2 = "0.14.2"
 hex = "0.4.3"
 itertools = "0.10.3"
 maplit = "1.0.2"
@@ -44,3 +44,6 @@ zstd = "0.10.0"
 assert_matches = "1.5.0"
 num_cpus = "1.13.1"
 test-case = "1.2.3"
+
+[features]
+vendored-openssl = ["git2/vendored-openssl"]


### PR DESCRIPTION
I was able to build a working musl binary with this change, by running
this command:

```
cargo build --release --target x86_64-unknown-linux-musl
```

Thanks to @arxanas for the tip.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
