### PR TITLE
Paginate help output

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use clap;
 use clap::builder::{NonEmptyStringValueParser, TypedValueParser, ValueParserFactory};
-use clap::{Arg, ArgMatches, Command, Error, FromArgMatches};
+use clap::{Arg, ArgAction, ArgMatches, Command, Error, FromArgMatches};
 use git2::{Oid, Repository};
 use itertools::Itertools;
 use jujutsu_lib::backend::{BackendError, CommitId, TreeId};
@@ -1304,6 +1304,16 @@ pub struct GlobalArgs {
         default_value = "@"
     )]
     pub at_operation: String,
+    /// Enable verbose logging
+    #[arg(long, short = 'v', global = true, help_heading = "Global Options")]
+    pub verbose: bool,
+
+    #[command(flatten)]
+    pub early_args: EarlyArgs,
+}
+
+#[derive(clap::Args, Clone, Debug)]
+pub struct EarlyArgs {
     /// When to colorize output (always, never, auto)
     #[arg(
         long,
@@ -1317,9 +1327,12 @@ pub struct GlobalArgs {
         long,
         value_name = "WHEN",
         global = true,
-        help_heading = "Global Options"
+        help_heading = "Global Options",
+        action = ArgAction::SetTrue
     )]
-    pub no_pager: bool,
+    // Parsing with ignore_errors will crash if this is bool, so use
+    // Option<bool>.
+    pub no_pager: Option<bool>,
     /// Additional configuration options
     //  TODO: Introduce a `--config` option with simpler syntax for simple
     //  cases, designed so that `--config ui.color=auto` works
@@ -1330,9 +1343,6 @@ pub struct GlobalArgs {
         help_heading = "Global Options"
     )]
     pub config_toml: Vec<String>,
-    /// Enable verbose logging
-    #[arg(long, short = 'v', global = true, help_heading = "Global Options")]
-    pub verbose: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1440,6 +1450,25 @@ fn resolve_aliases(
     }
 }
 
+/// Parse args that must be interpreted early, e.g. before printing help.
+fn handle_early_args(ui: &mut Ui, app: &clap::Command) -> Result<(), CommandError> {
+    // ignore_errors() bypasses errors like "--help" or missing subcommand
+    let early_matches = app.clone().ignore_errors(true).get_matches();
+    let mut args: EarlyArgs = EarlyArgs::from_arg_matches(&early_matches).unwrap();
+
+    if let Some(choice) = args.color {
+        args.config_toml
+            .push(format!("ui.color=\"{}\"", choice.to_string()));
+    }
+    if args.no_pager.unwrap_or_default() {
+        ui.set_pagination(crate::ui::PaginationChoice::No);
+    }
+    if !args.config_toml.is_empty() {
+        ui.extra_toml_settings(&args.config_toml)?;
+    }
+    Ok(())
+}
+
 pub fn parse_args(
     ui: &mut Ui,
     app: clap::Command,
@@ -1453,22 +1482,12 @@ pub fn parse_args(
             return Err(CommandError::CliError("Non-utf8 argument".to_string()));
         }
     }
+    handle_early_args(ui, &app)?;
 
     let string_args = resolve_aliases(ui.settings(), &app, &string_args)?;
     let matches = app.clone().try_get_matches_from(&string_args)?;
 
-    let mut args: Args = Args::from_arg_matches(&matches).unwrap();
-    if let Some(choice) = args.global_args.color {
-        args.global_args
-            .config_toml
-            .push(format!("ui.color=\"{}\"", choice.to_string()));
-    }
-    if args.global_args.no_pager {
-        ui.set_pagination(crate::ui::PaginationChoice::No);
-    }
-    if !args.global_args.config_toml.is_empty() {
-        ui.extra_toml_settings(&args.global_args.config_toml)?;
-    }
+    let args: Args = Args::from_arg_matches(&matches).unwrap();
     let command_helper = CommandHelper::new(app, string_args, args.global_args);
     Ok((command_helper, matches))
 }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1501,6 +1501,13 @@ pub fn handle_command_result(ui: &mut Ui, result: Result<(), CommandError>) -> i
                 inner.render().to_string()
             };
 
+            match inner.kind() {
+                clap::error::ErrorKind::DisplayHelp
+                | clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+                    ui.request_pager()
+                }
+                _ => {}
+            };
             // Definitions for exit codes and streams come from
             // https://github.com/clap-rs/clap/blob/master/src/error/mod.rs
             match inner.kind() {


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

It can be useful to paginate the help output (e.g. `jj help`) for easy reading. This should also support `--no-pager` for users who prefer not to use pagination, but because of how `clap` parse `help` (and others), this requires changing how we parse global args (see the second commit). As a side-benefit, we can now pass `--color` to `jj help`.

This is still a WIP because this does not have tests.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
