### PR TITLE
demos: allow running without `ui.allow-init-native = true`

### DIFF
--- a/demos/demo_juggle_conflicts.sh
+++ b/demos/demo_juggle_conflicts.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 . "$(dirname "$0")"/demo_helpers.sh
 
 new_tmp_dir
-jj init
+jj init --config-toml ui.allow-init-native=true
 echo "first" > file
 jj branch create first
 jj commit -m 'first' 


### PR DESCRIPTION
We need to use the native backend here because of #27, but we shouldn't require the user running the script to have it in their config.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
