### PR TITLE
cli: don't say "Creating branch push-*" if it already exists

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4927,16 +4927,18 @@ fn cmd_git_push(
             ui.settings().push_branch_prefix(),
             commit.change_id().hex()
         );
-        tx.mut_repo()
-            .set_local_branch(branch_name.clone(), RefTarget::Normal(commit.id().clone()));
-        if let Some(update) =
-            branch_updates_for_push(tx.mut_repo().as_repo_ref(), &args.remote, &branch_name)?
-        {
+        if tx.mut_repo().get_local_branch(&branch_name).is_none() {
             writeln!(
                 ui,
                 "Creating branch {} for revision {}",
                 branch_name, change_str
             )?;
+        }
+        tx.mut_repo()
+            .set_local_branch(branch_name.clone(), RefTarget::Normal(commit.id().clone()));
+        if let Some(update) =
+            branch_updates_for_push(tx.mut_repo().as_repo_ref(), &args.remote, &branch_name)?
+        {
             branch_updates.insert(branch_name.clone(), update);
         } else {
             writeln!(


### PR DESCRIPTION
I was a bit surprised to see the message when I used `jj git push
--change @-` on a commit that already had a branch because I had
pushed it earlier.

The fix means that we instead print the message even if we later
abandon the transaction (so the branch-creation is not persisted)
because the commit is open, for example. That's already what happens
if the commit is missing a description, and since we're planning to
remove the open/closed concept, I don't think this patch makes it much
worse. We probably should improve it later by printing the message
only once the push has succeeded.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
