### PR TITLE
git: when importing refs, abandon commits that were abandoned in git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$SSH_AUTH_SOCK` is set). This should help at least macOS users where
   ssh-agent is launched by default and only `$SSH_AUTH_SOCK` is set.
 
+* When importing from a git, any commits that are no longer referenced on the
+  git side will now be abandoned on the jj side as well. That means that
+  `jj git fetch` will now abandon unreferenced commits and rebase any local
+  changes you had on top.
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -305,33 +305,18 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
                 let local_target = self.mut_repo.get_local_branch(branch_name).unwrap();
                 for old_add in local_target.adds() {
                     if old_add == old_commit_id {
-                        branch_updates.push((branch_name.clone(), true));
-                    }
-                }
-                for old_add in local_target.removes() {
-                    if old_add == old_commit_id {
-                        // Arguments reversed for removes
-                        branch_updates.push((branch_name.clone(), false));
+                        branch_updates.push(branch_name.clone());
                     }
                 }
             }
             let (old_target, new_target) =
                 DescendantRebaser::ref_target_update(old_commit_id.clone(), new_commit_ids);
-            for (branch_name, is_add) in branch_updates {
-                if is_add {
-                    self.mut_repo.merge_single_ref(
-                        &RefName::LocalBranch(branch_name),
-                        Some(&old_target),
-                        Some(&new_target),
-                    );
-                } else {
-                    // Arguments reversed for removes
-                    self.mut_repo.merge_single_ref(
-                        &RefName::LocalBranch(branch_name),
-                        Some(&new_target),
-                        Some(&old_target),
-                    );
-                }
+            for branch_name in branch_updates {
+                self.mut_repo.merge_single_ref(
+                    &RefName::LocalBranch(branch_name),
+                    Some(&old_target),
+                    Some(&new_target),
+                );
             }
         }
 

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1122,9 +1122,9 @@ fn test_rebase_descendants_rewrite_updates_branch_conflict() {
     let test_repo = testutils::init_repo(&settings, false);
     let repo = &test_repo.repo;
 
-    // Branch "main" is a conflict removing commit A and adding commit B and C.
+    // Branch "main" is a conflict removing commit A and adding commits B and C.
     // A gets rewritten as A2 and A3. B gets rewritten as B2 and B2. The branch
-    // should become a conflict removing A2, A3, and B, and adding A, B2, B3, C.
+    // should become a conflict removing A and B, and adding B2, B3, C.
     let mut tx = repo.start_transaction("test");
     let mut graph_builder = CommitGraphBuilder::new(&settings, tx.mut_repo());
     let commit_a = graph_builder.initial_commit();
@@ -1156,14 +1156,9 @@ fn test_rebase_descendants_rewrite_updates_branch_conflict() {
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         Some(RefTarget::Conflict {
-            removes: vec![
-                commit_a2.id().clone(),
-                commit_a3.id().clone(),
-                commit_b.id().clone(),
-            ],
+            removes: vec![commit_a.id().clone(), commit_b.id().clone()],
             adds: vec![
                 commit_c.id().clone(),
-                commit_a.id().clone(),
                 commit_b2.id().clone(),
                 commit_b3.id().clone(),
             ]


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
