### PR TITLE
Test `jj split` commit description prompt

### DIFF
--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -112,7 +112,7 @@ mod tests {
         let target = temp_dir.path().join("file");
         let mut temp_file = NamedTempFile::new_in(&temp_dir).unwrap();
         temp_file.write_all(b"contents").unwrap();
-        assert!(persist_content_addressed_temp_file(temp_file, &target).is_ok());
+        assert!(persist_content_addressed_temp_file(temp_file, target).is_ok());
     }
 
     #[test_case(false ; "existing file open")]

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -303,7 +303,7 @@ fn upgrade_old_export_state(repo: &Arc<ReadonlyRepo>) {
         if let Ok(mut last_export_file) = OpenOptions::new()
             .write(true)
             .create(true)
-            .open(&repo.repo_path().join("git_export_view"))
+            .open(repo.repo_path().join("git_export_view"))
         {
             let thrift_view = simple_op_store_model::View::from(&last_export_store_view);
             simple_op_store::write_thrift(&thrift_view, &mut last_export_file)

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -122,7 +122,7 @@ fn upgrade_to_thrift(store_path: PathBuf) -> std::io::Result<()> {
 
     fs::write(tmp_store_path.join("thrift_store"), "")?;
     let backup_store_path = store_path.parent().unwrap().join("op_store_old");
-    fs::rename(&store_path, &backup_store_path)?;
+    fs::rename(&store_path, backup_store_path)?;
     fs::rename(&tmp_store_path, &store_path)?;
 
     // Update the pointers to the head(s) of the operation log
@@ -157,7 +157,7 @@ fn upgrade_to_thrift(store_path: PathBuf) -> std::io::Result<()> {
     // Update the pointer to the last operation exported to Git
     let git_export_path = store_path.parent().unwrap().join("git_export_operation_id");
     if let Ok(op_id_string) = fs::read_to_string(&git_export_path) {
-        if let Ok(op_id_bytes) = hex::decode(&op_id_string) {
+        if let Ok(op_id_bytes) = hex::decode(op_id_string) {
             let old_op_id = OperationId::new(op_id_bytes);
             let new_op_id = converted.get(&old_op_id).unwrap();
             fs::write(&git_export_path, new_op_id.hex())?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -228,7 +228,7 @@ impl Ui {
                 "Cannot prompt for input since the output is not connected to a terminal",
             ));
         }
-        rpassword::prompt_password(&format!("{}: ", prompt))
+        rpassword::prompt_password(format!("{prompt}: "))
     }
 
     pub fn size(&self) -> Option<(u16, u16)> {

--- a/testing/fake-diff-editor.rs
+++ b/testing/fake-diff-editor.rs
@@ -61,8 +61,9 @@ fn main() {
                 let actual = files_recursively(&args.before);
                 if actual != expected {
                     eprintln!(
-                        "unexpected files before: {:?}",
-                        actual.iter().sorted().collect_vec()
+                        "fake-diff-editor: unexpected files before. EXPECTED: {:?} ACTUAL: {:?}",
+                        expected.iter().sorted().collect_vec(),
+                        actual.iter().sorted().collect_vec(),
                     );
                     exit(1)
                 }
@@ -72,8 +73,9 @@ fn main() {
                 let actual = files_recursively(&args.after);
                 if actual != expected {
                     eprintln!(
-                        "unexpected files after: {:?}",
-                        actual.iter().sorted().collect_vec()
+                        "fake-diff-editor: unexpected files after. EXPECTED: {:?} ACTUAL: {:?}",
+                        expected.iter().sorted().collect_vec(),
+                        actual.iter().sorted().collect_vec(),
                     );
                     exit(1)
                 }
@@ -92,7 +94,7 @@ fn main() {
                 std::fs::write(args.after.join(file), payload).unwrap();
             }
             _ => {
-                eprintln!("unexpected command: {}", command);
+                eprintln!("fake-diff-editor: unexpected command: {}", command);
                 exit(1)
             }
         }

--- a/testing/fake-editor.rs
+++ b/testing/fake-editor.rs
@@ -48,7 +48,8 @@ fn main() {
             ["expect"] => {
                 let actual = String::from_utf8(std::fs::read(&args.file).unwrap()).unwrap();
                 if actual != payload {
-                    eprintln!("unexpected content: {}", actual);
+                    eprintln!("fake-editor: Unexpected content.\n");
+                    eprintln!("EXPECTED: {payload}\nRECEIVED: {actual}");
                     exit(1)
                 }
             }
@@ -56,7 +57,7 @@ fn main() {
                 std::fs::write(&args.file, payload).unwrap();
             }
             _ => {
-                eprintln!("unexpected command: {}", command);
+                eprintln!("fake-editor: unexpected command: {}", command);
                 exit(1)
             }
         }

--- a/testing/fake-editor.rs
+++ b/testing/fake-editor.rs
@@ -30,8 +30,16 @@ struct Args {
 fn main() {
     let args: Args = Args::parse();
     let edit_script_path = PathBuf::from(std::env::var_os("EDIT_SCRIPT").unwrap());
-    let edit_script = String::from_utf8(std::fs::read(edit_script_path).unwrap()).unwrap();
-    for instruction in edit_script.split('\0') {
+    let edit_script = String::from_utf8(std::fs::read(edit_script_path.clone()).unwrap()).unwrap();
+
+    let mut instructions = edit_script.split('\0').collect_vec();
+    if let Some(pos) = instructions.iter().position(|&i| i == "next invocation\n") {
+        // Overwrite the edit script. The next time `fake-editor` is called, it will
+        // only see the part after the `next invocation` command.
+        std::fs::write(edit_script_path, instructions[pos + 1..].join("\0")).unwrap();
+        instructions.truncate(pos);
+    }
+    for instruction in instructions {
         let (command, payload) = instruction.split_once('\n').unwrap_or((instruction, ""));
         let parts = command.split(' ').collect_vec();
         match parts.as_slice() {

--- a/tests/test_commit_command.rs
+++ b/tests/test_commit_command.rs
@@ -44,7 +44,7 @@ fn test_commit_with_editor() {
     test_env.jj_cmd_success(&workspace_path, &["describe", "-m=initial"]);
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(
-        &edit_script,
+        edit_script,
         "expect
 initial
 JJ: Lines starting with \"JJ: \" (like this one) will be removed.

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -17,7 +17,7 @@ use crate::common::TestEnvironment;
 pub mod common;
 
 #[test]
-fn test_split() {
+fn test_split_by_paths() {
     let mut test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
@@ -33,7 +33,27 @@ fn test_split() {
     "###);
 
     let edit_script = test_env.set_up_fake_editor();
-    std::fs::write(edit_script, "").unwrap();
+    std::fs::write(
+        edit_script,
+        "expect
+JJ: Enter commit description for the first part (parent).
+
+JJ: This part contains the following changes:
+JJ:     A file2
+
+JJ: Lines starting with \"JJ: \" (like this one) will be removed.
+\0next invocation
+\0expect
+JJ: Enter commit description for the second part (child).
+
+JJ: This part contains the following changes:
+JJ:     A file1
+JJ:     A file3
+
+JJ: Lines starting with \"JJ: \" (like this one) will be removed.
+",
+    )
+    .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     First part: 5eebce1de3b0 (no description set)


### PR DESCRIPTION
Adds a test for https://github.com/martinvonz/jj/commit/cf3b6ee2c9c773381c7919c8d95fd8a9262ac562

Also includes fixes to some clippy warnings.

