### PR TITLE
cli: in help output, list global options under separate heading

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -868,7 +868,11 @@ fn update_working_copy(
 /// To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/docs/tutorial.md.
 #[derive(clap::Parser, Clone, Debug)]
 #[clap(author = "Martin von Zweigbergk <martinvonz@google.com>", version)]
-#[clap(mut_arg("help", |arg| { arg.help("Print help information, more help with --help than with -h")}))]
+#[clap(mut_arg("help", |arg| {
+    arg
+        .help("Print help information, more help with --help than with -h")
+        .help_heading("GLOBAL OPTIONS")
+    }))]
 struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -876,7 +880,7 @@ struct Args {
     ///
     /// By default, Jujutsu searches for the closest .jj/ directory in an
     /// ancestor of the current working directory.
-    #[clap(long, short = 'R', global = true)]
+    #[clap(long, short = 'R', global = true, help_heading = "GLOBAL OPTIONS")]
     repository: Option<String>,
     /// Don't commit the working copy
     ///
@@ -886,7 +890,7 @@ struct Args {
     /// stale working copy commit, you can use `--no-commit-working-copy`.
     /// This may be useful e.g. in a command prompt, especially if you have
     /// another process that commits the working copy.
-    #[clap(long, global = true)]
+    #[clap(long, global = true, help_heading = "GLOBAL OPTIONS")]
     no_commit_working_copy: bool,
     /// Operation to load the repo at
     ///
@@ -907,7 +911,13 @@ struct Args {
     /// operation. Doing that is equivalent to having run concurrent commands
     /// starting at the earlier operation. There's rarely a reason to do that,
     /// but it is possible.
-    #[clap(long, alias = "at-op", global = true, default_value = "@")]
+    #[clap(
+        long,
+        alias = "at-op",
+        global = true,
+        help_heading = "GLOBAL OPTIONS",
+        default_value = "@"
+    )]
     at_operation: String,
 }
 

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -104,3 +104,27 @@ fn test_invalid_config() {
     insta::assert_snapshot!(stdout, @"Invalid config: expected newline, found an identifier at line 1 column 10 in config.toml
 ");
 }
+
+#[test]
+fn test_help() {
+    // Test that global options are separated out in the help output
+    let test_env = TestEnvironment::default();
+
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["edit", "-h"]);
+    insta::assert_snapshot!(stdout.replace(".exe", ""), @r###"
+    jj-edit 
+    Edit the content changes in a revision
+
+    USAGE:
+        jj edit [OPTIONS]
+
+    OPTIONS:
+        -r, --revision <REVISION>    The revision to edit [default: @]
+
+    GLOBAL OPTIONS:
+            --at-operation <AT_OPERATION>    Operation to load the repo at [default: @]
+        -h, --help                           Print help information, more help with --help than with -h
+            --no-commit-working-copy         Don't commit the working copy
+        -R, --repository <REPOSITORY>        Path to repository to operate on
+    "###);
+}


### PR DESCRIPTION
I've found it hard to read the `jj help` output because command
options are mixed with global options. This patch fixes that by
putting global options under a separate heading.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
