### PR TITLE
Add pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Commands with long output are paginated.
+
 * The new `jj git remote rename` command allows git remotes to be renamed
   in-place.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,6 +43,17 @@ This setting overrides the `NO_COLOR` environment variable (if set).
     ui.color = "never" # Turn off color
 
 
+### Paginating output
+
+The default pager is can be set via `ui.pager` or the `PAGER` environment
+variable.
+The priority is as follows (environment variables are marked with a `$`):
+
+`ui.pager` > `$PAGER`
+
+`less` is the default pager in the absence of any other setting.
+
+
 ### Editor
 
 The default editor is set via `ui.editor`,

--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -65,6 +65,7 @@ fn main() {
     let (mut ui, result) = create_ui();
     let result = result.and_then(|()| run(&mut ui));
     let exit_code = handle_command_result(&mut ui, result);
+    ui.finalize_writes();
     std::process::exit(exit_code);
 }
 

--- a/examples/custom-command/main.rs
+++ b/examples/custom-command/main.rs
@@ -63,5 +63,6 @@ fn main() {
     let (mut ui, result) = create_ui();
     let result = result.and_then(|()| run(&mut ui));
     let exit_code = handle_command_result(&mut ui, result);
+    ui.finalize_writes();
     std::process::exit(exit_code);
 }

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -137,12 +137,6 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
-    pub fn use_progress_indicator(&self) -> bool {
-        self.config
-            .get_bool("ui.progress-indicator")
-            .unwrap_or(true)
-    }
-
     pub fn relative_timestamps(&self) -> bool {
         self.config
             .get_bool("ui.relative-timestamps")

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1237,6 +1237,14 @@ pub struct GlobalArgs {
         help_heading = "Global Options"
     )]
     pub color: Option<ColorChoice>,
+    /// Disable the pager
+    #[arg(
+        long,
+        value_name = "WHEN",
+        global = true,
+        help_heading = "Global Options"
+    )]
+    pub no_pager: bool,
     /// Additional configuration options
     //  TODO: Introduce a `--config` option with simpler syntax for simple
     //  cases, designed so that `--config ui.color=auto` works
