### PR TITLE
cli: allow alias after global args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj branch` can accept any number of branches to update, rather than just one.
 
+* Aliases can now call other aliases.
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side
@@ -113,6 +115,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * You now get a proper error message instead of a crash when `$EDITOR` doesn't
   exist or exits with an error.
+
+* Global arguments, such as `--at-op=<operation>`, can now be passed before
+  an alias.
 
 * Fixed relative path to the current directory in output to be `.` instead of
   empty string.

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -17,6 +17,141 @@ use crate::common::TestEnvironment;
 pub mod common;
 
 #[test]
+fn test_alias_basic() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.add_config(
+        br#"[alias]
+    b = ["log", "-r", "@", "-T", "branches"]
+    "#,
+    );
+    test_env.jj_cmd_success(&repo_path, &["branch", "my-branch"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["b"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ my-branch
+    ~ 
+    "###);
+}
+
+#[test]
+fn test_alias_calls_unknown_command() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.add_config(
+        br#"[alias]
+    foo = ["nonexistent"]
+    "#,
+    );
+    // Should get an error about the unknown command
+    test_env.jj_cmd_cli_error(&repo_path, &["foo"]);
+}
+
+#[test]
+fn test_alias_cannot_override_builtin() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.add_config(
+        br#"[alias]
+    log = ["rebase"]
+    "#,
+    );
+    // Alias should be ignored
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
+    insta::assert_snapshot!(stdout, @r###"
+    o 000000000000 000000000000  1970-01-01 00:00:00.000 +00:00   
+
+    "###);
+}
+
+#[test]
+fn test_alias_recursive() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.add_config(
+        br#"[alias]
+    foo = ["foo"]
+    bar = ["baz"]
+    baz = ["bar"]
+    "#,
+    );
+    // Alias should not cause infinite recursion or hang
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["foo"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Recursive alias definition involving "foo"
+    "###);
+    // Also test with mutual recursion
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["bar"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Recursive alias definition involving "bar"
+    "###);
+}
+
+#[test]
+fn test_alias_global_args_before_and_after() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.add_config(
+        br#"[alias]
+    l = ["log", "-T", "commit_id"]
+    "#,
+    );
+    // Test the setup
+    let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    o 0000000000000000000000000000000000000000
+    "###);
+
+    // Can pass global args before
+    let stdout = test_env.jj_cmd_success(&repo_path, &["l", "--at-op", "@-"]);
+    insta::assert_snapshot!(stdout, @r###"
+    o 0000000000000000000000000000000000000000
+    "###);
+    // Can pass global args after
+    let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "@-", "l"]);
+    insta::assert_snapshot!(stdout, @r###"
+    o 0000000000000000000000000000000000000000
+    "###);
+    // Test passing global args both before and after
+    let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "abc123", "l", "--at-op", "@-"]);
+    insta::assert_snapshot!(stdout, @r###"
+    o 0000000000000000000000000000000000000000
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["-R", "../nonexistent", "l", "-R", "."]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    o 0000000000000000000000000000000000000000
+    "###);
+}
+
+#[test]
+fn test_alias_global_args_in_definition() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.add_config(
+        br#"[alias]
+    l = ["log", "-T", "commit_id", "--at-op", "@-"]
+    "#,
+    );
+
+    // The global argument in the alias is respected
+    let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
+    insta::assert_snapshot!(stdout, @r###"
+    o 0000000000000000000000000000000000000000
+    "###);
+}
+
+#[test]
 fn test_alias_invalid_definition() {
     let test_env = TestEnvironment::default();
 


### PR DESCRIPTION
Our support for aliases is very naively implemented; it assumes the
alias is the first argument in argv. It therefore fails to resolve
aliases after global arguments such as `--at-op`.

This patch fixes that by using doing an intial parse of the arguments
with a modified definition of the CLI passed to `clap`. The modified
definition has only global arguments, plus an "external
subcommand". That way we can convince `clap` to parse the global
arguments for us and give us the alias (or real command) and further
arguments back. Thanks to @epage for the suggestion on in
clap-rs/clap#3672. The only minor problem is that it doesn't seem
possible to tell `clap` to parse global arguments that come after the
external subcommand. To work around that, we manually merge any parsed
global argument before the alias with any parsed global arguments
after it.

Closes #292.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
