### PR TITLE
progress: use `clamp()` for readability

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -67,7 +67,7 @@ impl Drop for Progress<'_> {
 fn draw_progress(progress: f32, buffer: &mut String, width: usize) {
     const CHARS: [char; 9] = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
     const RESOLUTION: usize = CHARS.len() - 1;
-    let ticks = (width as f32 * progress.min(1.0).max(0.0) * RESOLUTION as f32).round() as usize;
+    let ticks = (width as f32 * progress.clamp(0.0, 1.0) * RESOLUTION as f32).round() as usize;
     let whole = ticks / RESOLUTION;
     for _ in 0..whole {
         buffer.push(CHARS[CHARS.len() - 1]);


### PR DESCRIPTION
This was actually what I meant in my code-review comment but I used the wrong word ("clip") :) I wasn't going to bother changing it, but Clippy nightly just started warning about it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
