### PR TITLE
Have `jj merge` output new commit id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj checkout` now lets you specify a description with `--message/-m`.
 
+* `jj merge` now outputs the id of the newly created commit.
+
 ### Fixed bugs
 
 * When rebasing a conflict where one side modified a file and the other side

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3925,11 +3925,18 @@ fn cmd_merge(ui: &mut Ui, command: &CommandHelper, args: &MergeArgs) -> Result<(
     };
     let merged_tree = merge_commit_trees(workspace_command.repo().as_repo_ref(), &commits);
     let mut tx = workspace_command.start_transaction("merge commits");
-    CommitBuilder::for_new_commit(ui.settings(), merged_tree.id().clone())
+    let new_commit = CommitBuilder::for_new_commit(ui.settings(), merged_tree.id().clone())
         .set_parents(parent_ids)
         .set_description(description)
         .set_open(false)
         .write_to_repo(tx.mut_repo());
+    ui.write("Created merge commit: ")?;
+    ui.write_commit_summary(
+        workspace_command.repo().as_repo_ref(),
+        &workspace_command.workspace_id(),
+        &new_commit,
+    )?;
+    ui.write("\n")?;
     workspace_command.finish_transaction(ui, tx)?;
 
     Ok(())


### PR DESCRIPTION
 I was using a custom `jj log` command and had some trouble finding
 the commit `jj merge` created. The default `jj log` command shows it
 by default, but my custom one didn't.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
