### PR TITLE
formatter: add a `with_label()` helper

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -40,6 +40,19 @@ pub trait Formatter: Write {
     fn remove_label(&mut self) -> io::Result<()>;
 }
 
+impl dyn Formatter + '_ {
+    pub fn with_label(
+        &mut self,
+        label: &str,
+        write_inner: impl FnOnce(&mut dyn Formatter) -> io::Result<()>,
+    ) -> io::Result<()> {
+        self.add_label(label)?;
+        // Call `remove_label()` whether or not `write_inner()` fails, but don't let
+        // its error replace the one from `write_inner()`.
+        write_inner(self).and(self.remove_label())
+    }
+}
+
 /// Creates `Formatter` instances with preconfigured parameters.
 #[derive(Clone, Debug)]
 pub struct FormatterFactory {


### PR DESCRIPTION
There's a risk of forgetting to call `remove_label()` and I've wanted to reduce that risk for a long time. I considered creating RAII adapters that implement `Drop`, but I didn't like that that would ignore errors (such as `BrokenPipe`) that can happen while emitting an escape sequence in `remove_label()`. I would ideally have liked Python's context managers here, but Rust doesn't have that. Instead, we get to use closures. That works pretty well, except that we can't return other errors than `io::Error` inside the closures. Even with that limitation, we can use the new `with_label()` method in all but a few cases.

We can't define the `with_label()` method directly in the trait because `&mut self` is not a trait object, so we can't pass it on to the closure (which expects a trait object). The solution is to use `impl dyn Formatter` (thanks to @kupiakos for figuring that out!). That unfortunately means that we can *only* call the function on trait objects, so if `f` is a concrete formatter type (e.g. `PlainTextFormatter`), then `f.with_label()` won't compile. Since we only ever access the formatters as trait objects, that's not really a problem, however.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
