### PR TITLE
feature: support relative timestamps as a config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   another branch called `main/sub`). We now print a warning about these branches
   instead.
 
+* `jj log`, `jj show`, and `jj obslog` now all support showing relative
+  timestamps by setting `ui.relative-timestamps = true` in the config file.
+
 ### Fixed bugs
 
 * (#463) A bug in the export of branches to Git caused spurious conflicted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "testutils",
  "textwrap 0.16.0",
  "thiserror",
+ "timeago",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1762,6 +1763,12 @@ dependencies = [
  "integer-encoding",
  "ordered-float",
 ]
+
+[[package]]
+name = "timeago"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec32dde57efb15c035ac074118d7f32820451395f28cb0524a01d4e94983b26"
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde = { version = "1.0", features = ["derive"] }
 slab = "0.4.7"
 tempfile = "3.3.0"
 textwrap = "0.16.0"
+timeago = { version = "0.3.1", default-features = false }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["std", "ansi", "env-filter", "fmt"] }

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,6 +91,15 @@ further settings are passed on via the following:
     merge-tools.kdiff3.program = "kdiff3"
     merge-tools.kdiff3.edit-args = ["--merge", "--cs", "CreateBakFiles=0"]
 
+
+## Relative timestamps
+
+    ui.relative-timestamps = true
+
+False by default, but setting to true will change timestamps to be rendered
+as `x days/hours/seconds ago` instead of being rendered as a full timestamp.
+
+
 # Alternative ways to specify configuration settings
 
 Instead of `~/.jjconfig.toml`, the config settings can be located at

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -13,3 +13,6 @@ ui.editor = "pico" # the default
 
 diff-editor = "meld" # default, requires meld to be installed
 # diff-editor = "vimdiff"
+
+ui.relative-timestamps = false # the default
+# ui.relative-timestamps = true # renders timestamps relatively, e.g. "x hours ago"

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -143,6 +143,12 @@ impl UserSettings {
             .unwrap_or(true)
     }
 
+    pub fn relative_timestamps(&self) -> bool {
+        self.config
+            .get_bool("ui.relative-timestamps")
+            .unwrap_or(false)
+    }
+
     pub fn config(&self) -> &config::Config {
         &self.config
     }

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{FixedOffset, LocalResult, TimeZone, Utc};
-use jujutsu_lib::backend::{CommitId, Signature};
+use chrono::{DateTime, FixedOffset, LocalResult, TimeZone, Utc};
+use jujutsu_lib::backend::{CommitId, Signature, Timestamp};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::RepoRef;
@@ -26,8 +26,9 @@ use crate::templater::{
     AuthorProperty, BranchProperty, ChangeIdProperty, CommitIdKeyword, CommitterProperty,
     ConditionalTemplate, ConflictProperty, ConstantTemplateProperty, DescriptionProperty,
     DivergentProperty, DynamicLabelTemplate, GitRefsProperty, IsGitHeadProperty,
-    IsWorkingCopyProperty, LabelTemplate, ListTemplate, LiteralTemplate, StringPropertyTemplate,
-    TagProperty, Template, TemplateFunction, TemplateProperty, WorkingCopiesProperty,
+    IsWorkingCopyProperty, LabelTemplate, ListTemplate, LiteralTemplate, SignatureTimestamp,
+    StringPropertyTemplate, TagProperty, Template, TemplateFunction, TemplateProperty,
+    WorkingCopiesProperty,
 };
 
 #[derive(Parser)]
@@ -94,25 +95,41 @@ impl TemplateProperty<Signature, String> for SignatureEmail {
     }
 }
 
