### PR TITLE
cli: parse early args in/after alias properly

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1414,8 +1414,8 @@ fn resolve_aliases(
     }
     loop {
         let app_clone = app.clone().allow_external_subcommands(true);
-        let matches = app_clone.try_get_matches_from(&string_args)?;
-        if let Some((command_name, submatches)) = matches.subcommand() {
+        let matches = app_clone.try_get_matches_from(&string_args).ok();
+        if let Some((command_name, submatches)) = matches.as_ref().and_then(|m| m.subcommand()) {
             if !real_commands.contains(command_name) {
                 let alias_name = command_name.to_string();
                 let alias_args = submatches
@@ -1447,6 +1447,7 @@ fn resolve_aliases(
                 }
             }
         }
+        // No more alias commands, or hit unknown option
         return Ok(string_args);
     }
 }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1453,9 +1453,13 @@ fn resolve_aliases(
 }
 
 /// Parse args that must be interpreted early, e.g. before printing help.
-fn handle_early_args(ui: &mut Ui, app: &clap::Command) -> Result<(), CommandError> {
+fn handle_early_args(
+    ui: &mut Ui,
+    app: &clap::Command,
+    args: &[String],
+) -> Result<(), CommandError> {
     // ignore_errors() bypasses errors like "--help" or missing subcommand
-    let early_matches = app.clone().ignore_errors(true).get_matches();
+    let early_matches = app.clone().ignore_errors(true).get_matches_from(args);
     let mut args: EarlyArgs = EarlyArgs::from_arg_matches(&early_matches).unwrap();
 
     if let Some(choice) = args.color {
@@ -1484,9 +1488,9 @@ pub fn parse_args(
             return Err(CommandError::CliError("Non-utf8 argument".to_string()));
         }
     }
-    handle_early_args(ui, &app)?;
 
     let string_args = resolve_aliases(ui.settings(), &app, &string_args)?;
+    handle_early_args(ui, &app, &string_args)?;
     let matches = app.clone().try_get_matches_from(&string_args)?;
 
     let args: Args = Args::from_arg_matches(&matches).unwrap();

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -207,14 +207,14 @@ fn test_alias_global_args_in_definition() {
     let repo_path = test_env.env_root().join("repo");
     test_env.add_config(
         br#"[alias]
-    l = ["log", "-T", "commit_id", "--at-op", "@-", "-r", "all()"]
+    l = ["log", "-T", "commit_id", "--at-op", "@-", "-r", "all()", "--color=always"]
     "#,
     );
 
     // The global argument in the alias is respected
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
-    o 0000000000000000000000000000000000000000
+    o [34m0000000000000000000000000000000000000000[0m
     "###);
 }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
