### PR TITLE
docs: add pointer to pre-built binary releases (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,15 @@ scripts if requested.
 
 ## Installation
 
+See below for how to build from source. There are also
+[pre-built binaries](https://github.com/martinvonz/jj/releases) for Windows,
+Mac, or Linux (musl).
+
 ### Linux
 
-On most distributions, you'll need to install from source.
+On most distributions, you'll need to build from source using `cargo` directly.
 
-#### From source
+#### Build using `cargo`
 
 First make sure that you have the `libssl-dev` and `openssl` packages installed
 by running something like this:


### PR DESCRIPTION
Users now have the option of installing from source or directly
installing a binary.

I also corrected some text that effectively said that installing a Nix
flake is not installing from source, but I think it actually does
install from source.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
