### PR TITLE
cli: add a command for listing git remotes and their URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The new `jj print` command prints the contents of a file in a revision.
 
+* (#243) The new `jj git remotes list` command lists the configured remotes and
+  their URLs.
+
 * `jj move` and `jj squash` now lets you limit the set of changes to move by
   specifying paths on the command line (in addition to the `--interactive`
   mode). For example, use `jj move --to @-- foo` to move the changes to file

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1721,6 +1721,7 @@ struct GitRemoteArgs {
 enum GitRemoteCommands {
     Add(GitRemoteAddArgs),
     Remove(GitRemoteRemoveArgs),
+    List(GitRemoteListArgs),
 }
 
 /// Add a Git remote
@@ -1738,6 +1739,10 @@ struct GitRemoteRemoveArgs {
     /// The remote's name
     remote: String,
 }
+
+/// List Git remotes
+#[derive(clap::Args, Clone, Debug)]
+struct GitRemoteListArgs {}
 
 /// Fetch from a Git remote
 #[derive(clap::Args, Clone, Debug)]
@@ -4562,6 +4567,9 @@ fn cmd_git_remote(
         GitRemoteCommands::Remove(command_matches) => {
             cmd_git_remote_remove(ui, command, command_matches)
         }
+        GitRemoteCommands::List(command_matches) => {
+            cmd_git_remote_list(ui, command, command_matches)
+        }
     }
 }
 
@@ -4591,7 +4599,7 @@ fn cmd_git_remote_remove(
     let repo = workspace_command.repo();
     let git_repo = get_git_repo(repo.store())?;
     if git_repo.find_remote(&args.remote).is_err() {
-        return Err(CommandError::UserError("Remote doesn't exists".to_string()));
+        return Err(CommandError::UserError("Remote doesn't exist".to_string()));
     }
     git_repo
         .remote_delete(&args.remote)
@@ -4609,6 +4617,21 @@ fn cmd_git_remote_remove(
             tx.mut_repo().remove_remote_branch(&branch, &args.remote);
         }
         workspace_command.finish_transaction(ui, tx)?;
+    }
+    Ok(())
+}
+
+fn cmd_git_remote_list(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &GitRemoteListArgs,
+) -> Result<(), CommandError> {
+    let workspace_command = command.workspace_helper(ui)?;
+    let repo = workspace_command.repo();
+    let git_repo = get_git_repo(repo.store())?;
+    for remote_name in git_repo.remotes()?.iter().flatten() {
+        let remote = git_repo.find_remote(remote_name)?;
+        writeln!(ui, "{} {}", remote_name, remote.url().unwrap_or("<no URL>"))?;
     }
     Ok(())
 }

--- a/tests/test_git_remotes.rs
+++ b/tests/test_git_remotes.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_git_remotes() {
+    let test_env = TestEnvironment::default();
+
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "--git", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
+    insta::assert_snapshot!(stdout, @"");
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["git", "remote", "add", "foo", "http://example.com/repo/foo"],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["git", "remote", "add", "bar", "http://example.com/repo/bar"],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
+    insta::assert_snapshot!(stdout, @r###"
+    bar http://example.com/repo/bar
+    foo http://example.com/repo/foo
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "remove", "foo"]);
+    insta::assert_snapshot!(stdout, @"");
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
+    insta::assert_snapshot!(stdout, @"bar http://example.com/repo/bar
+");
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "remove", "nonexistent"]);
+    insta::assert_snapshot!(stderr, @"Error: Remote doesn't exist
+");
+}


### PR DESCRIPTION
As requested by @talpr. I added this is a separate new command `jj git
remote list`. One could also imagine showing the listing when there is
no sub-command specified to `jj git remote`, but we don't have other
commands that behave that way yet.

Closes #243

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
