### PR TITLE
cli: make `op restore` require an operation ID

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1679,7 +1679,6 @@ struct OperationLogArgs {}
 #[derive(clap::Args, Clone, Debug)]
 struct OperationRestoreArgs {
     /// The operation to restore to
-    #[clap(default_value = "@")]
     operation: String,
 }
 


### PR DESCRIPTION
It doesn't make much sense to default to restoring to the current
operation.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
