### PR TITLE
cleanup: remove `extern crate` declarations

### DIFF
--- a/lib/build.rs
+++ b/lib/build.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate protobuf_codegen;
-extern crate version_check;
-
 use std::path::Path;
 
 fn main() {

--- a/lib/src/dag_walk.rs
+++ b/lib/src/dag_walk.rs
@@ -239,6 +239,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use maplit::{hashmap, hashset};
+
     use super::*;
 
     #[test]

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate byteorder;
-
 use std::cmp::{max, min, Ordering};
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet};
 use std::fmt::{Debug, Formatter};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,13 +15,6 @@
 #![deny(unused_must_use)]
 #![cfg_attr(feature = "map_first_last", feature(map_first_last))]
 
-#[macro_use]
-extern crate pest_derive;
-
-#[cfg(test)]
-#[macro_use]
-extern crate maplit;
-
 pub mod backend;
 pub mod commit;
 pub mod commit_builder;

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -322,6 +322,8 @@ impl Dirs {
 
 #[cfg(test)]
 mod tests {
+    use maplit::hashset;
+
     use super::*;
     use crate::repo_path::{RepoPath, RepoPathComponent};
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use pest::iterators::Pairs;
 use pest::Parser;
+use pest_derive::Parser;
 use thiserror::Error;
 
 use crate::backend::{BackendError, BackendResult, CommitId};

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -365,6 +365,8 @@ fn ref_target_from_proto(proto: &crate::protos::op_store::RefTarget) -> RefTarge
 
 #[cfg(test)]
 mod tests {
+    use maplit::{btreemap, hashmap, hashset};
+
     use super::*;
     use crate::testutils;
 

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -18,8 +18,6 @@
 //! a parent file, and the parent may have its own parent, and so on. The child
 //! file then represents the union of the entries.
 
-extern crate byteorder;
-
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate chrono;
-extern crate clap;
-extern crate clap_mangen;
-extern crate config;
-
 use std::collections::{HashSet, VecDeque};
 use std::ffi::OsString;
 use std::fmt::Debug;
@@ -28,6 +23,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{fs, io};
 
+use chrono::{FixedOffset, TimeZone, Utc};
 use clap::{ArgGroup, CommandFactory, Subcommand};
 use config::Value;
 use criterion::Criterion;
@@ -65,7 +61,6 @@ use jujutsu_lib::{conflicts, dag_walk, diff, files, git, revset, tree};
 use maplit::{hashmap, hashset};
 use pest::Parser;
 
-use self::chrono::{FixedOffset, TimeZone, Utc};
 use crate::commands::CommandError::UserError;
 use crate::diff_edit::DiffEditError;
 use crate::formatter::Formatter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,6 @@
 
 #![deny(unused_must_use)]
 
-#[macro_use]
-extern crate pest_derive;
-
 pub mod commands;
 pub mod config;
 pub mod diff_edit;

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate pest;
-
 use chrono::{FixedOffset, TimeZone, Utc};
 use jujutsu_lib::backend::{CommitId, Signature};
 use jujutsu_lib::commit::Commit;
@@ -21,6 +19,7 @@ use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::RepoRef;
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
+use pest_derive::Parser;
 
 use crate::formatter::PlainTextFormatter;
 use crate::templater::{


### PR DESCRIPTION
`extern crate` is no longer needed since edition 2018.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
