### PR TITLE
rustfmt: set edition to 2021

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 max_width = 100
 wrap_comments = true
 format_strings = true


### PR DESCRIPTION
We have `edition = "2021"` in our `Cargo.toml` files, so it makes
sense to have `rustfmt` use the same edition. That will let us format
code using `async` and `await`. I noticed this while looking at
@arxanas's fsmonitor PR.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
