### PR TITLE
aliases: when invalid command found, let `clap` handle it

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1224,10 +1224,8 @@ fn resolve_aliases(
                         }
                     }
                     Err(config::ConfigError::NotFound(_)) => {
-                        let mut app = app.clone();
-                        app.error(clap::ErrorKind::ArgumentNotFound, format!(
-                            r#"Found argument '{alias_name}' which wasn't expected, or isn't valid in this context"#
-                        )).exit();
+                        // Not a real command and not an alias, so return what we've resolved so far
+                        return Ok(string_args);
                     }
                     Err(err) => {
                         return Err(CommandError::from(err));


### PR DESCRIPTION
When we resolve aliases and we try to resolve something that is not a real command and not an alias, we currently replicate `clap`'s error message. I don't know why I did that because it seems that we should just stop resolving aliases and let `clap` try to parse what we have resolved at that point. This patch makes that change, thereby removing an additional call to `process::exit()`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
