### PR TITLE
cli: print clap errors through Ui

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -147,6 +147,13 @@ impl Ui {
         }
     }
 
+    pub fn write_stderr(&mut self, text: &str) -> io::Result<()> {
+        let data = text.as_bytes();
+        match &mut self.output_pair {
+            UiOutputPair::Terminal { stderr, .. } => stderr.write_all(data),
+        }
+    }
+
     pub fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
         match &mut self.output_pair {
             UiOutputPair::Terminal { stdout, .. } => stdout.write_fmt(fmt),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,6 +23,7 @@ use jujutsu_lib::settings::UserSettings;
 use crate::formatter::{Formatter, FormatterFactory};
 
 pub struct Ui {
+    color: bool,
     cwd: PathBuf,
     formatter_factory: FormatterFactory,
     output_pair: UiOutputPair,
@@ -78,6 +79,7 @@ impl Ui {
         let color = use_color(color_setting(&settings));
         let formatter_factory = FormatterFactory::prepare(&settings, color);
         Ui {
+            color,
             cwd,
             formatter_factory,
             output_pair: UiOutputPair::Terminal {
@@ -90,10 +92,14 @@ impl Ui {
 
     /// Reconfigures the underlying outputs with the new color choice.
     pub fn reset_color(&mut self, choice: ColorChoice) {
-        let color = use_color(choice);
-        if self.formatter_factory.is_color() != color {
-            self.formatter_factory = FormatterFactory::prepare(&self.settings, color);
+        self.color = use_color(choice);
+        if self.formatter_factory.is_color() != self.color {
+            self.formatter_factory = FormatterFactory::prepare(&self.settings, self.color);
         }
+    }
+
+    pub fn color(&self) -> bool {
+        self.color
     }
 
     pub fn cwd(&self) -> &Path {


### PR DESCRIPTION
Use the try_*() methods to parse args instead of panic!-ing, and print + exit the process using a new Ui.write_clap_err_and_exit(). The exit code 129 is arbitrarily-chosen (it is what git uses for usage).

With this new abstraction, teach the clap output to respect "ui.color" (--color doesn't seem to be understood). We'll also make use of it when we route output through the pager.

The "errors" returned by try_get_matches_from() can be found at https://docs.rs/clap/latest/clap/error/enum.ErrorKind.html. I've tested:

- no args
- --help
- help subcommand
- --version
- subcommand with --help
- subcommand with bad args

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
