### PR TITLE
Make optional the path argument to `resolve`, allow partial paths

### DIFF
--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -210,18 +210,22 @@ impl Tree {
         }
     }
 
-    pub fn has_conflict(&self) -> bool {
-        !self.conflicts().is_empty()
-    }
-
-    pub fn conflicts(&self) -> Vec<(RepoPath, ConflictId)> {
+    pub fn conflicts_matching(&self, matcher: &dyn Matcher) -> Vec<(RepoPath, ConflictId)> {
         let mut conflicts = vec![];
-        for (name, value) in self.entries() {
+        for (name, value) in self.entries_matching(matcher) {
             if let TreeValue::Conflict(id) = value {
                 conflicts.push((name.clone(), id.clone()));
             }
         }
         conflicts
+    }
+
+    pub fn conflicts(&self) -> Vec<(RepoPath, ConflictId)> {
+        self.conflicts_matching(&EverythingMatcher)
+    }
+
+    pub fn has_conflict(&self) -> bool {
+        !self.conflicts().is_empty()
     }
 }
 

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -766,13 +766,9 @@ impl WorkspaceCommandHelper {
         &self,
         ui: &mut Ui,
         tree: &Tree,
-        path: &str,
+        repo_path: &RepoPath,
     ) -> Result<TreeId, CommandError> {
-        Ok(crate::diff_edit::run_mergetool(
-            ui,
-            tree,
-            &self.parse_file_path(path)?,
-        )?)
+        Ok(crate::diff_edit::run_mergetool(ui, tree, repo_path)?)
     }
 
     pub fn edit_diff(

--- a/src/diff_edit.rs
+++ b/src/diff_edit.rs
@@ -89,7 +89,7 @@ pub enum ConflictResolveError {
     NotAConflictError(RepoPath),
     #[error(
         "Only conflicts that involve normal files (not symlinks, not executable, etc.) are \
-         supported. Conflict summary:\n {1}"
+         supported. Conflict summary for {0:?}:\n{1}"
     )]
     NotNormalFilesError(RepoPath, String),
     #[error(

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -406,8 +406,8 @@ fn test_file_vs_dir() {
 
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve", "file"]);
     insta::assert_snapshot!(error, @r###"
-    Error: Failed to use external tool to resolve: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary:
-     Conflict:
+    Error: Failed to use external tool to resolve: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
+    Conflict:
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
       Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -77,8 +77,8 @@ fn test_resolution() {
     let editor_script = test_env.set_up_fake_editor();
     // Check that output file starts out empty and resolve the conflict
     std::fs::write(&editor_script, "expect\n\0write\nresolution\n").unwrap();
-    test_env.jj_cmd_success(&repo_path, &["resolve", "file"]);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    test_env.jj_cmd_success(&repo_path, &["resolve"]);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Resolved conflict in file:
        1    1: <<<<<<<resolution
@@ -100,7 +100,7 @@ fn test_resolution() {
     // Check that the output file starts with conflict markers if
     // `merge-tool-edits-conflict-markers=true`
     test_env.jj_cmd_success(&repo_path, &["undo"]);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @"");
     std::fs::write(
         &editor_script,
@@ -123,10 +123,9 @@ resolution
             "resolve",
             "--config-toml",
             "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
-            "file",
         ],
     );
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Resolved conflict in file:
        1    1: <<<<<<<resolution
@@ -141,7 +140,7 @@ resolution
     // Check that if merge tool leaves conflict markers in output file and
     // `merge-tool-edits-conflict-markers=true`, these markers are properly parsed.
     test_env.jj_cmd_success(&repo_path, &["undo"]);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @"");
     std::fs::write(
         &editor_script,
@@ -170,11 +169,10 @@ conflict
             "resolve",
             "--config-toml",
             "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
-            "file",
         ],
     );
     // Note the "Modified" below
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Modified conflict in file:
        1    1: <<<<<<<
@@ -199,7 +197,7 @@ conflict
     // `merge-tool-edits-conflict-markers=false` or is not specified,
     // `jj` considers the conflict resolved.
     test_env.jj_cmd_success(&repo_path, &["undo"]);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @"");
     std::fs::write(
         &editor_script,
@@ -215,9 +213,9 @@ conflict
 ",
     )
     .unwrap();
-    test_env.jj_cmd_success(&repo_path, &["resolve", "file"]);
+    test_env.jj_cmd_success(&repo_path, &["resolve"]);
     // Note the "Resolved" below
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "-r", "conflict"]), 
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Resolved conflict in file:
        1    1: <<<<<<<
@@ -236,6 +234,9 @@ conflict
     Working copy changes:
     M file
     "###);
