### PR TITLE
cli: switch from `atty` crate to `is-terminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,6 @@ name = "jujutsu"
 version = "0.5.1"
 dependencies = [
  "assert_cmd",
- "atty",
  "chrono",
  "clap 4.0.26",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ harness = false
 members = ["lib"]
 
 [dependencies]
-atty = "0.2.14"
 chrono = { version = "0.4.23", default-features = false, features = ["std", "clock"] }
 clap = { version = "4.0.26", features = ["derive", "deprecated"] }
 clap_complete = "4.0.5"

--- a/deny.toml
+++ b/deny.toml
@@ -51,6 +51,7 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     #"RUSTSEC-0000-0000",
+    "RUSTSEC-2021-0145",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fmt, io};
 
-use atty::Stream;
+use crossterm::tty::IsTty;
 use jujutsu_lib::settings::UserSettings;
 
 use crate::formatter::{Formatter, FormatterFactory};
@@ -80,7 +80,7 @@ fn use_color(choice: ColorChoice) -> bool {
     match choice {
         ColorChoice::Always => true,
         ColorChoice::Never => false,
-        ColorChoice::Auto => atty::is(Stream::Stdout),
+        ColorChoice::Auto => io::stdout().is_tty(),
     }
 }
 
@@ -154,7 +154,7 @@ impl Ui {
     /// Whether continuous feedback should be displayed for long-running
     /// operations
     pub fn use_progress_indicator(&self) -> bool {
-        self.settings().use_progress_indicator() && atty::is(Stream::Stdout)
+        self.settings().use_progress_indicator() && io::stdout().is_tty()
     }
 
     pub fn write(&mut self, text: &str) -> io::Result<()> {
@@ -208,7 +208,7 @@ impl Ui {
     }
 
     pub fn prompt(&mut self, prompt: &str) -> io::Result<String> {
-        if !atty::is(Stream::Stdout) {
+        if !io::stdout().is_tty() {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Cannot prompt for input since the output is not connected to a terminal",
@@ -222,7 +222,7 @@ impl Ui {
     }
 
     pub fn prompt_password(&mut self, prompt: &str) -> io::Result<String> {
-        if !atty::is(Stream::Stdout) {
+        if !io::stdout().is_tty() {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Cannot prompt for input since the output is not connected to a terminal",


### PR DESCRIPTION
The `atty` crate seems unmaintained. There's
https://rustsec.org/advisories/RUSTSEC-2021-0145 filed against it, which `cargo-deny` complains about. A fix for that has been open for well over a year without being fixed
(https://github.com/softprops/atty/pull/51). The `is-terminal` crate is a fork of `atty` with that fixed, plus some other changes.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
