### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,7 +255,7 @@ No changes, only trying to get the automated build to work.
 
 ### Fixed bugs
 
- - (#131) Fixed crash when `core.excludesFile` pointed to non-existent file, and
+ - (#131) Fixed crash when `core.excludesFile` pointed to nonexistent file, and
    made leading `~/` in that config expand to `$HOME/`
 
 ## [0.3.0] - 2022-03-12

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,7 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
+    # The triple can be any string, but only the target triples built into
     # rustc (as of 1.40) can be checked against actual config expressions
     #{ triple = "x86_64-unknown-linux-musl" },
     # You can also specify which target_features you promise are enabled for a

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -44,7 +44,7 @@ a comparison with Git, including how workflows are different, see the
   parent of all commits Git would call "root commits".
 * **Staging area: Kind of.** The staging area will be ignored. For example,
   `jj diff` will show a diff from the Git HEAD to the working copy. There are
-  [ways of fulfilling your usecases without a staging
+  [ways of fulfilling your use cases without a staging
   area](https://github.com/martinvonz/jj/blob/main/docs/git-comparison.md#the-index).  
 * **Garbage collection: Yes.** It should be safe to run `git gc` in the Git
   repo, but it's not tested, so it's probably a good idea to make a backup of

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -54,7 +54,7 @@ impl CommitBuilder {
         commit.predecessors = vec![predecessor.id().clone()];
         commit.committer = settings.signature();
         // If the user had not configured a name and email before but now they have,
-        // update the the author fields with the new information.
+        // update the author fields with the new information.
         if commit.author.name == UserSettings::user_name_placeholder() {
             commit.author.name = commit.committer.name.clone();
         }

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -1744,7 +1744,7 @@ mod tests {
             index.resolve_prefix(&HexPrefix::new(id_2.hex()).unwrap()),
             PrefixResolution::SingleMatch(id_2)
         );
-        // Test non-existent commits
+        // Test nonexistent commits
         assert_eq!(
             index.resolve_prefix(&HexPrefix::new("ffffff".to_string()).unwrap()),
             PrefixResolution::NoMatch

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -493,7 +493,7 @@ mod tests {
         assert!(m.matches(&RepoPath::from_internal_string("foo")));
         assert!(!m.matches(&RepoPath::from_internal_string("bar")));
         assert!(m.matches(&RepoPath::from_internal_string("foo/bar")));
-        // Matches because the the "foo" pattern matches
+        // Matches because the "foo" pattern matches
         assert!(m.matches(&RepoPath::from_internal_string("foo/baz/foo")));
 
         assert_eq!(

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -548,7 +548,7 @@ fn test_fetch_initial_commit() {
     // No default branch because the origin repo's HEAD wasn't set
     assert_eq!(default_branch, None);
     let repo = tx.commit();
-    // The initial commit commit is visible after git::fetch().
+    // The initial commit is visible after git::fetch().
     let view = repo.view();
     assert!(view.heads().contains(&commit_id(&initial_git_commit)));
     let initial_commit_target = RefTarget::Normal(commit_id(&initial_git_commit));

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -318,10 +318,10 @@ fn test_resolve_symbol_git_refs() {
         RefTarget::Normal(commit3.id().clone()),
     );
 
-    // Non-existent ref
+    // Nonexistent ref
     assert_eq!(
-        resolve_symbol(mut_repo.as_repo_ref(), "non-existent", None),
-        Err(RevsetError::NoSuchRevision("non-existent".to_string()))
+        resolve_symbol(mut_repo.as_repo_ref(), "nonexistent", None),
+        Err(RevsetError::NoSuchRevision("nonexistent".to_string()))
     );
 
     // Full ref

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1235,7 +1235,7 @@ struct DiffFormatArgs {
 /// branch name) to the current checkout.
 #[derive(clap::Args, Clone, Debug)]
 struct DiffArgs {
-    /// Show changes changes in this revision, compared to its parent(s)
+    /// Show changes in this revision, compared to its parent(s)
     #[clap(long, short)]
     revision: Option<String>,
     /// Show changes from this revision
@@ -1253,7 +1253,7 @@ struct DiffArgs {
 /// Show commit description and changes in a revision
 #[derive(clap::Args, Clone, Debug)]
 struct ShowArgs {
-    /// Show changes changes in this revision, compared to its parent(s)
+    /// Show changes in this revision, compared to its parent(s)
     #[clap(default_value = "@")]
     revision: String,
     #[clap(flatten)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5129,7 +5129,7 @@ fn do_git_clone(
     let maybe_default_branch =
         git::fetch(fetch_tx.mut_repo(), &git_repo, remote_name).map_err(|err| match err {
             GitFetchError::NoSuchRemote(_) => {
-                panic!("should't happen as we just created the git remote")
+                panic!("shouldn't happen as we just created the git remote")
             }
             GitFetchError::InternalGitError(err) => {
                 CommandError::UserError(format!("Fetch failed: {err}"))

--- a/tests/test_print_command.rs
+++ b/tests/test_print_command.rs
@@ -45,7 +45,7 @@ fn test_print() {
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["print", "non-existent"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["print", "nonexistent"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: No such path
     "###);


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/jj/commit/07bc75dcd4b95570fc32b8388d7f64cfd5724953#commitcomment-83551182

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/jj/commit/090e2eb58d0ad925bff0d4983a0064ab43ebf2ec

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.