### PR TITLE
git_backend: delete obsolete (?) comment about not avoiding use of index

### DIFF
--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -360,8 +360,6 @@ impl Backend for GitBackend {
     }
 
     fn write_commit(&self, contents: &Commit) -> BackendResult<CommitId> {
-        // TODO: We shouldn't have to create an in-memory index just to write an
-        // object...
         let locked_repo = self.repo.lock().unwrap();
         let git_tree = locked_repo.find_tree(Oid::from_bytes(contents.root_tree.as_bytes())?)?;
         let author = signature_to_git(&contents.author);


### PR DESCRIPTION
It seems to me that we have never created a Git index in order to
create a commit, not even in the earliest versions of the code (before
it was moved to Git).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
