### PR TITLE
RevWalk: push all parents and deduplicate later, return early if filled with unwanted

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -967,15 +967,26 @@ impl PartialOrd for IndexEntryByGeneration<'_> {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 struct RevWalkWorkItem<'a> {
     entry: IndexEntryByPosition<'a>,
-    wanted: bool,
+    state: RevWalkWorkItemState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum RevWalkWorkItemState {
+    // Order matters: Unwanted should appear earlier in the max-heap.
+    Wanted,
+    Unwanted,
+}
+
+impl RevWalkWorkItem<'_> {
+    fn is_wanted(&self) -> bool {
+        self.state == RevWalkWorkItemState::Wanted
+    }
 }
 
 #[derive(Clone)]
 pub struct RevWalk<'a> {
     index: CompositeIndex<'a>,
     items: BinaryHeap<RevWalkWorkItem<'a>>,
-    wanted_boundary_set: HashSet<IndexPosition>,
-    unwanted_boundary_set: HashSet<IndexPosition>,
 }
 
 impl<'a> RevWalk<'a> {
@@ -983,29 +994,35 @@ impl<'a> RevWalk<'a> {
         Self {
             index,
             items: BinaryHeap::new(),
-            wanted_boundary_set: HashSet::new(),
-            unwanted_boundary_set: HashSet::new(),
         }
     }
 
     fn add_wanted(&mut self, pos: IndexPosition) {
-        if !self.wanted_boundary_set.insert(pos) {
-            return;
-        }
         self.items.push(RevWalkWorkItem {
             entry: IndexEntryByPosition(self.index.entry_by_pos(pos)),
-            wanted: true,
+            state: RevWalkWorkItemState::Wanted,
         });
     }
 
     fn add_unwanted(&mut self, pos: IndexPosition) {
-        if !self.unwanted_boundary_set.insert(pos) {
-            return;
-        }
         self.items.push(RevWalkWorkItem {
             entry: IndexEntryByPosition(self.index.entry_by_pos(pos)),
-            wanted: false,
+            state: RevWalkWorkItemState::Unwanted,
         });
+    }
+
+    fn pop_eq(&mut self, entry: &IndexEntry<'_>) -> Option<RevWalkWorkItem<'a>> {
+        if let Some(x) = self.items.peek() {
+            (&x.entry.0 == entry).then(|| self.items.pop().unwrap())
+        } else {
+            None
+        }
+    }
+
+    fn skip_while_eq(&mut self, entry: &IndexEntry<'_>) {
+        while self.pop_eq(entry).is_some() {
+            continue;
+        }
     }
 }
 
@@ -1014,17 +1031,13 @@ impl<'a> Iterator for RevWalk<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(item) = self.items.pop() {
-            if item.wanted {
-                self.wanted_boundary_set.remove(&item.entry.0.pos);
-                if self.unwanted_boundary_set.contains(&item.entry.0.pos) {
-                    continue;
-                }
+            self.skip_while_eq(&item.entry.0);
+            if item.is_wanted() {
                 for parent_pos in item.entry.0.parent_positions() {
                     self.add_wanted(parent_pos);
                 }
                 return Some(item.entry.0);
             } else {
-                self.unwanted_boundary_set.remove(&item.entry.0.pos);
                 for parent_pos in item.entry.0.parent_positions() {
                     self.add_unwanted(parent_pos);
                 }

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -987,6 +987,7 @@ impl RevWalkWorkItem<'_> {
 pub struct RevWalk<'a> {
     index: CompositeIndex<'a>,
     items: BinaryHeap<RevWalkWorkItem<'a>>,
+    unwanted_count: usize,
 }
 
 impl<'a> RevWalk<'a> {
@@ -994,6 +995,7 @@ impl<'a> RevWalk<'a> {
         Self {
             index,
             items: BinaryHeap::new(),
+            unwanted_count: 0,
         }
     }
 
@@ -1009,11 +1011,21 @@ impl<'a> RevWalk<'a> {
             entry: IndexEntryByPosition(self.index.entry_by_pos(pos)),
             state: RevWalkWorkItemState::Unwanted,
         });
+        self.unwanted_count += 1;
+    }
+
+    fn pop(&mut self) -> Option<RevWalkWorkItem<'a>> {
+        if let Some(x) = self.items.pop() {
+            self.unwanted_count -= !x.is_wanted() as usize;
+            Some(x)
+        } else {
+            None
+        }
     }
 
     fn pop_eq(&mut self, entry: &IndexEntry<'_>) -> Option<RevWalkWorkItem<'a>> {
         if let Some(x) = self.items.peek() {
-            (&x.entry.0 == entry).then(|| self.items.pop().unwrap())
+            (&x.entry.0 == entry).then(|| self.pop().unwrap())
         } else {
             None
         }
@@ -1030,19 +1042,28 @@ impl<'a> Iterator for RevWalk<'a> {
     type Item = IndexEntry<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(item) = self.items.pop() {
+        while let Some(item) = self.pop() {
             self.skip_while_eq(&item.entry.0);
             if item.is_wanted() {
                 for parent_pos in item.entry.0.parent_positions() {
                     self.add_wanted(parent_pos);
                 }
                 return Some(item.entry.0);
+            } else if self.items.len() == self.unwanted_count {
+                // No more wanted entries to walk
+                debug_assert!(!self.items.iter().any(|x| x.is_wanted()));
+                return None;
             } else {
                 for parent_pos in item.entry.0.parent_positions() {
                     self.add_unwanted(parent_pos);
                 }
             }
         }
+
+        debug_assert_eq!(
+            self.items.iter().filter(|x| !x.is_wanted()).count(),
+            self.unwanted_count
+        );
         None
     }
 }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
