### PR TITLE
cleanup: avoid an unnecessary `Box` for argument to formatter

### DIFF
--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -355,12 +355,9 @@ fn parse_commit_term<'a>(
                         let content: Box<dyn Template<Commit> + 'a> =
                             parse_commit_template_rule(repo, workspace_id, arg_template);
                         let get_labels = move |commit: &Commit| -> String {
-                            let mut buf: Vec<u8> = vec![];
-                            {
-                                let writer = Box::new(&mut buf);
-                                let mut formatter = PlainTextFormatter::new(writer);
-                                label_template.format(commit, &mut formatter).unwrap();
-                            }
+                            let mut buf = vec![];
+                            let mut formatter = PlainTextFormatter::new(&mut buf);
+                            label_template.format(commit, &mut formatter).unwrap();
                             String::from_utf8(buf).unwrap()
                         };
                         Box::new(DynamicLabelTemplate::new(content, Box::new(get_labels)))


### PR DESCRIPTION
I think this cleanup was enabled by a recent refactoring that replaced a trait object by a type parameter (3392e834863e).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
