### PR TITLE
add --color=always|never|auto option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (#330) `jj branch` now uses subcommands like `jj branch create` and
   `jj branch forget` instead of options like `jj branch --forget`.
 
+* The [`$NO_COLOR` environment variable](https://no-color.org/) no longer
+  overrides the `ui.color` configuration if explicitly set.
+
 ### New features
 
 * `jj rebase` now accepts a `--branch/-b <revision>` argument, which can be used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The "(no name/email configured)" placeholder value for name/email will now be
   replaced if once you modify a commit after having configured your name/email.
 
+* Color setting can now be overridden by `--color=always|never|auto` option.
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -74,7 +74,7 @@ use crate::graphlog::{AsciiGraphDrawer, Edge};
 use crate::template_parser::TemplateParser;
 use crate::templater::Template;
 use crate::ui;
-use crate::ui::{FilePathParseError, Ui};
+use crate::ui::{ColorChoice, FilePathParseError, Ui};
 
 pub enum CommandError {
     UserError(String),
@@ -1101,6 +1101,14 @@ struct GlobalArgs {
         default_value = "@"
     )]
     at_operation: String,
+    /// When to colorize output (always, never, auto)
+    #[clap(
+        long,
+        value_name = "WHEN",
+        global = true,
+        help_heading = "GLOBAL OPTIONS"
+    )]
+    color: Option<ColorChoice>,
 }
 
 #[derive(Subcommand, Clone, Debug)]
@@ -5207,6 +5215,10 @@ where
     }
 
     let args = parse_args(ui.settings(), &string_args)?;
+    if let Some(choice) = args.global_args.color {
+        // Here we assume ui was created for_terminal().
+        ui.reset_color_for_terminal(choice);
+    }
     let app = Args::command();
     let command_helper = CommandHelper::new(app, string_args, args.global_args.clone());
     match &args.command {

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,11 @@ fn config_path() -> Result<Option<PathBuf>, ConfigError> {
 /// Environment variables that should be overridden by config values
 fn env_base() -> config::Config {
     let mut builder = config::Config::builder();
+    if env::var("NO_COLOR").is_ok() {
+        // "User-level configuration files and per-instance command-line arguments
+        // should override $NO_COLOR." https://no-color.org/
+        builder = builder.set_override("ui.color", "never").unwrap();
+    }
     if let Ok(value) = env::var("VISUAL") {
         builder = builder.set_override("ui.editor", value).unwrap();
     } else if let Ok(value) = env::var("EDITOR") {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -118,6 +118,23 @@ impl<'stdout> Ui<'stdout> {
         Ui::new(cwd, stdout, stderr, color, settings)
     }
 
+    /// Reconfigures the underlying outputs with the new color choice.
+    ///
+    /// It's up to caller to ensure that the current output formatters have no
+    /// labels applied. Otherwise the current color would persist.
+    pub fn reset_color_for_terminal(&mut self, choice: ColorChoice) {
+        let color = use_color(choice);
+        if self.color != color {
+            // it seems uneasy to unwrap the underlying output from the formatter, so
+            // recreate it.
+            let stdout_formatter = new_formatter(&self.settings, color, Box::new(io::stdout()));
+            let stderr_formatter = new_formatter(&self.settings, color, Box::new(io::stderr()));
+            self.color = color;
+            *self.stdout_formatter.get_mut().unwrap() = stdout_formatter;
+            *self.stderr_formatter.get_mut().unwrap() = stderr_formatter;
+        }
+    }
+
     pub fn cwd(&self) -> &Path {
         &self.cwd
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -48,9 +48,6 @@ fn new_formatter<'output>(
 }
 
 fn use_color(settings: &UserSettings) -> bool {
-    if std::env::var("NO_COLOR").is_ok() {
-        return false;
-    }
     let color_setting = settings
         .config()
         .get_string("ui.color")

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -109,12 +109,12 @@ color="always""#,
     o [34m0000000000000000000000000000000000000000[0m
     "###);
 
-    // Test that NO_COLOR overrides the request for color in the config file
+    // Test that NO_COLOR does NOT override the request for color in the config file
     test_env.add_env_var("NO_COLOR", "");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    o 0000000000000000000000000000000000000000
+    @ [1;34m230dd059e1b059aefc0da06a2e5a7dbf22362f22[0m
+    o [34m0000000000000000000000000000000000000000[0m
     "###);
 }
 


### PR DESCRIPTION
I often redirect the jj output to pager, so I set ui.color = "always" in
config file. This patch allows me to remove such config, and instead specify
--color=always only when needed.

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
