### PR TITLE
github: remove `publish_results` field in wrong place

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -18,7 +18,6 @@ jobs:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       id-token: write
-      publish_results: true
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
When I read
https://github.com/ossf/scorecard-action#breaking-changes-in-v2 for 6d7ce74a9a7a, it seems like I misread the "for" as "and" in "`include id-token: write` for `publish_results: true`". The latter is not a permissions, it's another setting we have defined further down.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