-struct SignatureTimestamp;
+fn datetime_from_timestamp(context: &Timestamp) -> Option<DateTime<FixedOffset>> {
+    let utc = match Utc.timestamp_opt(
+        context.timestamp.0.div_euclid(1000),
+        (context.timestamp.0.rem_euclid(1000)) as u32 * 1000000,
+    ) {
+        LocalResult::None => {
+            return None;
+        }
+        LocalResult::Single(x) => x,
+        LocalResult::Ambiguous(y, _z) => y,
+    };
 
-impl TemplateProperty<Signature, String> for SignatureTimestamp {
-    fn extract(&self, context: &Signature) -> String {
-        let utc = match Utc.timestamp_opt(
-            context.timestamp.timestamp.0.div_euclid(1000),
-            (context.timestamp.timestamp.0.rem_euclid(1000)) as u32 * 1000000,
-        ) {
-            LocalResult::None => {
-                return "<out-of-range date>".to_string();
-            }
-            LocalResult::Single(x) => x,
-            LocalResult::Ambiguous(y, _z) => y,
-        };
-        let datetime = utc.with_timezone(
-            &FixedOffset::east_opt(context.timestamp.tz_offset * 60)
+    Some(
+        utc.with_timezone(
+            &FixedOffset::east_opt(context.tz_offset * 60)
                 .unwrap_or_else(|| FixedOffset::east_opt(0).unwrap()),
-        );
-        datetime.format("%Y-%m-%d %H:%M:%S.%3f %:z").to_string()
+        ),
+    )
+}
+
+struct RelativeTimestampString;
+
+impl TemplateProperty<Timestamp, String> for RelativeTimestampString {
+    fn extract(&self, context: &Timestamp) -> String {
+        datetime_from_timestamp(context)
+            .and_then(|datetime| {
+                let now = chrono::Local::now();
+
+                now.signed_duration_since(datetime).to_std().ok()
+            })
+            .map(|duration| {
+                let f = timeago::Formatter::new();
+                f.convert(duration)
+            })
+            .unwrap_or_else(|| "<out-of-range date>".to_string())
     }
 }
 
@@ -140,6 +157,10 @@ fn parse_method_chain<'a, I: 'a>(
             }
             Property::Signature(property) => {
                 let next_method = parse_signature_method(method);
+                next_method.after(property)
+            }
+            Property::Timestamp(property) => {
+                let next_method = parse_timestamp_method(method);
                 next_method.after(property)
             }
         }
@@ -200,8 +221,22 @@ fn parse_signature_method<'a>(method: Pair<Rule>) -> Property<'a, Signature> {
         //       `author % (name "<" email ">")`)?
         "name" => Property::String(Box::new(SignatureName)),
         "email" => Property::String(Box::new(SignatureEmail)),
-        "timestamp" => Property::String(Box::new(SignatureTimestamp)),
+        "timestamp" => Property::Timestamp(Box::new(SignatureTimestamp)),
         name => panic!("no such commit ID method: {}", name),
+    };
+    let chain_method = inner.last().unwrap();
+    parse_method_chain(chain_method, this_function)
+}
+
+fn parse_timestamp_method<'a>(method: Pair<Rule>) -> Property<'a, Timestamp> {
+    assert_eq!(method.as_rule(), Rule::method);
+    let mut inner = method.into_inner();
+    let name = inner.next().unwrap();
+    // TODO: validate arguments
+
+    let this_function = match name.as_str() {
+        "ago" => Property::String(Box::new(RelativeTimestampString)),
+        name => panic!("no such timestamp method: {}", name),
     };
     let chain_method = inner.last().unwrap();
     parse_method_chain(chain_method, this_function)
@@ -212,6 +247,7 @@ enum Property<'a, I> {
     Boolean(Box<dyn TemplateProperty<I, bool> + 'a>),
     CommitId(Box<dyn TemplateProperty<I, CommitId> + 'a>),
     Signature(Box<dyn TemplateProperty<I, Signature> + 'a>),
+    Timestamp(Box<dyn TemplateProperty<I, Timestamp> + 'a>),
 }
 
 impl<'a, I: 'a> Property<'a, I> {
@@ -230,6 +266,10 @@ impl<'a, I: 'a> Property<'a, I> {
                 Box::new(move |value| property.extract(&value)),
             ))),
             Property::Signature(property) => Property::Signature(Box::new(TemplateFunction::new(
+                first,
+                Box::new(move |value| property.extract(&value)),
+            ))),
+            Property::Timestamp(property) => Property::Timestamp(Box::new(TemplateFunction::new(
                 first,
                 Box::new(move |value| property.extract(&value)),
             ))),
@@ -281,6 +321,13 @@ fn coerce_to_string<'a, I: 'a>(
         Property::Signature(property) => Box::new(TemplateFunction::new(
             property,
             Box::new(|signature| signature.name),
+        )),
+        Property::Timestamp(property) => Box::new(TemplateFunction::new(
+            property,
+            Box::new(|timestamp| match datetime_from_timestamp(&timestamp) {
+                Some(datetime) => datetime.format("%Y-%m-%d %H:%M:%S.%3f %:z").to_string(),
+                None => "<out-of-range date>".to_string(),
+            }),
         )),
     }
 }

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -18,7 +18,7 @@ use std::io;
 use std::ops::{Add, AddAssign};
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{ChangeId, CommitId, Signature};
+use jujutsu_lib::backend::{ChangeId, CommitId, Signature, Timestamp};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::RepoRef;
@@ -436,5 +436,13 @@ impl CommitIdKeyword {
 impl TemplateProperty<Commit, CommitId> for CommitIdKeyword {
     fn extract(&self, context: &Commit) -> CommitId {
         context.id().clone()
+    }
+}
+
+pub struct SignatureTimestamp;
+
+impl TemplateProperty<Signature, Timestamp> for SignatureTimestamp {
+    fn extract(&self, context: &Signature) -> Timestamp {
+        context.timestamp.clone()
     }
 }

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use common::{get_stderr_string, get_stdout_string, TestEnvironment};
+use regex::Regex;
 
 pub mod common;
 
@@ -308,5 +309,39 @@ fn test_default_revset() {
             .jj_cmd_success(&repo_path, &["log", "-T", "commit_id"])
             .lines()
             .count()
+    );
+}
+
+#[test]
+fn test_log_author_timestamp() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @ 2001-02-03 04:05:09.000 +07:00
+    o 2001-02-03 04:05:07.000 +07:00
+    o 1970-01-01 00:00:00.000 +00:00
+    "###);
+}
+
+#[test]
+fn test_log_author_timestamp_ago() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().ago()"]);
+    let line_re = Regex::new(r"@|o [0-9]+ years ago").unwrap();
+    assert!(
+        stdout.lines().all(|x| line_re.is_match(x)),
+        "expected every line to match regex"
     );
 }

