### PR TITLE
Prompt for credentials when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * It is now possible to specity configuration options on the command line
   with he new `--config-toml` global option.
 
+* (#469) `jj git` subcommands will prompt for credentials when
+  required for HTTPS remotes rather than failing.
+
 ### Fixed bugs
 
 * `jj edit root` now fails gracefully.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "predicates",
  "rand",
  "regex",
+ "rpassword",
  "serde",
  "tempfile",
  "test-case",
@@ -1339,6 +1340,16 @@ name = "roff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
+name = "rpassword"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c9f5d2a0c3e2ea729ab3706d22217177770654c3ef5056b68b69d07332d3f5"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ pest = "2.4.0"
 pest_derive = "2.4"
 rand = "0.8.5"
 regex = "1.6.0"
+rpassword = "7.1.0"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.3.0"
 textwrap = "0.16.0"

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -827,6 +827,7 @@ fn test_push_updates_success() {
             force: false,
             new_target: Some(setup.new_commit.id().clone()),
         }],
+        git::RemoteCallbacks::default(),
     );
     assert_eq!(result, Ok(()));
 
@@ -868,6 +869,7 @@ fn test_push_updates_deletion() {
             force: false,
             new_target: None,
         }],
+        git::RemoteCallbacks::default(),
     );
     assert_eq!(result, Ok(()));
 
@@ -903,6 +905,7 @@ fn test_push_updates_mixed_deletion_and_addition() {
                 new_target: Some(setup.new_commit.id().clone()),
             },
         ],
+        git::RemoteCallbacks::default(),
     );
     assert_eq!(result, Ok(()));
 
@@ -936,6 +939,7 @@ fn test_push_updates_not_fast_forward() {
             force: false,
             new_target: Some(new_commit.id().clone()),
         }],
+        git::RemoteCallbacks::default(),
     );
     assert_eq!(result, Err(GitPushError::NotFastForward));
 }
@@ -957,6 +961,7 @@ fn test_push_updates_not_fast_forward_with_force() {
             force: true,
             new_target: Some(new_commit.id().clone()),
         }],
+        git::RemoteCallbacks::default(),
     );
     assert_eq!(result, Ok(()));
 
@@ -983,6 +988,7 @@ fn test_push_updates_no_such_remote() {
             force: false,
             new_target: Some(setup.new_commit.id().clone()),
         }],
+        git::RemoteCallbacks::default(),
     );
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }
@@ -1000,6 +1006,7 @@ fn test_push_updates_invalid_remote() {
             force: false,
             new_target: Some(setup.new_commit.id().clone()),
         }],
