### PR TITLE
revset: add unary negate (or set complement) operator '~y'

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -58,6 +58,7 @@ only symbols.
 * `x & y`: Revisions that are in both `x` and `y`.
 * `x | y`: Revisions that are in either `x` or `y` (or both).
 * `x ~ y`: Revisions that are in `x` but not in `y`.
+* `~x`: Revisions that are not in `x`.
 * `x-`: Parents of `x`.
 * `x+`: Children of `x`.
 * `:x`: Ancestors of `x`, including the commits in `x` itself.

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -37,6 +37,7 @@ range_ops = _{ dag_range_op | range_op }
 range_pre_ops = _{ dag_range_pre_op | range_pre_op }
 range_post_ops = _{ dag_range_post_op | range_post_op }
 
+negate_op = { "~" }
 union_op = { "|" }
 intersection_op = { "&" }
 difference_op = { "~" }
@@ -64,7 +65,8 @@ range_expression = _{
 }
 
 expression = {
-  whitespace* ~ range_expression ~ whitespace* ~ (infix_op ~ whitespace* ~ range_expression ~ whitespace*)*
+  whitespace* ~ (negate_op ~ whitespace*)* ~ range_expression ~ whitespace*
+  ~ (infix_op ~ whitespace* ~ (negate_op ~ whitespace*)* ~ range_expression ~ whitespace*)*
 }
 
 program = _{ SOI ~ expression ~ EOI }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -964,18 +964,24 @@ fn internalize_filter_intersection(
     })
 }
 
-/// Eliminates redundant intersection with `all()`.
-fn fold_intersection_with_all(expression: &Rc<RevsetExpression>) -> Option<Rc<RevsetExpression>> {
-    transform_expression_bottom_up(expression, |expression| {
-        if let RevsetExpression::Intersection(expression1, expression2) = expression.as_ref() {
+/// Eliminates redundant nodes like `x & all()`, `~~x`.
+///
+/// This does not rewrite 'x & none()' to 'none()' because 'x' may be an invalid
+/// symbol.
+fn fold_redundant_expression(expression: &Rc<RevsetExpression>) -> Option<Rc<RevsetExpression>> {
+    transform_expression_bottom_up(expression, |expression| match expression.as_ref() {
+        RevsetExpression::NotIn(outer) => match outer.as_ref() {
+            RevsetExpression::NotIn(inner) => Some(inner.clone()),
+            _ => None,
+        },
+        RevsetExpression::Intersection(expression1, expression2) => {
             match (expression1.as_ref(), expression2.as_ref()) {
                 (_, RevsetExpression::All) => Some(expression1.clone()),
                 (RevsetExpression::All, _) => Some(expression2.clone()),
                 _ => None,
             }
-        } else {
-            None
         }
+        _ => None,
     })
 }
 
@@ -998,7 +1004,7 @@ fn fold_difference(expression: &Rc<RevsetExpression>) -> Option<Rc<RevsetExpress
 /// tree.
 pub fn optimize(expression: Rc<RevsetExpression>) -> Rc<RevsetExpression> {
     let expression = internalize_filter_intersection(&expression).unwrap_or(expression);
-    let expression = fold_intersection_with_all(&expression).unwrap_or(expression);
+    let expression = fold_redundant_expression(&expression).unwrap_or(expression);
     fold_difference(&expression).unwrap_or(expression)
 }
 
@@ -2089,6 +2095,38 @@ mod tests {
             ),
             Symbol(
                 "foo",
+            ),
+        )
+        "###);
+
+        // Double/triple negates.
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~~bar").unwrap()), @r###"
+        Intersection(
+            Symbol(
+                "foo",
+            ),
+            Symbol(
+                "bar",
+            ),
+        )
+        "###);
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~~~bar").unwrap()), @r###"
+        Difference(
+            Symbol(
+                "foo",
+            ),
+            Symbol(
+                "bar",
+            ),
+        )
+        "###);
+        insta::assert_debug_snapshot!(optimize(parse("~(all() & ~foo) & bar").unwrap()), @r###"
+        Intersection(
+            Symbol(
+                "foo",
+            ),
+            Symbol(
+                "bar",
             ),
         )
         "###);

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -979,11 +979,27 @@ fn fold_intersection_with_all(expression: &Rc<RevsetExpression>) -> Option<Rc<Re
     })
 }
 
+/// Transforms negative intersection to difference. Redundant intersections like
+/// `all() & e` should have been removed.
+fn fold_difference(expression: &Rc<RevsetExpression>) -> Option<Rc<RevsetExpression>> {
+    transform_expression_bottom_up(expression, |expression| match expression.as_ref() {
+        RevsetExpression::Intersection(expression1, expression2) => {
+            match (expression1.as_ref(), expression2.as_ref()) {
+                (_, RevsetExpression::NotIn(complement)) => Some(expression1.minus(complement)),
+                (RevsetExpression::NotIn(complement), _) => Some(expression2.minus(complement)),
+                _ => None,
+            }
+        }
+        _ => None,
+    })
+}
+
 /// Rewrites the given `expression` tree to reduce evaluation cost. Returns new
 /// tree.
 pub fn optimize(expression: Rc<RevsetExpression>) -> Rc<RevsetExpression> {
     let expression = internalize_filter_intersection(&expression).unwrap_or(expression);
-    fold_intersection_with_all(&expression).unwrap_or(expression)
+    let expression = fold_intersection_with_all(&expression).unwrap_or(expression);
+    fold_difference(&expression).unwrap_or(expression)
 }
 
 pub trait Revset<'repo> {
@@ -2027,6 +2043,90 @@ mod tests {
             unwrap_union(&optimized).0
         ));
         assert_eq!(unwrap_union(&optimized).1.as_ref(), &RevsetExpression::Tags);
