### PR TITLE
cli: store bare output streams in ui, create formatter per request

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1275,8 +1275,7 @@ pub fn parse_args(
     let matches = app.clone().get_matches_from(&string_args);
     let args: Args = Args::from_arg_matches(&matches).unwrap();
     if let Some(choice) = args.global_args.color {
-        // Here we assume ui was created for_terminal().
-        ui.reset_color_for_terminal(choice);
+        ui.reset_color(choice);
     }
     let command_helper = CommandHelper::new(app, string_args, args.global_args);
     Ok((command_helper, matches))

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2113,8 +2113,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
             let commit = store.get_commit(&commit_id)?;
             let is_checkout = Some(&commit_id) == checkout_id;
             {
-                let writer = Box::new(&mut buffer);
-                let mut formatter = ui.new_formatter(writer);
+                let mut formatter = ui.new_formatter(&mut buffer);
                 if is_checkout {
                     formatter.add_label("working_copy")?;
                 }
@@ -2127,8 +2126,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
                 buffer.push(b'\n');
             }
             if let Some(diff_format) = diff_format {
-                let writer = Box::new(&mut buffer);
-                let mut formatter = ui.new_formatter(writer);
+                let mut formatter = ui.new_formatter(&mut buffer);
                 show_patch(
                     formatter.as_mut(),
                     &workspace_command,
@@ -2224,16 +2222,14 @@ fn cmd_obslog(ui: &mut Ui, command: &CommandHelper, args: &ObslogArgs) -> Result
             }
             let mut buffer = vec![];
             {
-                let writer = Box::new(&mut buffer);
-                let mut formatter = ui.new_formatter(writer);
+                let mut formatter = ui.new_formatter(&mut buffer);
                 template.format(&commit, formatter.as_mut())?;
             }
             if !buffer.ends_with(b"\n") {
                 buffer.push(b'\n');
             }
             if let Some(diff_format) = diff_format {
-                let writer = Box::new(&mut buffer);
-                let mut formatter = ui.new_formatter(writer);
+                let mut formatter = ui.new_formatter(&mut buffer);
                 show_predecessor_patch(
                     formatter.as_mut(),
                     &workspace_command,
@@ -3653,8 +3649,7 @@ fn cmd_op_log(
         let is_head_op = op.id() == &head_op_id;
         let mut buffer = vec![];
         {
-            let writer = Box::new(&mut buffer);
-            let mut formatter = ui.new_formatter(writer);
+            let mut formatter = ui.new_formatter(&mut buffer);
             formatter.add_label("op-log")?;
             if is_head_op {
                 formatter.add_label("head")?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -140,11 +140,11 @@ impl<'stdout> Ui<'stdout> {
     }
 
     pub fn write(&mut self, text: &str) -> io::Result<()> {
-        self.stdout_formatter().write_str(text)
+        self.stdout.get_mut().unwrap().write_all(text.as_bytes())
     }
 
     pub fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
-        self.stdout_formatter().write_fmt(fmt)
+        self.stdout.get_mut().unwrap().write_fmt(fmt)
     }
 
     pub fn write_hint(&mut self, text: impl AsRef<str>) -> io::Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -129,9 +129,9 @@ impl<'stdout> Ui<'stdout> {
         &self.settings
     }
 
-    pub fn new_formatter<'output>(
+    pub fn new_formatter<'output, W: Write + 'output>(
         &self,
-        output: Box<dyn Write + 'output>,
+        output: W,
     ) -> Box<dyn Formatter + 'output> {
         self.formatter_factory.new_formatter(output)
     }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
