### PR TITLE
cli: make `log` show only local commits by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * An alias that is not configured as a string list (e.g. `my-status = "status"`
   instead of `my-status = ["status"]`) is now an error instead of a warning.
 
+* (#250) `jj log` now defaults to showing only commits that are not on any
+  remote branches (plus their closest commit on the remote branch for context).
+  Use `jj log -r 'all()'` for the old behavior. Read more about revsets
+  [here](https://github.com/martinvonz/jj/blob/main/docs/revsets.md).
+
 ### New features
 
 * `jj rebase` now accepts a `--branch/-b <revision>` argument, which can be used

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ backend (the only minor reason might be
 The backend exists mainly to make sure that it's possible to eventually add
 functionality that cannot easily be added to the Git backend.
 
-<a href="https://asciinema.org/a/DRCzktCyEAxH6j788ZDT6aSjS" target="_blank">
-  <img src="https://asciinema.org/a/DRCzktCyEAxH6j788ZDT6aSjS.svg" />
+<a href="https://asciinema.org/a/YZTilpwDKJjf6bKjCDFwDpKf4" target="_blank">
+  <img src="https://asciinema.org/a/YZTilpwDKJjf6bKjCDFwDpKf4.svg" />
 </a>
 
 ### The working copy is automatically committed
@@ -61,8 +61,8 @@ working copy or any other commit. It also means that you can always check out a
 different commit without first explicitly committing the working copy changes
 (you can even check out a different commit while resolving merge conflicts).
 
-<a href="https://asciinema.org/a/zWMv4ffmoXykBtrxvDY6ohEaZ" target="_blank">
-  <img src="https://asciinema.org/a/zWMv4ffmoXykBtrxvDY6ohEaZ.svg" />
+<a href="https://asciinema.org/a/DYrJLVkp2TIPgfMmjyhptTo7d" target="_blank">
+  <img src="https://asciinema.org/a/DYrJLVkp2TIPgfMmjyhptTo7d.svg" />
 </a>
 
 ### Operations update the repo first, then possibly the working copy
@@ -92,8 +92,8 @@ resolving conflicts, regardless of which command caused them. This design also
 lets Jujutsu rebase merge commits correctly (unlike both Git and Mercurial).
 
 Basic conflict resolution:
-<a href="https://asciinema.org/a/MWQz2nAprRXevQEYtaHScN2tJ" target="_blank">
-  <img src="https://asciinema.org/a/MWQz2nAprRXevQEYtaHScN2tJ.svg" />
+<a href="https://asciinema.org/a/ANyfj9M0hXZlDyw68QktpU5UM" target="_blank">
+  <img src="https://asciinema.org/a/ANyfj9M0hXZlDyw68QktpU5UM.svg" />
 </a>
 
 Juggling conflicts:

--- a/demos/demo_git_compat.sh
+++ b/demos/demo_git_compat.sh
@@ -12,7 +12,7 @@ run_command "cd Hello-World"
 pause 1
 run_command "# Inspect it:"
 pause 1
-run_command "jj log"
+run_command "jj log -r '\''all()'\''"
 pause 5
 run_command "jj diff -r b1"
 pause 2

--- a/demos/demo_resolve_conflict.sh
+++ b/demos/demo_resolve_conflict.sh
@@ -10,7 +10,7 @@ cd Hello-World
 run_demo 'Basic conflict resolution flow' '
 run_command "# We are on the master branch of the"
 run_command "# octocat/Hello-World repo:"
-run_command "jj log"
+run_command "jj log -r '\''all()'\''"
 pause 7
 run_command "# Let'\''s make an edit that will conflict"
 run_command "# when we rebase it:"
@@ -30,7 +30,7 @@ run_command ""
 run_command "# Huh, that seemed to succeed. Let'\''s take a"
 run_command "# look at the repo:"
 pause 2
-run_command "jj log"
+run_command "jj log -r '\''all()'\''"
 pause 4
 run_command "jj status"
 pause 3

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -128,36 +128,31 @@ working copy commit by default.
 ## The log command, "revsets", and aliases
 
 You're probably familiar with `git log`. Jujutsu has very similar functionality
-in its `jj log` command. It produces hundreds of lines of output, so let's pipe
-its output into `head`:
+in its `jj log` command:
 ```shell script
-$ jj log | head
+$ jj log
 @ 192b456b024b f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00
 |
 o fb563a4c6d26 f63e76f175b9 martinvonz@google.com 2021-05-23 22:13:45.000 -07:00
 | Jujutsu is ready!
 o 080a9b37ff7e 6a91b4ba16c7 martinvonz@google.com 2021-05-23 22:08:37.000 -07:00 main
-| cli: make `jj st` show parent commit before working copy commit
-o ba8ff31e32fd 302257bdb7e5 martinvonz@google.com 2021-05-23 22:08:12.000 -07:00
-| cli: make the working copy changes in `jj status` clearer
-o dcfc888f50b3 7eddf8dfc70d martinvonz@google.com 2021-05-23 22:07:40.000 -07:00
-| cli: remove "Done" message at end of git clone
+~ cli: make `jj st` show parent commit before working copy commit
 ```
 
 The `@` indicates the working copy commit. The first hash on a line is the
 commit ID. The second hash is a "change ID", which is an ID that follows the
 commit as it's rewritten (similar to Gerrit's Change-Id). You can give either
 hash to commands that take revisions as arguments. We will generally prefer
-change ids because they stay the same when the commit is rewritten.
+change IDs because they stay the same when the commit is rewritten.
 
-By default, `jj log` lists all revisions (commits) in the repo that have not
-been rewritten (roughly speaking). We can use the `-r` flag to restrict which
-revisions we want to list. The flag accepts a ["revset"](revsets.md), which is
-an expression in a simple language for specifying revisions. For example, `@`
-refers to the working copy commit, `root` refers to the root commit,
-`branches()` refers to all commits pointed to by branches. We can combine
-expressions with `|` for union, `&` for intersection and `~` for difference.
-For example:
+By default, `jj log` list your local commits, with some remote commits added for
+context.  The `~` indicates that the commit has parents that are not included
+in the graph. We can use the `-r` flag to select a different set of revisions we
+want to list. The flag accepts a ["revset"](revsets.md), which is an expression
+in a simple language for specifying revisions. For example, `@` refers to the
+working copy commit, `root` refers to the root commit, `branches()` refers to
+all commits pointed to by branches. We can combine expressions with `|` for
+union, `&` for intersection and `~` for difference. For example:
 ```shell script
 $ jj log -r '@ | root | branches()'
 @ 192b456b024b f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00
@@ -174,23 +169,7 @@ There are also operators for getting the parents (`foo-`), children (`foo+`),
 ancestors (`:foo`), descendants (`foo:`), DAG range (`foo:bar`, like
 `git log --ancestry-path`), range (`foo..bar`, same as Git's). There are also a
 few more functions, such as `heads(<set>)`, which filters out revisions in the
-input set if they're ancestors of other revisions in the set. Let's define an
-alias based on that by adding the following to `~/.jjconfig.toml`:
-```
-[alias]
-l = ["log", "-r", "(heads(remote_branches())..@):"]
-```
-
-The alias lets us run `jj l` to see the commits we have created between public
-heads (exclusive) and the working copy (inclusive), as well as their
-descendants:
-```shell script
-$ jj l
-@ 192b456b024b f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00
-|
-o fb563a4c6d26 f63e76f175b9 martinvonz@google.com 2021-05-23 22:13:45.000 -07:00
-~ Jujutsu is ready!
-``` 
+input set if they're ancestors of other revisions in the set.
 
 ## Conflicts
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1274,7 +1274,11 @@ struct StatusArgs {}
 #[derive(clap::Args, Clone, Debug)]
 struct LogArgs {
     /// Which revisions to show
-    #[clap(long, short, default_value = ":heads()")]
+    #[clap(
+        long,
+        short,
+        default_value = "remote_branches().. | (remote_branches()..)-"
+    )]
     revisions: String,
     /// Don't show the graph, show a flat list of revisions
     #[clap(long)]


### PR DESCRIPTION
The default log output of showing all commits is not very useful when
contributing to an existing repo. Let's have it default to showing
commits not on any remote branch instead. I think that's the best we
can do since we don't have a configurable main branch yet, and we
don't even have per-repo configuration..

Closes #250.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
