### PR TITLE
git: revert change to SSH agent detection

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -586,16 +586,10 @@ impl<'a> RemoteCallbacks<'a> {
                 return Ok(creds);
             } else if let Some(username) = username_from_url {
                 if allowed_types.contains(git2::CredentialType::SSH_KEY) {
-                    if let Some((ssh_auth_sock, ssh_agent_pid)) = std::env::var("SSH_AUTH_SOCK")
-                        .ok()
-                        .zip(std::env::var("SSH_AGENT_PID").ok())
+                    if std::env::var("SSH_AUTH_SOCK").is_ok()
+                        || std::env::var("SSH_AGENT_PID").is_ok()
                     {
-                        tracing::debug!(
-                            username,
-                            ssh_auth_sock,
-                            ssh_agent_pid,
-                            "using ssh_key_from_agent"
-                        );
+                        tracing::debug!(username, "using ssh_key_from_agent");
                         return git2::Cred::ssh_key_from_agent(username).map_err(|err| {
                             tracing::error!(err = %err);
                             err


### PR DESCRIPTION
84b924946f4189960d6d8d7ae2e04d296d272906 switched to requiring both SSH_AUTH_SOCK and SSH_AGENT_PID for an agent to be used. This doesn't seem to be a typical situation, so perhaps it was not intended.

CC @rslabbert

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
