### PR TITLE
revset: use filter intersection for tree containing filter (e.g. `set & (filter() | set)`)

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -366,7 +366,7 @@ impl MutableIndex {
         );
     }
 
-    fn add_commit_data(
+    pub(crate) fn add_commit_data(
         &mut self,
         commit_id: CommitId,
         change_id: ChangeId,

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1539,6 +1539,14 @@ fn test_evaluate_expression_author(use_git: bool) {
         resolve_commit_ids(mut_repo.as_repo_ref(), "heads() & author(\"name2\")"),
         vec![]
     );
+    // Filter by union of pure predicate and set
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!("root.. & (author(name1) | {})", commit3.id().hex())
+        ),
+        vec![commit3.id().clone(), commit1.id().clone()]
+    );
 }
 
 #[test_case(false ; "local backend")]


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
