### PR TITLE
Change `pkgconfig` to `pkg-config`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             , lib
             , fetchFromGitHub
             , rustPlatform
-            , pkgconfig
+            , pkg-config
             , openssl
             , dbus
             , sqlite
@@ -45,7 +45,7 @@
                 lockFile = "${self}/Cargo.lock";
               };
               nativeBuildInputs = [
-                pkgconfig gzip makeWrapper
+                pkg-config gzip makeWrapper
                 installShellFiles
               ];
               buildInputs = [ openssl dbus sqlite ]


### PR DESCRIPTION
I there! I bumped into this while updating my home setup (a flake-based home manager following `main` on nixpkgs and jj). I though it might be useful :)

----

`pkgconfig` has been a alias to `pkg-config` since 2021-01-18, and has started being an error since 2022-09-24.

This commit makes recent nixpkgs versions work, but might make version older than January 2021 break (which is probably not an issue).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
