### PR TITLE
op_heads_store: don't pass whole `RepoLoader` into `get_heads()`

### DIFF
--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -23,7 +23,6 @@ use crate::backend::Timestamp;
 use crate::lock::FileLock;
 use crate::op_store::{OpStore, OperationId, OperationMetadata};
 use crate::operation::Operation;
-use crate::repo::RepoLoader;
 use crate::{dag_walk, op_store};
 
 /// Manages the very set of current heads of the operation log. The store is
@@ -124,15 +123,13 @@ impl OpHeadsStore {
 
     pub fn get_heads(
         self: &Arc<Self>,
-        repo_loader: &RepoLoader,
+        op_store: &Arc<dyn OpStore>,
     ) -> Result<OpHeads, OpHeadResolutionError> {
         let mut op_heads = self.get_op_heads();
 
         if op_heads.is_empty() {
             return Err(OpHeadResolutionError::NoHeads);
         }
-
-        let op_store = repo_loader.op_store();
 
         if op_heads.len() == 1 {
             let operation_id = op_heads.pop().unwrap();

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -373,7 +373,7 @@ impl RepoLoader {
     }
 
     pub fn load_at_head(&self) -> RepoAtHead {
-        let op_heads = self.op_heads_store.get_heads(self).unwrap();
+        let op_heads = self.op_heads_store.get_heads(&self.op_store).unwrap();
         match op_heads {
             OpHeads::Single(op) => {
                 let view = View::new(op.view().take_store_view());


### PR DESCRIPTION
We only need to be able to read operations, so it's better to pass in
just an `OpStore`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
