### PR TITLE
github: trigger all builds on main branch, and PR for any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
 
 permissions: read-all
 

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -3,7 +3,7 @@ name: Nix on Linux
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 permissions: read-all


### PR DESCRIPTION
The conditions for triggering Nix builds and other builds were
slightly different.

Nix builds triggered by PRs happened on PRs for any branch, not just
the `main` branch. That makes very little difference in practice
because PRs for other branches are very rare. Still, let's be
consistent. I decided to trigger the builds on PRs for any branch.

More importantly, Nix builds triggered by push were only done for
pushes to `master`, which is not what our main branch is called, so
those never happened.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
