### PR TITLE
Fix `rebase -r` of a parent of a merge commit

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4130,6 +4130,7 @@ fn rebase_revision(
     let children_expression = RevsetExpression::commit(old_commit.id().clone()).children();
     let mut num_rebased_descendants = 0;
     let store = workspace_command.repo.store();
+
     for child_commit in children_expression
         .evaluate(
             workspace_command.repo().as_repo_ref(),
@@ -4139,11 +4140,45 @@ fn rebase_revision(
         .iter()
         .commits(store)
     {
+        let child_commit = child_commit?;
+        let new_child_parent_ids: Vec<CommitId> = child_commit
+            .parents()
+            .iter()
+            .flat_map(|c| {
+                if c == &old_commit {
+                    old_commit
+                        .parents()
+                        .iter()
+                        .map(|c| c.id().clone())
+                        .collect()
+                } else {
+                    [c.id().clone()].to_vec()
+                }
+            })
+            .collect();
+
+        // Some of the new parents may be ancestors of others as in
+        // `test_rebase_single_revision`.
+        let new_child_parents: Result<Vec<Commit>, BackendError> = RevsetExpression::Difference(
+            RevsetExpression::commits(new_child_parent_ids.clone()),
+            RevsetExpression::commits(new_child_parent_ids.clone())
+                .parents()
+                .ancestors(),
+        )
+        .evaluate(
+            workspace_command.repo().as_repo_ref(),
+            Some(&workspace_command.workspace_id()),
+        )
+        .unwrap()
+        .iter()
+        .commits(store)
+        .collect();
+
         rebase_commit(
             ui.settings(),
             tx.mut_repo(),
-            &child_commit?,
-            &old_commit.parents(),
+            &child_commit,
+            &new_child_parents?,
         );
         num_rebased_descendants += 1;
     }


### PR DESCRIPTION
# Comments

(**UPDATE:** I deleted some no-longer relevant info from this comment) 

This is a fix to a bug in `rebase -r` described below. It also changes the behavior of another rebase test in a way that seems desired to me. 

I'm not friends with Rust yet, so I'm sure the style is not great.

Feel free to just use the test I wrote in here if you prefer a different fix.

# PR Description

Previously, using `rebase -r` on the parent of a merge commit
turned it into a non-merge commit. In other words, starting
with

```
    o   d
    |\
    o | c
    o | b
    | o a
    |/  
    o 
```

and doing `rebase -r c -d a` resulted in

```
    o d
    o b
    | o c
    | o a
    |/  
    o 
```

where `d` is no longer a merge commit.

For reference, here's a complete test that passed before this commit (but should NOT pass; see the diff for a test that should pass):

```
#[test]
fn test_rebase_single_revision_merge_parent() {
    let test_env = TestEnvironment::default();
    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
    let repo_path = test_env.env_root().join("repo");

    create_commit(&test_env, &repo_path, "a", &[]);
    create_commit(&test_env, &repo_path, "b", &[]);
    create_commit(&test_env, &repo_path, "c", &["b"]);
    create_commit(&test_env, &repo_path, "d", &["a", "c"]);
    // Test the setup
    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
    @
    o   d
    |\
    o | c
    o | b
    | o a
    |/
    o
    "###);

    let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
    insta::assert_snapshot!(stdout, @r###"
    Also rebased 2 descendant commits onto parent of rebased commit
    Working copy now at: 3e176b54d680 (no description set)
    Added 0 files, modified 0 files, removed 2 files
    "###);
    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
    @
    o d
    | o c
    o | b
    | o a
    |/
    o
    "###);
}
```