### PR TITLE
On export to git, skip branches that fail instead of erroring out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   some additional insight into what is happening behind the scenes. 
   Note: This is not comprehensively supported by all operations yet.
 
+* (#493) When exporting branches to Git, we used to fail if some branches could
+  not be exported (e.g. because Git doesn't allow a branch called `main` and
+  another branch called `main/sub`). We now print a warning about these branches
+  instead.
+
 ### Fixed bugs
 
 * (#463) A bug in the export of branches to Git caused spurious conflicted

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -257,8 +257,8 @@ fn export_changes(
 }
 
 /// Reflect changes made in the Jujutsu repo since last export in the underlying
-/// Git repo. If this is the first export, nothing will be exported. The
-/// exported view is recorded in the repo (`.jj/repo/git_export_view`).
+/// Git repo. The exported view is recorded in the repo
+/// (`.jj/repo/git_export_view`).
 pub fn export_refs(
     mut_repo: &mut MutableRepo,
     git_repo: &git2::Repository,

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -187,10 +187,9 @@ fn export_changes(
     let old_branches: HashSet<_> = old_view.branches().keys().cloned().collect();
     let new_branches: HashSet<_> = new_view.branches().keys().cloned().collect();
     let mut exported_view = old_view.store_view().clone();
-    // First find the changes we want need to make and then make them all at once to
-    // reduce the risk of making some changes before we fail.
     let mut refs_to_update = BTreeMap::new();
     let mut refs_to_delete = BTreeSet::new();
+    // First find the changes we want need to make without modifying mut_repo
     for branch_name in old_branches.union(&new_branches) {
         let old_branch = old_view.get_local_branch(branch_name);
         let new_branch = new_view.get_local_branch(branch_name);

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -422,7 +422,7 @@ fn test_export_refs_no_detach() {
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
 
     // Do an initial export to make sure `main` is considered
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(jj_id(&commit1)))
@@ -449,10 +449,10 @@ fn test_export_refs_no_op() {
     git::import_refs(mut_repo, &git_repo).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
 
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     // The export should be a no-op since nothing changed on the jj side since last
     // export
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(jj_id(&commit1)))
@@ -484,7 +484,7 @@ fn test_export_refs_branch_changed() {
     let mut_repo = tx.mut_repo();
     git::import_refs(mut_repo, &git_repo).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
 
     let new_commit = create_random_commit(&test_data.settings, &test_data.repo)
         .set_parents(vec![jj_id(&commit)])
@@ -494,7 +494,7 @@ fn test_export_refs_branch_changed() {
         RefTarget::Normal(new_commit.id().clone()),
     );
     mut_repo.remove_local_branch("delete-me");
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(new_commit.id().clone()))
@@ -527,7 +527,7 @@ fn test_export_refs_current_branch_changed() {
     let mut_repo = tx.mut_repo();
     git::import_refs(mut_repo, &git_repo).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
 
     let new_commit = create_random_commit(&test_data.settings, &test_data.repo)
         .set_parents(vec![jj_id(&commit1)])
@@ -536,7 +536,7 @@ fn test_export_refs_current_branch_changed() {
         "main".to_string(),
         RefTarget::Normal(new_commit.id().clone()),
     );
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(new_commit.id().clone()))
@@ -565,7 +565,7 @@ fn test_export_refs_unborn_git_branch() {
     let mut_repo = tx.mut_repo();
     git::import_refs(mut_repo, &git_repo).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
 
     let new_commit =
         create_random_commit(&test_data.settings, &test_data.repo).write_to_repo(mut_repo);
@@ -573,7 +573,7 @@ fn test_export_refs_unborn_git_branch() {
         "main".to_string(),
         RefTarget::Normal(new_commit.id().clone()),
     );
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(new_commit.id().clone()))
@@ -625,7 +625,7 @@ fn test_export_import_sequence() {
     mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));
 
     // Export the branch to git
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(commit_b.id().clone()))
@@ -668,7 +668,7 @@ fn test_export_conflicts() {
         "feature".to_string(),
         RefTarget::Normal(commit_a.id().clone()),
     );
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
 
     // Create a conflict and export. It should not be exported, but other changes
     // should be.
@@ -680,7 +680,7 @@ fn test_export_conflicts() {
             adds: vec![commit_b.id().clone(), commit_c.id().clone()],
         },
     );
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(()));
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(
         git_repo
             .find_reference("refs/heads/feature")
@@ -717,19 +717,31 @@ fn test_export_partial_failure() {
     // `main/sub` will conflict with `main` in Git, at least when using loose ref
     // storage
     mut_repo.set_local_branch("main/sub".to_string(), target);
-    // TODO: this should succeed
-    assert!(git::export_refs(mut_repo, &git_repo).is_err());
+    assert_eq!(
+        git::export_refs(mut_repo, &git_repo),
+        Ok(vec!["".to_string(), "main/sub".to_string()])
+    );
 
     // The `main` branch should have succeeded but the other should have failed
     assert!(git_repo.find_reference("refs/heads/").is_err());
-    assert!(git_repo.find_reference("refs/heads/main").is_err());
+    assert_eq!(
+        git_repo
+            .find_reference("refs/heads/main")
+            .unwrap()
+            .target()
+            .unwrap(),
+        git_id(&commit_a)
+    );
     assert!(git_repo.find_reference("refs/heads/main/sub").is_err());
 
     // Now remove the `main` branch and make sure that the `main/sub` gets exported
     // even though it didn't change
-    // TODO: this should succeed
     mut_repo.remove_local_branch("main");
-    assert!(git::export_refs(mut_repo, &git_repo).is_err());
+    // TODO: main/sub should not have failed
+    assert_eq!(
+        git::export_refs(mut_repo, &git_repo),
+        Ok(vec!["".to_string(), "main/sub".to_string()])
+    );
     assert!(git_repo.find_reference("refs/heads/").is_err());
     assert!(git_repo.find_reference("refs/heads/main").is_err());
     assert!(git_repo.find_reference("refs/heads/main/sub").is_err());

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -737,14 +737,20 @@ fn test_export_partial_failure() {
     // Now remove the `main` branch and make sure that the `main/sub` gets exported
     // even though it didn't change
     mut_repo.remove_local_branch("main");
-    // TODO: main/sub should not have failed
     assert_eq!(
         git::export_refs(mut_repo, &git_repo),
-        Ok(vec!["".to_string(), "main/sub".to_string()])
+        Ok(vec!["".to_string()])
     );
     assert!(git_repo.find_reference("refs/heads/").is_err());
     assert!(git_repo.find_reference("refs/heads/main").is_err());
-    assert!(git_repo.find_reference("refs/heads/main/sub").is_err());
+    assert_eq!(
+        git_repo
+            .find_reference("refs/heads/main/sub")
+            .unwrap()
+            .target()
+            .unwrap(),
+        git_id(&commit_a)
+    );
 }
 
 #[test]

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -63,7 +63,7 @@ fn test_init_external_git() {
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let git_repo_path = uncanonical.join("git");
     git2::Repository::init(&git_repo_path).unwrap();
-    std::fs::create_dir(&uncanonical.join("jj")).unwrap();
+    std::fs::create_dir(uncanonical.join("jj")).unwrap();
     let (workspace, repo) =
         Workspace::init_external_git(&settings, &uncanonical.join("jj"), &git_repo_path).unwrap();
     assert!(repo.store().git_repo().is_some());

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -436,7 +436,7 @@ fn test_snapshot_special_file() {
     std::fs::write(&file1_disk_path, "contents".as_bytes()).unwrap();
     let file2_path = RepoPath::from_internal_string("file2");
     let file2_disk_path = file2_path.to_fs_path(&workspace_root);
-    std::fs::write(&file2_disk_path, "contents".as_bytes()).unwrap();
+    std::fs::write(file2_disk_path, "contents".as_bytes()).unwrap();
     let socket_disk_path = workspace_root.join("socket");
     UnixListener::bind(&socket_disk_path).unwrap();
     // Test the setup

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -53,9 +53,9 @@ use maplit::{hashmap, hashset};
 use pest::Parser;
 
 use crate::cli_util::{
-    print_checkout_stats, resolve_base_revs, short_commit_description, short_commit_hash,
-    user_error, user_error_with_hint, write_commit_summary, Args, CommandError, CommandHelper,
-    WorkspaceCommandHelper,
+    print_checkout_stats, print_failed_git_export, resolve_base_revs, short_commit_description,
+    short_commit_hash, user_error, user_error_with_hint, write_commit_summary, Args, CommandError,
+    CommandHelper, WorkspaceCommandHelper,
 };
 use crate::formatter::{Formatter, PlainTextFormatter};
 use crate::graphlog::{AsciiGraphDrawer, Edge};
@@ -4538,8 +4538,9 @@ fn cmd_git_export(
     let repo = workspace_command.repo();
     let git_repo = get_git_repo(repo.store())?;
     let mut tx = workspace_command.start_transaction("export git refs");
-    git::export_refs(tx.mut_repo(), &git_repo)?;
+    let failed_branches = git::export_refs(tx.mut_repo(), &git_repo)?;
     workspace_command.finish_transaction(ui, tx)?;
+    print_failed_git_export(ui, &failed_branches)?;
     Ok(())
 }
 

--- a/tests/test_git_export.rs
+++ b/tests/test_git_export.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::{get_stderr_string, TestEnvironment};
+
+pub mod common;
+
+#[test]
+fn test_git_export_conflicting_git_refs() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // TODO: Make it an error to try to create a branch with an empty name
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", ""]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "main"]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "main/sub"]);
+    let assert = test_env
+        .jj_cmd(&repo_path, &["git", "export"])
+        .assert()
+        .success()
+        .stdout("");
+    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    Failed to export some branches:
+      
+      main/sub
+    "###);
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
