### PR TITLE
cli: show placeholder text for empty commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ backend (the only minor reason might be
 The backend exists mainly to make sure that it's possible to eventually add
 functionality that cannot easily be added to the Git backend.
 
-<a href="https://asciinema.org/a/YZTilpwDKJjf6bKjCDFwDpKf4" target="_blank">
-  <img src="https://asciinema.org/a/YZTilpwDKJjf6bKjCDFwDpKf4.svg" />
+<a href="https://asciinema.org/a/6UwpP2U4QxuRUY6eOGfRoJsgN" target="_blank">
+  <img src="https://asciinema.org/a/6UwpP2U4QxuRUY6eOGfRoJsgN.svg" />
 </a>
 
 ### The working copy is automatically committed
@@ -61,8 +61,8 @@ working copy or any other commit. It also means that you can always check out a
 different commit without first explicitly committing the working copy changes
 (you can even check out a different commit while resolving merge conflicts).
 
-<a href="https://asciinema.org/a/DYrJLVkp2TIPgfMmjyhptTo7d" target="_blank">
-  <img src="https://asciinema.org/a/DYrJLVkp2TIPgfMmjyhptTo7d.svg" />
+<a href="https://asciinema.org/a/OywNvPxShG4Zmul2eNcDiL3nj" target="_blank">
+  <img src="https://asciinema.org/a/OywNvPxShG4Zmul2eNcDiL3nj.svg" />
 </a>
 
 ### Operations update the repo first, then possibly the working copy
@@ -78,8 +78,8 @@ the repo state after the operation. This means that you can easily revert to an
 earlier repo state, or to simply undo a particular operation (which does not
 necessarily have to be the most recent operation).
 
-<a href="https://asciinema.org/a/OFOTcm2XlZ09LLEI5bHYM8Alw" target="_blank">
-  <img src="https://asciinema.org/a/OFOTcm2XlZ09LLEI5bHYM8Alw.svg" />
+<a href="https://asciinema.org/a/fggh1HkoYyH5HAA8amzm4LiV4" target="_blank">
+  <img src="https://asciinema.org/a/fggh1HkoYyH5HAA8amzm4LiV4.svg" />
 </a>
 
 ### Conflicts can be recorded in commits
@@ -92,13 +92,13 @@ resolving conflicts, regardless of which command caused them. This design also
 lets Jujutsu rebase merge commits correctly (unlike both Git and Mercurial).
 
 Basic conflict resolution:
-<a href="https://asciinema.org/a/ANyfj9M0hXZlDyw68QktpU5UM" target="_blank">
-  <img src="https://asciinema.org/a/ANyfj9M0hXZlDyw68QktpU5UM.svg" />
+<a href="https://asciinema.org/a/egs4vOJGCd2lt8OBhCx0f139z" target="_blank">
+  <img src="https://asciinema.org/a/egs4vOJGCd2lt8OBhCx0f139z.svg" />
 </a>
 
 Juggling conflicts:
-<a href="https://asciinema.org/a/HqYA9SL2tzarPAErpYs684GGR" target="_blank">
-  <img src="https://asciinema.org/a/HqYA9SL2tzarPAErpYs684GGR.svg" />
+<a href="https://asciinema.org/a/sTQnMCthulo2NfwRnHX30qegq" target="_blank">
+  <img src="https://asciinema.org/a/sTQnMCthulo2NfwRnHX30qegq.svg" />
 </a>
 
 ### Automatic rebase

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -15,7 +15,7 @@ Let's start by cloning the Jujutsu Git repo using `jj`:
 # repos yet)
 $ jj git clone https://github.com/martinvonz/jj.git
 Fetching into new repo in "<dir>/jj"
-Working copy now at: 265ecf5cab2d
+Working copy now at: 265ecf5cab2d (no description set)
 Added 98 files, modified 0 files, removed 0 files
 $ cd jj
 ```
@@ -24,7 +24,7 @@ Running `jj st` (short for`jj status`) now yields something like this:
 ```shell script
 $ jj st
 Parent commit: 723ebb380971 cleanup: restructure escaped newlines to make new rustc happy
-Working copy : 265ecf5cab2d
+Working copy : 265ecf5cab2d (no description set)
 The working copy is clean
 ```
 
@@ -38,7 +38,7 @@ Working copy now at: 608c179a60df
 Added 7 files, modified 65 files, removed 21 files
 $ jj st
 Parent commit: 080a9b37ff7e cli: make `jj st` show parent commit before working copy commit
-Working copy : 608c179a60df
+Working copy : 608c179a60df (no description set)
 The working copy is clean
 ```
 
@@ -67,7 +67,7 @@ Now make the change in the README:
 $ sed -i 's/not ready/ready/' README.md
 $ jj st
 Parent commit: 080a9b37ff7e cli: make `jj st` show parent commit before working copy commit
-Working copy : 5f80190c44b9
+Working copy : 5f80190c44b9 Jujutsu is ready!
 Working copy changes:
 M README.md
 ```
@@ -110,10 +110,10 @@ that commit itself will be checked out instead.
 So, let's say we're now done with this commit, so we close it:
 ```shell script
 $ jj close
-Working copy now at: 192b456b024b
+Working copy now at: 192b456b024b (no description set)
 $ jj st
 Parent commit: fb563a4c6d26 Jujutsu is ready!
-Working copy : 192b456b024b
+Working copy : 192b456b024b (no description set)
 The working copy is clean
 ```
 
@@ -132,7 +132,7 @@ in its `jj log` command:
 ```shell script
 $ jj log
 @ 192b456b024b f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00
-|
+| (no description set)
 o fb563a4c6d26 f63e76f175b9 martinvonz@google.com 2021-05-23 22:13:45.000 -07:00
 | Jujutsu is ready!
 o 080a9b37ff7e 6a91b4ba16c7 martinvonz@google.com 2021-05-23 22:08:37.000 -07:00 main
@@ -156,7 +156,7 @@ union, `&` for intersection and `~` for difference. For example:
 ```shell script
 $ jj log -r '@ | root | branches()'
 @ 192b456b024b f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00
-:
+: (no description set)
 o 080a9b37ff7e 6a91b4ba16c7 martinvonz@google.com 2021-05-23 22:08:37.000 -07:00 main
 : cli: make `jj st` show parent commit before working copy commit
 o 000000000000 000000000000  1970-01-01 00:00:00.000 +00:00
@@ -178,16 +178,16 @@ commits:
 ```shell script
 # Check out the grandparent of the working copy
 $ jj co @--
-Working copy now at: 9164f1d6a011
+Working copy now at: 9164f1d6a011 (no description set)
 Added 0 files, modified 1 files, removed 0 files
 $ echo a > file1; jj close -m A
-Working copy now at: 5be91b2b5b69
+Working copy now at: 5be91b2b5b69 (no description set)
 $ echo b1 > file1; jj close -m B1
-Working copy now at: a0331f1eeece
+Working copy now at: a0331f1eeece (no description set)
 $ echo b2 > file1; jj close -m B2
-Working copy now at: fd571967346e
+Working copy now at: fd571967346e (no description set)
 $ echo c > file2; jj close -m C
-Working copy now at: 4ae1e0587eef
+Working copy now at: 4ae1e0587eef (no description set)
 $ jj l
 @ 4ae1e0587eef 47684978bf4b martinvonz@google.com 2021-05-26 12:39:56.000 -07:00
 |
@@ -206,11 +206,11 @@ modifies a different file. Let's now rebase B2 directly onto A:
 ```shell script
 $ jj rebase -s 5548374c0794 -d cf49e6bec410
 Rebased 3 commits
-Working copy now at: 9195b6d2e8dc
+Working copy now at: 9195b6d2e8dc (no description set)
 Added 0 files, modified 1 files, removed 0 files
 $ jj l
 @ 9195b6d2e8dc 47684978bf4b martinvonz@google.com 2021-05-26 12:39:56.000 -07:00 conflict
-|
+| (no description set)
 o 66274d5a7d2d 8e6178b84ffb martinvonz@google.com 2021-05-26 12:39:35.000 -07:00  conflict
 | C
 o 0c305a9e6b27 5548374c0794 martinvonz@google.com 2021-05-26 12:39:30.000 -07:00  conflict
@@ -235,11 +235,11 @@ conflict, we'll squash the conflict resolution into the conflicted B2. That
 might look like this:
 ```shell script
 $ jj co 5548374c0794  # Replace the hash by what you have for B2
-Working copy now at: 619f58d8a988
+Working copy now at: 619f58d8a988 (no description set)
 Added 0 files, modified 1 files, removed 0 files
 $ jj st
 Parent commit: 5548374c0794 B2
-Working copy : 619f58d8a988
+Working copy : 619f58d8a988 (no description set)
 The working copy is clean
 There are unresolved conflicts at these paths:
 file1
@@ -255,10 +255,10 @@ b2
 $ echo resolved > file1
 $ jj squash
 Rebased 1 descendant commits
-Working copy now at: e659edc4a9fc
+Working copy now at: e659edc4a9fc (no description set)
 $ jj l
 @ e659edc4a9fc 461f38324592 martinvonz@google.com 2021-05-26 12:53:08.000 -07:00
-|
+| (no description set)
 | o 69dbcf76642a 8e6178b84ffb martinvonz@google.com 2021-05-26 12:39:35.000 -07:00
 |/  C
 o 576d647acf36 5548374c0794 martinvonz@google.com 2021-05-26 12:39:30.000 -07:00
@@ -337,17 +337,17 @@ We'll need some more complex content to test these commands, so let's create a
 few more commits:
 ```shell script
 $ jj co origin/main
-Working copy now at: 61b0efa09dbe 
+Working copy now at: 61b0efa09dbe (no description set)
 Added 0 files, modified 0 files, removed 1 files
 $ printf 'a\nb\nc\n' > file; jj close -m abc
-Working copy now at: f9147a088c0d 
+Working copy now at: f9147a088c0d (no description set)
 $ printf 'A\nB\nc\n' > file; jj close -m ABC
-Working copy now at: 9d97c5018b23 
+Working copy now at: 9d97c5018b23 (no description set)
 $ printf 'A\nB\nC\nD\n' > file; jj close -m ABCD
-Working copy now at: c5a985bc3f41 
+Working copy now at: c5a985bc3f41 (no description set)
 $ jj l
 @ c5a985bc3f41 3568f6e332d5 martinvonz@google.com 2021-05-26 14:36:46.000 -07:00 
-| 
+| (no description set)
 o 687009839bae 874f2d307594 martinvonz@google.com 2021-05-26 14:36:38.000 -07:00 
 | ABCD
 o ad9b1ce3b5d0 2bbc0c1eb382 martinvonz@google.com 2021-05-26 14:36:26.000 -07:00 
@@ -366,7 +366,7 @@ Now try that:
 ```shell script
 $ jj squash -i -r @-
 Rebased 1 descendant commits
-Working copy now at: 4b4c714b36aa 
+Working copy now at: 4b4c714b36aa (no description set)
 ```
 That will bring up Meld with a diff of the changes in the "ABCD" commit. Modify
 the right side of the diff to have the desired end state in "ABC" by removing
@@ -392,7 +392,7 @@ checking it out.
 $ jj edit -r @--
 Created 2423c134ea70 ABC
 Rebased 2 descendant commits
-Working copy now at: d31c52e8ca41 
+Working copy now at: d31c52e8ca41 (no description set)
 Added 0 files, modified 1 files, removed 0 files
 ```
 When Meld starts, edit the right side by e.g. adding something to the first

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -175,6 +175,8 @@ impl<'r> TemplateProperty<Commit, String> for DescriptionProperty {
         let description = context.description().to_owned();
         if description.ends_with('\n') {
             description
+        } else if description.is_empty() {
+            "(no description set)\n".to_string()
         } else {
             description.add("\n")
         }

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -25,8 +25,8 @@ fn smoke_test() {
     // Check the output of `jj status` right after initializing repo
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 000000000000 
-    Working copy : 230dd059e1b0 
+    Parent commit: 000000000000 (no description set)
+    Working copy : 230dd059e1b0 (no description set)
     The working copy is clean
     "###);
 
@@ -38,8 +38,8 @@ fn smoke_test() {
     // The working copy's ID should have changed
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 000000000000 
-    Working copy : d38745675403 
+    Parent commit: 000000000000 (no description set)
+    Working copy : d38745675403 (no description set)
     Working copy changes:
     A file1
     A file2
@@ -59,6 +59,6 @@ fn smoke_test() {
     // Close the commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["close"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: a13f828fab1a 
+    Working copy now at: a13f828fab1a (no description set)
     "###);
 }

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -65,7 +65,7 @@ fn test_alias_cannot_override_builtin() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
     insta::assert_snapshot!(stdout, @r###"
     o 000000000000 000000000000  1970-01-01 00:00:00.000 +00:00   
-
+      (no description set)
     "###);
 }
 

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -35,7 +35,7 @@ fn test_concurrent_operation_divergence() {
     o message 2
     | @ message 1
     |/  
-    o 
+    o (no description set)
     "###);
 }
 
@@ -63,6 +63,6 @@ fn test_concurrent_operations_auto_rebase() {
     Rebased 1 descendant commits onto commits rewritten by other operation
     o 4eeb7d76372418118a91c34f09e5e3936f0deeb5 new child
     @ 14176aeadc0259b2150fc7374969e74b1552a498 rewritten
-    o 0000000000000000000000000000000000000000 
+    o 0000000000000000000000000000000000000000 (no description set)
     "###);
 }

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -63,8 +63,8 @@ fn test_edit() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["edit"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 8c79910b5033 
-    Working copy now at: 8c79910b5033 
+    Created 8c79910b5033 (no description set)
+    Working copy now at: 8c79910b5033 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -77,9 +77,9 @@ fn test_edit() {
     std::fs::write(&edit_script, "write file3\nmodified\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["edit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 472de2debaff 
+    Created 472de2debaff (no description set)
     Rebased 1 descendant commits
-    Working copy now at: 6d19dc1ea106 
+    Working copy now at: 6d19dc1ea106 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let contents = String::from_utf8(std::fs::read(repo_path.join("file3")).unwrap()).unwrap();
@@ -130,7 +130,7 @@ fn test_edit_merge() {
     insta::assert_snapshot!(stdout, @r###"
     Created 608f32ad9e19 merge
     Rebased 1 descendant commits
-    Working copy now at: a791bdbda05c 
+    Working copy now at: a791bdbda05c (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -72,7 +72,7 @@ fn test_git_colocated_rebase_on_import() {
         test_env.jj_cmd_success(&workspace_root, &["log", "-T", "commit_id \" \" branches"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits off of commits rewritten from git
-    Working copy now at: a64f325e0516 
+    Working copy now at: a64f325e0516 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     @ a64f325e05167129f3488f85a570f22a8940634f 
     o f0f3ab56bfa927e3a65c2ac9a513693d438e271b master

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -85,7 +85,7 @@ fn test_init_git_external() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: f6950fc115ae 
+    Working copy now at: f6950fc115ae (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
     "###);

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -31,7 +31,7 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @ a new commit
     o add a file
-    o
+    o (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p"]);
@@ -43,14 +43,14 @@ fn test_log_with_or_without_diff() {
     o add a file
     | Added regular file file1:
     |         1: foo
-    o 
+    o (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
     a new commit
     add a file
-
+    (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -74,7 +74,7 @@ fn test_log_with_or_without_diff() {
     +++ b/file1
     @@ -1,0 +1,1 @@
     +foo
-
+    (no description set)
     "###);
 
     // `-s` implies `-p`, with or without graph
@@ -84,7 +84,7 @@ fn test_log_with_or_without_diff() {
     | M file1
     o add a file
     | A file1
-    o 
+    o (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -95,7 +95,7 @@ fn test_log_with_or_without_diff() {
     M file1
     add a file
     A file1
-
+    (no description set)
     "###);
 
     // `--git` implies `-p`, with or without graph
@@ -140,7 +140,7 @@ fn test_log_reversed() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
     insta::assert_snapshot!(stdout, @r###"
-    o 
+    o (no description set)
     o first
     @ second
     "###);
@@ -150,7 +150,7 @@ fn test_log_reversed() {
         &["log", "-T", "description", "--reversed", "--no-graph"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    
+    (no description set)
     first
     second
     "###);

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -78,7 +78,7 @@ fn test_move() {
     // Can move from sibling, which results in the source being abandoned
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1c03e3d3c63f 
+    Working copy now at: 1c03e3d3c63f (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -105,7 +105,7 @@ fn test_move() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: c8d83075e8c2 
+    Working copy now at: c8d83075e8c2 (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
@@ -130,7 +130,7 @@ fn test_move() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "e", "--to", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 2b723b1d6033 
+    Working copy now at: 2b723b1d6033 (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
@@ -193,7 +193,7 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 71b69e433fbc 
+    Working copy now at: 71b69e433fbc (no description set)
     Added 0 files, modified 2 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -223,7 +223,7 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 63f1a6e96edb 
+    Working copy now at: 63f1a6e96edb (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -256,7 +256,7 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 17c2e6632cc5 
+    Working copy now at: 17c2e6632cc5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_new.rs
+++ b/tests/test_new.rs
@@ -29,6 +29,6 @@ fn test_new_with_message() {
     insta::assert_snapshot!(stdout, @r###"
     @ 88436dbcdbedc2b8a6ebd0687981906d09ccc68f a new commit
     o 51e9c5819117991e4a6dc5a4a744283fc74f0746 add a file
-    o 0000000000000000000000000000000000000000 
+    o 0000000000000000000000000000000000000000 (no description set)
     "###);
 }

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -139,7 +139,7 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 commits
-    Working copy now at: f6eecf0d8f36 
+    Working copy now at: f6eecf0d8f36 (no description set)
     Added 1 files, modified 0 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches"]);
@@ -157,7 +157,7 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 commits
-    Working copy now at: a15dfb947f3f 
+    Working copy now at: a15dfb947f3f (no description set)
     Added 1 files, modified 0 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches"]);
@@ -202,7 +202,7 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 3 descendant commits onto parent of rebased commit
-    Working copy now at: ee6a5a3f71d4 
+    Working copy now at: ee6a5a3f71d4 (no description set)
     Added 0 files, modified 0 files, removed 2 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches"]);
@@ -219,7 +219,7 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "root"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 2 descendant commits onto parent of rebased commit
-    Working copy now at: 6dc5b752c6ad 
+    Working copy now at: 6dc5b752c6ad (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches"]);
@@ -300,7 +300,7 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 commits
-    Working copy now at: 60e083aa9086 
+    Working copy now at: 60e083aa9086 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_restore_command.rs
+++ b/tests/test_restore_command.rs
@@ -33,8 +33,8 @@ fn test_restore() {
     // Restores from parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created b05f8b84f2fc 
-    Working copy now at: b05f8b84f2fc 
+    Created b05f8b84f2fc (no description set)
+    Working copy now at: b05f8b84f2fc (no description set)
     Added 1 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -44,8 +44,8 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 9cb58509136b 
-    Working copy now at: 9cb58509136b 
+    Created 9cb58509136b (no description set)
+    Working copy now at: 9cb58509136b (no description set)
     Added 1 files, modified 0 files, removed 2 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -57,9 +57,9 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 5ed06151e039 
+    Created 5ed06151e039 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: ca6c95b68bd2 
+    Working copy now at: ca6c95b68bd2 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -74,9 +74,9 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created c83e17dc46fd 
+    Created c83e17dc46fd (no description set)
     Rebased 1 descendant commits
-    Working copy now at: df9fb6892f99 
+    Working copy now at: df9fb6892f99 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -91,8 +91,8 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 28647642d4a5 
-    Working copy now at: 28647642d4a5 
+    Created 28647642d4a5 (no description set)
+    Working copy now at: 28647642d4a5 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -146,8 +146,8 @@ fn test_restore_interactive() {
     std::fs::write(&edit_script, "reset file2\0reset file3").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created abdbf6271a1c 
-    Working copy now at: abdbf6271a1c 
+    Created abdbf6271a1c (no description set)
+    Working copy now at: abdbf6271a1c (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -160,8 +160,8 @@ fn test_restore_interactive() {
     std::fs::write(&edit_script, "write file3\nunrelated\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created e31f7f33ad07 
-    Working copy now at: e31f7f33ad07 
+    Created e31f7f33ad07 (no description set)
+    Working copy now at: e31f7f33ad07 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -36,9 +36,9 @@ fn test_split() {
     std::fs::write(edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
-    First part: 5eebce1de3b0 
-    Second part: 45833353d94e 
-    Working copy now at: 45833353d94e 
+    First part: 5eebce1de3b0 (no description set)
+    Second part: 45833353d94e (no description set)
+    Working copy now at: 45833353d94e (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.short()"]);

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -43,7 +43,7 @@ fn test_squash() {
     // Squashes the working copy into the parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 6ca29c9d2e7c 
+    Working copy now at: 6ca29c9d2e7c (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
@@ -61,7 +61,7 @@ fn test_squash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: e87cf8ebc7e1 
+    Working copy now at: e87cf8ebc7e1 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
@@ -108,7 +108,7 @@ fn test_squash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 626d78245205 
+    Working copy now at: 626d78245205 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
@@ -162,7 +162,7 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: f03d5ce4a973 
+    Working copy now at: f03d5ce4a973 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
@@ -181,7 +181,7 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: e7a40106bee6 
+    Working copy now at: e7a40106bee6 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
@@ -214,7 +214,7 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: a911fa1d0627 
+    Working copy now at: a911fa1d0627 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_undo.rs
+++ b/tests/test_undo.rs
@@ -33,7 +33,7 @@ fn test_undo_rewrite_with_child() {
     insta::assert_snapshot!(stdout, @r###"
     @ child
     o modified
-    o 
+    o (no description set)
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo", &op_id_hex]);
 
@@ -43,6 +43,6 @@ fn test_undo_rewrite_with_child() {
     insta::assert_snapshot!(stdout, @r###"
     @ child
     o initial
-    o 
+    o (no description set)
     "###);
 }

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -33,7 +33,7 @@ fn test_workspaces_add_second_workspace() {
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: 988d8c1dca7e 
+    default: 988d8c1dca7e (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -42,7 +42,7 @@ fn test_workspaces_add_second_workspace() {
     );
     insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
     Created workspace in "../secondary"
-    Working copy now at: 8ac248e0c8d2 
+    Working copy now at: 8ac248e0c8d2 (no description set)
     Added 1 files, modified 0 files, removed 0 files
     "###);
 
@@ -66,8 +66,8 @@ fn test_workspaces_add_second_workspace() {
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: 988d8c1dca7e 
-    second: 8ac248e0c8d2 
+    default: 988d8c1dca7e (no description set)
+    second: 8ac248e0c8d2 (no description set)
     "###);
 }
 
@@ -101,7 +101,7 @@ fn test_workspaces_conflicting_edits() {
     let stdout = test_env.jj_cmd_success(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 86bef7fee095 
+    Working copy now at: 86bef7fee095 (no description set)
     "###);
 
     // The secondary workspace's checkout was updated
@@ -143,7 +143,7 @@ fn test_workspaces_forget() {
     // When listing workspaces, only the secondary workspace shows up
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    secondary: 39a6d6c6f295 
+    secondary: 39a6d6c6f295 (no description set)
     "###);
 
     // `jj status` tells us that there's no working copy here


### PR DESCRIPTION
It can be confusing that some commits (typically the working copy)
don't have a description. Let's show a placeholder text in such cases.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
