### PR TITLE
cli: search @- for branches to push when @ has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The new `jj git remote rename` command allows git remotes to be renamed
   in-place.
 
+* `jj git push` will search `@-` for branches to push if `@` has none.
+
 ## [0.5.1] - 2022-10-17
 
 No changes (just trying to get automated GitHub release to work).

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -116,6 +116,23 @@ fn test_git_push_current_branch() {
 }
 
 #[test]
+fn test_git_push_parent_branch() {
+    let (test_env, workspace_root) = set_up();
+    test_env.jj_cmd_success(&workspace_root, &["edit", "branch1"]);
+    test_env.jj_cmd_success(
+        &workspace_root,
+        &["describe", "-m", "modified branch1 commit"],
+    );
+    test_env.jj_cmd_success(&workspace_root, &["new"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--dry-run"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Branch changes to push to origin:
+      Force branch branch1 from a3ccc578ea7b to ad7201b22c46
+    Dry-run requested, not pushing.
+    "###);
+}
+
+#[test]
 fn test_git_push_no_current_branch() {
     let (test_env, workspace_root) = set_up();
     test_env.jj_cmd_success(&workspace_root, &["new"]);


### PR DESCRIPTION
I went back and forth on whether scanning `@-` should be conditional on `@` being empty. Currently leaning towards "no" since you might have made some new changes before remembering you wanted to push, and since a nonempty new commit wouldn't land on a branch anyway unless the branch was explicitly updated.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
