### PR TITLE
revset: give higher precedence to intersection/difference operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `committer(needle)`, `merges()` revsets. Use `x & description(needle)`
   instead.
 
+* Adjusted precedence of revset union/intersection/difference operators.
+  `x | y & z` is now equivalent to `x | (y & z)`.
+
 * Support for open commits has been dropped. The `ui.enable-open-commits` config
   that was added in 0.5.0 is no longer respected. The `jj open/close` commands
   have been deleted.

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -66,3 +66,5 @@ infix_expression = {
 expression = {
   whitespace* ~ infix_expression ~ whitespace*
 }
+
+program = _{ SOI ~ expression ~ EOI }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -857,20 +857,8 @@ pub fn parse(
     revset_str: &str,
     workspace_ctx: Option<&RevsetWorkspaceContext>,
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
-    let mut pairs = RevsetParser::parse(Rule::expression, revset_str)?;
+    let mut pairs = RevsetParser::parse(Rule::program, revset_str)?;
     let first = pairs.next().unwrap();
-    assert!(pairs.next().is_none());
-    if first.as_span().end() != revset_str.len() {
-        let pos = pest::Position::new(revset_str, first.as_span().end()).unwrap();
-        let err = pest::error::Error::new_from_pos(
-            pest::error::ErrorVariant::CustomError {
-                message: "Incomplete parse".to_string(),
-            },
-            pos,
-        );
-        return Err(RevsetParseError::from(err));
-    }
-
     parse_expression_rule(first.into_inner(), workspace_ctx)
 }
 

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -17,6 +17,23 @@ use common::TestEnvironment;
 pub mod common;
 
 #[test]
+fn test_syntax_error() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "x &"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset:  --> 1:4
+      |
+    1 | x &
+      |    ^---
+      |
+      = expected range_expression
+    "###);
+}
+
+#[test]
 fn test_bad_function_call() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
