### PR TITLE
revset: add present(set) predicate that suppresses NoSuchRevision error

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -109,6 +109,8 @@ revsets (expressions) as arguments.
 * `committer(needle)`: Commits with the given string in the committer's
   name or email.
 * `file(pattern..)`: Commits modifying the paths specified by the `pattern..`.
+* `present(x)`: Same as `x`, but evaluated to `none()` if any of the commits
+  in `x` doesn't exist (e.g. is an unknown branch name.)
 
 
 ## Examples

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1152,6 +1152,14 @@ struct EagerRevset<'repo> {
     index_entries: Vec<IndexEntry<'repo>>,
 }
 
+impl EagerRevset<'static> {
+    pub const fn empty() -> Self {
+        EagerRevset {
+            index_entries: Vec::new(),
+        }
+    }
+}
+
 impl<'repo> Revset<'repo> for EagerRevset<'repo> {
     fn iter<'revset>(&'revset self) -> RevsetIterator<'revset, 'repo> {
         RevsetIterator::new(Box::new(self.index_entries.iter().cloned()))
@@ -1403,9 +1411,7 @@ pub fn evaluate_expression<'repo>(
     workspace_ctx: Option<&RevsetWorkspaceContext>,
 ) -> Result<Box<dyn Revset<'repo> + 'repo>, RevsetError> {
     match expression {
-        RevsetExpression::None => Ok(Box::new(EagerRevset {
-            index_entries: vec![],
-        })),
+        RevsetExpression::None => Ok(Box::new(EagerRevset::empty())),
         RevsetExpression::All => evaluate_expression(
             repo,
             &RevsetExpression::visible_heads().ancestors(),

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -125,6 +125,19 @@ fn test_resolve_symbol_commit_id() {
         resolve_symbol(repo_ref, "foo", None),
         Err(RevsetError::NoSuchRevision("foo".to_string()))
     );
+
+    // Test present() suppresses only NoSuchRevision error
+    assert_eq!(resolve_commit_ids(repo_ref, "present(foo)"), []);
+    assert_eq!(
+        optimize(parse("present(04)", None).unwrap())
+            .evaluate(repo_ref, None)
+            .map(|_| ()),
+        Err(RevsetError::AmbiguousCommitIdPrefix("04".to_string()))
+    );
+    assert_eq!(
+        resolve_commit_ids(repo_ref, "present(046)"),
+        vec![commits[2].id().clone()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
