### PR TITLE
cli: handle init destination error gracefully

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1067,12 +1067,14 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
         ));
     }
     let wc_path = ui.cwd().join(&args.destination);
-    if wc_path.exists() {
-        assert!(wc_path.is_dir());
-    } else {
-        fs::create_dir(&wc_path).unwrap();
+    match fs::create_dir(&wc_path) {
+        Ok(()) => {}
+        Err(_) if wc_path.is_dir() => {}
+        Err(e) => return Err(UserError(format!("Failed to create workspace: {e}"))),
     }
-    let wc_path = wc_path.canonicalize().unwrap();
+    let wc_path = wc_path
+        .canonicalize()
+        .map_err(|e| UserError(format!("Failed to create workspace: {e}")))?; // raced?
 
     if let Some(git_store_str) = &args.git_repo {
         let mut git_store_path = ui.cwd().join(git_store_str);

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -174,6 +174,14 @@ fn test_init_git_internal_but_could_be_colocated() {
 }
 
 #[test]
+fn test_init_git_bad_wc_path() {
+    let test_env = TestEnvironment::default();
+    std::fs::write(test_env.env_root().join("existing-file"), b"").unwrap();
+    let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["init", "--git", "existing-file"]);
+    assert!(stderr.contains("Failed to create workspace"));
+}
+
+#[test]
 fn test_init_local_disallowed() {
     let test_env = TestEnvironment::default();
     let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
