### PR TITLE
github: give Clippy action full permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,7 @@ jobs:
 
   clippy-stable:
     name: Clippy check (stable)
-    permissions:
-      pull-requests: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -72,8 +71,7 @@ jobs:
 
   clippy-nightly:
     name: Clippy check (nightly)
-    permissions:
-      pull-requests: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I've found it hard to figure out which actions need which
permissions. GitHub doesn't seem to even document what the permissions
mean. So let's just give Clippy full access.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
