### PR TITLE
cli: use committer timestamp instead of author timestamp in log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* The default log format now uses the committer timestamp instead of the author
+  timestamp.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1471,16 +1471,16 @@ fn log_template(settings: &UserSettings) -> String {
     // TODO: define a method on boolean values, so we can get auto-coloring
     //       with e.g. `conflict.then("conflict")`
 
-    let author_timestamp = if settings.relative_timestamps() {
-        "author.timestamp().ago()"
+    let committer_timestamp = if settings.relative_timestamps() {
+        "committer.timestamp().ago()"
     } else {
-        "author.timestamp()"
+        "committer.timestamp()"
     };
     let default_template = format!(
         r#"
             change_id.short()
             " " author.email()
-            " " label("timestamp", {author_timestamp})
+            " " label("timestamp", {committer_timestamp})
             if(branches, " " branches)
             if(tags, " " tags)
             if(working_copies, " " working_copies)

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -34,11 +34,11 @@ fn test_obslog_with_or_without_diff() {
 
     let stdout = get_log_output(&test_env, &repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  test.user@example.com 2001-02-03 04:05:08.000 +07:00 1daafc17fefb
+    @  test.user@example.com 2001-02-03 04:05:10.000 +07:00 1daafc17fefb
     | my description
-    o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 813918f7b4e6 conflict
+    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 813918f7b4e6 conflict
     | my description
-    o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 8f02f5470c55
+    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 8f02f5470c55
     | my description
     o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 c8ceb219336b
       my description
@@ -48,16 +48,16 @@ fn test_obslog_with_or_without_diff() {
     // (even even though it resulted in a conflict).
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "-p"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  test.user@example.com 2001-02-03 04:05:08.000 +07:00 1daafc17fefb
+    @  test.user@example.com 2001-02-03 04:05:10.000 +07:00 1daafc17fefb
     | my description
     | Resolved conflict in file1:
     |    1    1: <<<<<<<resolved
     |    2     : %%%%%%%
     |    3     : +bar
     |    4     : >>>>>>>
-    o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 813918f7b4e6 conflict
+    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 813918f7b4e6 conflict
     | my description
-    o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 8f02f5470c55
+    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 8f02f5470c55
     | my description
     | Modified regular file file1:
     |    1    1: foo
@@ -71,11 +71,11 @@ fn test_obslog_with_or_without_diff() {
     // Test `--no-graph`
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 1daafc17fefb
+     test.user@example.com 2001-02-03 04:05:10.000 +07:00 1daafc17fefb
     my description
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 813918f7b4e6 conflict
+     test.user@example.com 2001-02-03 04:05:09.000 +07:00 813918f7b4e6 conflict
     my description
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 8f02f5470c55
+     test.user@example.com 2001-02-03 04:05:09.000 +07:00 8f02f5470c55
     my description
      test.user@example.com 2001-02-03 04:05:08.000 +07:00 c8ceb219336b
     my description
@@ -84,7 +84,7 @@ fn test_obslog_with_or_without_diff() {
     // Test `--git` format, and that it implies `-p`
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "--no-graph", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 1daafc17fefb
+     test.user@example.com 2001-02-03 04:05:10.000 +07:00 1daafc17fefb
     my description
     diff --git a/file1 b/file1
     index e155302a24...2ab19ae607 100644
@@ -96,9 +96,9 @@ fn test_obslog_with_or_without_diff() {
     -+bar
     ->>>>>>>
     +resolved
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 813918f7b4e6 conflict
+     test.user@example.com 2001-02-03 04:05:09.000 +07:00 813918f7b4e6 conflict
     my description
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 8f02f5470c55
+     test.user@example.com 2001-02-03 04:05:09.000 +07:00 8f02f5470c55
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -136,20 +136,20 @@ fn test_obslog_squash() {
 
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o    test.user@example.com 2001-02-03 04:05:07.000 +07:00 9b6d4a272a6a
+    o    test.user@example.com 2001-02-03 04:05:10.000 +07:00 9b6d4a272a6a
     |\  squashed
     | | Modified regular file file1:
     | |    1    1: foo
     | |         2: bar
-    o |  test.user@example.com 2001-02-03 04:05:07.000 +07:00 803a7299cb1a
+    o |  test.user@example.com 2001-02-03 04:05:09.000 +07:00 803a7299cb1a
     | | first
     | | Added regular file file1:
     | |         1: foo
-    o |  test.user@example.com 2001-02-03 04:05:07.000 +07:00 85a1e2839620
+    o |  test.user@example.com 2001-02-03 04:05:08.000 +07:00 85a1e2839620
     | | first
     o |  test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
      /  (no description set)
-    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 69231a40d60d
+    o  test.user@example.com 2001-02-03 04:05:10.000 +07:00 69231a40d60d
     | second
     | Modified regular file file1:
     |    1    1: foo


### PR DESCRIPTION
The author timestamp is rarely useful (in my experience). The committer timestamp, on the other hand, can be useful for understanding when a change was most recently modified. IIRC, I originally picked the author timestamp to match the email (which is the author's), but it's probably not confusing to use the author email and the committer timestamp. I suspect few users will even reflect on it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
