### PR TITLE
changelog: asking for a combined description is a feature, not a bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mode). For example, use `jj move --to @-- foo` to move the changes to file
   (or directory) `foo` in the working copy to the grandparent commit.
 
+* When `jj move/squash/unsquash` abandons the source commit because it became
+  empty and both the source and the destination commits have non-empty
+  descriptions, it now asks for a combined description. If either description
+  was empty, it uses the other without asking.
+
 * `jj split` now lets you specify on the CLI which paths to include in the first
   commit. The interactive diff-editing is not started when you do that.
 
@@ -183,11 +188,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * When checking out a commit, the previous commit is no longer abandoned if it
   has a non-empty description.
-
-* When `jj move/squash/unsquash` abandons the source commit and both the source
-  and the destination commits have non-empty descriptions, it now asks for a
-  combined description. If either description was empty, it uses the other
-  without asking.
 
 * All commands now consistently snapshot the working copy (it was missing from
   e.g. `jj undo` and `jj merge` before). 


### PR DESCRIPTION
I suppose it could be seen as a bug fix that we no longer discard a
description without asking, but it was intentionally done the way it
was before.

While at it, I also clarified that the source commit gets abandoned if
it becomes empty.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
