### PR TITLE
lib: remove ineffective enabling of `map_first_last`

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![deny(unused_must_use)]
-#![cfg_attr(feature = "map_first_last", feature(map_first_last))]
 
 pub mod backend;
 pub mod commit;


### PR DESCRIPTION
If I'm reading this attribute correctly, it says that if the `map_first_last` feature is enabled, then we should enable the `map_first_last` feature, which seems like it would not have any effect. We started getting warnings from the nightly compiler about this line because it tries to enable a feature that's stable in that version.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
