### PR TITLE
Add a build status badge to the readme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Thanks to the people who made this release happen!
  * Ilya Grigoriev (@ilyagr)
  * Ruben Slabbert (@rslabbert)
  * Waleed Khan (@arxanas)
+ * Sean E. Russell (@xxxserxxx)
 
 
 ## [0.5.1] - 2022-10-17

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - [Disclaimer](#disclaimer)
 - [Introduction](#introduction)
-- [Status](#status)
+- [Status](#status) ![](https://github.com/martinvonz/jj/workflows/build/badge.svg)
 - [Installation](#installation)
 - [Command-line completion](#command-line-completion)
 - [Getting started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Jujutsu VCS
 
+![](https://img.shields.io/github/license/martinvonz/jj) ![](https://img.shields.io/github/v/release/martinvonz/jj) ![](https://img.shields.io/github/release-date/martinvonz/jj) ![](https://img.shields.io/crates/v/jujutsu)
+<br/>
+![](https://github.com/martinvonz/jj/workflows/build/badge.svg) ![](https://img.shields.io/codefactor/grade/github/martinvonz/jj/main) ![](https://img.shields.io/librariesio/github/martinvonz/jj)
+
 - [Disclaimer](#disclaimer)
 - [Introduction](#introduction)
-- [Status](#status) ![](https://github.com/martinvonz/jj/workflows/build/badge.svg)
+- [Status](#status)
 - [Installation](#installation)
 - [Command-line completion](#command-line-completion)
 - [Getting started](#getting-started)


### PR DESCRIPTION
This just adds a github CI build status badge to the README. Does it need to be called out in the changelog?

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)

