### PR TITLE
cli_util: avoid `exit()` in `handle_command_result()`

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1369,7 +1369,7 @@ pub fn handle_command_result(ui: &mut Ui, result: Result<(), CommandError>) -> i
                 }
             }
         }
-        Err(CommandError::BrokenPipe) => std::process::exit(3),
+        Err(CommandError::BrokenPipe) => 3,
         Err(CommandError::InternalError(message)) => {
             ui.write_error(&format!("Internal error: {}\n", message))
                 .unwrap();


### PR DESCRIPTION
We try to keep the calls to `exit()` in one place. I seem to just have missed this case in an earlier cleanup.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
