### PR TITLE
cli: make `log -s/--git` imply `-p`

### DIFF
--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -76,4 +76,55 @@ fn test_log_with_or_without_diff() {
     +foo
 
     "###);
+
+    // `-s` implies `-p`, with or without graph
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ a new commit
+    | M file1
+    o add a file
+    | A file1
+    o 
+    "###);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "-T", "description", "--no-graph", "-s"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    a new commit
+    M file1
+    add a file
+    A file1
+
+    "###);
+
+    // `--git` implies `-p`, with or without graph
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "-T", "description", "-r", "@", "--git"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ a new commit
+    ~ diff --git a/file1 b/file1
+      index 257cc5642c...3bd1f0e297 100644
+      --- a/file1
+      +++ b/file1
+      @@ -1,1 +1,2 @@
+       foo
+      +bar
+    "###);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "-T", "description", "-r", "@", "--no-graph", "--git"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    a new commit
+    diff --git a/file1 b/file1
+    index 257cc5642c...3bd1f0e297 100644
+    --- a/file1
+    +++ b/file1
+    @@ -1,1 +1,2 @@
+     foo
+    +bar
+    "###);
 }


### PR DESCRIPTION
`log -s/--summary` and `log --git` without `-p` don't do anything. I
also don't think it's very useful to pass these flags in an alias,
where you would then sometimes also pass `-p` to see the diff summary
in the output. We already have the `diff.format` config for that use
case. So let's make both of these flags imply `-p`.

I implemented it by making the `diff_format` variable an
`Option<DiffFormat>`, which is set iff we should show a patch. That
way we have the condition in one place, and the places we use it
cannot forget to check it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
