### PR TITLE
Do not use "..." between diff chunks when it only replaces 1 line of the diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Thanks to the people who made this release happen!
 
  * Martin von Zweigbergk (@martinvonz)
-
+ * Danny Hooper (hooper@google.com)
 
 ## [0.6.1] - 2022-12-05
 


### PR DESCRIPTION
The number of lines in the diff output is unchanged.

This makes diffs a little more readable when the "..." would otherwise hide a single line of code that helps in understanding the surrounding context lines.

This change mostly rearranges the loop that consumes the diff lines, so it can buffer up to num_context_lines*2+1 lines instead of just num_context_lines. There's a bit of extra code to handle times when a "..." replaces the last line of a diff.

Note that `jj diff --git` is unchanged, and will still output `@@` lines that replace a single line of context.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
