### PR TITLE
cli: make `jj status` not just care about the first parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are now better at adding Git refs to prevent that.
   [#815](https://github.com/martinvonz/jj/issues/815)
 
+* When the working-copy commit was a merge, `jj status` would list only the
+  first parent, and the diff summary would be against that parent. The output
+  now lists all parents and the diff summary is against the auto-merged parents.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1953,16 +1953,18 @@ fn cmd_status(
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
     if let Some(wc_commit) = &maybe_checkout {
-        formatter.write_str("Parent commit: ")?;
         let workspace_id = workspace_command.workspace_id();
-        write_commit_summary(
-            formatter,
-            repo.as_repo_ref(),
-            &workspace_id,
-            &wc_commit.parents()[0],
-            ui.settings(),
-        )?;
-        formatter.write_str("\n")?;
+        for parent in wc_commit.parents() {
+            formatter.write_str("Parent commit: ")?;
+            write_commit_summary(
+                formatter,
+                repo.as_repo_ref(),
+                &workspace_id,
+                &parent,
+                ui.settings(),
+            )?;
+            formatter.write_str("\n")?;
+        }
         formatter.write_str("Working copy : ")?;
         write_commit_summary(
             formatter,
@@ -2023,7 +2025,7 @@ fn cmd_status(
     }
 
     if let Some(wc_commit) = &maybe_checkout {
-        let parent_tree = wc_commit.parents()[0].tree();
+        let parent_tree = merge_commit_trees(repo.as_repo_ref(), &wc_commit.parents());
         let tree = wc_commit.tree();
         if tree.id() == parent_tree.id() {
             formatter.write_str("The working copy is clean\n")?;

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -92,6 +92,7 @@ fn test_resolution() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]), 
     @r###"
     Parent commit: 77c5ed9eda54 a
+    Parent commit: 7c4a3488ba53 b
     Working copy : 665f83829a6a conflict
     Working copy changes:
     M file
@@ -188,6 +189,7 @@ conflict
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]), 
     @r###"
     Parent commit: 77c5ed9eda54 a
+    Parent commit: 7c4a3488ba53 b
     Working copy : cbd3d65d2612 conflict
     Working copy changes:
     M file
@@ -232,6 +234,7 @@ conflict
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]), 
     @r###"
     Parent commit: 77c5ed9eda54 a
+    Parent commit: 7c4a3488ba53 b
     Working copy : d5b735448648 conflict
     Working copy changes:
     M file

--- a/tests/test_status_command.rs
+++ b/tests/test_status_command.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_status_merge() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file"), "base").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new", "-m=left"]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "create", "left"]);
+    test_env.jj_cmd_success(&repo_path, &["new", "@-", "-m=right"]);
+    std::fs::write(repo_path.join("file"), "right").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new", "left", "@"]);
+
+    // The output should mention each parent, and the diff should be empty (compared
+    // to the auto-merged parents)
+    let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Parent commit: c4097d2ac7c9 left
+    Parent commit: 481d94cd6e34 right
+    Working copy : 92fb36a0639c (no description set)
+    The working copy is clean
+    "###);
+}


### PR DESCRIPTION
It seems like I forgot to update the `jj status` output when I decided (years ago?) that the changes in a commit should always be compared to the auto-merged parents. I was very confused before I realized that `jj status` was showing the diff summary against the first parent. I suppose the fact that `jj status` lists only one parent should have been a hint. Thanks to ilyagr@ for finding this odd behavior. This patch fixes it by making the command list all parents, and changes the diff summary to be against the auto-merged parents.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
