### PR TITLE
diff_edit: load command arguments from merge-tools.<name> config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   will create a branch named after the revision's change ID, so you don't have
   to create a branch yourself.
 
+* Diff editor command arguments can now be specified by config file.
+  Example:
+
+      [merge-tools.kdiff3]
+      program = "kdiff3"
+      edit-args = ["--merge", "--cs", "CreateBakFiles=0"]
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,7 @@ dependencies = [
  "predicates",
  "rand",
  "regex",
+ "serde",
  "tempfile",
  "test-case",
  "textwrap 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ pest = "2.1.3"
 pest_derive = "2.1.0"
 rand = "0.8.5"
 regex = "1.5.5"
+serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.3.0"
 textwrap = "0.15.0"
 thiserror = "1.0.31"


### PR DESCRIPTION
Apparently, I need to pass `--merge` option to use kdiff3 as a diff editor.

We could add `diff-editor-args` or extend `diff-editor` to a list of command
arguments, but we'll eventually add stock merge tools and the configuration
would look like:

    [merge-tools.<name>]
    program = ...
    diff-args = [...]
    edit-args = [...]
    merge-args = [...]

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
