### PR TITLE
cli: prevent pushing commits without description, author, or committer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `push-`, but this can be overridden by the `push.branch-prefix` config
   setting.
 
+* `jj git push` now aborts if you attempt to push a commit without a
+  description or with the placeholder "(no name/email configured)" values for
+  author/committer.
+
 * Diff editor command arguments can now be specified by config file.
   Example:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj log` now accepts a `--reversed` option, which will show older commits
   first.
 
+* The "(no name/email configured)" placeholder value for name/email will now be
+  replaced if once you modify a commit after having configured your name/email.
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -66,6 +66,14 @@ impl CommitBuilder {
         let mut commit = predecessor.store_commit().clone();
         commit.predecessors = vec![predecessor.id().clone()];
         commit.committer = settings.signature();
+        // If the user had not configured a name and email before but now they have,
+        // update the the author fields with the new information.
+        if commit.author.name == UserSettings::user_name_placeholder() {
+            commit.author.name = commit.committer.name.clone();
+        }
+        if commit.author.email == UserSettings::user_email_placeholder() {
+            commit.author.email = commit.committer.email.clone();
+        }
         CommitBuilder {
             store: store.clone(),
             commit,

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -56,13 +56,21 @@ impl UserSettings {
     pub fn user_name(&self) -> String {
         self.config
             .get_string("user.name")
-            .unwrap_or_else(|_| "(no name configured)".to_string())
+            .unwrap_or_else(|_| Self::user_name_placeholder().to_string())
+    }
+
+    pub fn user_name_placeholder() -> &'static str {
+        "(no name configured)"
     }
 
     pub fn user_email(&self) -> String {
         self.config
             .get_string("user.email")
-            .unwrap_or_else(|_| "(no email configured)".to_string())
+            .unwrap_or_else(|_| Self::user_email_placeholder().to_string())
+    }
+
+    pub fn user_email_placeholder() -> &'static str {
+        "(no email configured)"
     }
 
     pub fn push_branch_prefix(&self) -> String {


### PR DESCRIPTION
This patch prevents perhaps pushing commits with an empty description
or the placeholder "(no user/email configured)" values for
author/committer (#322).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
