### PR TITLE
Make `diff --types` show diff summary as two states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Nodes in the (text-based) graphical log output now use a `●` symbol instead
   of the letter `o`. The ASCII-based graph styles still use `o`.  
 
+* Commands that accept a diff format (`jj diff`, `jj interdiff`, `jj show`,
+  `jj log`, and `jj obslog`) now accept `--types` to show only the type of file
+  before and after.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/src/diff_util.rs
+++ b/src/diff_util.rs
@@ -33,6 +33,7 @@ use crate::cli_util::{CommandError, WorkspaceCommandHelper};
 use crate::formatter::Formatter;
 
 #[derive(clap::Args, Clone, Debug)]
+#[command(group(clap::ArgGroup::new("diff-format").args(&["git", "color_words"])))]
 pub struct DiffFormatArgs {
     /// For each path, show only whether it was modified, added, or removed
     #[arg(long, short)]

--- a/tests/test_diff_command.rs
+++ b/tests/test_diff_command.rs
@@ -102,6 +102,22 @@ fn test_diff_basic() {
 }
 
 #[test]
+fn test_diff_bad_args() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &["diff", "--color-words", "--git"]);
+    insta::assert_snapshot!(stderr, @r###"
+    error: The argument '--color-words' cannot be used with '--git'
+
+    Usage: jj diff --color-words [PATHS]...
+
+    For more information try '--help'
+    "###);
+}
+
+#[test]
 fn test_diff_relative_paths() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -165,8 +165,8 @@ fn test_log_with_or_without_diff() {
     +foo
     "###);
 
-    // Both formats enabled if `--git` and `--color-words` are explicitly specified
-    let stdout = test_env.jj_cmd_success(
+    // Cannot use both `--git` and `--color-words`
+    let stderr = test_env.jj_cmd_cli_error(
         &repo_path,
         &[
             "log",
@@ -178,28 +178,12 @@ fn test_log_with_or_without_diff() {
             "--color-words",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    a new commit
-    diff --git a/file1 b/file1
-    index 257cc5642c...3bd1f0e297 100644
-    --- a/file1
-    +++ b/file1
-    @@ -1,1 +1,2 @@
-     foo
-    +bar
-    Modified regular file file1:
-       1    1: foo
-            2: bar
-    add a file
-    diff --git a/file1 b/file1
-    new file mode 100644
-    index 0000000000..257cc5642c
-    --- /dev/null
-    +++ b/file1
-    @@ -1,0 +1,1 @@
-    +foo
-    Added regular file file1:
-            1: foo
+    insta::assert_snapshot!(stderr, @r###"
+    error: The argument '--git' cannot be used with '--color-words'
+
+    Usage: jj log --template <TEMPLATE> --no-graph --patch --git [PATHS]...
+
+    For more information try '--help'
     "###);
 
     // `-s` with or without graph


### PR DESCRIPTION


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
