### PR TITLE
github: make release build create staging directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,17 @@ jobs:
     - name: Build archive
       shell: bash
       run: |
-        outdir="./target/${{ matrix.target }}/release"
+        outdir="target/${{ matrix.target }}/release"
         staging="jj-${{ github.event.release.tag_name }}-${{ matrix.target }}"
+        mkdir "$staging"
         cp {README.md,LICENSE} "$staging/"
         if [ "${{ matrix.os }}" = "windows-2022" ]; then
-          cp "target/${{ matrix.target }}/release/jj.exe" "$staging/"
+          cp "$outdir/jj.exe" "$staging/"
           cd "$staging"
           7z a "../$staging.zip" .
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
         else
-          cp "target/${{ matrix.target }}/release/jj" "$staging/"
+          cp "$outdir/jj" "$staging/"
           tar czf "$staging.tar.gz" -C "$staging" .
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
         fi


### PR DESCRIPTION
I think 672f9e85cb1d was correct in saying that we don't need the `$staging/complete` directory, but we do seem to need the `$staging` directory, so let's restore the code for creating that. While at it, I also cleaned up a bit so we use the `$outdir` variable instead of duplicating it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
