### PR TITLE
tests: move `testutils` module into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "slab",
  "tempfile",
  "test-case",
+ "testutils",
  "textwrap 0.16.0",
  "thiserror",
 ]
@@ -768,6 +769,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
+ "testutils",
  "thiserror",
  "uuid",
  "version_check",
@@ -1556,6 +1558,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "testutils"
+version = "0.5.1"
+dependencies = [
+ "config",
+ "git2",
+ "itertools",
+ "jujutsu-lib",
+ "rand",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ insta = "1.21.0"
 regex = "1.6.0"
 predicates = "2.1.1"
 test-case = "2.2.2"
+testutils = { path = "lib/testutils" }
 
 [features]
 default = ["vendored-openssl"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -46,6 +46,7 @@ assert_matches = "1.5.0"
 insta = "1.21.0"
 num_cpus = "1.13.1"
 test-case = "2.2.2"
+testutils = { path = "testutils" }
 
 [features]
 vendored-openssl = ["git2/vendored-openssl"]

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -91,7 +91,6 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
-    use crate::testutils;
 
     #[test]
     fn normalize_too_many_dot_dot() {

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -532,7 +532,6 @@ mod tests {
 
     use super::*;
     use crate::backend::{FileId, MillisSinceEpoch};
-    use crate::testutils;
 
     #[test]
     fn read_plain_git_commit() {

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -1466,7 +1466,6 @@ mod tests {
 
     use super::*;
     use crate::commit_builder::new_change_id;
-    use crate::testutils;
 
     #[test_case(false; "memory")]
     #[test_case(true; "file")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -45,7 +45,6 @@ pub mod settings;
 pub mod simple_op_store;
 pub mod stacked_table;
 pub mod store;
-pub mod testutils;
 pub mod transaction;
 pub mod tree;
 pub mod tree_builder;

--- a/lib/src/lock.rs
+++ b/lib/src/lock.rs
@@ -77,7 +77,6 @@ mod tests {
     use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
     use super::*;
-    use crate::testutils;
 
     #[test]
     fn lock_basic() {

--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -188,7 +188,6 @@ pub enum FsPathParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testutils;
 
     #[test]
     fn test_is_root() {

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -368,7 +368,6 @@ mod tests {
     use maplit::{btreemap, hashmap, hashset};
 
     use super::*;
-    use crate::testutils;
 
     #[test]
     fn test_read_write_view() {

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -508,7 +508,6 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
-    use crate::testutils;
 
     #[test_case(false; "memory")]
     #[test_case(true; "file")]

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -15,10 +15,9 @@
 use std::path::Path;
 
 use jujutsu_lib::repo::{BackendFactories, ReadonlyRepo};
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::workspace::Workspace;
 use test_case::test_case;
+use testutils::TestWorkspace;
 
 fn copy_directory(src: &Path, dst: &Path) {
     std::fs::create_dir(dst).ok();

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -16,10 +16,9 @@ use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::matchers::EverythingMatcher;
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{assert_rebased, CommitGraphBuilder, TestRepo};
 use jujutsu_lib::tree::DiffSummary;
 use test_case::test_case;
+use testutils::{assert_rebased, CommitGraphBuilder, TestRepo};
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -15,10 +15,10 @@
 use std::cmp::max;
 use std::thread;
 
+use jujutsu_lib::dag_walk;
 use jujutsu_lib::repo::{BackendFactories, ReadonlyRepo};
-use jujutsu_lib::testutils::TestWorkspace;
-use jujutsu_lib::{dag_walk, testutils};
 use test_case::test_case;
+use testutils::TestWorkspace;
 
 fn count_non_merge_operations(repo: &ReadonlyRepo) -> usize {
     let op_store = repo.op_store();

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -17,8 +17,7 @@ use jujutsu_lib::conflicts::{materialize_conflict, parse_conflict, update_confli
 use jujutsu_lib::files::MergeHunk;
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::store::Store;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestRepo;
+use testutils::TestRepo;
 
 #[test]
 fn test_materialize_conflict_basic() {

--- a/lib/tests/test_diff_summary.rs
+++ b/lib/tests/test_diff_summary.rs
@@ -14,11 +14,10 @@
 
 use jujutsu_lib::matchers::{EverythingMatcher, FilesMatcher};
 use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestRepo;
 use jujutsu_lib::tree::DiffSummary;
 use maplit::hashset;
 use test_case::test_case;
+use testutils::TestRepo;
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -18,15 +18,15 @@ use std::sync::Arc;
 use git2::Oid;
 use jujutsu_lib::backend::CommitId;
 use jujutsu_lib::commit::Commit;
+use jujutsu_lib::git;
 use jujutsu_lib::git::{GitFetchError, GitPushError, GitRefUpdate};
 use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::op_store::{BranchTarget, RefTarget};
 use jujutsu_lib::repo::ReadonlyRepo;
 use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::testutils::{create_random_commit, TestRepo};
-use jujutsu_lib::{git, testutils};
 use maplit::{btreemap, hashset};
 use tempfile::TempDir;
+use testutils::{create_random_commit, TestRepo};
 
 fn empty_git_commit<'r>(
     git_repo: &'r git2::Repository,

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -20,9 +20,8 @@ use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::index::IndexRef;
 use jujutsu_lib::repo::{BackendFactories, ReadonlyRepo};
 use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{create_random_commit, CommitGraphBuilder, TestRepo};
 use test_case::test_case;
+use testutils::{create_random_commit, CommitGraphBuilder, TestRepo};
 
 #[must_use]
 fn child_commit(settings: &UserSettings, repo: &ReadonlyRepo, commit: &Commit) -> CommitBuilder {

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -16,10 +16,9 @@ use std::path::{Path, PathBuf};
 
 use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::workspace::Workspace;
 use test_case::test_case;
+use testutils::TestWorkspace;
 
 fn canonicalize(input: &Path) -> (PathBuf, PathBuf) {
     let uncanonical = input.join("..").join(input.file_name().unwrap());

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use jujutsu_lib::repo::{BackendFactories, RepoLoader};
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestRepo;
 use test_case::test_case;
+use testutils::TestRepo;
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -18,10 +18,10 @@ use jujutsu_lib::backend::{ConflictPart, TreeValue};
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::repo_path::{RepoPath, RepoPathComponent};
 use jujutsu_lib::rewrite::rebase_commit;
-use jujutsu_lib::testutils::TestRepo;
+use jujutsu_lib::tree;
 use jujutsu_lib::tree::Tree;
-use jujutsu_lib::{testutils, tree};
 use test_case::test_case;
+use testutils::TestRepo;
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -14,10 +14,9 @@
 
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{assert_rebased, CommitGraphBuilder, TestRepo};
 use maplit::hashset;
 use test_case::test_case;
+use testutils::{assert_rebased, CommitGraphBuilder, TestRepo};
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -17,9 +17,8 @@ use std::path::Path;
 use jujutsu_lib::backend::CommitId;
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::repo::RepoRef;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestRepo;
 use test_case::test_case;
+use testutils::TestRepo;
 
 fn list_dir(dir: &Path) -> Vec<String> {
     std::fs::read_dir(dir)

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -14,8 +14,7 @@
 
 use jujutsu_lib::op_store::RefTarget;
 use jujutsu_lib::refs::merge_ref_targets;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{CommitGraphBuilder, TestWorkspace};
+use testutils::{CommitGraphBuilder, TestWorkspace};
 
 #[test]
 fn test_merge_ref_targets() {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 use jujutsu_lib::backend::{CommitId, MillisSinceEpoch, Signature, Timestamp};
 use jujutsu_lib::commit_builder::CommitBuilder;
+use jujutsu_lib::git;
 use jujutsu_lib::matchers::{FilesMatcher, Matcher};
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::repo::RepoRef;
@@ -23,10 +24,9 @@ use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::revset::{
     self, optimize, parse, resolve_symbol, RevsetError, RevsetExpression, RevsetWorkspaceContext,
 };
-use jujutsu_lib::testutils::{CommitGraphBuilder, TestRepo, TestWorkspace};
 use jujutsu_lib::workspace::Workspace;
-use jujutsu_lib::{git, testutils};
 use test_case::test_case;
+use testutils::{CommitGraphBuilder, TestRepo, TestWorkspace};
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_revset_graph_iterator.rs
+++ b/lib/tests/test_revset_graph_iterator.rs
@@ -15,9 +15,8 @@
 use itertools::Itertools;
 use jujutsu_lib::revset::revset_for_commits;
 use jujutsu_lib::revset_graph_iterator::RevsetGraphEdge;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{CommitGraphBuilder, TestRepo};
 use test_case::test_case;
+use testutils::{CommitGraphBuilder, TestRepo};
 
 #[test_case(false ; "keep transitive edges")]
 #[test_case(true ; "skip transitive edges")]

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -16,10 +16,9 @@ use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::rewrite::DescendantRebaser;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{assert_rebased, create_random_commit, CommitGraphBuilder, TestRepo};
 use maplit::{hashmap, hashset};
 use test_case::test_case;
+use testutils::{assert_rebased, create_random_commit, CommitGraphBuilder, TestRepo};
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -18,11 +18,10 @@ use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
 use jujutsu_lib::repo::ReadonlyRepo;
 use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::{CommitGraphBuilder, TestRepo};
 use jujutsu_lib::transaction::Transaction;
 use maplit::{btreemap, hashset};
 use test_case::test_case;
+use testutils::{CommitGraphBuilder, TestRepo};
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -29,11 +29,10 @@ use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::ReadonlyRepo;
 use jujutsu_lib::repo_path::{RepoPath, RepoPathComponent, RepoPathJoin};
 use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::tree_builder::TreeBuilder;
 use jujutsu_lib::working_copy::WorkingCopy;
 use test_case::test_case;
+use testutils::TestWorkspace;
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -19,11 +19,10 @@ use assert_matches::assert_matches;
 use jujutsu_lib::gitignore::GitIgnoreFile;
 use jujutsu_lib::repo::BackendFactories;
 use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::working_copy::CheckoutError;
 use jujutsu_lib::workspace::Workspace;
 use test_case::test_case;
+use testutils::TestWorkspace;
 
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]

--- a/lib/tests/test_working_copy_sparse.rs
+++ b/lib/tests/test_working_copy_sparse.rs
@@ -16,9 +16,8 @@ use itertools::Itertools;
 use jujutsu_lib::gitignore::GitIgnoreFile;
 use jujutsu_lib::matchers::EverythingMatcher;
 use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::working_copy::{CheckoutStats, WorkingCopy};
+use testutils::TestWorkspace;
 
 #[test]
 fn test_sparse_checkout() {

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -15,10 +15,9 @@
 use assert_matches::assert_matches;
 use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::BackendFactories;
-use jujutsu_lib::testutils;
-use jujutsu_lib::testutils::TestWorkspace;
 use jujutsu_lib::workspace::{Workspace, WorkspaceLoadError};
 use test_case::test_case;
+use testutils::TestWorkspace;
 
 #[test]
 fn test_load_bad_path() {

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "testutils"
+version = "0.5.1"
+authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
+edition = "2021"
+rust-version = "1.60"
+license = "Apache-2.0"
+description = "Integration test utils for the jujutsu-lib crate"
+homepage = "https://github.com/martinvonz/jj"
+repository = "https://github.com/martinvonz/jj"
+documentation = "https://docs.rs/jujutsu"
+readme = "../..//README.md"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+config = { version = "0.13.2", default-features = false, features = ["toml"] }
+git2 = "0.15.0"
+itertools = "0.10.5"
+jujutsu-lib = { path = ".." }
+rand = "0.8.5"
+tempfile = "3.3.0"

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -19,21 +19,20 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Once};
 
 use itertools::Itertools;
+use jujutsu_lib::backend::{FileId, TreeId, TreeValue};
+use jujutsu_lib::commit::Commit;
+use jujutsu_lib::commit_builder::CommitBuilder;
+use jujutsu_lib::git_backend::GitBackend;
+use jujutsu_lib::local_backend::LocalBackend;
+use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo};
+use jujutsu_lib::repo_path::RepoPath;
+use jujutsu_lib::rewrite::RebasedDescendant;
+use jujutsu_lib::settings::UserSettings;
+use jujutsu_lib::store::Store;
+use jujutsu_lib::tree::Tree;
+use jujutsu_lib::tree_builder::TreeBuilder;
+use jujutsu_lib::workspace::Workspace;
 use tempfile::TempDir;
-
-use crate::backend::{FileId, TreeId, TreeValue};
-use crate::commit::Commit;
-use crate::commit_builder::CommitBuilder;
-use crate::git_backend::GitBackend;
-use crate::local_backend::LocalBackend;
-use crate::repo::{MutableRepo, ReadonlyRepo};
-use crate::repo_path::RepoPath;
-use crate::rewrite::RebasedDescendant;
-use crate::settings::UserSettings;
-use crate::store::Store;
-use crate::tree::Tree;
-use crate::tree_builder::TreeBuilder;
-use crate::workspace::Workspace;
 
 pub fn hermetic_libgit2() {
     // libgit2 respects init.defaultBranch (and possibly other config

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,9 +16,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use jujutsu_lib::testutils;
 use regex::{Captures, Regex};
 use tempfile::TempDir;
+use testutils;
 
 pub struct TestEnvironment {
     _temp_dir: TempDir,


### PR DESCRIPTION
The `testutils` module should ideally not be part of the library dependencies. Since they're used by the integration tests (and the CLI tests), we need to move them to a separate crate to achieve that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
