### PR TITLE
cleanup: fix some `cargo clippy` warnings

### DIFF
--- a/src/diff_edit.rs
+++ b/src/diff_edit.rs
@@ -197,7 +197,7 @@ impl MergeTool {
 /// Loads merge tool options from `[merge-tools.<name>]`. The given name is used
 /// as an executable name if no configuration found for that name.
 fn get_tool(settings: &UserSettings, name: &str) -> Result<MergeTool, ConfigError> {
-    const TABLE_KEY: &'static str = "merge-tools";
+    const TABLE_KEY: &str = "merge-tools";
     let tools_table = match settings.config().get_table(TABLE_KEY) {
         Ok(table) => table,
         Err(ConfigError::NotFound(_)) => return Ok(MergeTool::with_program(name)),

--- a/testing/fake-diff-editor.rs
+++ b/testing/fake-diff-editor.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 
 use clap::Parser;
@@ -30,7 +30,7 @@ struct Args {
     after: PathBuf,
 }
 
-fn files_recursively(dir: &PathBuf) -> HashSet<String> {
+fn files_recursively(dir: &Path) -> HashSet<String> {
     let mut files = HashSet::new();
     for dir_entry in std::fs::read_dir(dir).unwrap() {
         let dir_entry = dir_entry.unwrap();


### PR DESCRIPTION
No idea why these aren't picked up by CI already.
