### PR TITLE
cli: use `.` in output for current directory instead of empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * You now get a proper error message instead of a crash when `$EDITOR` doesn't
   exist or exits with an error.
 
+* Fixed relative path to the current directory in output to be `.` instead of
+  empty string.
+
 ## [0.4.0] - 2022-04-02
 
 ### Breaking changes

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -190,13 +190,19 @@ pub fn relative_path(mut from: &Path, to: &Path) -> PathBuf {
     let mut result = PathBuf::from("");
     loop {
         if let Ok(suffix) = to.strip_prefix(from) {
-            return result.join(suffix);
+            result = result.join(suffix);
+            break;
         }
         if let Some(parent) = from.parent() {
             result = result.join("..");
             from = parent;
         } else {
-            return to.to_owned();
+            result = to.to_path_buf();
+            break;
         }
     }
+    if result.as_os_str().is_empty() {
+        result = PathBuf::from(".");
+    }
+    result
 }

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -117,8 +117,7 @@ fn test_init_git_colocated() {
     let workspace_root = test_env.env_root().join("repo");
     init_git_repo(&workspace_root);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
-    // TODO: We should say "." instead of "" here
-    insta::assert_snapshot!(stdout, @r###"Initialized repo in ""
+    insta::assert_snapshot!(stdout, @r###"Initialized repo in "."
 "###);
 
     let jj_path = workspace_root.join(".jj");


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
