### PR TITLE
cli: disallow initializing repo with native backend by default

### DIFF
--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -100,6 +100,12 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
+    pub fn allow_native_backend(&self) -> bool {
+        self.config
+            .get_bool("ui.allow-init-native")
+            .unwrap_or(false)
+    }
+
     pub fn config(&self) -> &config::Config {
         &self.config
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1097,6 +1097,13 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
     } else if args.git {
         Workspace::init_internal_git(ui.settings(), &wc_path)?;
     } else {
+        if !ui.settings().allow_native_backend() {
+            return Err(CommandError::UserError(
+                "The native backend is disallowed by default. Did you mean to pass `--git`?
+Set `ui.allow-init-native` to allow initializing a repo with the native backend."
+                    .to_string(),
+            ));
+        }
         Workspace::init_local(ui.settings(), &wc_path)?;
     };
     let cwd = ui.cwd().canonicalize().unwrap();

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -144,8 +144,23 @@ fn test_init_git_colocated() {
 }
 
 #[test]
+fn test_init_local_disallowed() {
+    let test_env = TestEnvironment::default();
+    let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Error: The native backend is disallowed by default. Did you mean to pass `--git`?
+    Set `ui.allow-init-native` to allow initializing a repo with the native backend.
+    "###);
+}
+
+#[test]
 fn test_init_local() {
     let test_env = TestEnvironment::default();
+    test_env.add_config(
+        br#"[ui]
+    allow-init-native = true
+    "#,
+    );
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["init", "repo"]);
     insta::assert_snapshot!(stdout, @r###"
     Initialized repo in "repo"

--- a/tests/test_untrack_command.rs
+++ b/tests/test_untrack_command.rs
@@ -21,6 +21,11 @@ pub mod common;
 #[test]
 fn test_untrack() {
     let test_env = TestEnvironment::default();
+    test_env.add_config(
+        br#"[ui]
+    allow-init-native = true
+    "#,
+    );
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
@@ -88,6 +93,11 @@ fn test_untrack() {
 #[test]
 fn test_untrack_sparse() {
     let test_env = TestEnvironment::default();
+    test_env.add_config(
+        br#"[ui]
+    allow-init-native = true
+    "#,
+    );
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 


### PR DESCRIPTION
The native backend is just a proof of concept and there's no real reason to use it other than for testing, so let's reduce the risk of accidentally creating repos using it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
