### PR TITLE
cli: don't show open commits in green when open commits are disabled

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -201,9 +201,11 @@ impl<'stdout> Ui<'stdout> {
             .config()
             .get_string("template.commit_summary")
             .unwrap_or_else(|_| {
-                String::from(
-                    r#"label(if(open, "open"), commit_id.short() " " description.first_line())"#,
-                )
+                if self.settings.enable_open_commits() {
+                    String::from(r#"label(if(open, "open"), commit_id.short() " " description.first_line())"#)
+                } else {
+                    String::from(r#"commit_id.short() " " description.first_line()"#)
+                }
             });
         let template =
             crate::template_parser::parse_commit_template(repo, workspace_id, &template_string);


### PR DESCRIPTION
I had missed that `Ui::write_commit_summary()` still shows open commits in green even when open commits are disabled (as they are by default these days). This patch fixes that.

The user can still override templates to format open commits differently, but I'm not sure it's worth fixing that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
