### PR TITLE
working_copy: use OnceCell for lazy instantiation of TreeState, return fields by ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,7 @@ dependencies = [
  "itertools",
  "maplit",
  "num_cpus",
+ "once_cell",
  "pest",
  "pest_derive",
  "protobuf",
@@ -920,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,6 +28,7 @@ git2 = "0.15.0"
 hex = "0.4.3"
 itertools = "0.10.5"
 maplit = "1.0.2"
+once_cell = "1.15.0"
 pest = "2.3.1"
 pest_derive = "2.3.1"
 protobuf = { version = "3.0.1", features = ["with-bytes"] }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1071,16 +1071,16 @@ impl WorkingCopy {
         self.tree_state.get_mut().unwrap()
     }
 
-    pub fn current_tree_id(&self) -> TreeId {
-        self.tree_state().current_tree_id().clone()
+    pub fn current_tree_id(&self) -> &TreeId {
+        self.tree_state().current_tree_id()
     }
 
-    pub fn file_states(&self) -> BTreeMap<RepoPath, FileState> {
-        self.tree_state().file_states().clone()
+    pub fn file_states(&self) -> &BTreeMap<RepoPath, FileState> {
+        self.tree_state().file_states()
     }
 
-    pub fn sparse_patterns(&self) -> Vec<RepoPath> {
-        self.tree_state().sparse_patterns().clone()
+    pub fn sparse_patterns(&self) -> &[RepoPath] {
+        self.tree_state().sparse_patterns()
     }
 
     fn save(&mut self) {
@@ -1100,7 +1100,7 @@ impl WorkingCopy {
         // has changed.
         self.tree_state.take();
         let old_operation_id = self.operation_id();
-        let old_tree_id = self.current_tree_id();
+        let old_tree_id = self.current_tree_id().clone();
 
         LockedWorkingCopy {
             wc: self,
@@ -1180,7 +1180,7 @@ impl LockedWorkingCopy<'_> {
         Ok(())
     }
 
-    pub fn sparse_patterns(&self) -> Vec<RepoPath> {
+    pub fn sparse_patterns(&self) -> &[RepoPath] {
         self.wc.sparse_patterns()
     }
 
@@ -1199,7 +1199,7 @@ impl LockedWorkingCopy<'_> {
     }
 
     pub fn finish(mut self, operation_id: OperationId) {
-        assert!(self.tree_state_dirty || self.old_tree_id == self.wc.current_tree_id());
+        assert!(self.tree_state_dirty || &self.old_tree_id == self.wc.current_tree_id());
         if self.tree_state_dirty {
             self.wc.tree_state_mut().save();
         }

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -74,7 +74,7 @@ fn test_concurrent_checkout(use_git: bool) {
     // Check that the tree2 is still checked out on disk.
     let workspace3 =
         Workspace::load(&settings, &workspace1_root, &BackendFactories::default()).unwrap();
-    assert_eq!(workspace3.working_copy().current_tree_id(), tree_id2);
+    assert_eq!(workspace3.working_copy().current_tree_id(), &tree_id2);
 }
 
 #[test_case(false ; "local backend")]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3969,7 +3969,7 @@ fn cmd_sparse(ui: &mut Ui, command: &CommandHelper, args: &SparseArgs) -> Result
     if args.list {
         let workspace_command = command.workspace_helper(ui)?;
         for path in workspace_command.working_copy().sparse_patterns() {
-            let ui_path = workspace_command.format_file_path(&path);
+            let ui_path = workspace_command.format_file_path(path);
             writeln!(ui, "{}", ui_path)?;
         }
     } else {
@@ -3982,7 +3982,7 @@ fn cmd_sparse(ui: &mut Ui, command: &CommandHelper, args: &SparseArgs) -> Result
             new_patterns.insert(RepoPath::root());
         } else {
             if !args.clear {
-                new_patterns.extend(locked_wc.sparse_patterns());
+                new_patterns.extend(locked_wc.sparse_patterns().iter().cloned());
                 let paths_to_remove = repo_paths_from_values(ui, &workspace_root, &args.remove)?;
                 for path in paths_to_remove {
                     new_patterns.remove(&path);


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
