### PR TITLE
Make it possible to add a custom commit backend

### DIFF
--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -1,0 +1,152 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Read;
+use std::path::Path;
+
+use clap::{FromArgMatches, Subcommand};
+use git2::Repository;
+use jujutsu::cli_util::{create_ui, parse_args, report_command_error, CommandError};
+use jujutsu::commands::{default_app, run_command};
+use jujutsu::ui::Ui;
+use jujutsu_lib::backend::{
+    Backend, BackendResult, Commit, CommitId, Conflict, ConflictId, FileId, SymlinkId, Tree, TreeId,
+};
+use jujutsu_lib::git_backend::GitBackend;
+use jujutsu_lib::repo::BackendFactories;
+use jujutsu_lib::repo_path::RepoPath;
+use jujutsu_lib::workspace::Workspace;
+
+#[derive(clap::Parser, Clone, Debug)]
+enum CustomCommands {
+    /// Initialize a workspace using the Jit backend
+    InitJit,
+}
+
+fn run(ui: &mut Ui) -> Result<(), CommandError> {
+    let app = CustomCommands::augment_subcommands(default_app());
+    let (mut command_helper, matches) = parse_args(ui, app, std::env::args_os())?;
+    let mut backend_factories = BackendFactories::default();
+    // Register the backend so it can be loaded when the repo is loaded. The name
+    // must match `Backend::name()`.
+    backend_factories.add_backend(
+        "jit",
+        Box::new(|store_path| Box::new(JitBackend::load(store_path))),
+    );
+    command_helper.set_backend_factories(backend_factories);
+    match CustomCommands::from_arg_matches(&matches) {
+        // Handle our custom command
+        Ok(CustomCommands::InitJit) => {
+            let wc_path = ui.cwd();
+            // Initialize a workspace with the custom backend
+            Workspace::init_with_backend(ui.settings(), wc_path, |store_path| {
+                Box::new(JitBackend::init(store_path))
+            })?;
+            Ok(())
+        }
+        // Handle default commands
+        Err(_) => run_command(ui, &command_helper, &matches),
+    }
+}
+
+fn main() {
+    let mut ui = create_ui();
+    let exit_code = match run(&mut ui) {
+        Ok(()) => 0,
+        Err(err) => report_command_error(&mut ui, err),
+    };
+    std::process::exit(exit_code);
+}
+
+/// A commit backend that's extremely similar to the Git backend
+#[derive(Debug)]
+struct JitBackend {
+    inner: GitBackend,
+}
+
+impl JitBackend {
+    fn init(store_path: &Path) -> Self {
+        JitBackend {
+            inner: GitBackend::init_internal(store_path),
+        }
+    }
+
+    fn load(store_path: &Path) -> Self {
+        JitBackend {
+            inner: GitBackend::load(store_path),
+        }
+    }
+}
+
+impl Backend for JitBackend {
+    fn name(&self) -> &str {
+        "jit"
+    }
+
+    fn hash_length(&self) -> usize {
+        self.inner.hash_length()
+    }
+
+    fn git_repo(&self) -> Option<Repository> {
+        self.inner.git_repo()
+    }
+
+    fn read_file(&self, path: &RepoPath, id: &FileId) -> BackendResult<Box<dyn Read>> {
+        self.inner.read_file(path, id)
+    }
+
+    fn write_file(&self, path: &RepoPath, contents: &mut dyn Read) -> BackendResult<FileId> {
+        self.inner.write_file(path, contents)
+    }
+
+    fn read_symlink(&self, path: &RepoPath, id: &SymlinkId) -> BackendResult<String> {
+        self.inner.read_symlink(path, id)
+    }
+
+    fn write_symlink(&self, path: &RepoPath, target: &str) -> BackendResult<SymlinkId> {
+        self.inner.write_symlink(path, target)
+    }
+
+    fn root_commit_id(&self) -> &CommitId {
+        self.inner.root_commit_id()
+    }
+
+    fn empty_tree_id(&self) -> &TreeId {
+        self.inner.empty_tree_id()
+    }
+
+    fn read_tree(&self, path: &RepoPath, id: &TreeId) -> BackendResult<Tree> {
+        self.inner.read_tree(path, id)
+    }
+
+    fn write_tree(&self, path: &RepoPath, contents: &Tree) -> BackendResult<TreeId> {
+        self.inner.write_tree(path, contents)
+    }
+
+    fn read_conflict(&self, path: &RepoPath, id: &ConflictId) -> BackendResult<Conflict> {
+        self.inner.read_conflict(path, id)
+    }
+
+    fn write_conflict(&self, path: &RepoPath, contents: &Conflict) -> BackendResult<ConflictId> {
+        self.inner.write_conflict(path, contents)
+    }
+
+    fn read_commit(&self, id: &CommitId) -> BackendResult<Commit> {
+        self.inner.read_commit(id)
+    }
+
+    fn write_commit(&self, contents: &Commit) -> BackendResult<CommitId> {
+        self.inner.write_commit(contents)
+    }
+}

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -398,6 +398,10 @@ pub fn make_root_commit(empty_tree_id: TreeId) -> Commit {
 }
 
 pub trait Backend: Send + Sync + Debug {
+    /// A unique name that identifies this backend. Written to
+    /// `.jj/repo/store/backend` when the repo is created.
+    fn name(&self) -> &str;
+
     fn hash_length(&self) -> usize;
 
     fn git_repo(&self) -> Option<git2::Repository>;

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -164,6 +164,10 @@ impl Debug for GitBackend {
 }
 
 impl Backend for GitBackend {
+    fn name(&self) -> &str {
+        "git"
+    }
+
     fn hash_length(&self) -> usize {
         HASH_LENGTH
     }

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 use std::fs;
 use std::fs::File;
 use std::io::{ErrorKind, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use blake2::{Blake2b512, Digest};
 use protobuf::{Message, MessageField};
@@ -56,7 +56,7 @@ pub struct LocalBackend {
 }
 
 impl LocalBackend {
-    pub fn init(store_path: PathBuf) -> Self {
+    pub fn init(store_path: &Path) -> Self {
         fs::create_dir(store_path.join("commits")).unwrap();
         fs::create_dir(store_path.join("trees")).unwrap();
         fs::create_dir(store_path.join("files")).unwrap();
@@ -70,11 +70,11 @@ impl LocalBackend {
         backend
     }
 
-    pub fn load(store_path: PathBuf) -> Self {
+    pub fn load(store_path: &Path) -> Self {
         let root_commit_id = CommitId::from_bytes(&[0; 64]);
         let empty_tree_id = TreeId::from_hex("786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce");
         LocalBackend {
-            path: store_path,
+            path: store_path.to_path_buf(),
             root_commit_id,
             empty_tree_id,
         }

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -110,6 +110,10 @@ fn not_found_to_backend_error(err: std::io::Error) -> BackendError {
 }
 
 impl Backend for LocalBackend {
+    fn name(&self) -> &str {
+        "local"
+    }
+
     fn hash_length(&self) -> usize {
         64
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -128,30 +128,6 @@ impl Debug for ReadonlyRepo {
 }
 
 impl ReadonlyRepo {
-    pub fn init_local(settings: &UserSettings, repo_path: &Path) -> Arc<ReadonlyRepo> {
-        Self::init(settings, repo_path, |store_path| {
-            Box::new(LocalBackend::init(store_path))
-        })
-    }
-
-    /// Initializes a repo with a new Git backend in .jj/git/ (bare Git repo)
-    pub fn init_internal_git(settings: &UserSettings, repo_path: &Path) -> Arc<ReadonlyRepo> {
-        Self::init(settings, repo_path, |store_path| {
-            Box::new(GitBackend::init_internal(store_path))
-        })
-    }
-
-    /// Initializes a repo with an existing Git backend at the specified path
-    pub fn init_external_git(
-        settings: &UserSettings,
-        repo_path: &Path,
-        git_repo_path: &Path,
-    ) -> Arc<ReadonlyRepo> {
-        Self::init(settings, repo_path, |store_path| {
-            Box::new(GitBackend::init_external(store_path, git_repo_path))
-        })
-    }
-
     fn init_repo_dir(repo_path: &Path) {
         fs::create_dir(repo_path.join("store")).unwrap();
         fs::create_dir(repo_path.join("op_store")).unwrap();

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -142,7 +142,10 @@ impl ReadonlyRepo {
     ) -> Arc<ReadonlyRepo> {
         let repo_path = repo_path.canonicalize().unwrap();
         ReadonlyRepo::init_repo_dir(&repo_path);
-        let store = Store::new(backend_factory(&repo_path.join("store")));
+        let store_path = repo_path.join("store");
+        let backend = backend_factory(&store_path);
+        fs::write(&store_path.join("backend"), backend.name()).unwrap();
+        let store = Store::new(backend);
         let repo_settings = user_settings.with_repo(&repo_path).unwrap();
         let op_store: Arc<dyn OpStore> = Arc::new(SimpleOpStore::init(repo_path.join("op_store")));
         let mut root_view = op_store::View::default();

--- a/lib/src/testutils.rs
+++ b/lib/src/testutils.rs
@@ -77,11 +77,11 @@ impl TestRepo {
         let repo = if use_git {
             let git_path = temp_dir.path().join("git-repo");
             git2::Repository::init(&git_path).unwrap();
-            ReadonlyRepo::init(&settings, repo_dir, |store_path| {
-                Box::new(GitBackend::init_external(store_path, git_path.clone()))
+            ReadonlyRepo::init(&settings, &repo_dir, |store_path| {
+                Box::new(GitBackend::init_external(store_path, &git_path))
             })
         } else {
-            ReadonlyRepo::init(&settings, repo_dir, |store_path| {
+            ReadonlyRepo::init(&settings, &repo_dir, |store_path| {
                 Box::new(LocalBackend::init(store_path))
             })
         };
@@ -109,9 +109,9 @@ impl TestWorkspace {
         let (workspace, repo) = if use_git {
             let git_path = temp_dir.path().join("git-repo");
             git2::Repository::init(&git_path).unwrap();
-            Workspace::init_external_git(settings, workspace_root, git_path).unwrap()
+            Workspace::init_external_git(settings, &workspace_root, &git_path).unwrap()
         } else {
-            Workspace::init_local(settings, workspace_root).unwrap()
+            Workspace::init_local(settings, &workspace_root).unwrap()
         };
 
         Self {

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -23,7 +23,7 @@ use crate::backend::Backend;
 use crate::git_backend::GitBackend;
 use crate::local_backend::LocalBackend;
 use crate::op_store::WorkspaceId;
-use crate::repo::{ReadonlyRepo, RepoLoader};
+use crate::repo::{BackendFactories, ReadonlyRepo, RepoLoader};
 use crate::settings::UserSettings;
 use crate::working_copy::WorkingCopy;
 
@@ -192,7 +192,7 @@ impl Workspace {
                 return Err(WorkspaceLoadError::RepoDoesNotExist(repo_dir));
             }
         }
-        let repo_loader = RepoLoader::init(user_settings, &repo_dir);
+        let repo_loader = RepoLoader::init(user_settings, &repo_dir, &BackendFactories::default());
         let working_copy_state_path = jj_dir.join("working_copy");
         let working_copy = WorkingCopy::load(
             repo_loader.store().clone(),

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -162,10 +162,9 @@ impl Workspace {
             .write_all(repo_dir.to_str().unwrap().as_bytes())
             .unwrap();
 
-        let repo_loader = RepoLoader::init(user_settings, &repo_dir);
         let (working_copy, repo) =
             init_working_copy(user_settings, repo, workspace_root, &jj_dir, workspace_id);
-        let workspace = Workspace::new(workspace_root, working_copy, repo_loader);
+        let workspace = Workspace::new(workspace_root, working_copy, repo.loader());
         Ok((workspace, repo))
     }
 

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -131,7 +131,7 @@ impl Workspace {
         })
     }
 
-    fn init_with_backend(
+    pub fn init_with_backend(
         user_settings: &UserSettings,
         workspace_root: &Path,
         backend_factory: impl FnOnce(&Path) -> Box<dyn Backend>,

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -175,6 +175,7 @@ impl Workspace {
     pub fn load(
         user_settings: &UserSettings,
         workspace_path: &Path,
+        backend_factories: &BackendFactories,
     ) -> Result<Self, WorkspaceLoadError> {
         let jj_dir = find_jj_dir(workspace_path)
             .ok_or_else(|| WorkspaceLoadError::NoWorkspaceHere(workspace_path.to_owned()))?;
@@ -192,7 +193,7 @@ impl Workspace {
                 return Err(WorkspaceLoadError::RepoDoesNotExist(repo_dir));
             }
         }
-        let repo_loader = RepoLoader::init(user_settings, &repo_dir, &BackendFactories::default());
+        let repo_loader = RepoLoader::init(user_settings, &repo_dir, backend_factories);
         let working_copy_state_path = jj_dir.join("working_copy");
         let working_copy = WorkingCopy::load(
             repo_loader.store().clone(),

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -108,6 +108,8 @@ impl Workspace {
         })
     }
 
+    /// Initializes a workspace with a new Git backend in .jj/git/ (bare Git
+    /// repo)
     pub fn init_internal_git(
         user_settings: &UserSettings,
         workspace_root: &Path,
@@ -117,6 +119,8 @@ impl Workspace {
         })
     }
 
+    /// Initializes a workspace with an existing Git backend at the specified
+    /// path
     pub fn init_external_git(
         user_settings: &UserSettings,
         workspace_root: &Path,

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -90,11 +90,7 @@ fn init_working_copy(
 }
 
 impl Workspace {
-    fn new(
-        workspace_root: PathBuf,
-        working_copy: WorkingCopy,
-        repo_loader: RepoLoader,
-    ) -> Workspace {
+    fn new(workspace_root: &Path, working_copy: WorkingCopy, repo_loader: RepoLoader) -> Workspace {
         let workspace_root = workspace_root.canonicalize().unwrap();
         Workspace {
             workspace_root,
@@ -105,7 +101,7 @@ impl Workspace {
 
     pub fn init_local(
         user_settings: &UserSettings,
-        workspace_root: PathBuf,
+        workspace_root: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         Self::init_with_backend(user_settings, workspace_root, |store_path| {
             Box::new(LocalBackend::init(store_path))
@@ -114,7 +110,7 @@ impl Workspace {
 
     pub fn init_internal_git(
         user_settings: &UserSettings,
-        workspace_root: PathBuf,
+        workspace_root: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         Self::init_with_backend(user_settings, workspace_root, |store_path| {
             Box::new(GitBackend::init_internal(store_path))
@@ -123,27 +119,27 @@ impl Workspace {
 
     pub fn init_external_git(
         user_settings: &UserSettings,
-        workspace_root: PathBuf,
-        git_repo_path: PathBuf,
+        workspace_root: &Path,
+        git_repo_path: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         Self::init_with_backend(user_settings, workspace_root, |store_path| {
-            Box::new(GitBackend::init_external(store_path, git_repo_path.clone()))
+            Box::new(GitBackend::init_external(store_path, git_repo_path))
         })
     }
 
     fn init_with_backend(
         user_settings: &UserSettings,
-        workspace_root: PathBuf,
-        backend_factory: impl FnOnce(PathBuf) -> Box<dyn Backend>,
+        workspace_root: &Path,
+        backend_factory: impl FnOnce(&Path) -> Box<dyn Backend>,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
-        let jj_dir = create_jj_dir(&workspace_root)?;
+        let jj_dir = create_jj_dir(workspace_root)?;
         let repo_dir = jj_dir.join("repo");
         std::fs::create_dir(&repo_dir).unwrap();
-        let repo = ReadonlyRepo::init(user_settings, repo_dir, backend_factory);
+        let repo = ReadonlyRepo::init(user_settings, &repo_dir, backend_factory);
         let (working_copy, repo) = init_working_copy(
             user_settings,
             &repo,
-            &workspace_root,
+            workspace_root,
             &jj_dir,
             WorkspaceId::default(),
         );
@@ -154,11 +150,11 @@ impl Workspace {
 
     pub fn init_workspace_with_existing_repo(
         user_settings: &UserSettings,
-        workspace_root: PathBuf,
+        workspace_root: &Path,
         repo: &Arc<ReadonlyRepo>,
         workspace_id: WorkspaceId,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
-        let jj_dir = create_jj_dir(&workspace_root)?;
+        let jj_dir = create_jj_dir(workspace_root)?;
 
         let repo_dir = repo.repo_path().canonicalize().unwrap();
         let mut repo_file = File::create(jj_dir.join("repo")).unwrap();
@@ -166,19 +162,19 @@ impl Workspace {
             .write_all(repo_dir.to_str().unwrap().as_bytes())
             .unwrap();
 
-        let repo_loader = RepoLoader::init(user_settings, repo_dir);
+        let repo_loader = RepoLoader::init(user_settings, &repo_dir);
         let (working_copy, repo) =
-            init_working_copy(user_settings, repo, &workspace_root, &jj_dir, workspace_id);
+            init_working_copy(user_settings, repo, workspace_root, &jj_dir, workspace_id);
         let workspace = Workspace::new(workspace_root, working_copy, repo_loader);
         Ok((workspace, repo))
     }
 
     pub fn load(
         user_settings: &UserSettings,
-        workspace_path: PathBuf,
+        workspace_path: &Path,
     ) -> Result<Self, WorkspaceLoadError> {
-        let jj_dir = find_jj_dir(&workspace_path)
-            .ok_or(WorkspaceLoadError::NoWorkspaceHere(workspace_path))?;
+        let jj_dir = find_jj_dir(workspace_path)
+            .ok_or_else(|| WorkspaceLoadError::NoWorkspaceHere(workspace_path.to_owned()))?;
         let workspace_root = jj_dir.parent().unwrap().to_owned();
         let mut repo_dir = jj_dir.join("repo");
         // If .jj/repo is a file, then we interpret its contents as a relative path to
@@ -193,14 +189,14 @@ impl Workspace {
                 return Err(WorkspaceLoadError::RepoDoesNotExist(repo_dir));
             }
         }
-        let repo_loader = RepoLoader::init(user_settings, repo_dir);
+        let repo_loader = RepoLoader::init(user_settings, &repo_dir);
         let working_copy_state_path = jj_dir.join("working_copy");
         let working_copy = WorkingCopy::load(
             repo_loader.store().clone(),
             workspace_root.clone(),
             working_copy_state_path,
         );
-        Ok(Workspace::new(workspace_root, working_copy, repo_loader))
+        Ok(Workspace::new(&workspace_root, working_copy, repo_loader))
     }
 
     pub fn workspace_root(&self) -> &PathBuf {

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -14,7 +14,7 @@
 
 use std::path::Path;
 
-use jujutsu_lib::repo::ReadonlyRepo;
+use jujutsu_lib::repo::{BackendFactories, ReadonlyRepo};
 use jujutsu_lib::testutils;
 use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::workspace::Workspace;
@@ -188,10 +188,14 @@ fn test_bad_locking_interrupted(use_git: bool) {
 
     copy_directory(backup_path.path(), &op_heads_dir);
     // Reload the repo and check that only the new head is present.
-    let reloaded_repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+    let reloaded_repo =
+        ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+            .unwrap();
     assert_eq!(reloaded_repo.op_id(), &op_id);
     // Reload once more to make sure that the .jj/op_heads/ directory was updated
     // correctly.
-    let reloaded_repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+    let reloaded_repo =
+        ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+            .unwrap();
     assert_eq!(reloaded_repo.op_id(), &op_id);
 }

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -108,7 +108,12 @@ fn test_bad_locking_children(use_git: bool) {
     // Simulate a write of a commit that happens on one machine
     let machine1_root = testutils::new_temp_dir();
     copy_directory(workspace_root, machine1_root.path());
-    let machine1_workspace = Workspace::load(&settings, machine1_root.path()).unwrap();
+    let machine1_workspace = Workspace::load(
+        &settings,
+        machine1_root.path(),
+        &BackendFactories::default(),
+    )
+    .unwrap();
     let machine1_repo = machine1_workspace
         .repo_loader()
         .load_at_head()
@@ -123,7 +128,12 @@ fn test_bad_locking_children(use_git: bool) {
     // Simulate a write of a commit that happens on another machine
     let machine2_root = testutils::new_temp_dir();
     copy_directory(workspace_root, machine2_root.path());
-    let machine2_workspace = Workspace::load(&settings, machine2_root.path()).unwrap();
+    let machine2_workspace = Workspace::load(
+        &settings,
+        machine2_root.path(),
+        &BackendFactories::default(),
+    )
+    .unwrap();
     let machine2_repo = machine2_workspace
         .repo_loader()
         .load_at_head()
@@ -144,7 +154,8 @@ fn test_bad_locking_children(use_git: bool) {
         machine2_root.path(),
         merged_path.path(),
     );
-    let merged_workspace = Workspace::load(&settings, merged_path.path()).unwrap();
+    let merged_workspace =
+        Workspace::load(&settings, merged_path.path(), &BackendFactories::default()).unwrap();
     let merged_repo = merged_workspace
         .repo_loader()
         .load_at_head()

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -108,7 +108,7 @@ fn test_bad_locking_children(use_git: bool) {
     // Simulate a write of a commit that happens on one machine
     let machine1_root = testutils::new_temp_dir();
     copy_directory(workspace_root, machine1_root.path());
-    let machine1_workspace = Workspace::load(&settings, machine1_root.path().to_owned()).unwrap();
+    let machine1_workspace = Workspace::load(&settings, machine1_root.path()).unwrap();
     let machine1_repo = machine1_workspace
         .repo_loader()
         .load_at_head()
@@ -123,7 +123,7 @@ fn test_bad_locking_children(use_git: bool) {
     // Simulate a write of a commit that happens on another machine
     let machine2_root = testutils::new_temp_dir();
     copy_directory(workspace_root, machine2_root.path());
-    let machine2_workspace = Workspace::load(&settings, machine2_root.path().to_owned()).unwrap();
+    let machine2_workspace = Workspace::load(&settings, machine2_root.path()).unwrap();
     let machine2_repo = machine2_workspace
         .repo_loader()
         .load_at_head()
@@ -144,7 +144,7 @@ fn test_bad_locking_children(use_git: bool) {
         machine2_root.path(),
         merged_path.path(),
     );
-    let merged_workspace = Workspace::load(&settings, merged_path.path().to_owned()).unwrap();
+    let merged_workspace = Workspace::load(&settings, merged_path.path()).unwrap();
     let merged_repo = merged_workspace
         .repo_loader()
         .load_at_head()
@@ -188,10 +188,10 @@ fn test_bad_locking_interrupted(use_git: bool) {
 
     copy_directory(backup_path.path(), &op_heads_dir);
     // Reload the repo and check that only the new head is present.
-    let reloaded_repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+    let reloaded_repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
     assert_eq!(reloaded_repo.op_id(), &op_id);
     // Reload once more to make sure that the .jj/op_heads/ directory was updated
     // correctly.
-    let reloaded_repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+    let reloaded_repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
     assert_eq!(reloaded_repo.op_id(), &op_id);
 }

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -15,7 +15,7 @@
 use std::cmp::max;
 use std::thread;
 
-use jujutsu_lib::repo::ReadonlyRepo;
+use jujutsu_lib::repo::{BackendFactories, ReadonlyRepo};
 use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::{dag_walk, testutils};
 use test_case::test_case;
@@ -85,7 +85,9 @@ fn test_commit_parallel_instances(use_git: bool) {
     let mut threads = vec![];
     for _ in 0..num_threads {
         let settings = settings.clone();
-        let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+        let repo =
+            ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+                .unwrap();
         let handle = thread::spawn(move || {
             let mut tx = repo.start_transaction("test");
             testutils::create_random_commit(&settings, &repo).write_to_repo(tx.mut_repo());
@@ -98,7 +100,9 @@ fn test_commit_parallel_instances(use_git: bool) {
     }
     // One commit per thread plus the commit from the initial checkout on top of the
     // root commit
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+    let repo =
+        ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+            .unwrap();
     assert_eq!(repo.view().heads().len(), num_threads + 1);
 
     // One addition operation for initializing the repo, one for checking out the

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -85,7 +85,7 @@ fn test_commit_parallel_instances(use_git: bool) {
     let mut threads = vec![];
     for _ in 0..num_threads {
         let settings = settings.clone();
-        let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+        let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
         let handle = thread::spawn(move || {
             let mut tx = repo.start_transaction("test");
             testutils::create_random_commit(&settings, &repo).write_to_repo(tx.mut_repo());
@@ -98,7 +98,7 @@ fn test_commit_parallel_instances(use_git: bool) {
     }
     // One commit per thread plus the commit from the initial checkout on top of the
     // root commit
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
     assert_eq!(repo.view().heads().len(), num_threads + 1);
 
     // One addition operation for initializing the repo, one for checking out the

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -284,7 +284,7 @@ impl GitRepoData {
             git2::Repository::clone(origin_repo_dir.to_str().unwrap(), &git_repo_dir).unwrap();
         let jj_repo_dir = temp_dir.path().join("jj");
         std::fs::create_dir(&jj_repo_dir).unwrap();
-        let repo = ReadonlyRepo::init_external_git(&settings, jj_repo_dir, git_repo_dir);
+        let repo = ReadonlyRepo::init_external_git(&settings, &jj_repo_dir, &git_repo_dir);
         Self {
             settings,
             _temp_dir: temp_dir,
@@ -520,7 +520,7 @@ fn test_init() {
     let initial_git_commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let initial_commit_id = commit_id(&initial_git_commit);
     std::fs::create_dir(&jj_repo_dir).unwrap();
-    let repo = ReadonlyRepo::init_external_git(&settings, jj_repo_dir, git_repo_dir);
+    let repo = ReadonlyRepo::init_external_git(&settings, &jj_repo_dir, &git_repo_dir);
     // The refs were *not* imported -- it's the caller's responsibility to import
     // any refs they care about.
     assert!(!repo.view().heads().contains(&initial_commit_id));
@@ -682,7 +682,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
     let initial_commit_id = commit_id(&initial_git_commit);
     git2::Repository::clone(source_repo_dir.to_str().unwrap(), &clone_repo_dir).unwrap();
     std::fs::create_dir(&jj_repo_dir).unwrap();
-    let jj_repo = ReadonlyRepo::init_external_git(settings, jj_repo_dir, clone_repo_dir);
+    let jj_repo = ReadonlyRepo::init_external_git(settings, &jj_repo_dir, &clone_repo_dir);
     let mut tx = jj_repo.start_transaction("test");
     let new_commit = testutils::create_random_commit(settings, &jj_repo)
         .set_parents(vec![initial_commit_id])

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -18,7 +18,7 @@ use jujutsu_lib::backend::CommitId;
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::index::IndexRef;
-use jujutsu_lib::repo::ReadonlyRepo;
+use jujutsu_lib::repo::{BackendFactories, ReadonlyRepo};
 use jujutsu_lib::settings::UserSettings;
 use jujutsu_lib::testutils;
 use jujutsu_lib::testutils::{create_random_commit, CommitGraphBuilder, TestRepo};
@@ -256,7 +256,9 @@ fn test_index_commits_previous_operations(use_git: bool) {
     std::fs::remove_dir_all(&index_operations_dir).unwrap();
     std::fs::create_dir(&index_operations_dir).unwrap();
 
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+    let repo =
+        ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+            .unwrap();
     let index = repo.index();
     // There should be the root commit, plus 3 more
     assert_eq!(index.num_commits(), 1 + 3);
@@ -301,7 +303,9 @@ fn test_index_commits_incremental(use_git: bool) {
     let commit_c = child_commit(&settings, &repo, &commit_b).write_to_repo(tx.mut_repo());
     tx.commit();
 
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+    let repo =
+        ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+            .unwrap();
     let index = repo.index();
     // There should be the root commit, plus 3 more
     assert_eq!(index.num_commits(), 1 + 3);
@@ -344,7 +348,9 @@ fn test_index_commits_incremental_empty_transaction(use_git: bool) {
 
     repo.start_transaction("test").commit();
 
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
+    let repo =
+        ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &BackendFactories::default())
+            .unwrap();
     let index = repo.index();
     // There should be the root commit, plus 1 more
     assert_eq!(index.num_commits(), 1 + 1);

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -256,7 +256,7 @@ fn test_index_commits_previous_operations(use_git: bool) {
     std::fs::remove_dir_all(&index_operations_dir).unwrap();
     std::fs::create_dir(&index_operations_dir).unwrap();
 
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
     let index = repo.index();
     // There should be the root commit, plus 3 more
     assert_eq!(index.num_commits(), 1 + 3);
@@ -301,7 +301,7 @@ fn test_index_commits_incremental(use_git: bool) {
     let commit_c = child_commit(&settings, &repo, &commit_b).write_to_repo(tx.mut_repo());
     tx.commit();
 
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
     let index = repo.index();
     // There should be the root commit, plus 3 more
     assert_eq!(index.num_commits(), 1 + 3);
@@ -344,7 +344,7 @@ fn test_index_commits_incremental_empty_transaction(use_git: bool) {
 
     repo.start_transaction("test").commit();
 
-    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path().clone()).unwrap();
+    let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path()).unwrap();
     let index = repo.index();
     // There should be the root commit, plus 1 more
     assert_eq!(index.num_commits(), 1 + 1);

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -32,7 +32,7 @@ fn test_init_local() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_local(&settings, uncanonical).unwrap();
+    let (workspace, repo) = Workspace::init_local(&settings, &uncanonical).unwrap();
     assert!(repo.store().git_repo().is_none());
     assert_eq!(repo.repo_path(), &canonical.join(".jj").join("repo"));
     assert_eq!(workspace.workspace_root(), &canonical);
@@ -47,7 +47,7 @@ fn test_init_internal_git() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_internal_git(&settings, uncanonical).unwrap();
+    let (workspace, repo) = Workspace::init_internal_git(&settings, &uncanonical).unwrap();
     assert!(repo.store().git_repo().is_some());
     assert_eq!(repo.repo_path(), &canonical.join(".jj").join("repo"));
     assert_eq!(workspace.workspace_root(), &canonical);
@@ -66,7 +66,7 @@ fn test_init_external_git() {
     git2::Repository::init(&git_repo_path).unwrap();
     std::fs::create_dir(&uncanonical.join("jj")).unwrap();
     let (workspace, repo) =
-        Workspace::init_external_git(&settings, uncanonical.join("jj"), git_repo_path).unwrap();
+        Workspace::init_external_git(&settings, &uncanonical.join("jj"), &git_repo_path).unwrap();
     assert!(repo.store().git_repo().is_some());
     assert_eq!(
         repo.repo_path(),

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::repo::RepoLoader;
+use jujutsu_lib::repo::{BackendFactories, RepoLoader};
 use jujutsu_lib::testutils;
 use jujutsu_lib::testutils::TestRepo;
 use test_case::test_case;
@@ -34,13 +34,13 @@ fn test_load_at_operation(use_git: bool) {
 
     // If we load the repo at head, we should not see the commit since it was
     // removed
-    let loader = RepoLoader::init(&settings, repo.repo_path());
+    let loader = RepoLoader::init(&settings, repo.repo_path(), &BackendFactories::default());
     let head_repo = loader.load_at_head().resolve(&settings).unwrap();
     assert!(!head_repo.view().heads().contains(commit.id()));
 
     // If we load the repo at the previous operation, we should see the commit since
     // it has not been removed yet
-    let loader = RepoLoader::init(&settings, repo.repo_path());
+    let loader = RepoLoader::init(&settings, repo.repo_path(), &BackendFactories::default());
     let old_repo = loader.load_at(repo.operation());
     assert!(old_repo.view().heads().contains(commit.id()));
 }

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -34,13 +34,13 @@ fn test_load_at_operation(use_git: bool) {
 
     // If we load the repo at head, we should not see the commit since it was
     // removed
-    let loader = RepoLoader::init(&settings, repo.repo_path().clone());
+    let loader = RepoLoader::init(&settings, repo.repo_path());
     let head_repo = loader.load_at_head().resolve(&settings).unwrap();
     assert!(!head_repo.view().heads().contains(commit.id()));
 
     // If we load the repo at the previous operation, we should see the commit since
     // it has not been removed yet
-    let loader = RepoLoader::init(&settings, repo.repo_path().clone());
+    let loader = RepoLoader::init(&settings, repo.repo_path());
     let old_repo = loader.load_at(repo.operation());
     assert!(old_repo.view().heads().contains(commit.id()));
 }

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -57,7 +57,7 @@ fn test_concurrent_checkout(use_git: bool) {
 
     // Check out tree2 from another process (simulated by another workspace
     // instance)
-    let mut workspace2 = Workspace::load(&settings, workspace1_root.clone()).unwrap();
+    let mut workspace2 = Workspace::load(&settings, &workspace1_root).unwrap();
     workspace2
         .working_copy_mut()
         .check_out(repo1.op_id().clone(), Some(&tree_id1), &tree2)
@@ -70,7 +70,7 @@ fn test_concurrent_checkout(use_git: bool) {
     );
 
     // Check that the tree2 is still checked out on disk.
-    let workspace3 = Workspace::load(&settings, workspace1_root).unwrap();
+    let workspace3 = Workspace::load(&settings, &workspace1_root).unwrap();
     assert_eq!(workspace3.working_copy().current_tree_id(), tree_id2);
 }
 
@@ -112,7 +112,7 @@ fn test_checkout_parallel(use_git: bool) {
         let settings = settings.clone();
         let workspace_root = workspace_root.clone();
         let handle = thread::spawn(move || {
-            let mut workspace = Workspace::load(&settings, workspace_root).unwrap();
+            let mut workspace = Workspace::load(&settings, &workspace_root).unwrap();
             let tree = workspace
                 .repo_loader()
                 .store()

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -17,6 +17,7 @@ use std::thread;
 
 use assert_matches::assert_matches;
 use jujutsu_lib::gitignore::GitIgnoreFile;
+use jujutsu_lib::repo::BackendFactories;
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::testutils;
 use jujutsu_lib::testutils::TestWorkspace;
@@ -57,7 +58,8 @@ fn test_concurrent_checkout(use_git: bool) {
 
     // Check out tree2 from another process (simulated by another workspace
     // instance)
-    let mut workspace2 = Workspace::load(&settings, &workspace1_root).unwrap();
+    let mut workspace2 =
+        Workspace::load(&settings, &workspace1_root, &BackendFactories::default()).unwrap();
     workspace2
         .working_copy_mut()
         .check_out(repo1.op_id().clone(), Some(&tree_id1), &tree2)
@@ -70,7 +72,8 @@ fn test_concurrent_checkout(use_git: bool) {
     );
 
     // Check that the tree2 is still checked out on disk.
-    let workspace3 = Workspace::load(&settings, &workspace1_root).unwrap();
+    let workspace3 =
+        Workspace::load(&settings, &workspace1_root, &BackendFactories::default()).unwrap();
     assert_eq!(workspace3.working_copy().current_tree_id(), tree_id2);
 }
 
@@ -112,7 +115,8 @@ fn test_checkout_parallel(use_git: bool) {
         let settings = settings.clone();
         let workspace_root = workspace_root.clone();
         let handle = thread::spawn(move || {
-            let mut workspace = Workspace::load(&settings, &workspace_root).unwrap();
+            let mut workspace =
+                Workspace::load(&settings, &workspace_root, &BackendFactories::default()).unwrap();
             let tree = workspace
                 .repo_loader()
                 .store()

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -24,7 +24,7 @@ fn test_load_bad_path() {
     let temp_dir = testutils::new_temp_dir();
     let workspace_root = temp_dir.path().to_owned();
     // We haven't created a repo in the workspace_root, so it should fail to load.
-    let result = Workspace::load(&settings, workspace_root.clone());
+    let result = Workspace::load(&settings, &workspace_root);
     assert_eq!(
         result.err(),
         Some(WorkspaceLoadError::NoWorkspaceHere(workspace_root))
@@ -40,7 +40,7 @@ fn test_load_from_subdir(use_git: bool) {
 
     let subdir = workspace.workspace_root().join("dir").join("subdir");
     std::fs::create_dir_all(subdir.clone()).unwrap();
-    let same_workspace = Workspace::load(&settings, subdir);
+    let same_workspace = Workspace::load(&settings, &subdir);
     assert!(same_workspace.is_ok());
     let same_workspace = same_workspace.unwrap();
     assert_eq!(same_workspace.repo_path(), workspace.repo_path());
@@ -59,7 +59,7 @@ fn test_init_additional_workspace(use_git: bool) {
     std::fs::create_dir(&ws2_root).unwrap();
     let (ws2, repo) = Workspace::init_workspace_with_existing_repo(
         &settings,
-        ws2_root.clone(),
+        &ws2_root,
         &test_workspace.repo,
         ws2_id.clone(),
     )
@@ -78,7 +78,7 @@ fn test_init_additional_workspace(use_git: bool) {
         workspace.repo_path().canonicalize().unwrap()
     );
     assert_eq!(*ws2.workspace_root(), ws2_root.canonicalize().unwrap());
-    let same_workspace = Workspace::load(&settings, ws2_root);
+    let same_workspace = Workspace::load(&settings, &ws2_root);
     assert!(same_workspace.is_ok());
     let same_workspace = same_workspace.unwrap();
     assert_eq!(same_workspace.workspace_id(), ws2_id);

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use jujutsu_lib::op_store::WorkspaceId;
+use jujutsu_lib::repo::BackendFactories;
 use jujutsu_lib::testutils;
 use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::workspace::{Workspace, WorkspaceLoadError};
@@ -24,7 +25,7 @@ fn test_load_bad_path() {
     let temp_dir = testutils::new_temp_dir();
     let workspace_root = temp_dir.path().to_owned();
     // We haven't created a repo in the workspace_root, so it should fail to load.
-    let result = Workspace::load(&settings, &workspace_root);
+    let result = Workspace::load(&settings, &workspace_root, &BackendFactories::default());
     assert_eq!(
         result.err(),
         Some(WorkspaceLoadError::NoWorkspaceHere(workspace_root))
@@ -40,7 +41,7 @@ fn test_load_from_subdir(use_git: bool) {
 
     let subdir = workspace.workspace_root().join("dir").join("subdir");
     std::fs::create_dir_all(subdir.clone()).unwrap();
-    let same_workspace = Workspace::load(&settings, &subdir);
+    let same_workspace = Workspace::load(&settings, &subdir, &BackendFactories::default());
     assert!(same_workspace.is_ok());
     let same_workspace = same_workspace.unwrap();
     assert_eq!(same_workspace.repo_path(), workspace.repo_path());
@@ -78,7 +79,7 @@ fn test_init_additional_workspace(use_git: bool) {
         workspace.repo_path().canonicalize().unwrap()
     );
     assert_eq!(*ws2.workspace_root(), ws2_root.canonicalize().unwrap());
-    let same_workspace = Workspace::load(&settings, &ws2_root);
+    let same_workspace = Workspace::load(&settings, &ws2_root, &BackendFactories::default());
     assert!(same_workspace.is_ok());
     let same_workspace = same_workspace.unwrap();
     assert_eq!(same_workspace.workspace_id(), ws2_id);

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -201,7 +201,7 @@ impl<'help> CommandHelper<'help> {
     pub fn workspace_helper(&self, ui: &mut Ui) -> Result<WorkspaceCommandHelper, CommandError> {
         let wc_path_str = self.global_args.repository.as_deref().unwrap_or(".");
         let wc_path = ui.cwd().join(wc_path_str);
-        let workspace = match Workspace::load(ui.settings(), wc_path) {
+        let workspace = match Workspace::load(ui.settings(), &wc_path) {
             Ok(workspace) => workspace,
             Err(WorkspaceLoadError::NoWorkspaceHere(wc_path)) => {
                 let mut message = format!("There is no jj repo in \"{}\"", wc_path_str);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1122,7 +1122,7 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
                 .join(relative_path);
         }
         let (workspace, repo) =
-            Workspace::init_external_git(ui.settings(), wc_path.clone(), git_store_path)?;
+            Workspace::init_external_git(ui.settings(), &wc_path, &git_store_path)?;
         let git_repo = repo.store().git_repo().unwrap();
         let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;
         if workspace_command.working_copy_shared_with_git() {
@@ -1143,9 +1143,9 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
             }
         }
     } else if args.git {
-        Workspace::init_internal_git(ui.settings(), wc_path.clone())?;
+        Workspace::init_internal_git(ui.settings(), &wc_path)?;
     } else {
-        Workspace::init_local(ui.settings(), wc_path.clone())?;
+        Workspace::init_local(ui.settings(), &wc_path)?;
     };
     let cwd = ui.cwd().canonicalize().unwrap();
     let relative_wc_path = ui::relative_path(&cwd, &wc_path);
@@ -3883,7 +3883,7 @@ fn cmd_workspace_add(
     }
     let (new_workspace, repo) = Workspace::init_workspace_with_existing_repo(
         ui.settings(),
-        destination_path.clone(),
+        &destination_path,
         repo,
         workspace_id,
     )?;
@@ -4194,7 +4194,7 @@ fn do_git_clone(
     source: &str,
     wc_path: &Path,
 ) -> Result<(WorkspaceCommandHelper, Option<String>), CommandError> {
-    let (workspace, repo) = Workspace::init_internal_git(ui.settings(), wc_path.to_path_buf())?;
+    let (workspace, repo) = Workspace::init_internal_git(ui.settings(), wc_path)?;
     let git_repo = get_git_repo(repo.store())?;
     writeln!(ui, r#"Fetching into new repo in "{}""#, wc_path.display())?;
     let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;


### PR DESCRIPTION
We're going to want to use a custom commit backend at Google (to read and write commits to the cloud). This series makes that easier to do.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
