### PR TITLE
Reduce dependencies a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,12 +90,6 @@ dependencies = [
  "instant",
  "rand",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -305,16 +288,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f1667b8320afa80d69d8bbe40830df2c8a06003d86f73d8e003b2c48df416d"
 dependencies = [
  "async-trait",
- "json5",
  "lazy_static",
  "nom",
  "pathdiff",
- "ron",
- "rust-ini",
  "serde",
- "serde_json",
  "toml",
- "yaml-rust",
 ]
 
 [[package]]
@@ -483,12 +461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,9 +553,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "heck"
@@ -694,17 +663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -958,16 +916,6 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list",
- "hashbrown",
 ]
 
 [[package]]
@@ -1307,27 +1255,6 @@ name = "roff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
-
-[[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64",
- "bitflags",
- "serde",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { version = "0.4.22", default-features = false, features = ["std", "clo
 clap = { version = "4.0.8", features = ["derive", "deprecated"] }
 clap_complete = "4.0.2"
 clap_mangen = "0.2.2"
-config = { version = "0.13.2", features = ["toml"] }
+config = { version = "0.13.2", default-features = false, features = ["toml"] }
 criterion = "0.4.0"
 dirs = "4.0.0"
 git2 = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ clap = { version = "4.0.8", features = ["derive", "deprecated"] }
 clap_complete = "4.0.2"
 clap_mangen = "0.2.2"
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
-criterion = "0.4.0"
 dirs = "4.0.0"
 git2 = "0.15.0"
 hex = "0.4.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ blake2 = "0.10.4"
 bytes = "1.2.1"
 byteorder = "1.4.3"
 chrono = { version = "0.4.22", default-features = false, features = ["std", "clock"] }
-config = { version = "0.13.2", features = ["toml"] }
+config = { version = "0.13.2", default-features = false, features = ["toml"] }
 git2 = "0.15.0"
 hex = "0.4.3"
 itertools = "0.10.5"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,12 +19,10 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
 use std::{fs, io};
 
 use chrono::{FixedOffset, TimeZone, Utc};
 use clap::{ArgGroup, ArgMatches, CommandFactory, FromArgMatches, Subcommand};
-use criterion::Criterion;
 use itertools::Itertools;
 use jujutsu_lib::backend::{BackendError, CommitId, Timestamp, TreeValue};
 use jujutsu_lib::commit::Commit;
@@ -33,7 +31,7 @@ use jujutsu_lib::dag_walk::topo_order_reverse;
 use jujutsu_lib::diff::{Diff, DiffHunk};
 use jujutsu_lib::files::DiffLine;
 use jujutsu_lib::git::{GitFetchError, GitRefUpdate};
-use jujutsu_lib::index::{HexPrefix, IndexEntry};
+use jujutsu_lib::index::IndexEntry;
 use jujutsu_lib::matchers::{EverythingMatcher, Matcher};
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::operation::Operation;
@@ -116,8 +114,6 @@ enum Commands {
     Sparse(SparseArgs),
     #[command(subcommand)]
     Git(GitCommands),
-    #[command(subcommand)]
-    Bench(BenchCommands),
     #[command(subcommand)]
     Debug(DebugCommands),
 }
@@ -920,47 +916,6 @@ struct GitImportArgs {}
 /// Update the underlying Git repo with changes made in the repo
 #[derive(clap::Args, Clone, Debug)]
 struct GitExportArgs {}
-
-/// Commands for benchmarking internal operations
-#[derive(Subcommand, Clone, Debug)]
-enum BenchCommands {
-    #[command(name = "commonancestors")]
-    CommonAncestors(BenchCommonAncestorsArgs),
-    #[command(name = "isancestor")]
-    IsAncestor(BenchIsAncestorArgs),
-    #[command(name = "walkrevs")]
-    WalkRevs(BenchWalkRevsArgs),
-    #[command(name = "resolveprefix")]
-    ResolvePrefix(BenchResolvePrefixArgs),
-}
-
-/// Find the common ancestor(s) of a set of commits
-#[derive(clap::Args, Clone, Debug)]
-struct BenchCommonAncestorsArgs {
-    revision1: String,
-    revision2: String,
-}
-
-/// Checks if the first commit is an ancestor of the second commit
-#[derive(clap::Args, Clone, Debug)]
-struct BenchIsAncestorArgs {
-    ancestor: String,
-    descendant: String,
-}
-
-/// Walk revisions that are ancestors of the second argument but not ancestors
-/// of the first
-#[derive(clap::Args, Clone, Debug)]
-struct BenchWalkRevsArgs {
-    unwanted: String,
-    wanted: String,
-}
-
-/// Resolve a commit ID prefix
-#[derive(clap::Args, Clone, Debug)]
-struct BenchResolvePrefixArgs {
-    prefix: String,
-}
 
 /// Low-level commands not intended for users
 #[derive(Subcommand, Clone, Debug)]
@@ -3586,100 +3541,6 @@ fn cmd_debug(
     Ok(())
 }
 
-fn run_bench<R, O>(ui: &mut Ui, id: &str, mut routine: R) -> io::Result<()>
-where
-    R: (FnMut() -> O) + Copy,
-    O: Debug,
-{
-    let mut criterion = Criterion::default();
-    let before = Instant::now();
-    let result = routine();
-    let after = Instant::now();
-    writeln!(
-        ui,
-        "First run took {:?} and produced: {:?}",
-        after.duration_since(before),
-        result
-    )?;
-    criterion.bench_function(id, |bencher: &mut criterion::Bencher| {
-        bencher.iter(routine);
-    });
-    Ok(())
-}
-
-fn cmd_bench(
-    ui: &mut Ui,
-    command: &CommandHelper,
-    subcommand: &BenchCommands,
-) -> Result<(), CommandError> {
-    match subcommand {
-        BenchCommands::CommonAncestors(command_matches) => {
-            let workspace_command = command.workspace_helper(ui)?;
-            let commit1 = workspace_command.resolve_single_rev(&command_matches.revision1)?;
-            let commit2 = workspace_command.resolve_single_rev(&command_matches.revision2)?;
-            let index = workspace_command.repo().index();
-            let routine =
-                || index.common_ancestors(&[commit1.id().clone()], &[commit2.id().clone()]);
-            run_bench(
-                ui,
-                &format!(
-                    "commonancestors-{}-{}",
-                    &command_matches.revision1, &command_matches.revision2
-                ),
-                routine,
-            )?;
-        }
-        BenchCommands::IsAncestor(command_matches) => {
-            let workspace_command = command.workspace_helper(ui)?;
-            let ancestor_commit =
-                workspace_command.resolve_single_rev(&command_matches.ancestor)?;
-            let descendant_commit =
-                workspace_command.resolve_single_rev(&command_matches.descendant)?;
-            let index = workspace_command.repo().index();
-            let routine = || index.is_ancestor(ancestor_commit.id(), descendant_commit.id());
-            run_bench(
-                ui,
-                &format!(
-                    "isancestor-{}-{}",
-                    &command_matches.ancestor, &command_matches.descendant
-                ),
-                routine,
-            )?;
-        }
-        BenchCommands::WalkRevs(command_matches) => {
-            let workspace_command = command.workspace_helper(ui)?;
-            let unwanted_commit =
-                workspace_command.resolve_single_rev(&command_matches.unwanted)?;
-            let wanted_commit = workspace_command.resolve_single_rev(&command_matches.wanted)?;
-            let index = workspace_command.repo().index();
-            let routine = || {
-                index
-                    .walk_revs(
-                        &[wanted_commit.id().clone()],
-                        &[unwanted_commit.id().clone()],
-                    )
-                    .count()
-            };
-            run_bench(
-                ui,
-                &format!(
-                    "walkrevs-{}-{}",
-                    &command_matches.unwanted, &command_matches.wanted
-                ),
-                routine,
-            )?;
-        }
-        BenchCommands::ResolvePrefix(command_matches) => {
-            let workspace_command = command.workspace_helper(ui)?;
-            let prefix = HexPrefix::new(command_matches.prefix.clone()).unwrap();
-            let index = workspace_command.repo().index();
-            let routine = || index.resolve_prefix(&prefix);
-            run_bench(ui, &format!("resolveprefix-{}", prefix.hex()), routine)?;
-        }
-    }
-    Ok(())
-}
-
 fn format_timestamp(timestamp: &Timestamp) -> String {
     let utc = Utc
         .timestamp(
@@ -4567,7 +4428,6 @@ pub fn run_command(
         Commands::Workspace(sub_args) => cmd_workspace(ui, command_helper, sub_args),
         Commands::Sparse(sub_args) => cmd_sparse(ui, command_helper, sub_args),
         Commands::Git(sub_args) => cmd_git(ui, command_helper, sub_args),
-        Commands::Bench(sub_args) => cmd_bench(ui, command_helper, sub_args),
         Commands::Debug(sub_args) => cmd_debug(ui, command_helper, sub_args),
     }
 }


### PR DESCRIPTION
I had intended for the `features = ["toml"]` to enable *only* the `toml` feature, but I forgot to disable the default features so it had no effect. This shrinks the binary from 17.4 MiB to 16.8 MiB.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
