### PR TITLE
Add git remote rename subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New features
+
+* The new `jj git remote rename` command allows git remotes to be renamed
+  in-place.
+
 ## [0.5.1] - 2022-10-17
 
 No changes (just trying to get automated GitHub release to work).

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -754,6 +754,10 @@ impl MutableRepo {
         self.view_mut().remove_remote_branch(name, remote_name);
     }
 
+    pub fn rename_remote(&mut self, old: &str, new: &str) {
+        self.view_mut().rename_remote(old, new);
+    }
+
     pub fn get_tag(&self, name: &str) -> Option<RefTarget> {
         self.view.borrow().get_tag(name)
     }

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -212,6 +212,14 @@ impl View {
         }
     }
 
+    pub fn rename_remote(&mut self, old: &str, new: &str) {
+        for branch in self.data.branches.values_mut() {
+            if let Some(target) = branch.remote_targets.remove(old) {
+                branch.remote_targets.insert(new.to_owned(), target);
+            }
+        }
+    }
+
     pub fn get_tag(&self, name: &str) -> Option<RefTarget> {
         self.data.tags.get(name).cloned()
     }

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -612,3 +612,19 @@ fn test_rebase_descendants_conflicting_rewrite(use_git: bool) {
         .unwrap()
         .is_none());
 }
+
+#[test_case(false ; "local backend")]
+#[test_case(true ; "git backend")]
+fn test_rename_remote(use_git: bool) {
+    let settings = testutils::user_settings();
+    let test_repo = TestRepo::init(use_git);
+    let repo = &test_repo.repo;
+    let mut tx = repo.start_transaction("test");
+    let mut_repo = tx.mut_repo();
+    let commit = testutils::create_random_commit(&settings, repo).write_to_repo(mut_repo);
+    let target = RefTarget::Normal(commit.id().clone());
+    mut_repo.set_remote_branch("main".to_string(), "origin".to_string(), target.clone());
+    mut_repo.rename_remote("origin", "upstream");
+    assert_eq!(mut_repo.get_remote_branch("main", "upstream"), Some(target));
+    assert_eq!(mut_repo.get_remote_branch("main", "origin"), None);
+}

--- a/tests/test_git_remotes.rs
+++ b/tests/test_git_remotes.rs
@@ -49,3 +49,21 @@ fn test_git_remotes() {
     insta::assert_snapshot!(stderr, @"Error: Remote doesn't exist
 ");
 }
+
+#[test]
+fn test_git_remote_rename() {
+    let test_env = TestEnvironment::default();
+
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "--git", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(
+        &repo_path,
+        &["git", "remote", "add", "foo", "http://example.com/repo/foo"],
+    );
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "foo"]);
+    insta::assert_snapshot!(stderr, @"Error: Remote doesn't exist\n");
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "rename", "foo", "bar"]);
+    insta::assert_snapshot!(stdout, @"");
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
+    insta::assert_snapshot!(stdout, @"bar http://example.com/repo/foo");
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

I regularly reach for this when, upon deciding to contribute to a project, I rename `origin` to `upstream` and add a new `origin` addressing my fork.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
