### PR TITLE
cargo: use only "toml" feature from `config` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ chrono = "0.4.19"
 clap = { version = "3.1.18", features = ["derive"] }
 clap_complete = "3.1.4"
 clap_mangen = "0.1"
-config = "0.13.1"
+config = { version = "0.13.1", features = ["toml"] }
 criterion = "0.3.5"
 dirs = "4.0.0"
 git2 = "0.14.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ blake2 = "0.10.4"
 bytes = "1.1.0"
 byteorder = "1.4.3"
 chrono = "0.4.19"
-config = "0.13.1"
+config = { version = "0.13.1", features = ["toml"] }
 git2 = "0.14.2"
 hex = "0.4.3"
 itertools = "0.10.3"


### PR DESCRIPTION
We don't need the `config` crate's support for JSON etc., so let's
just enable the TOML feature. (Trying to import all the JSON, RON,
dependencies etc. into Google's source control was a pain.)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
