### PR TITLE
working_copy: rename `write_tree()` to `snapshot`()

### DIFF
--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -324,9 +324,9 @@ impl TreeState {
         self.store.write_symlink(path, str_target).unwrap()
     }
 
-    // Look for changes to the working copy. If there are any changes, create
-    // a new tree from it and return it, and also update the dirstate on disk.
-    pub fn write_tree(&mut self, base_ignores: Arc<GitIgnoreFile>) -> TreeId {
+    /// Look for changes to the working copy. If there are any changes, create
+    /// a new tree from it and return it, and also update the dirstate on disk.
+    pub fn snapshot(&mut self, base_ignores: Arc<GitIgnoreFile>) -> TreeId {
         let sparse_matcher = self.sparse_matcher();
         let mut work = vec![(
             RepoPath::root(),
@@ -965,12 +965,12 @@ impl LockedWorkingCopy<'_> {
     // The base_ignores are passed in here rather than being set on the TreeState
     // because the TreeState may be long-lived if the library is used in a
     // long-lived process.
-    pub fn write_tree(&mut self, base_ignores: Arc<GitIgnoreFile>) -> TreeId {
+    pub fn snapshot(&mut self, base_ignores: Arc<GitIgnoreFile>) -> TreeId {
         self.wc
             .tree_state()
             .as_mut()
             .unwrap()
-            .write_tree(base_ignores)
+            .snapshot(base_ignores)
     }
 
     pub fn check_out(&mut self, new_tree: &Tree) -> Result<CheckoutStats, CheckoutError> {

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -41,7 +41,7 @@ fn test_root(use_git: bool) {
     let wc = test_workspace.workspace.working_copy_mut();
     assert_eq!(wc.sparse_patterns(), vec![RepoPath::root()]);
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.discard();
     let checkout_id = repo.view().get_checkout(&WorkspaceId::default()).unwrap();
     let checkout_commit = repo.store().get_commit(checkout_id).unwrap();
@@ -205,7 +205,7 @@ fn test_checkout_file_transitions(use_git: bool) {
 
     // Check that the working copy is clean.
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.discard();
     assert_eq!(new_tree_id, right_tree_id);
 
@@ -307,7 +307,7 @@ fn test_reset() {
     assert!(ignored_path.to_fs_path(&workspace_root).is_file());
     assert!(!wc.file_states().contains_key(&ignored_path));
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     assert_eq!(new_tree_id, *tree_without_file.id());
     locked_wc.discard();
 
@@ -320,7 +320,7 @@ fn test_reset() {
     assert!(ignored_path.to_fs_path(&workspace_root).is_file());
     assert!(!wc.file_states().contains_key(&ignored_path));
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     assert_eq!(new_tree_id, *tree_without_file.id());
     locked_wc.discard();
 
@@ -332,7 +332,7 @@ fn test_reset() {
     assert!(ignored_path.to_fs_path(&workspace_root).is_file());
     assert!(wc.file_states().contains_key(&ignored_path));
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     assert_eq!(new_tree_id, *tree_with_file.id());
     locked_wc.discard();
 }
@@ -408,7 +408,7 @@ fn test_commit_racy_timestamps(use_git: bool) {
                 .unwrap();
         }
         let mut locked_wc = wc.start_mutation();
-        let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+        let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
         locked_wc.discard();
         assert_ne!(new_tree_id, previous_tree_id);
         previous_tree_id = new_tree_id;
@@ -442,7 +442,7 @@ fn test_gitignores(use_git: bool) {
 
     let wc = test_workspace.workspace.working_copy_mut();
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id1 = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id1 = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.finish(repo.op_id().clone());
     let tree1 = repo
         .store()
@@ -472,7 +472,7 @@ fn test_gitignores(use_git: bool) {
     testutils::write_working_copy_file(&workspace_root, &subdir_ignored_path, "2");
 
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id2 = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id2 = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.discard();
     let tree2 = repo
         .store()
@@ -532,7 +532,7 @@ fn test_gitignores_checkout_overwrites_ignored(use_git: bool) {
 
     // Check that the file is in the tree created by committing the working copy
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.discard();
     let new_tree = repo
         .store()
@@ -578,7 +578,7 @@ fn test_gitignores_ignored_directory_already_tracked(use_git: bool) {
     // Check that the file is still in the tree created by committing the working
     // copy (that it didn't get removed because the directory is ignored)
     let mut locked_wc = wc.start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.discard();
     let new_tree = repo
         .store()
@@ -609,7 +609,7 @@ fn test_dotgit_ignored(use_git: bool) {
         "contents",
     );
     let mut locked_wc = test_workspace.workspace.working_copy_mut().start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     assert_eq!(new_tree_id, *repo.store().empty_tree_id());
     locked_wc.discard();
     std::fs::remove_dir_all(&dotgit_path).unwrap();
@@ -621,7 +621,7 @@ fn test_dotgit_ignored(use_git: bool) {
         "contents",
     );
     let mut locked_wc = test_workspace.workspace.working_copy_mut().start_mutation();
-    let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     assert_eq!(new_tree_id, *repo.store().empty_tree_id());
     locked_wc.discard();
 }

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -129,7 +129,7 @@ fn test_checkout_parallel(use_git: bool) {
             // write_tree() should take the same lock as check_out(), write_tree()
             // should never produce a different tree.
             let mut locked_wc = workspace.working_copy_mut().start_mutation();
-            let new_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+            let new_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
             locked_wc.discard();
             assert!(tree_ids.contains(&new_tree_id));
         });

--- a/lib/tests/test_working_copy_sparse.rs
+++ b/lib/tests/test_working_copy_sparse.rs
@@ -167,7 +167,7 @@ fn test_sparse_commit() {
     // Create a tree from the working copy. Only dir1/file1 should be updated in the
     // tree.
     let mut locked_wc = wc.start_mutation();
-    let modified_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let modified_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.finish(repo.op_id().clone());
     let modified_tree = repo
         .store()
@@ -191,7 +191,7 @@ fn test_sparse_commit() {
     // Create a tree from the working copy. Only dir1/file1 and dir2/file1 should be
     // updated in the tree.
     let mut locked_wc = wc.start_mutation();
-    let modified_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let modified_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.finish(repo.op_id().clone());
     let modified_tree = repo
         .store()
@@ -232,7 +232,7 @@ fn test_sparse_commit_gitignore() {
     // Create a tree from the working copy. Only dir1/file2 should be updated in the
     // tree because dir1/file1 is ignored.
     let mut locked_wc = wc.start_mutation();
-    let modified_tree_id = locked_wc.write_tree(GitIgnoreFile::empty());
+    let modified_tree_id = locked_wc.snapshot(GitIgnoreFile::empty());
     locked_wc.finish(repo.op_id().clone());
     let modified_tree = repo
         .store()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -640,7 +640,7 @@ impl WorkspaceCommandHelper {
                 )));
             }
         }
-        let new_tree_id = locked_wc.write_tree(base_ignores);
+        let new_tree_id = locked_wc.snapshot(base_ignores);
         if new_tree_id != *checkout_commit.tree_id() {
             let mut tx = self.repo.start_transaction("commit working copy");
             let mut_repo = tx.mut_repo();
@@ -2076,7 +2076,7 @@ fn cmd_untrack(
     locked_working_copy.reset(&new_tree)?;
     // Commit the working copy again so we can inform the user if paths couldn't be
     // untracked because they're not ignored.
-    let wc_tree_id = locked_working_copy.write_tree(base_ignores);
+    let wc_tree_id = locked_working_copy.snapshot(base_ignores);
     if wc_tree_id != new_tree_id {
         let wc_tree = store.get_tree(&RepoPath::root(), &wc_tree_id)?;
         let added_back = wc_tree.entries_matching(matcher.as_ref()).collect_vec();

--- a/src/diff_edit.rs
+++ b/src/diff_edit.rs
@@ -147,5 +147,5 @@ pub fn edit_diff(
         std::fs::remove_file(instructions_path).ok();
     }
 
-    Ok(right_tree_state.write_tree(base_ignores))
+    Ok(right_tree_state.snapshot(base_ignores))
 }


### PR DESCRIPTION
I think I copied the name `write_tree()` from Git, but I find it quite
confusing, since it's not clear if it write a tree to the working copy
or reads the working copy and writes a tree to the store (it's the
former).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
