### PR TITLE
cleanup: remove workaround for fixed `split_inclusive()` bug

### DIFF
--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -107,31 +107,19 @@ fn write_diff_hunks(left: &[u8], right: &[u8], file: &mut dyn Write) -> std::io:
     for hunk in diff.hunks() {
         match hunk {
             DiffHunk::Matching(content) => {
-                // TODO: Remove this check once https://github.com/rust-lang/rust/issues/89716
-                // has been fixed and released for long enough.
-                if !content.is_empty() {
-                    for line in content.split_inclusive(|b| *b == b'\n') {
-                        file.write_all(b" ")?;
-                        file.write_all(line)?;
-                    }
+                for line in content.split_inclusive(|b| *b == b'\n') {
+                    file.write_all(b" ")?;
+                    file.write_all(line)?;
                 }
             }
             DiffHunk::Different(content) => {
-                // TODO: Remove this check once https://github.com/rust-lang/rust/issues/89716
-                // has been fixed and released for long enough.
-                if !content[0].is_empty() {
-                    for line in content[0].split_inclusive(|b| *b == b'\n') {
-                        file.write_all(b"-")?;
-                        file.write_all(line)?;
-                    }
+                for line in content[0].split_inclusive(|b| *b == b'\n') {
+                    file.write_all(b"-")?;
+                    file.write_all(line)?;
                 }
-                // TODO: Remove this check once https://github.com/rust-lang/rust/issues/89716
-                // has been fixed and released for long enough.
-                if !content[1].is_empty() {
-                    for line in content[1].split_inclusive(|b| *b == b'\n') {
-                        file.write_all(b"+")?;
-                        file.write_all(line)?;
-                    }
+                for line in content[1].split_inclusive(|b| *b == b'\n') {
+                    file.write_all(b"+")?;
+                    file.write_all(line)?;
                 }
             }
         }

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -85,56 +85,42 @@ impl<'a> Iterator for DiffLineIterator<'a> {
             self.current_pos += 1;
             match hunk {
                 diff::DiffHunk::Matching(text) => {
-                    // TODO: Remove this check once https://github.com/rust-lang/rust/issues/89716
-                    // has been fixed and released for long enough.
-                    if !text.is_empty() {
-                        let lines = text.split_inclusive(|b| *b == b'\n');
-                        for line in lines {
-                            self.current_line.has_left_content = true;
-                            self.current_line.has_right_content = true;
-                            self.current_line.hunks.push(DiffHunk::Matching(line));
-                            if line.ends_with(b"\n") {
-                                self.queued_lines.push_back(self.current_line.clone());
-                                self.current_line.left_line_number += 1;
-                                self.current_line.right_line_number += 1;
-                                self.current_line.reset_line();
-                            }
+                    let lines = text.split_inclusive(|b| *b == b'\n');
+                    for line in lines {
+                        self.current_line.has_left_content = true;
+                        self.current_line.has_right_content = true;
+                        self.current_line.hunks.push(DiffHunk::Matching(line));
+                        if line.ends_with(b"\n") {
+                            self.queued_lines.push_back(self.current_line.clone());
+                            self.current_line.left_line_number += 1;
+                            self.current_line.right_line_number += 1;
+                            self.current_line.reset_line();
                         }
                     }
                 }
                 diff::DiffHunk::Different(contents) => {
-                    let left = contents[0];
-                    let right = contents[1];
-                    // TODO: Remove this check once https://github.com/rust-lang/rust/issues/89716
-                    // has been fixed and released for long enough.
-                    if !left.is_empty() {
-                        let left_lines = left.split_inclusive(|b| *b == b'\n');
-                        for left_line in left_lines {
-                            self.current_line.has_left_content = true;
-                            self.current_line
-                                .hunks
-                                .push(DiffHunk::Different(vec![left_line, b""]));
-                            if left_line.ends_with(b"\n") {
-                                self.queued_lines.push_back(self.current_line.clone());
-                                self.current_line.left_line_number += 1;
-                                self.current_line.reset_line();
-                            }
+                    let left_lines = contents[0].split_inclusive(|b| *b == b'\n');
+                    for left_line in left_lines {
+                        self.current_line.has_left_content = true;
+                        self.current_line
+                            .hunks
+                            .push(DiffHunk::Different(vec![left_line, b""]));
+                        if left_line.ends_with(b"\n") {
+                            self.queued_lines.push_back(self.current_line.clone());
+                            self.current_line.left_line_number += 1;
+                            self.current_line.reset_line();
                         }
                     }
-                    // TODO: Remove this check once https://github.com/rust-lang/rust/issues/89716
-                    // has been fixed and released for long enough.
-                    if !right.is_empty() {
-                        let right_lines = right.split_inclusive(|b| *b == b'\n');
-                        for right_line in right_lines {
-                            self.current_line.has_right_content = true;
-                            self.current_line
-                                .hunks
-                                .push(DiffHunk::Different(vec![b"", right_line]));
-                            if right_line.ends_with(b"\n") {
-                                self.queued_lines.push_back(self.current_line.clone());
-                                self.current_line.right_line_number += 1;
-                                self.current_line.reset_line();
-                            }
+                    let right_lines = contents[1].split_inclusive(|b| *b == b'\n');
+                    for right_line in right_lines {
+                        self.current_line.has_right_content = true;
+                        self.current_line
+                            .hunks
+                            .push(DiffHunk::Different(vec![b"", right_line]));
+                        if right_line.ends_with(b"\n") {
+                            self.queued_lines.push_back(self.current_line.clone());
+                            self.current_line.right_line_number += 1;
+                            self.current_line.reset_line();
                         }
                     }
                 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2678,9 +2678,6 @@ fn unified_diff_hunks<'content>(
         match hunk {
             DiffHunk::Matching(content) => {
                 let lines = content.split_inclusive(|b| *b == b'\n').collect_vec();
-                // TODO: Remove this statement once https://github.com/rust-lang/rust/issues/89716
-                // has been fixed and released for long enough.
-                let lines = if content.is_empty() { vec![] } else { lines };
                 // Number of context lines to print after the previous non-matching hunk.
                 let num_after_lines = lines.len().min(if show_context_after {
                     num_context_lines
@@ -2719,18 +2716,6 @@ fn unified_diff_hunks<'content>(
                 show_context_after = true;
                 let left_lines = content[0].split_inclusive(|b| *b == b'\n').collect_vec();
                 let right_lines = content[1].split_inclusive(|b| *b == b'\n').collect_vec();
-                // TODO: Remove these two statements once https://github.com/rust-lang/rust/issues/89716
-                // has been fixed and released for long enough.
-                let left_lines = if content[0].is_empty() {
-                    vec![]
-                } else {
-                    left_lines
-                };
-                let right_lines = if content[1].is_empty() {
-                    vec![]
-                } else {
-                    right_lines
-                };
                 if !left_lines.is_empty() {
                     current_hunk.left_line_range.end += left_lines.len();
                     for line in left_lines {


### PR DESCRIPTION
The fix for rustlang/rust#89716 was released in 1.59.0, which is our
MSRV.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
