### PR TITLE
Teach `jj log` option to show older revisions first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Aliases can now call other aliases.
 
+* `jj log` now accepts a `--reversed` option, which will show older commits
+  first.
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -833,6 +833,12 @@ impl<'revset, 'repo> RevsetIterator<'revset, 'repo> {
         }
     }
 
+    pub fn reversed(self) -> ReverseRevsetIterator<'repo> {
+        ReverseRevsetIterator {
+            entries: self.into_iter().collect_vec(),
+        }
+    }
+
     pub fn graph(self) -> RevsetGraphIterator<'revset, 'repo> {
         RevsetGraphIterator::new(self)
     }
@@ -870,6 +876,18 @@ impl Iterator for RevsetCommitIterator<'_, '_> {
         self.iter
             .next()
             .map(|index_entry| self.store.get_commit(&index_entry.commit_id()))
+    }
+}
+
+pub struct ReverseRevsetIterator<'repo> {
+    entries: Vec<IndexEntry<'repo>>,
+}
+
+impl<'repo> Iterator for ReverseRevsetIterator<'repo> {
+    type Item = IndexEntry<'repo>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.entries.pop()
     }
 }
 

--- a/lib/tests/test_revset_graph_iterator.rs
+++ b/lib/tests/test_revset_graph_iterator.rs
@@ -69,7 +69,9 @@ fn test_graph_iterator_virtual_octopus(skip_transitive_edges: bool) {
     let repo = &test_repo.repo;
 
     // Tests that merges outside the set can result in more parent edges than there
-    // was in the input: F
+    // was in the input:
+    //
+    // F
     // |\
     // d e            F
     // |\|\      =>  /|\
@@ -378,4 +380,65 @@ fn test_graph_iterator_edge_escapes_from_(skip_transitive_edges: bool) {
     assert_eq!(commits[2].1, vec![RevsetGraphEdge::indirect(pos_a)]);
     assert_eq!(commits[3].1, vec![RevsetGraphEdge::indirect(pos_a)]);
     assert_eq!(commits[4].1, vec![RevsetGraphEdge::missing(pos_root)]);
+}
+
+#[test]
+fn test_reverse_graph_iterator() {
+    let settings = testutils::user_settings();
+    let test_repo = testutils::init_repo(&settings, true);
+    let repo = &test_repo.repo;
+
+    // Tests that merges, forks, direct edges, indirect edges, and "missing" edges
+    // are correct in reversed graph. "Missing" edges (i.e. edges to commits not
+    // in the input set) won't be part of the reversed graph. Conversely, there
+    // won't be missing edges to children not in the input.
+    //
+    //  F
+    //  |\
+    //  D E
+    //  |/
+    //  C
+    //  |
+    //  b
+    //  |
+    //  A
+    //  |
+    // root
+    let mut tx = repo.start_transaction("test");
+    let mut graph_builder = CommitGraphBuilder::new(&settings, tx.mut_repo());
+    let commit_a = graph_builder.initial_commit();
+    let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
+    let commit_c = graph_builder.commit_with_parents(&[&commit_b]);
+    let commit_d = graph_builder.commit_with_parents(&[&commit_c]);
+    let commit_e = graph_builder.commit_with_parents(&[&commit_c]);
+    let commit_f = graph_builder.commit_with_parents(&[&commit_d, &commit_e]);
+    let repo = tx.commit();
+
+    let pos_c = repo.index().commit_id_to_pos(commit_c.id()).unwrap();
+    let pos_d = repo.index().commit_id_to_pos(commit_d.id()).unwrap();
+    let pos_e = repo.index().commit_id_to_pos(commit_e.id()).unwrap();
+    let pos_f = repo.index().commit_id_to_pos(commit_f.id()).unwrap();
+
+    let revset = revset_for_commits(
+        repo.as_repo_ref(),
+        &[&commit_a, &commit_c, &commit_d, &commit_e, &commit_f],
+    );
+    let commits = revset.iter().graph().reversed().collect_vec();
+    assert_eq!(commits.len(), 5);
+    assert_eq!(commits[0].0.commit_id(), *commit_a.id());
+    assert_eq!(commits[1].0.commit_id(), *commit_c.id());
+    assert_eq!(commits[2].0.commit_id(), *commit_d.id());
+    assert_eq!(commits[3].0.commit_id(), *commit_e.id());
+    assert_eq!(commits[4].0.commit_id(), *commit_f.id());
+    assert_eq!(commits[0].1, vec![RevsetGraphEdge::indirect(pos_c)]);
+    assert_eq!(
+        commits[1].1,
+        vec![
+            RevsetGraphEdge::direct(pos_e),
+            RevsetGraphEdge::direct(pos_d),
+        ]
+    );
+    assert_eq!(commits[2].1, vec![RevsetGraphEdge::direct(pos_f)]);
+    assert_eq!(commits[3].1, vec![RevsetGraphEdge::direct(pos_f)]);
+    assert_eq!(commits[4].1, vec![]);
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -42,7 +42,7 @@ use jujutsu_lib::diff::{Diff, DiffHunk};
 use jujutsu_lib::files::DiffLine;
 use jujutsu_lib::git::{GitExportError, GitFetchError, GitImportError, GitRefUpdate};
 use jujutsu_lib::gitignore::GitIgnoreFile;
-use jujutsu_lib::index::HexPrefix;
+use jujutsu_lib::index::{HexPrefix, IndexEntry};
 use jujutsu_lib::matchers::{EverythingMatcher, Matcher, PrefixMatcher, Visit};
 use jujutsu_lib::op_heads_store::{OpHeadResolutionError, OpHeads, OpHeadsStore};
 use jujutsu_lib::op_store::{OpStore, OpStoreError, OperationId, RefTarget, WorkspaceId};
@@ -51,7 +51,7 @@ use jujutsu_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPus
 use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, RepoRef};
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::revset::{RevsetError, RevsetExpression, RevsetParseError};
-use jujutsu_lib::revset_graph_iterator::RevsetGraphEdgeType;
+use jujutsu_lib::revset_graph_iterator::{RevsetGraphEdge, RevsetGraphEdgeType};
 use jujutsu_lib::rewrite::{back_out_commit, merge_commit_trees, rebase_commit, DescendantRebaser};
 use jujutsu_lib::settings::UserSettings;
 use jujutsu_lib::store::Store;
@@ -1276,6 +1276,9 @@ struct LogArgs {
     /// Which revisions to show
     #[clap(long, short, default_value = ":heads()")]
     revisions: String,
+    /// Show revisions in the opposite order (older revisions first)
+    #[clap(long)]
+    reversed: bool,
     /// Don't show the graph, show a flat list of revisions
     #[clap(long)]
     no_graph: bool,
@@ -3012,7 +3015,12 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
 
     if !args.no_graph {
         let mut graph = AsciiGraphDrawer::new(&mut formatter);
-        for (index_entry, edges) in revset.iter().graph() {
+        let iter: Box<dyn Iterator<Item = (IndexEntry, Vec<RevsetGraphEdge>)>> = if args.reversed {
+            Box::new(revset.iter().graph().reversed())
+        } else {
+            Box::new(revset.iter().graph())
+        };
+        for (index_entry, edges) in iter {
             let mut graphlog_edges = vec![];
             // TODO: Should we update RevsetGraphIterator to yield this flag instead of all
             // the missing edges since we don't care about where they point here
@@ -3068,7 +3076,12 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
             )?;
         }
     } else {
-        for index_entry in revset.iter() {
+        let iter: Box<dyn Iterator<Item = IndexEntry>> = if args.reversed {
+            Box::new(revset.iter().reversed())
+        } else {
+            Box::new(revset.iter())
+        };
+        for index_entry in iter {
             let commit = store.get_commit(&index_entry.commit_id())?;
             template.format(&commit, formatter)?;
             if let Some(diff_format) = diff_format {

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -128,3 +128,30 @@ fn test_log_with_or_without_diff() {
     +bar
     "###);
 }
+
+#[test]
+fn test_log_reversed() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
+    insta::assert_snapshot!(stdout, @r###"
+    o 
+    o first
+    @ second
+    "###);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "-T", "description", "--reversed", "--no-graph"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    
+    first
+    second
+    "###);
+}


### PR DESCRIPTION
Per @arxanas's request :)
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
