### PR TITLE
make `jj log --patch --summary` show both summary and diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The default log format now uses the committer timestamp instead of the author
   timestamp.
 
+* `jj log --summary --patch` now shows both summary and diff outputs.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1513,8 +1513,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
     };
 
     let store = repo.store();
-    let diff_format = (args.patch || args.diff_format.git || args.diff_format.summary)
-        .then(|| diff_util::diff_format_for(ui, &args.diff_format));
+    let diff_format = diff_util::diff_format_for_log(ui, &args.diff_format, args.patch);
 
     let template_string = match &args.template {
         Some(value) => value.to_string(),
@@ -1654,8 +1653,7 @@ fn cmd_obslog(ui: &mut Ui, command: &CommandHelper, args: &ObslogArgs) -> Result
         .view()
         .get_wc_commit_id(&workspace_id);
 
-    let diff_format = (args.patch || args.diff_format.git || args.diff_format.summary)
-        .then(|| diff_util::diff_format_for(ui, &args.diff_format));
+    let diff_format = diff_util::diff_format_for_log(ui, &args.diff_format, args.patch);
 
     let template_string = match &args.template {
         Some(value) => value.to_string(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1311,10 +1311,6 @@ fn cmd_diff(ui: &mut Ui, command: &CommandHelper, args: &DiffArgs) -> Result<(),
 fn cmd_show(ui: &mut Ui, command: &CommandHelper, args: &ShowArgs) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision)?;
-    let parents = commit.parents();
-    let from_tree = merge_commit_trees(workspace_command.repo().as_repo_ref(), &parents);
-    let to_tree = commit.tree();
-    let diff_iterator = from_tree.diff(&to_tree, &EverythingMatcher);
     // TODO: Add branches, tags, etc
     // TODO: Indent the description like Git does
     let (author_timestamp_template, committer_timestamp_template) =
@@ -1342,10 +1338,11 @@ fn cmd_show(ui: &mut Ui, command: &CommandHelper, args: &ShowArgs) -> Result<(),
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
     template.format(&commit, formatter)?;
-    diff_util::show_diff(
+    diff_util::show_patch(
         formatter,
         &workspace_command,
-        diff_iterator,
+        &commit,
+        &EverythingMatcher,
         diff_util::diff_format_for(ui, &args.format),
     )?;
     Ok(())

--- a/src/diff_util.rs
+++ b/src/diff_util.rs
@@ -62,12 +62,16 @@ pub fn diff_format_for(ui: &Ui, args: &DiffFormatArgs) -> DiffFormat {
     } else if args.color_words {
         DiffFormat::ColorWords
     } else {
-        match ui.settings().config().get_string("diff.format").as_deref() {
-            Ok("summary") => DiffFormat::Summary,
-            Ok("git") => DiffFormat::Git,
-            Ok("color-words") => DiffFormat::ColorWords,
-            _ => DiffFormat::ColorWords,
-        }
+        default_diff_format(ui)
+    }
+}
+
+fn default_diff_format(ui: &Ui) -> DiffFormat {
+    match ui.settings().config().get_string("diff.format").as_deref() {
+        Ok("summary") => DiffFormat::Summary,
+        Ok("git") => DiffFormat::Git,
+        Ok("color-words") => DiffFormat::ColorWords,
+        _ => DiffFormat::ColorWords,
     }
 }
 

--- a/src/diff_util.rs
+++ b/src/diff_util.rs
@@ -67,7 +67,7 @@ pub fn diff_format_for(ui: &Ui, args: &DiffFormatArgs) -> DiffFormat {
 }
 
 pub fn diff_format_for_log(ui: &Ui, args: &DiffFormatArgs, patch: bool) -> Option<DiffFormat> {
-    (patch || args.git || args.summary).then(|| diff_format_for(ui, args))
+    (patch || args.git || args.color_words || args.summary).then(|| diff_format_for(ui, args))
 }
 
 fn default_diff_format(ui: &Ui) -> DiffFormat {

--- a/src/diff_util.rs
+++ b/src/diff_util.rs
@@ -66,6 +66,10 @@ pub fn diff_format_for(ui: &Ui, args: &DiffFormatArgs) -> DiffFormat {
     }
 }
 
+pub fn diff_format_for_log(ui: &Ui, args: &DiffFormatArgs, patch: bool) -> Option<DiffFormat> {
+    (patch || args.git || args.summary).then(|| diff_format_for(ui, args))
+}
+
 fn default_diff_format(ui: &Ui) -> DiffFormat {
     match ui.settings().config().get_string("diff.format").as_deref() {
         Ok("summary") => DiffFormat::Summary,

--- a/tests/test_diff_command.rs
+++ b/tests/test_diff_command.rs
@@ -71,6 +71,34 @@ fn test_diff_basic() {
     @@ -1,0 +1,1 @@
     +foo
     "###);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "--git"]);
+    insta::assert_snapshot!(stdout, @r###"
+    R file1
+    M file2
+    A file3
+    diff --git a/file1 b/file1
+    deleted file mode 100644
+    index 257cc5642c..0000000000
+    --- a/file1
+    +++ /dev/null
+    @@ -1,1 +1,0 @@
+    -foo
+    diff --git a/file2 b/file2
+    index 257cc5642c...3bd1f0e297 100644
+    --- a/file2
+    +++ b/file2
+    @@ -1,1 +1,2 @@
+     foo
+    +bar
+    diff --git a/file3 b/file3
+    new file mode 100644
+    index 0000000000..257cc5642c
+    --- /dev/null
+    +++ b/file3
+    @@ -1,0 +1,1 @@
+    +foo
+    "###);
 }
 
 #[test]

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -142,6 +142,36 @@ fn test_log_with_or_without_diff() {
      foo
     +bar
     "###);
+
+    // `--color-words` implies `-p`, with or without graph
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "-T", "description", "-r", "@", "--color-words"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ a new commit
+    ~ Modified regular file file1:
+         1    1: foo
+              2: bar
+    "###);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "-T",
+            "description",
+            "-r",
+            "@",
+            "--no-graph",
+            "--color-words",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    a new commit
+    Modified regular file file1:
+       1    1: foo
+            2: bar
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
