### PR TITLE
release: bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "jujutsu"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "atty",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "jujutsu-lib"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_matches",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jujutsu"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -37,7 +37,7 @@ hex = "0.4.3"
 indoc = "1.0.3"
 insta = "1.13.0"
 itertools = "0.10.3"
-jujutsu-lib = { version = "=0.3.0", path = "lib"}
+jujutsu-lib = { version = "=0.3.1", path = "lib"}
 maplit = "1.0.2"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jujutsu-lib"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This release is just to get #131 out and to see if the automated
release builds work now that we use a vendored OpenSSL from libgit2.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
