### PR TITLE
cleanup: fix an unused import on Windows

### DIFF
--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -23,7 +23,9 @@ use std::sync::Arc;
 use itertools::Itertools;
 use jujutsu_lib::backend::{Conflict, ConflictPart, TreeValue};
 use jujutsu_lib::gitignore::GitIgnoreFile;
-use jujutsu_lib::op_store::{OperationId, WorkspaceId};
+#[cfg(unix)]
+use jujutsu_lib::op_store::OperationId;
+use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::ReadonlyRepo;
 use jujutsu_lib::repo_path::{RepoPath, RepoPathComponent, RepoPathJoin};
 use jujutsu_lib::settings::UserSettings;


### PR DESCRIPTION
`OperationId` is only used in `test_snapshot_special_file()`, which
doesn't run (or even  build) on Windows.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
