### PR TITLE
drop: downgrade two assertions to error messages

### DIFF
--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -175,11 +175,8 @@ impl UnpublishedOperation {
 
 impl Drop for UnpublishedOperation {
     fn drop(&mut self) {
-        if !std::thread::panicking() {
-            assert!(
-                self.closed,
-                "UnpublishedOperation was dropped without being closed."
-            );
+        if !self.closed && !std::thread::panicking() {
+            eprintln!("BUG: UnpublishedOperation was dropped without being closed.");
         }
     }
 }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1063,11 +1063,8 @@ impl LockedWorkingCopy<'_> {
 
 impl Drop for LockedWorkingCopy<'_> {
     fn drop(&mut self) {
-        if !std::thread::panicking() {
-            assert!(
-                self.closed,
-                "Working copy lock was dropped without being closed."
-            );
+        if !self.closed && !std::thread::panicking() {
+            eprintln!("BUG: Working copy lock was dropped without being closed.");
         }
     }
 }


### PR DESCRIPTION
These assertions were there to catch bugs, but when the bugs happen,
the assertions can obsure the underlying error (as @tp-woven found out
on #258). Let's just print errors instead.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
