### PR TITLE
Alias `-B` for `--allow-backwards` in `branch set`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -727,7 +727,7 @@ enum BranchSubcommand {
         revision: Option<String>,
 
         /// Allow moving the branch backwards or sideways.
-        #[arg(long)]
+        #[arg(long, short = 'B')]
         allow_backwards: bool,
 
         /// The branches to update.


### PR DESCRIPTION
I find myself using this argument almost every time, but it's
long to type. At the same time, fish completion does not work well
for `--allow-backwards` for some reason (though I think an alias would
be nice regardless).

