### PR TITLE
cli: add `jj hide` as an alias for `jj abandon`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1407,6 +1407,7 @@ struct DuplicateArgs {
 /// similar to `jj restore`; the difference is that `jj abandon` gives you a new
 /// change, while `jj restore` updates the existing change.
 #[derive(clap::Args, Clone, Debug)]
+#[clap(visible_alias = "hide")]
 struct AbandonArgs {
     /// The revision(s) to abandon
     #[clap(default_value = "@")]


### PR DESCRIPTION
I keep explaining the functionality as hiding the commit, so it seems
that `jj hide` is a natural name for it. Let's start by adding it as
an alias. My only hesitation with making `hide` the real command name
and `abandon` an alias that we start phasing out is that it feels more
natural to `abandon` the working copy in order to start working on a
new change than it does to `hide` it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
