### PR TITLE
git: fix an obsolete comment about a `.jj/` path

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -209,8 +209,8 @@ pub fn export_changes(
 
 /// Reflect changes made in the Jujutsu repo since last export in the underlying
 /// Git repo. If this is the first export, nothing will be exported. The
-/// exported state's operation ID is recorded in the repo (`.jj/
-/// git_export_operation_id`).
+/// exported state's operation ID is recorded in the repo
+/// (`.jj/repo/git_export_operation_id`).
 pub fn export_refs(
     repo: &Arc<ReadonlyRepo>,
     git_repo: &git2::Repository,


### PR DESCRIPTION
The path to the file that indicates the last export to git was changed
when we added support for multiple workspaces.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