+    }
+
+    #[test]
+    fn test_optimize_difference() {
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~bar").unwrap()), @r###"
+        Difference(
+            Symbol(
+                "foo",
+            ),
+            Symbol(
+                "bar",
+            ),
+        )
+        "###);
+        insta::assert_debug_snapshot!(optimize(parse("~foo & bar").unwrap()), @r###"
+        Difference(
+            Symbol(
+                "bar",
+            ),
+            Symbol(
+                "foo",
+            ),
+        )
+        "###);
+        insta::assert_debug_snapshot!(optimize(parse("~foo & bar & ~baz").unwrap()), @r###"
+        Difference(
+            Difference(
+                Symbol(
+                    "bar",
+                ),
+                Symbol(
+                    "foo",
+                ),
+            ),
+            Symbol(
+                "baz",
+            ),
+        )
+        "###);
+        insta::assert_debug_snapshot!(optimize(parse("(all() & ~foo) & bar").unwrap()), @r###"
+        Difference(
+            Symbol(
+                "bar",
+            ),
+            Symbol(
+                "foo",
+            ),
+        )
+        "###);
+
+        // Should be better than '(all() & ~foo) & (all() & ~bar)'.
+        insta::assert_debug_snapshot!(optimize(parse("~foo & ~bar").unwrap()), @r###"
+        Difference(
+            NotIn(
+                Symbol(
+                    "foo",
+                ),
+            ),
+            Symbol(
+                "bar",
+            ),
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_optimize_filter_difference() {
+        // '& baz' can be moved into the filter node, and form a difference node.
+        insta::assert_debug_snapshot!(
+            optimize(parse("(author(foo) & ~bar) & baz").unwrap()), @r###"
+        Filter {
+            candidates: Difference(
+                Symbol(
+                    "baz",
+                ),
+                Symbol(
+                    "bar",
+                ),
+            ),
+            predicate: Author(
+                "foo",
+            ),
+        }
+        "###)
     }
 
     #[test]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1716,6 +1716,12 @@ fn test_evaluate_expression_difference(use_git: bool) {
     let commit4 = graph_builder.commit_with_parents(&[&commit3]);
     let commit5 = graph_builder.commit_with_parents(&[&commit2]);
 
+    // Difference from all
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), &format!("~:{}", commit5.id().hex())),
+        vec![commit4.id().clone(), commit3.id().clone()]
+    );
+
     // Difference between ancestors
     assert_eq!(
         resolve_commit_ids(
@@ -1728,6 +1734,13 @@ fn test_evaluate_expression_difference(use_git: bool) {
         resolve_commit_ids(
             mut_repo.as_repo_ref(),
             &format!(":{} ~ :{}", commit5.id().hex(), commit4.id().hex())
+        ),
+        vec![commit5.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!("~:{} & :{}", commit4.id().hex(), commit5.id().hex())
         ),
         vec![commit5.id().clone()]
     );

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -29,7 +29,7 @@ fn test_syntax_error() {
     1 | x &
       |    ^---
       |
-      = expected dag_range_pre_op, range_pre_op, or primary
+      = expected dag_range_pre_op, range_pre_op, negate_op, or primary
     "###);
 }
 


### PR DESCRIPTION
Because a unary negation node `~y` is more primitive than the corresponding
difference node `x~y`, `~y` is easier to deal with while rewriting the tree.
That's the main reason to add RevsetExpression::NotIn node.

As we have a NotIn node, it makes sense to add an operator for that. This
patch reuses `~` token, which I feel intuitive since the other set operators
looks like bitwise ops. Another option is `!`.

The other things to bikeshed:

 - Do we still need the infix difference operator `x ~ y`?
   (`x & ~y` will be optimized to `Difference(x, y)`)
 - Operator naming: negate_op, not_op, complement_op
 - Variant naming: Negated(), Not(), NotIn(), Complement()

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
