### PR TITLE
cli: suggest 'jj init --git-repo' if .git directory already exists

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1125,6 +1125,13 @@ Set `ui.allow-init-native` to allow initializing a repo with the native backend.
     let cwd = ui.cwd().canonicalize().unwrap();
     let relative_wc_path = file_util::relative_path(&cwd, &wc_path);
     writeln!(ui, "Initialized repo in \"{}\"", relative_wc_path.display())?;
+    if args.git && wc_path.join(".git").exists() {
+        ui.write_warn(format!(
+            "Empty repo created. To create repo backed by existing Git repo, run `jj init \
+             --git-repo={}` instead.\n",
+            relative_wc_path.display()
+        ))?;
+    }
     Ok(())
 }
 

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -14,7 +14,7 @@
 
 use std::path::PathBuf;
 
-use crate::common::TestEnvironment;
+use crate::common::{get_stderr_string, get_stdout_string, TestEnvironment};
 
 pub mod common;
 
@@ -140,6 +140,24 @@ fn test_init_git_colocated() {
     insta::assert_snapshot!(stdout, @r###"
     o 8d698d4a8ee1 d3866db7e30a git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch   HEAD@git
     ~ My commit message
+    "###);
+}
+
+#[test]
+fn test_init_git_internal_but_could_be_colocated() {
+    let test_env = TestEnvironment::default();
+    let workspace_root = test_env.env_root().join("repo");
+    init_git_repo(&workspace_root);
+
+    let assert = test_env
+        .jj_cmd(&workspace_root, &["init", "--git"])
+        .assert()
+        .success();
+    insta::assert_snapshot!(get_stdout_string(&assert), @r###"
+    Initialized repo in "."
+    "###);
+    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    Empty repo created. To create repo backed by existing Git repo, run `jj init --git-repo=.` instead.
     "###);
 }
 


### PR DESCRIPTION
I made new empty repository by mistake, and didn't notice it until I ran 'jj status'.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
