### PR TITLE
revset: fold nested parents expressions to evaluate lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Thanks to the people who made this release happen!
 
  * Martin von Zweigbergk (@martinvonz)
  * Danny Hooper (hooper@google.com)
+ * Yuya Nishihara (@yuja)
 
 ## [0.6.1] - 2022-12-05
 

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -714,6 +714,26 @@ fn test_evaluate_expression_parents(use_git: bool) {
         ),
         vec![commit3.id().clone(), commit2.id().clone()]
     );
+
+    // Can find parents of parents, which may be optimized to single query
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), &format!("{}--", commit4.id().hex())),
+        vec![commit1.id().clone(), root_commit.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!("({} | {})--", commit4.id().hex(), commit5.id().hex())
+        ),
+        vec![commit1.id().clone(), root_commit.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!("({} | {})--", commit4.id().hex(), commit2.id().hex())
+        ),
+        vec![commit1.id().clone(), root_commit.id().clone()]
+    );
 }
 
 #[test_case(false ; "local backend")]
@@ -799,6 +819,43 @@ fn test_evaluate_expression_ancestors(use_git: bool) {
         vec![
             commit4.id().clone(),
             commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+            root_commit.id().clone(),
+        ]
+    );
+
+    // Can find ancestors of parents or parents of ancestors, which may be optimized
+    // to single query
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!(":({}-)", commit4.id().hex()),
+        ),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+            root_commit.id().clone(),
+        ]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!("(:({}|{}))-", commit3.id().hex(), commit2.id().hex()),
+        ),
+        vec![
+            commit2.id().clone(),
+            commit1.id().clone(),
+            root_commit.id().clone(),
+        ]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            &format!(":(({}|{})-)", commit3.id().hex(), commit2.id().hex()),
+        ),
+        vec![
             commit2.id().clone(),
             commit1.id().clone(),
             root_commit.id().clone(),


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added myself to the contributors in `CHANGELOG.md` (optional)