@@ -1410,6 +1418,9 @@ pub fn parse_args(
         args.global_args
             .config_toml
             .push(format!("ui.color=\"{}\"", choice.to_string()));
+    }
+    if args.global_args.no_pager {
+        ui.set_pagination(crate::ui::PaginationChoice::No);
     }
     if !args.global_args.config_toml.is_empty() {
         ui.extra_toml_settings(&args.global_args.config_toml)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1332,6 +1332,7 @@ fn show_color_words_diff_line(
 }
 
 fn cmd_diff(ui: &mut Ui, command: &CommandHelper, args: &DiffArgs) -> Result<(), CommandError> {
+    ui.request_pager();
     let workspace_command = command.workspace_helper(ui)?;
     let from_tree;
     let to_tree;
@@ -1359,6 +1360,7 @@ fn cmd_diff(ui: &mut Ui, command: &CommandHelper, args: &DiffArgs) -> Result<(),
 }
 
 fn cmd_show(ui: &mut Ui, command: &CommandHelper, args: &ShowArgs) -> Result<(), CommandError> {
+    ui.request_pager();
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let parents = commit.parents();
@@ -2031,6 +2033,7 @@ fn log_template(settings: &UserSettings) -> String {
 }
 
 fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), CommandError> {
+    ui.request_pager();
     let workspace_command = command.workspace_helper(ui)?;
 
     let default_revset = ui.settings().default_revset();
@@ -2193,6 +2196,7 @@ fn show_patch(
 }
 
 fn cmd_obslog(ui: &mut Ui, command: &CommandHelper, args: &ObslogArgs) -> Result<(), CommandError> {
+    ui.request_pager();
     let workspace_command = command.workspace_helper(ui)?;
 
     let start_commit = workspace_command.resolve_single_rev(&args.revision)?;
@@ -2288,6 +2292,7 @@ fn cmd_interdiff(
     command: &CommandHelper,
     args: &InterdiffArgs,
 ) -> Result<(), CommandError> {
+    ui.request_pager();
     let workspace_command = command.workspace_helper(ui)?;
     let from = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"))?;
     let to = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;
@@ -3604,6 +3609,7 @@ fn cmd_op_log(
     command: &CommandHelper,
     _args: &OperationLogArgs,
 ) -> Result<(), CommandError> {
+    ui.request_pager();
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
     let head_op = repo.operation().clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,9 @@ fn env_base() -> config::Config {
         // should override $NO_COLOR." https://no-color.org/
         builder = builder.set_override("ui.color", "never").unwrap();
     }
+    if let Ok(value) = env::var("PAGER") {
+        builder = builder.set_override("ui.pager", value).unwrap();
+    }
     if let Ok(value) = env::var("VISUAL") {
         builder = builder.set_override("ui.editor", value).unwrap();
     } else if let Ok(value) = env::var("EDITOR") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,5 +59,6 @@ fn main() {
     let (mut ui, result) = create_ui();
     let result = result.and_then(|()| run(&mut ui, reload_log_filter));
     let exit_code = handle_command_result(&mut ui, result);
+    ui.finalize_writes();
     std::process::exit(exit_code);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,10 +24,18 @@ use crate::formatter::{Formatter, FormatterFactory};
 
 pub struct Ui {
     color: bool,
+    progress_indicator: bool,
     cwd: PathBuf,
     formatter_factory: FormatterFactory,
     output: UiOutput,
     settings: UserSettings,
+}
+
+fn progress_indicator_setting(settings: &UserSettings) -> bool {
+    settings
+        .config()
+        .get_bool("ui.progress-indicator")
+        .unwrap_or(true)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -88,11 +96,13 @@ impl Ui {
     pub fn for_terminal(settings: UserSettings) -> Ui {
         let cwd = std::env::current_dir().unwrap();
         let color = use_color(color_setting(&settings));
+        let progress_indicator = progress_indicator_setting(&settings);
         let formatter_factory = FormatterFactory::prepare(&settings, color);
         Ui {
             color,
             cwd,
             formatter_factory,
+            progress_indicator,
             output: UiOutput::new_terminal(),
             settings,
         }
@@ -151,7 +161,7 @@ impl Ui {
     /// Whether continuous feedback should be displayed for long-running
     /// operations
     pub fn use_progress_indicator(&self) -> bool {
-        self.settings().use_progress_indicator() && io::stdout().is_tty()
+        self.progress_indicator && io::stdout().is_tty()
     }
 
     pub fn write(&mut self, text: &str) -> io::Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -25,6 +25,7 @@ use crate::formatter::{Formatter, FormatterFactory};
 
 pub struct Ui {
     color: bool,
+    paginate: PaginationChoice,
     progress_indicator: bool,
     cwd: PathBuf,
     formatter_factory: FormatterFactory,
@@ -93,6 +94,18 @@ fn use_color(choice: ColorChoice) -> bool {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PaginationChoice {
+    No,
+    Auto,
+}
+
+impl Default for PaginationChoice {
+    fn default() -> Self {
+        PaginationChoice::Auto
+    }
+}
+
 fn pager_setting(settings: &UserSettings) -> String {
     settings
         .config()
@@ -110,6 +123,7 @@ impl Ui {
             color,
             cwd,
             formatter_factory,
+            paginate: PaginationChoice::Auto,
             progress_indicator,
             output: UiOutput::new_terminal(),
             settings,
@@ -124,8 +138,17 @@ impl Ui {
         }
     }
 
+    /// Sets the pagination value.
+    pub fn set_pagination(&mut self, choice: PaginationChoice) {
+        self.paginate = choice;
+    }
+
     /// Switches the output to use the pager, if allowed.
     pub fn request_pager(&mut self) {
+        if self.paginate == PaginationChoice::No {
+            return;
+        }
+
         match self.output {
             UiOutput::Paged { .. } => {}
             UiOutput::Terminal { .. } => {

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -253,6 +253,7 @@ fn test_help() {
           --no-commit-working-copy       Don't commit the working copy
           --at-operation <AT_OPERATION>  Operation to load the repo at [default: @] [aliases: at-op]
           --color <WHEN>                 When to colorize output (always, never, auto)
+          --no-pager                     Disable the pager
           --config-toml <TOML>           Additional configuration options
       -v, --verbose                      Enable verbose logging
     "###);


### PR DESCRIPTION
Add pager support via the following config variables:

- ui.pager: the program to use as the pager. Defaults to $PAGER.
- ui.paginate: whether to paginate output. Supported values are 'auto',
  'always' and 'never'. Defaults to 'auto'.

Support for the `--pager` (or should it be called `--paginate`?) flag is WIP.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
