### PR TITLE
readme: explain that Rust >= 1.60 is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ See below for how to build from source. There are also
 [pre-built binaries](https://github.com/martinvonz/jj/releases) for Windows,
 Mac, or Linux (musl).
 
+If you're installing from source, you need to use Rust version 1.60 or higher,
+or you will get a cryptic message like this:
+```
+error: failed to select a version for the requirement `libgit2-sys = "=0.14.0"``
+candidate versions found which didn't match: 0.13.2+1.4.2, 0.13.1+1.4.2, 0.13.0+1.4.1, ...
+```
+
 ### Linux
 
 On most distributions, you'll need to build from source using `cargo` directly.


### PR DESCRIPTION
We have `rust-version = "1.60"` in `Cargo.toml`, but Cargo doesn't
check that until after dependency resolution, which fails if you have
an older version (I don't know why).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
