### PR TITLE
cli: add interdiff command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* The new `jj interdiff` command compares the changes in commits, ignoring
+  changes from intervening commits.
+
 * `jj rebase` now accepts a `--branch/-b <revision>` argument, which can be used
   instead of `-r` or `-s` to specify which commits to rebase. It will rebase the
   whole branch, relative to the destination. The default mode has changed from

--- a/tests/test_interdiff_command.rs
+++ b/tests/test_interdiff_command.rs
@@ -1,0 +1,168 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_interdiff_basic() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file2"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "left"]);
+
+    test_env.jj_cmd_success(&repo_path, &["checkout", "root"]);
+    std::fs::write(repo_path.join("file3"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file2"), "foo\nbar\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "right"]);
+
+    // implicit --to
+    let stdout = test_env.jj_cmd_success(&repo_path, &["interdiff", "--from", "left"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Modified regular file file2:
+       1    1: foo
+            2: bar
+    "###);
+
+    // explicit --to
+    test_env.jj_cmd_success(&repo_path, &["checkout", "@-"]);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["interdiff", "--from", "left", "--to", "right"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Modified regular file file2:
+       1    1: foo
+            2: bar
+    "###);
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+
+    // formats specifiers
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["interdiff", "--from", "left", "--to", "right", "-s"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    M file2
+    "###);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["interdiff", "--from", "left", "--to", "right", "--git"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    diff --git a/file2 b/file2
+    index 257cc5642c...3bd1f0e297 100644
+    --- a/file2
+    +++ b/file2
+    @@ -1,1 +1,2 @@
+     foo
+    +bar
+    "###);
+}
+
+#[test]
+fn test_interdiff_paths() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file1"), "bar\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "bar\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "left"]);
+
+    test_env.jj_cmd_success(&repo_path, &["checkout", "root"]);
+    std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file1"), "baz\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "baz\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "right"]);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["interdiff", "--from", "left", "--to", "right", "file1"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Modified regular file file1:
+       1    1: barbaz
+    "###);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "interdiff",
+            "--from",
+            "left",
+            "--to",
+            "right",
+            "file1",
+            "file2",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Modified regular file file1:
+       1    1: barbaz
+    Modified regular file file2:
+       1    1: barbaz
+    "###);
+}
+
+#[test]
+fn test_interdiff_conflicting() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file"), "bar\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "left"]);
+
+    test_env.jj_cmd_success(&repo_path, &["checkout", "root"]);
+    std::fs::write(repo_path.join("file"), "abc\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file"), "def\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "right"]);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["interdiff", "--from", "left", "--to", "right", "--git"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    diff --git a/file b/file
+    index f845ab93f0...24c5735c3e 100644
+    --- a/file
+    +++ b/file
+    @@ -1,8 +1,1 @@
+    -<<<<<<<
+    --------
+    -+++++++
+    --foo
+    -+abc
+    -+++++++
+    -bar
+    ->>>>>>>
+    +def
+    "###);
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

**Description**
This adds a simple `jj interdiff` command as per https://github.com/martinvonz/jj/issues/23, i.e. compare the changes introduced by two commits, ignoring changes from intervening commits. This is basically a more general form of `jj obslog -p` that doesn't assume that the compared commits are predecessor and successor.

The CLI is based on `jj diff`, which probably won't work as well with the more generalized version suggested in https://github.com/martinvonz/jj/issues/498 and I haven't given much thought to the generalized version yet.

**Things to pay extra attention to:**
- I struggled quite a lot with the wording; I'm not sure how to adequately describe `jj interdiff` except in contrast to `jj obslog` or `jj diff`
- I'm also completely new to Rust, so I expect to have broken some idioms :)

Closes https://github.com/martinvonz/jj/issues/23

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
