### PR TITLE
cli: fix crash by "jj <global_opts>" without subcommand

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4548,7 +4548,7 @@ fn cmd_git(
 
 pub fn default_app() -> clap::Command {
     let app: clap::Command = Commands::augment_subcommands(Args::command());
-    app.arg_required_else_help(true)
+    app.arg_required_else_help(true).subcommand_required(true)
 }
 
 pub fn run_command(

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -43,6 +43,21 @@ fn test_non_utf8_arg() {
 }
 
 #[test]
+fn test_no_subcommand() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_cli_error(test_env.env_root(), &[]);
+    test_env.jj_cmd_cli_error(test_env.env_root(), &["-R."]);
+
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["--version"]);
+    insta::assert_snapshot!(stdout.replace(|c: char| c.is_ascii_digit(), "?"), @r###"
+    jj ?.?.?
+    "###);
+
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["--help"]);
+    insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Jujutsu (An experimental VCS)");
+}
+
+#[test]
 fn test_no_commit_working_copy() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
