### PR TITLE
diff: make sure word diff print final newline

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2298,6 +2298,13 @@ fn show_color_words_diff_hunks(
         }
     }
 
+    // If the last diff line doesn't end with newline, add it.
+    let no_hunk = left.is_empty() && right.is_empty();
+    let any_last_newline = left.ends_with(b"\n") || right.ends_with(b"\n");
+    if !skipped_context && !no_hunk && !any_last_newline {
+        formatter.write_bytes(b"\n")?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Since whitespace change is barely visible in color-words diff, I think it
would be too verbose to add "\ No newline at end of file" marker. Let's just
append missing newline to make the command output readable.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
