### PR TITLE
simple_op_store: create temporary Thrift store in .jj/repo directory

### DIFF
--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -66,7 +66,7 @@ fn upgrade_to_thrift(store_path: PathBuf) -> std::io::Result<()> {
     let proto_store = ProtoOpStore::load(store_path.clone());
     let tmp_store_dir = tempfile::Builder::new()
         .prefix("jj-op-store-upgrade-")
-        .tempdir()
+        .tempdir_in(store_path.parent().unwrap())
         .unwrap();
     let tmp_store_path = tmp_store_dir.path().to_path_buf();
 


### PR DESCRIPTION
Otherwise rename() would fail if /tmp is on different device.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
