### PR TITLE
Simplify Ui lifetimes

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1175,7 +1175,7 @@ pub struct GlobalArgs {
     pub color: Option<ColorChoice>,
 }
 
-pub fn create_ui() -> (Ui<'static>, Result<(), CommandError>) {
+pub fn create_ui() -> (Ui, Result<(), CommandError>) {
     // TODO: We need to do some argument parsing here, at least for things like
     // --config, and for reading user configs from the repo pointed to by -R.
     match read_config() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,10 +24,10 @@ use jujutsu_lib::settings::UserSettings;
 
 use crate::formatter::{Formatter, FormatterFactory};
 
-pub struct Ui<'a> {
+pub struct Ui {
     cwd: PathBuf,
     formatter_factory: FormatterFactory,
-    output_pair: UiOutputPair<'a>,
+    output_pair: UiOutputPair,
     settings: UserSettings,
 }
 
@@ -74,14 +74,14 @@ fn use_color(choice: ColorChoice, maybe_tty: bool) -> bool {
     }
 }
 
-impl<'stdout> Ui<'stdout> {
+impl Ui {
     pub fn new(
         cwd: PathBuf,
-        stdout: Box<dyn Write + 'stdout>,
-        stderr: Box<dyn Write + 'stdout>,
+        stdout: Box<dyn Write>,
+        stderr: Box<dyn Write>,
         color: bool,
         settings: UserSettings,
-    ) -> Ui<'stdout> {
+    ) -> Ui {
         let formatter_factory = FormatterFactory::prepare(&settings, color);
         Ui {
             cwd,
@@ -94,7 +94,7 @@ impl<'stdout> Ui<'stdout> {
         }
     }
 
-    pub fn for_terminal(settings: UserSettings) -> Ui<'static> {
+    pub fn for_terminal(settings: UserSettings) -> Ui {
         let cwd = std::env::current_dir().unwrap();
         let color = use_color(color_setting(&settings), true);
         let formatter_factory = FormatterFactory::prepare(&settings, color);
@@ -227,10 +227,10 @@ impl<'stdout> Ui<'stdout> {
     }
 }
 
-enum UiOutputPair<'output> {
+enum UiOutputPair {
     Dyn {
-        stdout: Mutex<Box<dyn Write + 'output>>,
-        stderr: Mutex<Box<dyn Write + 'output>>,
+        stdout: Mutex<Box<dyn Write>>,
+        stderr: Mutex<Box<dyn Write>>,
     },
     Terminal {
         stdout: Stdout,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -283,8 +283,6 @@ pub fn relative_path(mut from: &Path, to: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use jujutsu_lib::testutils;
 
     use super::*;
@@ -294,10 +292,8 @@ mod tests {
         let temp_dir = testutils::new_temp_dir();
         let cwd_path = temp_dir.path().join("repo");
         let wc_path = cwd_path.clone();
-        let mut unused_stdout_buf = vec![];
-        let mut unused_stderr_buf = vec![];
-        let unused_stdout = Box::new(Cursor::new(&mut unused_stdout_buf));
-        let unused_stderr = Box::new(Cursor::new(&mut unused_stderr_buf));
+        let unused_stdout = Box::new(Vec::new());
+        let unused_stderr = Box::new(Vec::new());
         let ui = Ui::new(
             cwd_path,
             unused_stdout,
@@ -336,10 +332,8 @@ mod tests {
         let temp_dir = testutils::new_temp_dir();
         let cwd_path = temp_dir.path().join("dir");
         let wc_path = cwd_path.parent().unwrap().to_path_buf();
-        let mut unused_stdout_buf = vec![];
-        let mut unused_stderr_buf = vec![];
-        let unused_stdout = Box::new(Cursor::new(&mut unused_stdout_buf));
-        let unused_stderr = Box::new(Cursor::new(&mut unused_stderr_buf));
+        let unused_stdout = Box::new(Vec::new());
+        let unused_stderr = Box::new(Vec::new());
         let ui = Ui::new(
             cwd_path,
             unused_stdout,
@@ -380,10 +374,8 @@ mod tests {
         let temp_dir = testutils::new_temp_dir();
         let cwd_path = temp_dir.path().join("cwd");
         let wc_path = cwd_path.join("repo");
-        let mut unused_stdout_buf = vec![];
-        let mut unused_stderr_buf = vec![];
-        let unused_stdout = Box::new(Cursor::new(&mut unused_stdout_buf));
-        let unused_stderr = Box::new(Cursor::new(&mut unused_stderr_buf));
+        let unused_stdout = Box::new(Vec::new());
+        let unused_stderr = Box::new(Vec::new());
         let ui = Ui::new(
             cwd_path,
             unused_stdout,


### PR DESCRIPTION
The lifetime parameter didn't seem to be used anywhere except a few tests where it wasn't needed, so presuming there isn't a long-term plan that requires it, this makes the code a bit simpler.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
