### PR TITLE
cli: include tags as upstream commits to exclude in default log revset

### DIFF
--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -82,7 +82,9 @@ impl UserSettings {
     pub fn default_revset(&self) -> String {
         self.config
             .get_string("ui.default-revset")
-            .unwrap_or_else(|_| "@ | remote_branches().. | (remote_branches()..)-".to_string())
+            .unwrap_or_else(|_| {
+                "@ | (remote_branches() | tags()).. | ((remote_branches() | tags())..)-".to_string()
+            })
     }
 
     pub fn signature(&self) -> Signature {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -259,7 +259,8 @@ struct StatusArgs {}
 #[derive(clap::Args, Clone, Debug)]
 struct LogArgs {
     /// Which revisions to show. Defaults to the `ui.default-revset` setting,
-    /// or "@ | remote_branches().. | (remote_branches()..)-" if it is not set.
+    /// or `@ | (remote_branches() | tags()).. | ((remote_branches() |
+    /// tags())..)-` if it is not set.
     #[arg(long, short)]
     revisions: Option<String>,
     /// Show commits modifying the given paths


### PR DESCRIPTION
Sometimes a tagged commit is not in any branch on the remote, but we should still consider them upstream and not include them in the default log template.

This was reported by @colemickens but now that I think about it, I remember seeing such commits in the Git core repo (v1.4.4.5 and a few commits before it were never merged into main).

We don't have a good way of testing this because we don't have a command for creating tags.

Closes #681

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
