### PR TITLE
github: set top-level permissions to readonly for all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -52,6 +54,8 @@ jobs:
 
   clippy-stable:
     name: Clippy check (stable)
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -68,6 +72,8 @@ jobs:
 
   clippy-nightly:
     name: Clippy check (nightly)
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
 
+permissions: read-all
+
 jobs:
   nix:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,16 @@
 name: Release
+
 on:
   release:
     types: [created]
+
+permissions: read-all
+
 jobs:
   build-release:
     name: build-release
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The new code scanner is complaining that actions have permissions to
do too much. It wasn't obvious to me what permissions the jobs need,
but let's see how this works.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