--- a/tests/test_show_command.rs
+++ b/tests/test_show_command.rs
@@ -1,0 +1,64 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::TestEnvironment;
+use itertools::Itertools;
+use regex::Regex;
+
+pub mod common;
+
+#[test]
+fn test_show() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
+    let stdout = stdout.lines().skip(2).join("\n");
+
+    insta::assert_snapshot!(stdout, @r###"
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+
+    (no description set)
+    "###);
+}
+
+#[test]
+fn test_show_relative_timestamps() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.add_config(
+        br#"[ui]
+        relative-timestamps = true
+        "#,
+    );
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
+    let timestamp_re = Regex::new(r"\([0-9]+ years ago\)").unwrap();
+    let stdout = stdout
+        .lines()
+        .skip(2)
+        .map(|x| timestamp_re.replace_all(x, "(...timestamp...)"))
+        .join("\n");
+
+    insta::assert_snapshot!(stdout, @r###"
+    Author: Test User <test.user@example.com> (...timestamp...)
+    Committer: Test User <test.user@example.com> (...timestamp...)
+
+    (no description set)
+    "###);
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

This makes the commits logs an extra bit more readable for me, mainly because it doesn't consume as much horizontal space per log line anymore.

Example output:
![image](https://user-images.githubusercontent.com/4464102/204075296-a4f6d232-799b-4b2a-9607-a3d87d4f2c2d.png)

# Code notes
1. It's a bit awkward having this be a setting since it requires passing the settings throughout the parsing code. If this was the only way of formatting datetimes we could rip all that out but I didn't want to make a unilateral decision there and I wanted to get feedback on it first.

2. I'm also not super happy with having the `chrono::Local::new()` deep in a method and I would have preferred to create a "called_time" or equivalently named variable at the start and pass that through (probably in the Ui or another context object) but that would have been a far deeper refactor which I would have wanted feedback on as well.

3. I'm using [timeago](https://lib.rs/crates/timeago) because of the options I checked it seems to hit the best sweet spot of date/minimal/functional. Other options I looked into were [chrono-english](https://lib.rs/crates/chrono-english), [humantime](https://lib.rs/crates/humantime), and [chrono-humanize](https://lib.rs/crates/chrono-humanize) (humanize was the original attempt but it unconditionally pulls in extra dependencies). In the future it might make sense to use [RelativeTimeFormat](https://github.com/unicode-org/icu4x/pull/2822) for the icu4 project once it has landed.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
