### PR TITLE
cli: remind the user to configure their name and email

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -797,6 +797,14 @@ impl WorkspaceCommandHelper {
             let git_repo = self.repo.store().git_repo().unwrap();
             git::export_refs(&self.repo, &git_repo)?;
         }
+        let settings = ui.settings();
+        if settings.user_name() == UserSettings::user_name_placeholder()
+            || settings.user_email() == UserSettings::user_email_placeholder()
+        {
+            ui.write_warn(r#"Name and email not configured. Add something like the following to $HOME/.jjconfig.toml:
+  user.name = "Some One"
+  user.email = "someone@example.com""#)?;
+        }
         Ok(())
     }
 }

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -145,6 +145,35 @@ fn test_invalid_config() {
 }
 
 #[test]
+fn test_no_user_configured() {
+    // Test that the user is reminded if they haven't configured their name or email
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let assert = test_env
+        .jj_cmd(&repo_path, &["describe", "-m", "without name"])
+        .env_remove("JJ_USER")
+        .assert()
+        .success();
+    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    Name and email not configured. Add something like the following to $HOME/.jjconfig.toml:
+      user.name = "Some One"
+      user.email = "someone@example.com"
+    "###);
+    let assert = test_env
+        .jj_cmd(&repo_path, &["describe", "-m", "without email"])
+        .env_remove("JJ_EMAIL")
+        .assert()
+        .success();
+    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    Name and email not configured. Add something like the following to $HOME/.jjconfig.toml:
+      user.name = "Some One"
+      user.email = "someone@example.com"
+    "###);
+}
+
+#[test]
 fn test_help() {
     // Test that global options are separated out in the help output
     let test_env = TestEnvironment::default();


### PR DESCRIPTION
This commit adds a reminder in `finish_transaction()` if the user hasn't configured their name and email. That means they'll get a reminder after most mutating commits, except for commands that only snapshot the working copy, and a few more cases.

Closes #530.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
