### PR TITLE
Fix crash on automatic import from git

### DIFF
--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -53,6 +53,9 @@ fn test_git_colocated_rebase_on_import() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     test_env.jj_cmd_success(&workspace_root, &["branch", "master"]);
     test_env.jj_cmd_success(&workspace_root, &["close", "-m", "modify a file"]);
+    // TODO: We shouldn't need this command here to trigger an import of the
+    // refs/heads/master we just exported
+    test_env.jj_cmd_success(&workspace_root, &["st"]);
 
     // Move `master` backwards, which should cause the working copy to be rebased
     // off of the old position.
@@ -65,6 +68,14 @@ fn test_git_colocated_rebase_on_import() {
     let commit2 = git_repo.find_commit(commit2_oid).unwrap();
     let commit1 = commit2.parents().next().unwrap();
     git_repo.branch("master", &commit1, true).unwrap();
-    // TODO: This shouldn't fail
-    test_env.jj_cmd_failure(&workspace_root, &["log", "-T", "commit_id \" \" branches"]);
+    let stdout =
+        test_env.jj_cmd_success(&workspace_root, &["log", "-T", "commit_id \" \" branches"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Rebased 1 descendant commits off of commits rewritten from git
+    Working copy now at: a64f325e0516 
+    Added 0 files, modified 1 files, removed 0 files
+    @ a64f325e05167129f3488f85a570f22a8940634f 
+    o f0f3ab56bfa927e3a65c2ac9a513693d438e271b master
+    o 0000000000000000000000000000000000000000 
+    "###);
 }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
