### PR TITLE
working_copy: use OnceCell to manage {operation_id, workspace_id}

### DIFF
--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1050,12 +1050,12 @@ impl WorkingCopy {
         self.checkout_state.get_mut().unwrap()
     }
 
-    pub fn operation_id(&self) -> OperationId {
-        self.checkout_state().operation_id.clone()
+    pub fn operation_id(&self) -> &OperationId {
+        &self.checkout_state().operation_id
     }
 
-    pub fn workspace_id(&self) -> WorkspaceId {
-        self.checkout_state().workspace_id.clone()
+    pub fn workspace_id(&self) -> &WorkspaceId {
+        &self.checkout_state().workspace_id
     }
 
     fn tree_state(&self) -> &TreeState {
@@ -1101,7 +1101,7 @@ impl WorkingCopy {
         // TODO: It's expensive to reload the whole tree. We should first check if it
         // has changed.
         self.tree_state.take();
-        let old_operation_id = self.operation_id();
+        let old_operation_id = self.operation_id().clone();
         let old_tree_id = self.current_tree_id().clone();
 
         LockedWorkingCopy {

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1214,7 +1214,6 @@ impl LockedWorkingCopy<'_> {
 
     pub fn discard(mut self) {
         // Undo the changes in memory
-        self.wc.load_proto();
         self.wc.tree_state.take();
         self.tree_state_dirty = false;
         self.closed = true;

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -207,7 +207,7 @@ impl Workspace {
         &self.workspace_root
     }
 
-    pub fn workspace_id(&self) -> WorkspaceId {
+    pub fn workspace_id(&self) -> &WorkspaceId {
         self.working_copy.workspace_id()
     }
 

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -73,7 +73,7 @@ fn test_init_additional_workspace(use_git: bool) {
         wc_commit.parent_ids(),
         vec![repo.store().root_commit_id().clone()]
     );
-    assert_eq!(ws2.workspace_id(), ws2_id);
+    assert_eq!(ws2.workspace_id(), &ws2_id);
     assert_eq!(
         *ws2.repo_path(),
         workspace.repo_path().canonicalize().unwrap()
@@ -82,7 +82,7 @@ fn test_init_additional_workspace(use_git: bool) {
     let same_workspace = Workspace::load(&settings, &ws2_root, &BackendFactories::default());
     assert!(same_workspace.is_ok());
     let same_workspace = same_workspace.unwrap();
-    assert_eq!(same_workspace.workspace_id(), ws2_id);
+    assert_eq!(same_workspace.workspace_id(), &ws2_id);
     assert_eq!(
         *same_workspace.repo_path(),
         workspace.repo_path().canonicalize().unwrap()

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -364,7 +364,7 @@ impl WorkspaceCommandHelper {
             // If the Git HEAD has changed, abandon our old checkout and check out the new
             // Git HEAD.
             if new_git_head != old_git_head && new_git_head.is_some() {
-                let workspace_id = self.workspace.workspace_id();
+                let workspace_id = self.workspace_id();
                 let mut locked_working_copy = self.workspace.working_copy_mut().start_mutation();
                 if let Some(old_wc_commit_id) = self.repo.view().get_wc_commit_id(&workspace_id) {
                     tx.mut_repo()
@@ -470,7 +470,7 @@ impl WorkspaceCommandHelper {
     }
 
     pub fn workspace_id(&self) -> WorkspaceId {
-        self.workspace.workspace_id()
+        self.workspace.workspace_id().clone()
     }
 
     pub fn working_copy_shared_with_git(&self) -> bool {


### PR DESCRIPTION
For consistency with the tree_state handling. This isn't that simple and
concise compared to the tree_state one, so I'm fine to drop the series.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
