### PR TITLE
cli: always call locked_wc.finish() after snapshotting working copy   

### DIFF
--- a/lib/src/tree_builder.rs
+++ b/lib/src/tree_builder.rs
@@ -48,6 +48,10 @@ impl TreeBuilder {
         self.store.as_ref()
     }
 
+    pub fn has_overrides(&self) -> bool {
+        !self.overrides.is_empty()
+    }
+
     pub fn set(&mut self, path: RepoPath, value: TreeValue) {
         self.overrides.insert(path, Override::Replace(value));
     }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1207,8 +1207,10 @@ impl LockedWorkingCopy<'_> {
         if self.tree_state_dirty {
             self.wc.tree_state_mut().save();
         }
-        self.wc.operation_id.replace(Some(operation_id));
-        self.wc.save();
+        if self.old_operation_id != operation_id {
+            self.wc.operation_id.replace(Some(operation_id));
+            self.wc.save();
+        }
         // TODO: Clear the "pending_checkout" file here.
         self.tree_state_dirty = false;
         self.closed = true;

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -588,7 +588,6 @@ impl WorkspaceCommandHelper {
         // divergence.
         let wc_commit = repo.store().get_commit(&wc_commit_id)?;
         let wc_tree_id = locked_wc.old_tree_id().clone();
-        let mut wc_was_stale = false;
         if *wc_commit.tree_id() != wc_tree_id {
             let wc_operation_data = self
                 .repo
@@ -630,7 +629,6 @@ impl WorkspaceCommandHelper {
                             err
                         ))
                     })?;
-                    wc_was_stale = true;
                 } else {
                     return Err(CommandError::InternalError(format!(
                         "The repo was loaded at operation {}, which seems to be a sibling of the \
@@ -668,12 +666,8 @@ impl WorkspaceCommandHelper {
             }
 
             self.repo = tx.commit();
-            locked_wc.finish(self.repo.op_id().clone());
-        } else if wc_was_stale {
-            locked_wc.finish(self.repo.op_id().clone());
-        } else {
-            locked_wc.discard();
         }
+        locked_wc.finish(self.repo.op_id().clone());
         Ok(())
     }
 

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1030,7 +1030,6 @@ fn update_working_copy(
         Some(stats)
     } else {
         // Record new operation id which represents the latest working-copy state
-        // TODO: no need to rewrite the tree_state file
         let locked_wc = wc.start_mutation();
         locked_wc.finish(repo.op_id().clone());
         None

--- a/src/diff_edit.rs
+++ b/src/diff_edit.rs
@@ -177,7 +177,8 @@ pub fn edit_diff(
         std::fs::remove_file(instructions_path).ok();
     }
 
-    Ok(right_tree_state.snapshot(base_ignores)?)
+    right_tree_state.snapshot(base_ignores)?;
+    Ok(right_tree_state.current_tree_id().clone())
 }
 
 /// Merge/diff tool loaded from the settings.


### PR DESCRIPTION
Otherwise mtime information could be lost, and snapshot() would always
need to build a tree object.
  
Closes #554

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
