### PR TITLE
Add --config-toml command-line argument for additional TOML config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The new revset function `file(pattern..)` finds commits modifying the
   paths specified by the `pattern..`.
 
+* It is now possible to specity configuration options on the command line
+  with he new `--config-toml` global option.
+
 ### Fixed bugs
 
 * `jj edit root` now fails gracefully.

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,16 +2,20 @@
 
 These are the config settings available to jj/Jujutsu.
 
-The config settings are located at `~/.jjconfig.toml`.
+The config settings are located at `~/.jjconfig.toml`. Less common ways to specify `jj` config settings are discussed in a later section.
 
-See the [TOML site](https://toml.io/en/) for more on syntax,
-but one thing to remember is that anything under a heading can be dotted
+See the [TOML site](https://toml.io/en/) for more on syntax.
+One thing to remember is that anything under a heading can be dotted
 e.g. `user.name = "YOUR NAME"` is equivalent to:
 
     [user]
       name = "YOUR NAME"
 
-Headings only need to be set once in the real config file but Jujutsu favours the dotted style in these instructions, if only because it's easier to write down in an unconfusing way. If you are confident with TOML then use whichever suits you in your config.
+Headings only need to be set once in the real config file but Jujutsu
+favors the dotted style in these instructions, if only because it's
+easier to write down in an unconfusing way. If you are confident with
+TOML then use whichever suits you in your config. If you mix the styles,
+put the dotted keys before the first heading.
 
 The other thing to remember is that the value of a setting (the part to the 
 right of the `=` sign) should be surrounded in quotes if it's a string. 
@@ -86,3 +90,34 @@ further settings are passed on via the following:
 
     merge-tools.kdiff3.program = "kdiff3"
     merge-tools.kdiff3.edit-args = ["--merge", "--cs", "CreateBakFiles=0"]
+
+# Alternative ways to specify configuration settings
+
+Instead of `~/.jjconfig.toml`, the config settings can be located at
+`$XDG_CONFIG_HOME/jj/config.toml` as per the [XDG specification].
+It is an error for both of these files to exist.
+
+[XDG specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+The location of the `jj` config file can also be overriden with the `JJ_CONFIG`
+environment variable. If it is not empty, it should contain the path to
+a TOML file that will be used instead of any configuration file in the
+default locations. For example,
+
+    env JJ_CONFIG=/dev/null jj log       # Ignores any settings specified in the config file.
+
+You can use one or more `--config-toml` options on the command line to
+specify additional configuration settings. This overrides settings
+defined in config files or environment variables. For example,
+
+    jj --config-toml='ui.color="always"' --config-toml='ui.difftool="kdiff3"' split
+
+Config specified this way must be valid TOML. In paritcular, string
+values must be surrounded by quotes. To pass these quotes to `jj`, most
+shells require surrounding those quotes with single quotes as shown above.
+
+In `sh`-compatible shells, `--config-toml` can be used to merge entire TOML
+files with the config specified in `.jjconfig.toml`:
+
+    jj --config-toml="$(cat extra-config.toml)" log
+

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -41,6 +41,21 @@ impl UserSettings {
         UserSettings { config, timestamp }
     }
 
+    pub fn with_toml_strings(
+        &self,
+        toml_strs: &[String],
+    ) -> Result<UserSettings, config::ConfigError> {
+        let mut config_builder = config::Config::builder().add_source(self.config.clone());
+        for s in toml_strs {
+            config_builder =
+                config_builder.add_source(config::File::from_str(s, config::FileFormat::Toml));
+        }
+        Ok(UserSettings {
+            config: config_builder.build()?,
+            timestamp: self.timestamp.clone(),
+        })
+    }
+
     pub fn with_repo(&self, repo_path: &Path) -> Result<RepoSettings, config::ConfigError> {
         let config = config::Config::builder()
             .add_source(self.config.clone())

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1203,6 +1203,16 @@ pub struct GlobalArgs {
         help_heading = "Global Options"
     )]
     pub color: Option<ColorChoice>,
+    /// Additional configuration options
+    //  TODO: Introduce a `--config` option with simpler syntax for simple
+    //  cases, designed so that `--config ui.color=auto` works
+    #[arg(
+        long,
+        value_name = "TOML",
+        global = true,
+        help_heading = "Global Options"
+    )]
+    pub config_toml: Vec<String>,
 }
 
 pub fn create_ui() -> (Ui, Result<(), CommandError>) {
@@ -1323,9 +1333,14 @@ pub fn parse_args(
     let string_args = resolve_aliases(ui, &app, &string_args)?;
     let matches = app.clone().try_get_matches_from(&string_args)?;
 
-    let args: Args = Args::from_arg_matches(&matches).unwrap();
+    let mut args: Args = Args::from_arg_matches(&matches).unwrap();
     if let Some(choice) = args.global_args.color {
-        ui.reset_color(choice);
+        args.global_args
+            .config_toml
+            .push(format!("ui.color=\"{}\"", choice.to_string()));
+    }
+    if !args.global_args.config_toml.is_empty() {
+        ui.extra_toml_settings(&args.global_args.config_toml)?;
     }
     let command_helper = CommandHelper::new(app, string_args, args.global_args);
     Ok((command_helper, matches))

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -56,6 +56,17 @@ impl FromStr for ColorChoice {
     }
 }
 
+impl ToString for ColorChoice {
+    fn to_string(&self) -> String {
+        match self {
+            ColorChoice::Always => "always",
+            ColorChoice::Never => "never",
+            ColorChoice::Auto => "auto",
+        }
+        .to_string()
+    }
+}
+
 fn color_setting(settings: &UserSettings) -> ColorChoice {
     settings
         .config()
@@ -108,6 +119,12 @@ impl Ui {
 
     pub fn settings(&self) -> &UserSettings {
         &self.settings
+    }
+
+    pub fn extra_toml_settings(&mut self, toml_strs: &[String]) -> Result<(), config::ConfigError> {
+        self.settings = self.settings.with_toml_strings(toml_strs)?;
+        self.reset_color(color_setting(&self.settings));
+        Ok(())
     }
 
     pub fn new_formatter<'output, W: Write + 'output>(

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -123,6 +123,47 @@ color="always""#,
     o 0000000000000000000000000000000000000000
     "###);
 
+    // Test that --color=auto overrides the config.
+    let stdout = test_env.jj_cmd_success(&repo_path, &["--color=auto", "log", "-T", "commit_id"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    o 0000000000000000000000000000000000000000
+    "###);
+
+    // Test that --config-toml 'ui.color="never"' overrides the config.
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "--config-toml",
+            "ui.color=\"never\"",
+            "log",
+            "-T",
+            "commit_id",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    o 0000000000000000000000000000000000000000
+    "###);
+
+    // --color overrides --config-toml 'ui.color=...'.
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "--color",
+            "never",
+            "--config-toml",
+            "ui.color=\"always\"",
+            "log",
+            "-T",
+            "commit_id",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    o 0000000000000000000000000000000000000000
+    "###);
+
     // Test that NO_COLOR does NOT override the request for color in the config file
     test_env.add_env_var("NO_COLOR", "");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
@@ -193,5 +234,6 @@ fn test_help() {
           --no-commit-working-copy       Don't commit the working copy
           --at-operation <AT_OPERATION>  Operation to load the repo at [default: @] [aliases: at-op]
           --color <WHEN>                 When to colorize output (always, never, auto)
+          --config-toml <TOML>           Additional configuration options
     "###);
 }


### PR DESCRIPTION
Unfortunately, TOML requires quotes around the argument. So, the
usage is `jj --config-toml ui.color=\"always\"` in bash. The plan is
to eventually have a `--config` option with simpler syntax for
simple cases.

As discussed in https://github.com/martinvonz/jj/discussions/688.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
