### PR TITLE
revset: fix parsing of concatenated-identifier in expression

### DIFF
--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -14,9 +14,9 @@
 
 identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "@" | "/")+ }
 identifier = @{
-  (identifier_part+ ~ ("." | "-" | "+" ))+ ~ identifier_part+
-  | identifier_part+
-} 
+  identifier_part ~ ("." | "-" | "+" ) ~ identifier
+  | identifier_part
+}
 symbol = {
   identifier
   | literal_string

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1516,6 +1516,10 @@ mod tests {
             parse("foo.bar-v1+7"),
             Ok(RevsetExpression::symbol("foo.bar-v1+7".to_string()))
         );
+        assert_eq!(
+            parse("foo.bar-v1+7-"),
+            Ok(RevsetExpression::symbol("foo.bar-v1+7".to_string()).parents())
+        );
         // '.' is not allowed at the beginning or end
         assert_matches!(parse(".foo"), Err(RevsetParseError::SyntaxError(_)));
         assert_matches!(parse("foo."), Err(RevsetParseError::SyntaxError(_)));


### PR DESCRIPTION
Previously an expression 'foo-bar-' failed to parse because

 1. try first rule: 'foo-bar-' matches (identifier_part+ ~ '-')+, but the trailing '' doesn't match identifier_part+
 2. fall back to second rule: 'foo' matches identifier_part+ => (identifier 'foo')

Instead, we need to consume as much (identifier_part ~ '-' ~ ...) as possible before falling back to the identifier_part rule.

I think the trailing + of identifier_part+ is redundant, so removed it as well.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
