### PR TITLE
cli: add `update` and `up` as aliases for `checkout`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1172,7 +1172,7 @@ struct InitArgs {
 /// be created on top, and that will be checked out. For more information, see
 /// https://github.com/martinvonz/jj/blob/main/docs/working-copy.md.
 #[derive(clap::Args, Clone, Debug)]
-#[clap(visible_alias = "co")]
+#[clap(visible_aliases = &["co", "update", "up"])]
 struct CheckoutArgs {
     /// The revision to update to
     revision: String,


### PR DESCRIPTION
Mercurial has these aliases, so it will be familiar for Mercurial
users. My only hesitation about adding these aliases is that we might
want the these names for something else in the future. You could
imagine `up` and `down` commands, for example. We still have a long
time before 1.0, so we have plenty of opportunity to make breaking
changes if we think of some other use for the names :)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
