### PR TITLE
cli: push only branches pointing to `@` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj git push` no longer aborts if you attempt to push an open commit (but it
   now aborts if a commit does not have a description).
 
+* `jj git push` now pushes only branches pointing to the `@` by default. Use
+  `--all` to push all branches.
+
 ### New features
 
 * `jj rebase` now accepts a `--branch/-b <revision>` argument, which can be used

--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -108,7 +108,7 @@ parent.
     </tr>
     <tr>
       <td>Update a remote repo with all branches from the local repo</td>
-      <td><code>jj git push [--remote &lt;remote&gt;]</code> (there is no
+      <td><code>jj git push --all [--remote &lt;remote&gt;]</code> (there is no
           support for pushing from non-Git repos yet)</td>
       <td><code>git push --all [&lt;remote&gt;]</code></td>
     </tr>


### PR DESCRIPTION
Since we now allow pushing open commits, we can implement support for
pushing the "current" branch by defining a "current" branch as any
branch pointing to `@`. That definition of a current/active seems to
have been the consensus in discussion #411.

Closes #246.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
