### PR TITLE
cli: snapshot the working copy before pushing

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5070,6 +5070,7 @@ fn cmd_git_push(
     args: &GitPushArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
+    workspace_command.maybe_commit_working_copy(ui)?;
 
     let mut tx;
     let mut branch_updates = vec![];


### PR DESCRIPTION
The working copy does not get snapshotted by `jj git push`, `jj git
push --all`, and `jj git push --branch`. This fixes that.

We should probably do the snapshotting in a more central place, so we
can't forget it like this, but I'll leave that for later.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
