### PR TITLE
cli: hide `jj close/commit` and `jj open/uncommit`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1426,7 +1426,7 @@ struct DescribeArgs {
 /// For information about open/closed revisions, see
 /// https://github.com/martinvonz/jj/blob/main/docs/working-copy.md.
 #[derive(clap::Args, Clone, Debug)]
-#[clap(visible_alias = "commit")]
+#[clap(visible_alias = "commit", hide = true)]
 struct CloseArgs {
     /// The revision to close
     #[clap(default_value = "@")]
@@ -1447,7 +1447,7 @@ struct CloseArgs {
 /// For information about open/closed revisions,
 /// see https://github.com/martinvonz/jj/blob/main/docs/working-copy.md.
 #[derive(clap::Args, Clone, Debug)]
-#[clap(visible_alias = "uncommit")]
+#[clap(alias = "uncommit", hide = true)]
 struct OpenArgs {
     /// The revision to open
     revision: String,


### PR DESCRIPTION
Now that open commits are disabled by default, seeing `close` and `open` in `jj help` is confusing.

I'm a little ambivalent about hiding `jj commit` because it's useful as a way of adding a description and starting a new change with a single command. We can always add a new command for that if we want to.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
