### PR TITLE
cli: add .txt suffix to temporary commit description file

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3165,7 +3165,7 @@ fn edit_description(
     description: &str,
 ) -> Result<String, CommandError> {
     let random: u32 = rand::random();
-    let description_file_path = repo.repo_path().join(format!("description-{}", random));
+    let description_file_path = repo.repo_path().join(format!("description-{}.txt", random));
     {
         let mut description_file = OpenOptions::new()
             .write(true)


### PR DESCRIPTION
I've configured emacs to enable spell checking for text-mode. This helps
emacs open a description file in text-mode.

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
