### PR TITLE
Prevent rebasing onto both commits and their ancestrs 

### DIFF
--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -303,6 +303,7 @@ fn test_rebase_descendants_internal_merge(use_git: bool) {
     );
     let new_commit_c = assert_rebased(rebaser.rebase_next().unwrap(), &commit_c, &[&commit_f]);
     let new_commit_d = assert_rebased(rebaser.rebase_next().unwrap(), &commit_d, &[&commit_f]);
+    // TODO: Fix reorder error below
     let new_commit_e = assert_rebased(
         rebaser.rebase_next().unwrap(),
         &commit_e,
@@ -556,6 +557,7 @@ fn test_rebase_descendants_abandon_widen_merge(use_git: bool) {
         hashmap! {},
         hashset! {commit_e.id().clone()},
     );
+    // TODO: Fix reorder below
     let new_commit_f = assert_rebased(
         rebaser.rebase_next().unwrap(),
         &commit_f,

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -172,73 +172,6 @@ fn test_rebase_single_revision() {
 
     create_commit(&test_env, &repo_path, "a", &[]);
     create_commit(&test_env, &repo_path, "b", &[]);
-    create_commit(&test_env, &repo_path, "c", &["a", "b"]);
-    create_commit(&test_env, &repo_path, "d", &["c"]);
-    // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @ 
-    o d
-    o   c
-    |\  
-    o | b
-    | o a
-    |/  
-    o 
-    "###);
-
-    // Descendants of the rebased commit "b" should be rebased onto parents. First
-    // we test with a non-merge commit. Normally, the descendant "c" would still
-    // have 2 parents afterwards: the parent of "b" -- the root commit -- and
-    // "a". However, since the root commit is an ancestor of "a", we don't
-    // actually want both to be parents of the same commit. So, only "a" becomes
-    // a parent.
-    let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "b", "-d", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    Also rebased 3 descendant commits onto parent of rebased commit
-    Working copy now at: e7299ad0c9a7 (no description set)
-    Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @ 
-    o d
-    o c
-    | o b
-    |/  
-    o a
-    o 
-    "###);
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
-
-    // Now, let's try moving the merge commit. After, both parents of "c" ("a" and
-    // "b") should become parents of "d".
-    let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    Also rebased 2 descendant commits onto parent of rebased commit
-    Working copy now at: 2d90465bd244 (no description set)
-    Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @ 
-    o   d
-    |\  
-    | | o c
-    o | | b
-    | |/  
-    |/|   
-    | o a
-    |/  
-    o 
-    "###);
-}
-
-#[test]
-fn test_rebase_single_revision_merge_parent() {
-    let test_env = TestEnvironment::default();
-    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
-    let repo_path = test_env.env_root().join("repo");
-
-    create_commit(&test_env, &repo_path, "a", &[]);
-    create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &["b"]);
     create_commit(&test_env, &repo_path, "d", &["a", "c"]);
     // Test the setup
@@ -272,6 +205,51 @@ fn test_rebase_single_revision_merge_parent() {
     |/  
     o 
     "###);
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+
+    // Now, let's try to move "a", the other descendant of the merge commit.
+    // Normally, the descendant "d" would still have 2 parents afterwards: the
+    // parent of "a" -- the root commit -- and "c". However, since the root
+    // commit is an ancestor of "c", we don't actually want both to be parents
+    // of the same commit. So, only "c" becomes a parent.
+    let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "a", "-d", "b"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Also rebased 2 descendant commits onto parent of rebased commit
+    Working copy now at: acd0eefe8a31 (no description set)
+    Added 0 files, modified 0 files, removed 1 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @ 
+    o d
+    | o a
+    o | c
+    |/  
+    o b
+    o 
+    "###);
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+
+    // Now, let's try moving the merge commit. After, both parents of "d" ("a" and
+    // "c") should become parents of "@".
+    let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "d", "-d", "root"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Also rebased 1 descendant commits onto parent of rebased commit
+    Working copy now at: fdcdf681cd63 (no description set)
+    Added 0 files, modified 0 files, removed 1 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @   
+    |\  
+    | | o d
+    o | | c
+    o | | b
+    | |/  
+    |/|   
+    | o a
+    |/  
+    o 
+    "###);
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
 }
 
 #[test]


### PR DESCRIPTION
Previously, something like `rebase -r @ -d a -d a--` created a commit
that has one parent be an ancestor of another parent. Now, such
ancestors are automatically removed from the list.

The implementation simply moves the check that I introduced in
https://github.com/martinvonz/jj/commit/67738a87542dbaa1ab0ce0460ebcbddf4d53c7fe from `rebase_revision`
to the more low-level `rebase_commit`.

There are two potential issues to resolve still:

- The user should probably be informed when this occurs, similarly
to https://github.com/martinvonz/jj/commit/b21a123bc8947e51f84d498e78c952d8511a25bc (which deals with a
special case of this situation). I'm not sure how best to do that (should there
be some system for functions to generate user-facing warnings?).

- I'm not sure if the use of `unwrap` in `rebase_commit` is kosher,
but I was not sure how feasible it is to make the return type of
`rebase_commit` be a `Result`.

--------

This also includes a separate commit consolidating a test I wrote previously with other tests. I'm not sure whether this makes the resulting test difficult to follow, let me know.