### PR TITLE
github: remove `complete` directory for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
       run: |
         outdir="./target/${{ matrix.target }}/release"
         staging="jj-${{ github.event.release.tag_name }}-${{ matrix.target }}"
-        mkdir -p "$staging"/complete
         cp {README.md,LICENSE} "$staging/"
         if [ "${{ matrix.os }}" = "windows-2022" ]; then
           cp "target/${{ matrix.target }}/release/jj.exe" "$staging/"


### PR DESCRIPTION
This directory doesn't seem to do anything.

I mostly copied and pasted this `release.yml` into git-branchless and it worked nicely on the first try :)