### PR TITLE
errors: use custom error for failed tree merge

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -55,7 +55,7 @@ use jujutsu_lib::rewrite::{back_out_commit, merge_commit_trees, rebase_commit, D
 use jujutsu_lib::settings::UserSettings;
 use jujutsu_lib::store::Store;
 use jujutsu_lib::transaction::Transaction;
-use jujutsu_lib::tree::{merge_trees, Tree, TreeDiffIterator};
+use jujutsu_lib::tree::{merge_trees, Tree, TreeDiffIterator, TreeMergeError};
 use jujutsu_lib::working_copy::{
     CheckoutStats, LockedWorkingCopy, ResetError, SnapshotError, WorkingCopy,
 };
@@ -116,6 +116,12 @@ impl From<OpHeadResolutionError> for CommandError {
 impl From<SnapshotError> for CommandError {
     fn from(err: SnapshotError) -> Self {
         CommandError::InternalError(format!("Failed to snapshot the working copy: {:?}", err))
+    }
+}
+
+impl From<TreeMergeError> for CommandError {
+    fn from(err: TreeMergeError) -> Self {
+        CommandError::InternalError(format!("Merge failed: {}", err))
     }
 }
 


### PR DESCRIPTION
Tree merges can currently fail because of a failure to look up an
object, or because of a failure to read its contents. Both results in
`BackendError` because of a `impl From<std::io::Error> for
BackendError`. That's kind of correct in this case, but it wasn't
intentional (that impl was from `local_backend`), and we need to
making errors more specific for better error handling.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
