### PR TITLE
github: enable auto-merge on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  dependabot-auto-merge:
+    name: 'Dependabot auto-merge'
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - name: Enable auto-merge for Dependabot PRs
+      run: gh pr merge --auto "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
To merge a Dependabot PR, I have to enable auto-merge (two clicks,
including one to confim) and then review and approve it. Since our
branch protections require the PR to be approved, it seems that that
should be enough. This patch adds a GitHub action that calls runs the
GitHub CLI to do that. It is based on
https://dev.to/slashgear_/how-to-automatically-merge-dependabot-pull-requests-with-github-actions--30pe

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
