### PR TITLE
cli: on finish_transaction(), record operation id even if working cop…

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1004,6 +1004,10 @@ fn update_working_copy(
             })?;
         Some(stats)
     } else {
+        // Record new operation id which represents the latest working-copy state
+        // TODO: no need to rewrite the tree_state file
+        let locked_wc = wc.start_mutation();
+        locked_wc.finish(repo.op_id().clone());
         None
     };
     if Some(&new_commit) != old_commit {


### PR DESCRIPTION
…y is clean

While debugging stale working-copy recovery, I noticed the checkout commit
resurrected from the ancestor_op was way beyond the ancestor commit made by
jj squash. This patch is a workaround for the problem.

I'm not pretty sure if updating operation id is the right thing. If not, maybe
we'll need to look up more recent operation corresponding to the wc tree id from
the <ancestor_op>: range?

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