+
+    // TODO: Check that running `jj new` and then `jj resolve -r conflict` works
+    // correctly.
 }
 
 fn check_resolve_produces_input_file(
@@ -248,10 +249,8 @@ fn check_resolve_produces_input_file(
     std::fs::write(editor_script, format!("expect\n{expected_content}")).unwrap();
 
     let merge_arg_config = format!(r#"merge-tools.fake-editor.merge-args = ["${role}"]"#);
-    let error = test_env.jj_cmd_failure(
-        repo_path,
-        &["resolve", "--config-toml", &merge_arg_config, "file"],
-    );
+    let error =
+        test_env.jj_cmd_failure(repo_path, &["resolve", "--config-toml", &merge_arg_config]);
     // This error means that fake-editor exited successfully but did not modify the
     // output file.
     insta::assert_snapshot!(error, @r###"
@@ -344,7 +343,7 @@ fn test_too_many_parents() {
     create_commit(&test_env, &repo_path, "c", &["base"], &[("file", "c\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b", "c"], &[]);
 
-    let error = test_env.jj_cmd_failure(&repo_path, &["resolve", "file"]);
+    let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
     Error: Failed to use external tool to resolve: The conflict at "file" has 2 removes and 3 adds.
     At most 1 remove and 2 adds are supported.
@@ -404,7 +403,7 @@ fn test_file_vs_dir() {
     std::fs::write(repo_path.join("file").join("placeholder"), "").unwrap();
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
 
-    let error = test_env.jj_cmd_failure(&repo_path, &["resolve", "file"]);
+    let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
     Error: Failed to use external tool to resolve: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
     Conflict:
@@ -412,5 +411,166 @@ fn test_file_vs_dir() {
       Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
 
+    "###);
+}
+
+#[test]
+fn test_multiple_conflicts() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    create_commit(
+        &test_env,
+        &repo_path,
+        "base",
+        &[],
+        &[("file1", "first base\n"), ("file2", "second base\n")],
+    );
+    create_commit(
+        &test_env,
+        &repo_path,
+        "a",
+        &["base"],
+        &[("file1", "first a\n"), ("file2", "second a\n")],
+    );
+    create_commit(
+        &test_env,
+        &repo_path,
+        "b",
+        &["base"],
+        &[("file1", "first b\n"), ("file2", "second b\n")],
+    );
+    create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
+    // Test the setup
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+        @   conflict
+        |\  
+        o | b
+        | o a
+        |/  
+        o base
+        o 
+        "###);
+    insta::assert_snapshot!(
+    std::fs::read_to_string(repo_path.join("file1")).unwrap()
+        , @r###"
+    <<<<<<<
+    %%%%%%%
+    -first base
+    +first a
+    +++++++
+    first b
+    >>>>>>>
+    "###);
+    insta::assert_snapshot!(
+    std::fs::read_to_string(repo_path.join("file2")).unwrap()
+        , @r###"
+    <<<<<<<
+    %%%%%%%
+    -second base
+    +second a
+    +++++++
+    second b
+    >>>>>>>
+    "###);
+
+    let editor_script = test_env.set_up_fake_editor();
+
+    // Check that we can manually pick which of the conflicts to resolve first
+    std::fs::write(&editor_script, "expect\n\0write\nresolution file2\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["resolve", "file2"]);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
+    @r###"
+    Resolved conflict in file2:
+       1     : <<<<<<<
+       2     : %%%%%%%
+       3    1: -secondresolution basefile2
+       4     : +second a
+       5     : +++++++
+       6     : second b
+       7     : >>>>>>>
+    "###);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]), 
+    @r###"
+    Parent commit: 9a25592b7aee a
+    Working copy : 00dac0bec4b1 conflict
+    Working copy changes:
+    M file1
+    M file2
+    There are unresolved conflicts at these paths:
+    file1
+    "###);
+
+    // For the rest of the test, we call `jj resolve` several times in a row to
+    // resolve each conflict in the order it chooses.
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
+    @"");
+    std::fs::write(
+        &editor_script,
+        "expect\n\0write\nfirst resolution for auto-chosen file\n",
+    )
+    .unwrap();
+    test_env.jj_cmd_success(&repo_path, &["resolve"]);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
+    @r###"
+    Resolved conflict in file1:
+       1     : <<<<<<<
+       2     : %%%%%%%
+       3    1: -first base
+       4    1: +firstresolution a
+       5     : +++++++
+       6    1: firstfor bauto-chosen file
+       7     : >>>>>>>
+    "###);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]), 
+    @r###"
+    Parent commit: 9a25592b7aee a
+    Working copy : f06196060882 conflict
+    Working copy changes:
+    M file1
+    M file2
+    There are unresolved conflicts at these paths:
+    file2
+    "###);
+    std::fs::write(
+        &editor_script,
+        "expect\n\0write\nsecond resolution for auto-chosen file\n",
+    )
+    .unwrap();
+
+    test_env.jj_cmd_success(&repo_path, &["resolve"]);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
+    @r###"
+    Resolved conflict in file1:
+       1     : <<<<<<<
+       2     : %%%%%%%
+       3    1: -first base
+       4    1: +firstresolution a
+       5     : +++++++
+       6    1: firstfor bauto-chosen file
+       7     : >>>>>>>
+    Resolved conflict in file2:
+       1     : <<<<<<<
+       2     : %%%%%%%
+       3    1: -second base
+       4    1: +secondresolution a
+       5     : +++++++
+       6    1: secondfor bauto-chosen file
+       7     : >>>>>>>
+    "###);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]), 
+    @r###"
+    Parent commit: 9a25592b7aee a
+    Working copy : 0fafecce390d conflict
+    Working copy changes:
+    M file1
+    M file2
+    "###);
+
+    insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve"]), 
+    @r###"
+    Error: No conflicts found at this revision
     "###);
 }


### PR DESCRIPTION
Also allows several paths to be specified. By default, `jj resolve`
will find the first conflict that matches provided paths (if any)
and try to resolve it.