### PR TITLE
revset: code cleanup, add empty() predicate to find commits with no file change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The new revset function `file(pattern..)` finds commits modifying the
   paths specified by the `pattern..`.
 
+* The new revset function `empty()` finds commits modifying no files.
+
 * It is now possible to specify configuration options on the command line
   with the new `--config-toml` global option.
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -108,6 +108,8 @@ revsets (expressions) as arguments.
   email.
 * `committer(needle)`: Commits with the given string in the committer's
   name or email.
+* `empty()`: Commits modifying no files. This also includes `merges()` without
+  user modifications and `root`.
 * `file(pattern..)`: Commits modifying the paths specified by the `pattern..`.
 * `present(x)`: Same as `x`, but evaluated to `none()` if any of the commits
   in `x` doesn't exist (e.g. is an unknown branch name.)

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -735,18 +735,20 @@ fn parse_function_expression(
             expect_no_arguments(name, arguments_pair)?;
             Ok(RevsetExpression::all().with_parent_count(2..u32::MAX))
         }
-        "description" | "author" | "committer" => {
+        "description" => {
             let arg = expect_one_argument(name, arguments_pair)?;
             let needle = parse_function_argument_to_string(name, arg)?;
-            let candidates = RevsetExpression::all();
-            match name {
-                "description" => Ok(candidates.with_description(needle)),
-                "author" => Ok(candidates.with_author(needle)),
-                "committer" => Ok(candidates.with_committer(needle)),
-                _ => {
-                    panic!("unexpected function name: {}", name)
-                }
-            }
+            Ok(RevsetExpression::all().with_description(needle))
+        }
+        "author" => {
+            let arg = expect_one_argument(name, arguments_pair)?;
+            let needle = parse_function_argument_to_string(name, arg)?;
+            Ok(RevsetExpression::all().with_author(needle))
+        }
+        "committer" => {
+            let arg = expect_one_argument(name, arguments_pair)?;
+            let needle = parse_function_argument_to_string(name, arg)?;
+            Ok(RevsetExpression::all().with_committer(needle))
         }
         "file" => {
             if let Some(ctx) = workspace_ctx {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1816,6 +1816,9 @@ fn test_filter_by_diff(use_git: bool) {
     let commit3 =
         CommitBuilder::for_new_commit(&settings, vec![commit2.id().clone()], tree3.id().clone())
             .write_to_repo(mut_repo);
+    let commit4 =
+        CommitBuilder::for_new_commit(&settings, vec![commit3.id().clone()], tree3.id().clone())
+            .write_to_repo(mut_repo);
 
     // matcher API:
     let resolve = |file_path: &RepoPath| -> Vec<CommitId> {
@@ -1861,5 +1864,14 @@ fn test_filter_by_diff(use_git: bool) {
             Some(test_workspace.workspace.workspace_root()),
         ),
         vec![commit2.id().clone()]
+    );
+
+    // empty() revset, which is identical to ~file(".")
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!("{}: & empty()", commit1.id().hex())
+        ),
+        vec![commit4.id().clone()]
     );
 }


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
