### PR TITLE
docs: indent conflict marker examples to not confuse tools

### DIFF
--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -59,19 +59,19 @@ conflict). Here's an example of how Git can render a conflict using [its "diff3"
 style](https://git-scm.com/docs/git-merge#_how_conflicts_are_presented):
 
 ```
-<<<<<<< left
-apple
-grapefruit
-orange
-======= base
-apple
-grape
-orange
-||||||| right
-APPLE
-GRAPE
-ORANGE
->>>>>>>
+  <<<<<<< left
+  apple
+  grapefruit
+  orange
+  ======= base
+  apple
+  grape
+  orange
+  ||||||| right
+  APPLE
+  GRAPE
+  ORANGE
+  >>>>>>>
 ```
 
 In this example, the left side changed "grape" to "grapefruit", and the right
@@ -86,17 +86,17 @@ you, making it easier to spot the differences to apply to the other side. Here's
 how that would look for the same example as above:
 
 ```
-<<<<<<<
-%%%%%%%
- apple
--grape
-+grapefruit
- orange
-+++++++
-APPLE
-GRAPE
-ORANGE
->>>>>>>
+  <<<<<<<
+  %%%%%%%
+   apple
+  -grape
+  +grapefruit
+   orange
+  +++++++
+  APPLE
+  GRAPE
+  ORANGE
+  >>>>>>>
 ```
 
 As in Git, the `<<<<<<<` and `>>>>>>>` lines mark the start and end of the


### PR DESCRIPTION
When importing `conflicts.md` into the Google repo, our internal tools complained that it contained conflict markers. Similarly, if you ever get an actual merge conflict in the file, the working-copy snapshotting would parse our sample conflict markers here, forcing you to work around it. Let's avoid that by indenting the conflict markers. Hopefully readers will understand that the leading space is not part of the markers.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added myself to the contributors in `CHANGELOG.md` (optional)
