### PR TITLE
diff: consider uncommon words to match only if they have the same count

### DIFF
--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -383,9 +383,8 @@ mod tests {
             ])
         );
         // One side changes a line and adds a block after. The other side just adds the
-        // same block. This currently behaves as one would reasonably hope, but
-        // it's likely that it will change if when we fix
-        // https://github.com/martinvonz/jj/issues/761. Git and Mercurial both duplicate
+        // same block. This currently results in a conflict, but  it's likely that it
+        // will change if when we fix https://github.com/martinvonz/jj/issues/761. Git and Mercurial both duplicate
         // the block in the result.
         assert_eq!(
             merge(
@@ -415,17 +414,16 @@ b {
 "
                 ],
             ),
-            MergeResult::Resolved(hunk(
-                b"\
-a {
-    q
-}
-
-b {
-    x
-}
-"
-            ))
+            MergeResult::Conflict(vec![
+                Conflict::resolved(hunk(b"a {\n")),
+                Conflict::new(
+                    vec![hunk(b"    p\n}\n")],
+                    vec![
+                        hunk(b"    q\n}\n\nb {\n    x\n}\n"),
+                        hunk(b"    p\n}\n\nb {\n    x\n}\n"),
+                    ]
+                )
+            ])
         );
     }
 }

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -61,12 +61,13 @@ fn test_obslog_with_or_without_diff() {
     @  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     │  my description
     │  Resolved conflict in file1:
-    │     1    1: <<<<<<<resolved
+    │     1     : <<<<<<<
     │     2     : %%%%%%%
     │     3     :  foo
     │     4     : +bar
     │     5     : +++++++
     │     6     : >>>>>>>
+    │          1: resolved
     ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     │  my description
     ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -98,13 +98,14 @@ fn test_resolution() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Resolved conflict in file:
-       1    1: <<<<<<<resolution
+       1     : <<<<<<<
        2     : %%%%%%%
        3     : -base
        4     : +a
        5     : +++++++
        6     : b
        7     : >>>>>>>
+            1: resolution
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -142,13 +143,14 @@ fn test_resolution() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Resolved conflict in file:
-       1    1: <<<<<<<resolution
+       1     : <<<<<<<
        2     : %%%%%%%
        3     : -base
        4     : +a
        5     : +++++++
        6     : b
        7     : >>>>>>>
+            1: resolution
     "###);
 
     // Check that if merge tool leaves conflict markers in output file and
@@ -644,11 +646,12 @@ fn test_multiple_conflicts() {
     Resolved conflict in another_file:
        1     : <<<<<<<
        2     : %%%%%%%
-       3    1: -secondresolution baseanother_file
+       3     : -second base
        4     : +second a
        5     : +++++++
        6     : second b
        7     : >>>>>>>
+            1: resolution another_file
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -682,11 +685,12 @@ fn test_multiple_conflicts() {
     Resolved conflict in another_file:
        1     : <<<<<<<
        2     : %%%%%%%
-       3    1: first resolution for auto-secondchosen basefile
+       3    1: first resolution for auto-second base
        4     : +second a
        5     : +++++++
        6     : second b
        7     : >>>>>>>
+            1: chosen file
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -704,19 +708,21 @@ fn test_multiple_conflicts() {
     Resolved conflict in another_file:
        1     : <<<<<<<
        2     : %%%%%%%
-       3    1: first resolution for auto-secondchosen basefile
+       3    1: first resolution for auto-second base
        4     : +second a
        5     : +++++++
        6     : second b
        7     : >>>>>>>
+            1: chosen file
     Resolved conflict in this_file_has_a_very_long_name_to_test_padding:
        1     : <<<<<<<
        2     : %%%%%%%
-       3    1: second resolution for auto-firstchosen basefile
+       3    1: second resolution for auto-first base
        4     : +first a
        5     : +++++++
        6     : first b
        7     : >>>>>>>
+            1: chosen file
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 


### PR DESCRIPTION
Patience diff starts by lining up unique elements (e.g. lines) to find matching segments of the inputs. After that, it refines the non-matching segments by repeating the process. Histogram expands on that by not just considering unique elements but by continuing with elements of count 2, then 3, etc.

Before this commit, when diffing "a b a b b" against "a b a b a b", we would match the two "a"s in the first input against the first two "a"s in the second input. After this patch, we ignore the "a"s because their counts differ, so we try to align the "b"s instead.

I have had this commit lying around since I wrote the histogram diff implementation 18 months ago. I vaguely remember thinking that the way I had implemented it (without this commit) was a bit weird, but I wasn't sure if this commit would be an improvement or not. The bug report from @chooglen today of a case where we behave differently from Git is enough to make me think that we make this change after all.

Many unit tests of the diff algorithm are affected, mostly because we no longer match the leading space in " a " against the space in " b" and similar.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
