### PR TITLE
cli: fix incompatibility between #271 and #273

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -363,7 +363,7 @@ impl WorkspaceCommandHelper {
                 self.repo = tx.commit();
                 locked_working_copy.finish(self.repo.op_id().clone());
             } else {
-                let num_rebased = tx.mut_repo().rebase_descendants(ui.settings());
+                let num_rebased = tx.mut_repo().rebase_descendants(ui.settings())?;
                 if num_rebased > 0 {
                     writeln!(
                         ui,


### PR DESCRIPTION
The two PRs were incompatible, but it seems they were allowed to
"merge" (rebase) because the merge was conflict free?

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
