### PR TITLE
repo: remove last mutating method from `ReadonlyRepo`

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -206,12 +206,6 @@ impl ReadonlyRepo {
         })
     }
 
-    pub fn reindex(&mut self) -> &Arc<ReadonlyIndex> {
-        self.index_store.reinit();
-        self.index.take();
-        self.index()
-    }
-
     pub fn store(&self) -> &Arc<Store> {
         &self.store
     }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -465,10 +465,6 @@ impl WorkspaceCommandHelper {
         &self.repo
     }
 
-    pub fn repo_mut(&mut self) -> &mut Arc<ReadonlyRepo> {
-        &mut self.repo
-    }
-
     pub fn working_copy(&self) -> &WorkingCopy {
         self.workspace.working_copy()
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3519,10 +3519,14 @@ fn cmd_debug(
             }
         }
         DebugCommands::ReIndex(_reindex_matches) => {
-            let mut workspace_command = command.workspace_helper(ui)?;
-            let mut_repo = Arc::get_mut(workspace_command.repo_mut()).unwrap();
-            let index = mut_repo.reindex();
-            writeln!(ui, "Finished indexing {:?} commits.", index.num_commits())?;
+            let workspace_command = command.workspace_helper(ui)?;
+            let repo = workspace_command.repo();
+            let repo = repo.reload_at(repo.operation());
+            writeln!(
+                ui,
+                "Finished indexing {:?} commits.",
+                repo.index().num_commits()
+            )?;
         }
         DebugCommands::Operation(operation_args) => {
             let workspace_command = command.workspace_helper(ui)?;


### PR DESCRIPTION
`ReadonlyRepo::reindex()` is only used in `jj debug reindex`, and it can be implemented by creating a new instance instead of mutating `ReadonlyRepo`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
