### PR TITLE
tests: give stable prefix to temporary dirs, do not persist them

### DIFF
--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -42,10 +42,11 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+    use crate::testutils;
 
     #[test]
     fn test_persist_no_existing_file() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let target = temp_dir.path().join("file");
         let mut temp_file = NamedTempFile::new_in(&temp_dir).unwrap();
         temp_file.write_all(b"contents").unwrap();
@@ -55,7 +56,7 @@ mod tests {
     #[test_case(false ; "existing file open")]
     #[test_case(true ; "existing file closed")]
     fn test_persist_target_exists(existing_file_closed: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let target = temp_dir.path().join("file");
         let mut temp_file = NamedTempFile::new_in(&temp_dir).unwrap();
         temp_file.write_all(b"contents").unwrap();

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -510,10 +510,11 @@ mod tests {
 
     use super::*;
     use crate::backend::{FileId, MillisSinceEpoch};
+    use crate::testutils;
 
     #[test]
     fn read_plain_git_commit() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store_path = temp_dir.path().to_path_buf();
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(&git_repo_path).unwrap();
@@ -624,7 +625,7 @@ mod tests {
 
     #[test]
     fn commit_has_ref() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = GitBackend::init_internal(temp_dir.path().to_path_buf());
         let signature = Signature {
             name: "Someone".to_string(),
@@ -660,7 +661,7 @@ mod tests {
 
     #[test]
     fn overlapping_git_commit_id() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = GitBackend::init_internal(temp_dir.path().to_path_buf());
         let signature = Signature {
             name: "Someone".to_string(),

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -1468,11 +1468,12 @@ mod tests {
 
     use super::*;
     use crate::commit_builder::new_change_id;
+    use crate::testutils;
 
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn index_empty(on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let index = MutableIndex::full(3);
         let mut _saved_index = None;
         let index = if on_disk {
@@ -1499,7 +1500,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn index_root_commit(on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let mut index = MutableIndex::full(3);
         let id_0 = CommitId::from_hex("000000");
         let change_id0 = new_change_id();
@@ -1549,7 +1550,7 @@ mod tests {
     #[test_case(true, false; "incremental in memory")]
     #[test_case(true, true; "incremental on disk")]
     fn index_multiple_commits(incremental: bool, on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let mut index = MutableIndex::full(3);
         // 5
         // |\
@@ -1645,7 +1646,7 @@ mod tests {
     #[test_case(false; "in memory")]
     #[test_case(true; "on disk")]
     fn index_many_parents(on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let mut index = MutableIndex::full(3);
         //     6
         //    /|\
@@ -1708,7 +1709,7 @@ mod tests {
 
     #[test]
     fn resolve_prefix() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let mut index = MutableIndex::full(3);
 
         // Create some commits with different various common prefixes.

--- a/lib/src/lock.rs
+++ b/lib/src/lock.rs
@@ -72,16 +72,17 @@ impl Drop for FileLock {
 #[cfg(test)]
 mod tests {
     use std::cmp::max;
-    use std::{env, thread};
+    use std::thread;
 
     use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
     use super::*;
+    use crate::testutils;
 
     #[test]
     fn lock_basic() {
-        let number: u32 = rand::random();
-        let lock_path = env::temp_dir().join(format!("test-{}.lock", number));
+        let temp_dir = testutils::new_temp_dir();
+        let lock_path = temp_dir.path().join("test.lock");
         assert!(!lock_path.exists());
         {
             let _lock = FileLock::lock(lock_path.clone());
@@ -92,9 +93,9 @@ mod tests {
 
     #[test]
     fn lock_concurrent() {
-        let number: u32 = rand::random();
-        let data_path = env::temp_dir().join(format!("test-{}", number));
-        let lock_path = env::temp_dir().join(format!("test-{}.lock", number));
+        let temp_dir = testutils::new_temp_dir();
+        let data_path = temp_dir.path().join("test");
+        let lock_path = temp_dir.path().join("test.lock");
         let mut data_file = OpenOptions::new()
             .create(true)
             .write(true)

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -365,13 +365,12 @@ fn ref_target_from_proto(proto: &crate::protos::op_store::RefTarget) -> RefTarge
 
 #[cfg(test)]
 mod tests {
-    use tempfile::TempDir;
-
     use super::*;
+    use crate::testutils;
 
     #[test]
     fn test_read_write_view() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = SimpleOpStore::init(temp_dir.path().to_owned());
         let head_id1 = CommitId::from_hex("aaa111");
         let head_id2 = CommitId::from_hex("aaa222");
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_read_write_operation() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = SimpleOpStore::init(temp_dir.path().to_owned());
         let operation = Operation {
             view_id: ViewId::from_hex("aaa111"),

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -510,11 +510,12 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+    use crate::testutils;
 
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn stacked_table_empty(on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut_table = store.get_head().unwrap().start_mutation();
         let mut _saved_table = None;
@@ -534,7 +535,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn stacked_table_single_key(on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_table = store.get_head().unwrap().start_mutation();
         mut_table.add_entry(b"abc".to_vec(), b"value".to_vec());
@@ -555,7 +556,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn stacked_table_multiple_keys(on_disk: bool) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_table = store.get_head().unwrap().start_mutation();
         mut_table.add_entry(b"zzz".to_vec(), b"val3".to_vec());
@@ -581,7 +582,7 @@ mod tests {
 
     #[test]
     fn stacked_table_multiple_keys_with_parent_file() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_table = store.get_head().unwrap().start_mutation();
         mut_table.add_entry(b"abd".to_vec(), b"value 2".to_vec());
@@ -611,7 +612,7 @@ mod tests {
 
     #[test]
     fn stacked_table_merge() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_base_table = store.get_head().unwrap().start_mutation();
         mut_base_table.add_entry(b"abc".to_vec(), b"value1".to_vec());
@@ -644,7 +645,7 @@ mod tests {
     #[test]
     fn stacked_table_automatic_merge() {
         // Same test as above, but here we let the store do the merging on load
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_base_table = store.get_head().unwrap().start_mutation();
         mut_base_table.add_entry(b"abc".to_vec(), b"value1".to_vec());

--- a/lib/src/testutils.rs
+++ b/lib/src/testutils.rs
@@ -35,10 +35,17 @@ use crate::tree::Tree;
 use crate::tree_builder::TreeBuilder;
 use crate::workspace::Workspace;
 
+pub fn new_temp_dir() -> TempDir {
+    tempfile::Builder::new()
+        .prefix("jj-test-")
+        .tempdir()
+        .unwrap()
+}
+
 pub fn new_user_home() -> TempDir {
     // Set $HOME to some arbitrary place so libgit2 doesn't use ~/.gitignore
     // of the person running the tests.
-    let home_dir = tempfile::tempdir().unwrap();
+    let home_dir = new_temp_dir();
     std::env::set_var("HOME", home_dir.path());
     home_dir
 }
@@ -62,7 +69,7 @@ pub struct TestRepo {
 impl TestRepo {
     pub fn init(use_git: bool) -> Self {
         let settings = user_settings();
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = new_temp_dir();
 
         let repo_dir = temp_dir.path().join("repo");
         fs::create_dir(&repo_dir).unwrap();
@@ -94,7 +101,7 @@ pub struct TestWorkspace {
 
 impl TestWorkspace {
     pub fn init(settings: &UserSettings, use_git: bool) -> Self {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = new_temp_dir();
 
         let workspace_root = temp_dir.path().join("repo");
         fs::create_dir(&workspace_root).unwrap();

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -18,7 +18,6 @@ use jujutsu_lib::repo::ReadonlyRepo;
 use jujutsu_lib::testutils;
 use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::workspace::Workspace;
-use tempfile::TempDir;
 use test_case::test_case;
 
 fn copy_directory(src: &Path, dst: &Path) {
@@ -107,7 +106,7 @@ fn test_bad_locking_children(use_git: bool) {
     tx.commit();
 
     // Simulate a write of a commit that happens on one machine
-    let machine1_root = TempDir::new().unwrap().into_path();
+    let machine1_root = testutils::new_temp_dir().into_path();
     copy_directory(workspace_root, &machine1_root);
     let machine1_workspace = Workspace::load(&settings, machine1_root.clone()).unwrap();
     let machine1_repo = machine1_workspace
@@ -122,7 +121,7 @@ fn test_bad_locking_children(use_git: bool) {
     machine1_tx.commit();
 
     // Simulate a write of a commit that happens on another machine
-    let machine2_root = TempDir::new().unwrap().into_path();
+    let machine2_root = testutils::new_temp_dir().into_path();
     copy_directory(workspace_root, &machine2_root);
     let machine2_workspace = Workspace::load(&settings, machine2_root.clone()).unwrap();
     let machine2_repo = machine2_workspace
@@ -138,7 +137,7 @@ fn test_bad_locking_children(use_git: bool) {
 
     // Simulate that the distributed file system now has received the changes from
     // both machines
-    let merged_path = TempDir::new().unwrap().into_path();
+    let merged_path = testutils::new_temp_dir().into_path();
     merge_directories(&machine1_root, workspace_root, &machine2_root, &merged_path);
     let merged_workspace = Workspace::load(&settings, merged_path).unwrap();
     let merged_repo = merged_workspace
@@ -174,7 +173,7 @@ fn test_bad_locking_interrupted(use_git: bool) {
     // operation and then copying that back afterwards, leaving the existing
     // op-head(s) in place.
     let op_heads_dir = repo.repo_path().join("op_heads");
-    let backup_path = TempDir::new().unwrap().into_path();
+    let backup_path = testutils::new_temp_dir().into_path();
     copy_directory(&op_heads_dir, &backup_path);
     let mut tx = repo.start_transaction("test");
     testutils::create_random_commit(&settings, &repo)

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -276,7 +276,7 @@ struct GitRepoData {
 impl GitRepoData {
     fn create() -> Self {
         let settings = testutils::user_settings();
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let origin_repo_dir = temp_dir.path().join("source");
         let origin_repo = git2::Repository::init_bare(&origin_repo_dir).unwrap();
         let git_repo_dir = temp_dir.path().join("git");
@@ -513,7 +513,7 @@ fn test_export_refs_unborn_git_branch() {
 #[test]
 fn test_init() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let git_repo_dir = temp_dir.path().join("git");
     let jj_repo_dir = temp_dir.path().join("jj");
     let git_repo = git2::Repository::init_bare(&git_repo_dir).unwrap();
@@ -698,7 +698,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
 #[test]
 fn test_push_updates_success() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = setup.jj_repo.store().git_repo().unwrap();
     let result = git::push_updates(
@@ -734,7 +734,7 @@ fn test_push_updates_success() {
 #[test]
 fn test_push_updates_deletion() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = setup.jj_repo.store().git_repo().unwrap();
 
@@ -767,7 +767,7 @@ fn test_push_updates_deletion() {
 #[test]
 fn test_push_updates_mixed_deletion_and_addition() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = setup.jj_repo.store().git_repo().unwrap();
     let result = git::push_updates(
@@ -804,7 +804,7 @@ fn test_push_updates_mixed_deletion_and_addition() {
 #[test]
 fn test_push_updates_not_fast_forward() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let mut tx = setup.jj_repo.start_transaction("test");
     let new_commit =
@@ -825,7 +825,7 @@ fn test_push_updates_not_fast_forward() {
 #[test]
 fn test_push_updates_not_fast_forward_with_force() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let mut tx = setup.jj_repo.start_transaction("test");
     let new_commit =
@@ -855,7 +855,7 @@ fn test_push_updates_not_fast_forward_with_force() {
 #[test]
 fn test_push_updates_no_such_remote() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let result = git::push_updates(
         &setup.jj_repo.store().git_repo().unwrap(),
@@ -872,7 +872,7 @@ fn test_push_updates_no_such_remote() {
 #[test]
 fn test_push_updates_invalid_remote() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let result = git::push_updates(
         &setup.jj_repo.store().git_repo().unwrap(),

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -30,7 +30,7 @@ fn canonicalize(input: &Path) -> (PathBuf, PathBuf) {
 #[test]
 fn test_init_local() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let (workspace, repo) = Workspace::init_local(&settings, uncanonical).unwrap();
     assert!(repo.store().git_repo().is_none());
@@ -45,7 +45,7 @@ fn test_init_local() {
 #[test]
 fn test_init_internal_git() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let (workspace, repo) = Workspace::init_internal_git(&settings, uncanonical).unwrap();
     assert!(repo.store().git_repo().is_some());
@@ -60,7 +60,7 @@ fn test_init_internal_git() {
 #[test]
 fn test_init_external_git() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let git_repo_path = uncanonical.join("git");
     git2::Repository::init(&git_repo_path).unwrap();

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -21,7 +21,7 @@ use test_case::test_case;
 #[test]
 fn test_load_bad_path() {
     let settings = testutils::user_settings();
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = testutils::new_temp_dir();
     let workspace_root = temp_dir.path().to_owned();
     // We haven't created a repo in the workspace_root, so it should fail to load.
     let result = Workspace::load(&settings, workspace_root.clone());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -273,11 +273,13 @@ pub fn relative_path(mut from: &Path, to: &Path) -> PathBuf {
 mod tests {
     use std::io::Cursor;
 
+    use jujutsu_lib::testutils;
+
     use super::*;
 
     #[test]
     fn parse_file_path_wc_in_cwd() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let cwd_path = temp_dir.path().join("repo");
         let wc_path = cwd_path.clone();
         let mut unused_stdout_buf = vec![];
@@ -319,7 +321,7 @@ mod tests {
 
     #[test]
     fn parse_file_path_wc_in_cwd_parent() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let cwd_path = temp_dir.path().join("dir");
         let wc_path = cwd_path.parent().unwrap().to_path_buf();
         let mut unused_stdout_buf = vec![];
@@ -363,7 +365,7 @@ mod tests {
 
     #[test]
     fn parse_file_path_wc_in_cwd_child() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = testutils::new_temp_dir();
         let cwd_path = temp_dir.path().join("cwd");
         let wc_path = cwd_path.join("repo");
         let mut unused_stdout_buf = vec![];

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use jujutsu_lib::testutils;
 use lazy_static::lazy_static;
 use tempfile::TempDir;
 
@@ -51,7 +52,7 @@ impl Default for TestEnvironment {
     fn default() -> Self {
         lazy_static::initialize(&CONFIGURE_GIT2);
 
-        let tmp_dir = TempDir::new().unwrap();
+        let tmp_dir = testutils::new_temp_dir();
         let env_root = tmp_dir.path().canonicalize().unwrap();
         let home_dir = env_root.join("home");
         std::fs::create_dir(&home_dir).unwrap();


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
