### PR TITLE
cli: snapshot working copy even on e.g. `jj diff -r <some hash>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When using `jj move/squash/unsquash` results in the source commit becoming
   empty, it is no longer abandoned if it is checked out (in any workspace).
 
+* All commands now consistently snapshot the working copy (it was missing from
+  e.g. `jj undo` and `jj merge` before). 
+
 ## [0.4.0] - 2022-04-02
 
 ### Breaking changes

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -87,9 +87,9 @@ fn test_squash() {
     test_env.jj_cmd_success(&repo_path, &["merge", "-m", "merge", "c", "d"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "e", "-r", "@+"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    o   b9ad3fdfc2c4 e
+    o   7789610d8ec6 e
     |\  
-    @ | 9a18f8da1e69 d
+    @ | 5658521e0f8b d
     | o 90fe0a96fc90 c
     |/  
     o fa5efbdf533c b
@@ -106,13 +106,13 @@ fn test_squash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b4e9307669d0 (no description set)
+    Working copy now at: e14f5bbc3213 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @ b4e9307669d0 
-    o   2a25465aba5f e
+    @ e14f5bbc3213 
+    o   5301447e4764 e
     |\  
-    o | 9a18f8da1e69 d
+    o | 5658521e0f8b d
     | o 90fe0a96fc90 c
     |/  
     o fa5efbdf533c b

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -86,9 +86,9 @@ fn test_unsquash() {
     test_env.jj_cmd_success(&repo_path, &["merge", "-m", "merge", "c", "d"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "e", "-r", "@+"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    o   b9ad3fdfc2c4 e
+    o   7789610d8ec6 e
     |\  
-    @ | 9a18f8da1e69 d
+    @ | 5658521e0f8b d
     | o 90fe0a96fc90 c
     |/  
     o fa5efbdf533c b
@@ -105,12 +105,12 @@ fn test_unsquash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 31067df4a375 (no description set)
+    Working copy now at: 60ac673b534b (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @   31067df4a375 
+    @   60ac673b534b 
     |\  
-    o | 9a18f8da1e69 d e?
+    o | 5658521e0f8b d e?
     | o 90fe0a96fc90 c e?
     |/  
     o fa5efbdf533c b

--- a/tests/test_untrack_command.rs
+++ b/tests/test_untrack_command.rs
@@ -41,7 +41,7 @@ fn test_untrack() {
     // Errors out when not run at the head operation
     let stderr = test_env.jj_cmd_failure(&repo_path, &["untrack", "file1", "--at-op", "@-"]);
     insta::assert_snapshot!(stderr.replace("jj.exe", "jj"), @r###"
-    Error: Refusing to commit working copy (maybe because you're using --at-op)
+    Error: This command must be able to update the working copy (don't use --at-op).
     "###);
     // Errors out when no path is specified
     test_env.jj_cmd_cli_error(&repo_path, &["untrack"]);


### PR DESCRIPTION
I was initially worried about the cost of always snapshotting the
working copy, so that's why e.g. `jj diff -r <some hash>` doesn't do
it. However, there's been a few caused by missing snapshotting, and
there are still a few (I just noticed it in `jj undo` while writing
this patch). Let's always do the snapshotting and if the user really
doesn't want it, they can pass `--no-commit-working-copy` (which we
should probably rename to `--no-snapshot-working-copy` or maybe just
`--no-snapshot`). That should reduce bugs and make the CLI more
predictable.

Two test cases were affected becasue `jj merge` also didn't snapshot
the working copy.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
