### PR TITLE
add default log revset configuration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * (#250) `jj log` now defaults to showing only commits that are not on any
   remote branches (plus their closest commit on the remote branch for context).
+  This set of commits can be overridden by setting `ui.default-revset`.
   Use `jj log -r 'all()'` for the old behavior. Read more about revsets
   [here](https://github.com/martinvonz/jj/blob/main/docs/revsets.md).
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -79,6 +79,12 @@ impl UserSettings {
             .unwrap_or_else(|_| "push-".to_string())
     }
 
+    pub fn default_revset(&self) -> String {
+        self.config
+            .get_string("ui.default-revset")
+            .unwrap_or_else(|_| "remote_branches().. | (remote_branches()..)-".to_string())
+    }
+
     pub fn signature(&self) -> Signature {
         let timestamp = self.timestamp.clone().unwrap_or_else(Timestamp::now);
         Signature {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -262,13 +262,10 @@ struct StatusArgs {}
 /// Show commit history
 #[derive(clap::Args, Clone, Debug)]
 struct LogArgs {
-    /// Which revisions to show
-    #[arg(
-        long,
-        short,
-        default_value = "remote_branches().. | (remote_branches()..)-"
-    )]
-    revisions: String,
+    /// Which revisions to show. Defaults to the `ui.default-revset` setting,
+    /// or "remote_branches().. | (remote_branches()..)-" if it is not set.
+    #[arg(long, short)]
+    revisions: Option<String>,
     /// Show commits modifying the given paths
     #[arg(value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
@@ -2082,7 +2079,8 @@ fn log_template(settings: &UserSettings) -> String {
 fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
 
-    let revset_expression = revset::parse(&args.revisions)?;
+    let default_revset = ui.settings().default_revset();
+    let revset_expression = revset::parse(args.revisions.as_ref().unwrap_or(&default_revset))?;
     let repo = workspace_command.repo();
     let workspace_id = workspace_command.workspace_id();
     let checkout_id = repo.view().get_wc_commit_id(&workspace_id);

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -198,3 +198,30 @@ fn test_log_filtered_by_path() {
     A file2
     "###);
 }
+
+#[test]
+fn test_default_revset() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "add a file"]);
+
+    // Set configuration to only show the root commit.
+    test_env.add_config(
+        br#"[ui]
+        default-revset = "root"
+        "#,
+    );
+
+    // Log should only contain one line (for the root commit), and not show the
+    // commit created above.
+    assert_eq!(
+        1,
+        test_env
+            .jj_cmd_success(&repo_path, &["log", "-T", "commit_id"])
+            .lines()
+            .count()
+    );
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

Following the Discord discussion re: short hashes, this PR adds a "default revset" setting to be used
by `jj log` if a revset is not specified.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
