### PR TITLE
Improvements to `jj new` (and others)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checkout will be checked out. That was always the intent, but the root commit
   was accidentally checked out instead.
 
+* When checking out a commit, the previous commit is no longer abandoned if it
+  has a non-empty description.
+
 ## [0.4.0] - 2022-04-02
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Use `jj log -r 'all()'` for the old behavior. Read more about revsets
   [here](https://github.com/martinvonz/jj/blob/main/docs/revsets.md).
 
+* `jj new` now always checks out the new commit (used to be only if the parent
+  was `@`).
+
 ### New features
 
 * `jj rebase` now accepts a `--branch/-b <revision>` argument, which can be used

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -588,7 +588,10 @@ impl MutableRepo {
         if let Some(current_checkout_id) = maybe_current_checkout_id {
             let current_checkout = self.store().get_commit(&current_checkout_id).unwrap();
             assert!(current_checkout.is_open(), "current checkout is closed");
-            if current_checkout.is_empty() && self.view().heads().contains(current_checkout.id()) {
+            if current_checkout.is_empty()
+                && current_checkout.description().is_empty()
+                && self.view().heads().contains(current_checkout.id())
+            {
                 // Abandon the checkout we're leaving if it's empty and a head commit
                 self.record_abandoned_commit(current_checkout_id);
             }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1385,10 +1385,9 @@ struct AbandonArgs {
 /// Create a new, empty change
 ///
 /// This may be useful if you want to make some changes you're unsure of on top
-/// of the working copy. If the changes turned out to useful, you can `jj
+/// of the working copy. If the changes turned out to be useful, you can `jj
 /// squash` them into the previous working copy. If they turned out to be
-/// unsuccessful, you can `jj abandon` them and `jj co @-` the previous working
-/// copy.
+/// unsuccessful, you can `jj abandon` them.
 #[derive(clap::Args, Clone, Debug)]
 struct NewArgs {
     /// Parent of the new change

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1382,7 +1382,7 @@ struct AbandonArgs {
     revisions: String,
 }
 
-/// Create a new, empty change
+/// Create a new, empty change and check it out
 ///
 /// This may be useful if you want to make some changes you're unsure of on top
 /// of the working copy. If the changes turned out to be useful, you can `jj
@@ -1391,9 +1391,6 @@ struct AbandonArgs {
 #[derive(clap::Args, Clone, Debug)]
 struct NewArgs {
     /// Parent of the new change
-    ///
-    /// If the parent is the working copy, then the new change will be checked
-    /// out.
     #[clap(default_value = "@")]
     revision: String,
     /// The change description to use
@@ -3371,9 +3368,7 @@ fn cmd_new(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(), C
     let mut_repo = tx.mut_repo();
     let new_commit = commit_builder.write_to_repo(mut_repo);
     let workspace_id = workspace_command.workspace_id();
-    if mut_repo.view().get_checkout(&workspace_id) == Some(parent.id()) {
-        mut_repo.check_out(workspace_id, ui.settings(), &new_commit);
-    }
+    mut_repo.check_out(workspace_id, ui.settings(), &new_commit);
     workspace_command.finish_transaction(ui, tx)?;
     Ok(())
 }

--- a/tests/test_new.rs
+++ b/tests/test_new.rs
@@ -37,6 +37,7 @@ fn test_new() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id \" \" description"]);
     insta::assert_snapshot!(stdout, @r###"
     @ d8c0a3e1570f1f5b08113a3427b3160900c3d48e off of root
+    | o 88436dbcdbedc2b8a6ebd0687981906d09ccc68f a new commit
     | o 51e9c5819117991e4a6dc5a4a744283fc74f0746 add a file
     |/  
     o 0000000000000000000000000000000000000000 (no description set)

--- a/tests/test_new.rs
+++ b/tests/test_new.rs
@@ -17,7 +17,7 @@ use crate::common::TestEnvironment;
 pub mod common;
 
 #[test]
-fn test_new_with_message() {
+fn test_new() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
@@ -29,6 +29,16 @@ fn test_new_with_message() {
     insta::assert_snapshot!(stdout, @r###"
     @ 88436dbcdbedc2b8a6ebd0687981906d09ccc68f a new commit
     o 51e9c5819117991e4a6dc5a4a744283fc74f0746 add a file
+    o 0000000000000000000000000000000000000000 (no description set)
+    "###);
+
+    // Start a new change off of a specific commit (the root commit in this case).
+    test_env.jj_cmd_success(&repo_path, &["new", "-m", "off of root", "root"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id \" \" description"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ d8c0a3e1570f1f5b08113a3427b3160900c3d48e off of root
+    | o 51e9c5819117991e4a6dc5a4a744283fc74f0746 add a file
+    |/  
     o 0000000000000000000000000000000000000000 (no description set)
     "###);
 }


### PR DESCRIPTION
Some small steps related to #321 (see commit descriptions for details, as usual)

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
