### PR TITLE
revset: implement simple symbol alias expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The new revset function `empty()` finds commits modifying no files.
 
+* Added support for revset aliases. New symbols can be configured by
+  `revset-aliases.<name> = <expression>`.
+
 * It is now possible to specify configuration options on the command line
   with the new `--config-toml` global option.
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -115,6 +115,18 @@ revsets (expressions) as arguments.
   in `x` doesn't exist (e.g. is an unknown branch name.)
 
 
+## Aliases
+
+New symbols can be defined in the config file, by using any combination
+of the predefined symbols/functions and other aliases.
+
+For example:
+```toml
+[revset-aliases]
+'mine' = 'author(martinvonz)'
+```
+
+
 ## Examples
 
 Show the parent(s) of the working-copy commit (like `git log -1 HEAD`):

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -68,3 +68,7 @@ expression = {
 }
 
 program = _{ SOI ~ expression ~ EOI }
+
+alias_declaration = _{
+  SOI ~ identifier ~ EOI
+}

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -22,7 +22,8 @@ use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::repo::RepoRef;
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::revset::{
-    self, optimize, parse, resolve_symbol, RevsetError, RevsetExpression, RevsetWorkspaceContext,
+    self, optimize, parse, resolve_symbol, RevsetAliasesMap, RevsetError, RevsetExpression,
+    RevsetWorkspaceContext,
 };
 use jujutsu_lib::workspace::Workspace;
 use test_case::test_case;
@@ -135,7 +136,7 @@ fn test_resolve_symbol_commit_id() {
     // Test present() suppresses only NoSuchRevision error
     assert_eq!(resolve_commit_ids(repo_ref, "present(foo)"), []);
     assert_eq!(
-        optimize(parse("present(04)", None).unwrap())
+        optimize(parse("present(04)", &RevsetAliasesMap::new(), None).unwrap())
             .evaluate(repo_ref, None)
             .map(|_| ()),
         Err(RevsetError::AmbiguousCommitIdPrefix("04".to_string()))
@@ -443,7 +444,7 @@ fn test_resolve_symbol_git_refs() {
 }
 
 fn resolve_commit_ids(repo: RepoRef, revset_str: &str) -> Vec<CommitId> {
-    let expression = optimize(parse(revset_str, None).unwrap());
+    let expression = optimize(parse(revset_str, &RevsetAliasesMap::new(), None).unwrap());
     expression
         .evaluate(repo, None)
         .unwrap()
@@ -463,7 +464,8 @@ fn resolve_commit_ids_in_workspace(
         workspace_id: workspace.workspace_id(),
         workspace_root: workspace.workspace_root(),
     };
-    let expression = optimize(parse(revset_str, Some(&workspace_ctx)).unwrap());
+    let expression =
+        optimize(parse(revset_str, &RevsetAliasesMap::new(), Some(&workspace_ctx)).unwrap());
     expression
         .evaluate(repo, Some(&workspace_ctx))
         .unwrap()

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -16,6 +16,7 @@ use std::collections::{HashSet, VecDeque};
 use std::env::ArgsOs;
 use std::ffi::OsString;
 use std::fmt::Debug;
+use std::iter;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -175,7 +176,8 @@ impl From<GitExportError> for CommandError {
 
 impl From<RevsetParseError> for CommandError {
     fn from(err: RevsetParseError) -> Self {
-        user_error(format!("Failed to parse revset: {err}"))
+        let message = iter::successors(Some(&err), |e| e.origin()).join("\n");
+        user_error(format!("Failed to parse revset: {message}"))
     }
 }
 

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -36,7 +36,8 @@ use jujutsu_lib::operation::Operation;
 use jujutsu_lib::repo::{BackendFactories, MutableRepo, ReadonlyRepo, RepoRef, RewriteRootCommit};
 use jujutsu_lib::repo_path::{FsPathParseError, RepoPath};
 use jujutsu_lib::revset::{
-    Revset, RevsetError, RevsetExpression, RevsetParseError, RevsetWorkspaceContext,
+    Revset, RevsetAliasesMap, RevsetError, RevsetExpression, RevsetParseError,
+    RevsetWorkspaceContext,
 };
 use jujutsu_lib::settings::UserSettings;
 use jujutsu_lib::transaction::Transaction;
@@ -606,7 +607,8 @@ impl WorkspaceCommandHelper {
         &self,
         revision_str: &str,
     ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
-        let expression = revset::parse(revision_str, Some(&self.revset_context()))?;
+        let aliases_map = RevsetAliasesMap::new(); // TODO: load from settings
+        let expression = revset::parse(revision_str, &aliases_map, Some(&self.revset_context()))?;
         Ok(revset::optimize(expression))
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -40,7 +40,7 @@ use jujutsu_lib::operation::Operation;
 use jujutsu_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
 use jujutsu_lib::repo::{ReadonlyRepo, RepoRef};
 use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::revset::RevsetExpression;
+use jujutsu_lib::revset::{RevsetAliasesMap, RevsetExpression};
 use jujutsu_lib::revset_graph_iterator::{RevsetGraphEdge, RevsetGraphEdgeType};
 use jujutsu_lib::rewrite::{back_out_commit, merge_commit_trees, rebase_commit, DescendantRebaser};
 use jujutsu_lib::settings::UserSettings;
@@ -2164,7 +2164,9 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
                  often not useful because all non-empty commits touch '.'.  If you meant to show \
                  the working copy commit, pass -r '@' instead.\n"
             ))?;
-        } else if revset.is_empty() && revset::parse(only_path, None).is_ok() {
+        } else if revset.is_empty()
+            && revset::parse(only_path, &RevsetAliasesMap::new(), None).is_ok()
+        {
             ui.write_warn(&format!(
                 "warning: The argument {only_path:?} is being interpreted as a path. To specify a \
                  revset, pass -r {only_path:?} instead.\n"


### PR DESCRIPTION
Example:
```
[revset-alias]
'M' = 'present("main") | present("master")'
'mine' = 'author("yuya")'
```

Config syntax to bikeshed:
- naming: `[revset-alias]` vs `[revset-aliases]`?
- function alias will need quotes: `'f(x)' = 'x'`

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
