### PR TITLE
docs: describe `git commit --fixup` equivalent

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -227,6 +227,11 @@ parent.
       <td><code>git add -p; git commit --amend</code></td>
     </tr>
     <tr>
+      <td>Move the diff in the working copy into an ancestor</td>
+      <td><code>jj move --to X</code></td>
+      <td><code>git commit --fixup=X; git rebase -i --autosquash X^</code></td>
+    </tr>
+    <tr>
       <td>Interactively move part of the diff in an arbitrary change to another
           arbitrary change</td>
       <td><code>jj move -i --from X --to Y</code></td>


### PR DESCRIPTION
It's probably not obvious that `jj move` can be used for the `git commit --fixup` usecase.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
