### PR TITLE
diff_edit: do not make directories readonly, give stable prefix to temp dir

### DIFF
--- a/src/diff_edit.rs
+++ b/src/diff_edit.rs
@@ -82,14 +82,18 @@ fn check_out(
 }
 
 fn set_readonly_recursively(path: &Path) -> Result<(), std::io::Error> {
+    // Directory permission is unchanged since files under readonly directory cannot
+    // be removed.
     if path.is_dir() {
         for entry in path.read_dir()? {
             set_readonly_recursively(&entry?.path())?;
         }
+        Ok(())
+    } else {
+        let mut perms = std::fs::metadata(path)?.permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(path, perms)
     }
-    let mut perms = std::fs::metadata(path)?.permissions();
-    perms.set_readonly(true);
-    std::fs::set_permissions(path, perms)
 }
 
 pub fn edit_diff(

--- a/src/diff_edit.rs
+++ b/src/diff_edit.rs
@@ -28,7 +28,6 @@ use jujutsu_lib::settings::UserSettings;
 use jujutsu_lib::store::Store;
 use jujutsu_lib::tree::Tree;
 use jujutsu_lib::working_copy::{CheckoutError, SnapshotError, TreeState};
-use tempfile::tempdir;
 use thiserror::Error;
 
 use crate::ui::Ui;
@@ -109,7 +108,10 @@ pub fn edit_diff(
 
     // Check out the two trees in temporary directories. Only include changed files
     // in the sparse checkout patterns.
-    let temp_dir = tempdir().map_err(DiffEditError::SetUpDirError)?;
+    let temp_dir = tempfile::Builder::new()
+        .prefix("jj-diff-edit-")
+        .tempdir()
+        .map_err(DiffEditError::SetUpDirError)?;
     let left_wc_dir = temp_dir.path().join("left");
     let left_state_dir = temp_dir.path().join("left_state");
     let right_wc_dir = temp_dir.path().join("right");


### PR DESCRIPTION
Otherwise directories containing files cannot be removed.

I think making files readonly is enough to tell user that the left side
cannot be edited, but I haven't tested that with Meld. If that's not enough,
we'll probably need to undo set_readonly_recursively() at exit.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
