### PR TITLE
build: mark `Cargo.lock` as `binary` for merging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-flake.lock linguist-generated=true
+Cargo.lock linguist-generated=true merge=binary
+flake.lock linguist-generated=true merge=binary


### PR DESCRIPTION
Copy of https://github.com/arxanas/git-branchless/pull/375.

Maybe we should mark `flake.lock` as `merge=binary` too?