+        git::RemoteCallbacks::default(),
     );
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -593,7 +593,13 @@ fn test_fetch_empty_repo() {
     let test_data = GitRepoData::create();
 
     let mut tx = test_data.repo.start_transaction("test");
-    let default_branch = git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    let default_branch = git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     // No default branch and no refs
     assert_eq!(default_branch, None);
     assert_eq!(*tx.mut_repo().view().git_refs(), btreemap! {});
@@ -606,7 +612,13 @@ fn test_fetch_initial_commit() {
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction("test");
-    let default_branch = git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    let default_branch = git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     // No default branch because the origin repo's HEAD wasn't set
     assert_eq!(default_branch, None);
     let repo = tx.commit();
@@ -637,7 +649,13 @@ fn test_fetch_success() {
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction("test");
-    git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     test_data.repo = tx.commit();
 
     test_data.origin_repo.set_head("refs/heads/main").unwrap();
@@ -648,7 +666,13 @@ fn test_fetch_success() {
     );
 
     let mut tx = test_data.repo.start_transaction("test");
-    let default_branch = git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    let default_branch = git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     // The default branch is "main"
     assert_eq!(default_branch, Some("main".to_string()));
     let repo = tx.commit();
@@ -679,7 +703,13 @@ fn test_fetch_prune_deleted_ref() {
     empty_git_commit(&test_data.git_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction("test");
-    git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     // Test the setup
     assert!(tx.mut_repo().get_branch("main").is_some());
 
@@ -690,7 +720,13 @@ fn test_fetch_prune_deleted_ref() {
         .delete()
         .unwrap();
     // After re-fetching, the branch should be deleted
-    git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     assert!(tx.mut_repo().get_branch("main").is_none());
 }
 
@@ -700,7 +736,13 @@ fn test_fetch_no_default_branch() {
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction("test");
-    git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
 
     empty_git_commit(
         &test_data.origin_repo,
@@ -715,7 +757,13 @@ fn test_fetch_no_default_branch() {
         .set_head_detached(initial_git_commit.id())
         .unwrap();
 
-    let default_branch = git::fetch(tx.mut_repo(), &test_data.git_repo, "origin", None).unwrap();
+    let default_branch = git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "origin",
+        git::RemoteCallbacks::default(),
+    )
+    .unwrap();
     // There is no default branch
     assert_eq!(default_branch, None);
 }
@@ -725,7 +773,12 @@ fn test_fetch_no_such_remote() {
     let test_data = GitRepoData::create();
 
     let mut tx = test_data.repo.start_transaction("test");
-    let result = git::fetch(tx.mut_repo(), &test_data.git_repo, "invalid-remote", None);
+    let result = git::fetch(
+        tx.mut_repo(),
+        &test_data.git_repo,
+        "invalid-remote",
+        git::RemoteCallbacks::default(),
+    );
     assert!(matches!(result, Err(GitFetchError::NoSuchRemote(_))));
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4066,7 +4066,7 @@ fn with_remote_callbacks<T>(ui: &mut Ui, f: impl FnOnce(git::RemoteCallbacks<'_>
         let mut progress = Progress::new(Instant::now());
         let ui = &ui;
         callback = Some(move |x: &git::Progress| {
-            progress.update(Instant::now(), x, *ui.lock().unwrap());
+            _ = progress.update(Instant::now(), x, *ui.lock().unwrap());
         });
     }
     let mut callbacks = git::RemoteCallbacks::default();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4066,14 +4066,11 @@ fn git_fetch(
             progress.update(Instant::now(), x);
         });
     }
-    let result = git::fetch(
-        mut_repo,
-        git_repo,
-        remote_name,
-        callback
-            .as_mut()
-            .map(|x| x as &mut dyn FnMut(&git::Progress)),
-    );
+    let mut callbacks = git::RemoteCallbacks::default();
+    callbacks.progress = callback
+        .as_mut()
+        .map(|x| x as &mut dyn FnMut(&git::Progress));
+    let result = git::fetch(mut_repo, git_repo, remote_name, callbacks);
     result
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4060,9 +4060,9 @@ fn do_git_clone(
 fn with_remote_callbacks<T>(ui: &mut Ui, f: impl FnOnce(git::RemoteCallbacks<'_>) -> T) -> T {
     let mut callback = None;
     if ui.use_progress_indicator() {
-        let mut progress = Progress::new(Instant::now(), ui);
+        let mut progress = Progress::new(Instant::now());
         callback = Some(move |x: &git::Progress| {
-            progress.update(Instant::now(), x);
+            progress.update(Instant::now(), x, ui);
         });
     }
     let mut callbacks = git::RemoteCallbacks::default();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -37,7 +37,7 @@ use jujutsu_lib::matchers::{EverythingMatcher, Matcher};
 use jujutsu_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
 use jujutsu_lib::operation::Operation;
 use jujutsu_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
-use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, RepoRef};
+use jujutsu_lib::repo::{ReadonlyRepo, RepoRef};
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::revset::RevsetExpression;
 use jujutsu_lib::revset_graph_iterator::{RevsetGraphEdge, RevsetGraphEdgeType};
@@ -3933,8 +3933,10 @@ fn cmd_git_fetch(
     let git_repo = get_git_repo(repo.store())?;
     let mut tx =
         workspace_command.start_transaction(&format!("fetch from git remote {}", &args.remote));
-    git_fetch(ui, tx.mut_repo(), &git_repo, &args.remote)
-        .map_err(|err| UserError(err.to_string()))?;
+    with_remote_callbacks(ui, |cb| {
+        git::fetch(tx.mut_repo(), &git_repo, &args.remote, cb)
+    })
+    .map_err(|err| UserError(err.to_string()))?;
     workspace_command.finish_transaction(ui, tx)?;
     Ok(())
 }
@@ -4041,24 +4043,21 @@ fn do_git_clone(
     let remote_name = "origin";
     git_repo.remote(remote_name, source).unwrap();
     let mut fetch_tx = workspace_command.start_transaction("fetch from git remote into empty repo");
-    let maybe_default_branch =
-        git_fetch(ui, fetch_tx.mut_repo(), &git_repo, remote_name).map_err(|err| match err {
-            GitFetchError::NoSuchRemote(_) => {
-                panic!("shouldn't happen as we just created the git remote")
-            }
-            GitFetchError::InternalGitError(err) => UserError(format!("Fetch failed: {err}")),
-        })?;
+
+    let maybe_default_branch = with_remote_callbacks(ui, |cb| {
+        git::fetch(fetch_tx.mut_repo(), &git_repo, remote_name, cb)
+    })
+    .map_err(|err| match err {
+        GitFetchError::NoSuchRemote(_) => {
+            panic!("shouldn't happen as we just created the git remote")
+        }
+        GitFetchError::InternalGitError(err) => UserError(format!("Fetch failed: {err}")),
+    })?;
     workspace_command.finish_transaction(ui, fetch_tx)?;
     Ok((workspace_command, maybe_default_branch))
 }
 
-// Wrapper around git::fetch that adds progress feedback on TTYs
-fn git_fetch(
-    ui: &mut Ui,
-    mut_repo: &mut MutableRepo,
-    git_repo: &git2::Repository,
-    remote_name: &str,
-) -> Result<Option<String>, GitFetchError> {
+fn with_remote_callbacks<T>(ui: &mut Ui, f: impl FnOnce(git::RemoteCallbacks<'_>) -> T) -> T {
     let mut callback = None;
     if ui.use_progress_indicator() {
         let mut progress = Progress::new(Instant::now(), ui);
@@ -4070,10 +4069,9 @@ fn git_fetch(
     callbacks.progress = callback
         .as_mut()
         .map(|x| x as &mut dyn FnMut(&git::Progress));
-    let mut get_ssh_key = get_ssh_key; // Hack around odd borrowck behavior
+    let mut get_ssh_key = get_ssh_key; // Coerce to unit fn type
     callbacks.get_ssh_key = Some(&mut get_ssh_key);
-    let result = git::fetch(mut_repo, git_repo, remote_name, callbacks);
-    result
+    f(callbacks)
 }
 
 fn get_ssh_key(_username: &str) -> Option<PathBuf> {
@@ -4343,11 +4341,10 @@ fn cmd_git_push(
     }
 
     let git_repo = get_git_repo(repo.store())?;
-    let mut get_ssh_key = get_ssh_key; // Coerce to unit fn type
-    let mut callbacks = git::RemoteCallbacks::default();
-    callbacks.get_ssh_key = Some(&mut get_ssh_key);
-    git::push_updates(&git_repo, &args.remote, &ref_updates, callbacks)
-        .map_err(|err| UserError(err.to_string()))?;
+    with_remote_callbacks(ui, |cb| {
+        git::push_updates(&git_repo, &args.remote, &ref_updates, cb)
+    })
+    .map_err(|err| UserError(err.to_string()))?;
     git::import_refs(tx.mut_repo(), &git_repo)?;
     workspace_command.finish_transaction(ui, tx)?;
     Ok(())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -207,6 +207,30 @@ impl Ui {
         }
     }
 
+    pub fn prompt(&mut self, prompt: &str) -> io::Result<String> {
+        if !atty::is(Stream::Stdout) {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Cannot prompt for input since the output is not connected to a terminal",
+            ));
+        }
+        write!(self, "{}: ", prompt)?;
+        self.flush()?;
+        let mut buf = String::new();
+        io::stdin().read_line(&mut buf)?;
+        Ok(buf)
+    }
+
+    pub fn prompt_password(&mut self, prompt: &str) -> io::Result<String> {
+        if !atty::is(Stream::Stdout) {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Cannot prompt for input since the output is not connected to a terminal",
+            ));
+        }
+        rpassword::prompt_password(&format!("{}: ", prompt))
+    }
+
     pub fn size(&self) -> Option<(u16, u16)> {
         crossterm::terminal::size().ok()
     }


### PR DESCRIPTION
Terminal password prompts don't go through `Ui` because that undermines `rpassword`'s facility for suppressing terminal echo. Not sure it's worth hacking around that, since the terminal's a global resource anyway.

In the long run I'd like to move away from basically aping libgit2 in favor of a more composable async API, but that's major refactoring that shouldn't block basic UI cleanup.

I couldn't come up with a graceful way to prompt for usernames via pinentry, so it's relegated to the password-only case.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
