### PR TITLE
Add configuration option to override branch name prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj git push` gained a `--change <revision>` argument. When that's used, it
   will create a branch named after the revision's change ID, so you don't have
-  to create a branch yourself.
+  to create a branch yourself. By default, the branch name will start with
+  `push-`, but this can be overridden by the `push.branch-prefix` config
+  setting.
 
 * Diff editor command arguments can now be specified by config file.
   Example:

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -65,6 +65,12 @@ impl UserSettings {
             .unwrap_or_else(|_| "(no email configured)".to_string())
     }
 
+    pub fn push_branch_prefix(&self) -> String {
+        self.config
+            .get_string("push.branch-prefix")
+            .unwrap_or("push-".to_string())
+    }
+
     pub fn signature(&self) -> Signature {
         let timestamp = self.timestamp.clone().unwrap_or_else(Timestamp::now);
         Signature {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4857,7 +4857,11 @@ fn cmd_git_push(
         }
     } else if let Some(change_str) = &args.change {
         let commit = workspace_command.resolve_single_rev(ui, change_str)?;
-        let branch_name = format!("push-{}", commit.change_id().hex());
+        let branch_name = format!(
+            "{}{}",
+            ui.settings().push_branch_prefix(),
+            commit.change_id().hex()
+        );
         tx.mut_repo()
             .set_local_branch(branch_name.clone(), RefTarget::Normal(commit.id().clone()));
         if let Some(update) =


### PR DESCRIPTION
Fixes #340. ~I haven't updated the changelog yet, this is just an initial implementation to get your thoughts on it (especially the config setting name).~

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
