### PR TITLE
Remove an unused import warning on recent versions of Rust

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -33,6 +33,9 @@ use crate::backend::{ChangeId, CommitId};
 use crate::commit::Commit;
 use crate::file_util::persist_content_addressed_temp_file;
 #[cfg(not(feature = "map_first_last"))]
+// This import is used on Rust 1.60, but not on recent version.
+// TODO: Remove it when our MSRV becomes recent enough.
+#[allow(unused_imports)]
 use crate::nightly_shims::BTreeSetExt;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]


### PR DESCRIPTION
This warning used to show up, at least, on Rust nightly:

     unused import: `crate::nightly_shims::BTreeSetExt`
