### PR TITLE
trees: when merging trees and one is missing, treat it as empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   but the contents was the same used to lead to a crash. That has now been
   fixed. 
 
+* If one side of a merge modified a directory and the other side deleted it, it
+  used to be considered a conflict. The same was true if both sides added a
+  directory with different files in. They are now merged as if the missing
+  directory had been empty.
+
 * `jj untrack` now requires at least one path (allowing no arguments was a UX
   bug).
 


### PR DESCRIPTION
When a directory is missing in one merge input (base or one side), we
would consider that a merge conflict. This patch changes that so we
instead merge trees by treating the missing tree as empty.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
