### PR TITLE
github: restrict Clippy's access again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,8 @@ jobs:
 
   clippy-stable:
     name: Clippy check (stable)
-    permissions: write-all
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
@@ -71,7 +72,8 @@ jobs:
 
   clippy-nightly:
     name: Clippy check (nightly)
-    permissions: write-all
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846


### PR DESCRIPTION
Maybe "issues" is the permissions it needs to be able to comment on
pull-requests?

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->
