### PR TITLE
WIP: invoke post-rewrite hook

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::default::Default;
 use std::io::Read;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 use git2::Oid;
 use itertools::Itertools;
@@ -560,6 +561,66 @@ pub fn rename_remote(
     for (old, new, target) in git_refs {
         mut_repo.set_git_ref_target(&old, RefTarget::absent());
         mut_repo.set_git_ref_target(&new, target);
+    }
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+pub enum GitHookError {
+    #[error("Could not construct stdin string: {0}")]
+    ConstructStdin(std::fmt::Error),
+}
+
+pub fn invoke_post_rewrite_hook(
+    git_repo: &git2::Repository,
+    abandoned_commits: &HashSet<CommitId>,
+    rewritten_commits: &HashMap<CommitId, HashSet<CommitId>>,
+) -> Result<(), GitHookError> {
+    let hooks_dir = {
+        let config = git_repo.config().unwrap();
+        let hooks_dir = match config.get_path("core.hooksPath") {
+            Ok(value) => value,
+            Err(err) if err.code() == git2::ErrorCode::NotFound => PathBuf::from("hooks"),
+            Err(err) => panic!("@nocommit raise err {err}"),
+        };
+        if hooks_dir.is_relative() {
+            git_repo.path().join(hooks_dir)
+        } else {
+            hooks_dir
+        }
+    };
+
+    let post_rewrite_hook_path = hooks_dir.join("post-rewrite");
+    if !post_rewrite_hook_path.is_file() {
+        return Ok(());
+    }
+
+    let payload = {
+        use std::fmt::Write;
+        let mut payload = String::new();
+        for commit_id in abandoned_commits {
+            writeln!(payload, "{} {}", commit_id.hex(), Oid::zero())
+                .map_err(GitHookError::ConstructStdin)?;
+        }
+        for (old_commit_id, new_commit_ids) in rewritten_commits {
+            for new_commit_id in new_commit_ids {
+                writeln!(payload, "{} {}", old_commit_id.hex(), new_commit_id.hex())
+                    .map_err(GitHookError::ConstructStdin)?;
+            }
+        }
+        payload
+    };
+
+    // TODO: need to set working directory?
+    let mut process = Command::new(post_rewrite_hook_path)
+        .arg("rebase") // rewrite type
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = process.stdin.take().unwrap();
+    {
+        use std::io::Write;
+        write!(stdin, "{}", payload).unwrap();
     }
     Ok(())
 }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -663,7 +663,7 @@ impl RepoLoader {
         let mut tx = base_repo.start_transaction(user_settings, "resolve concurrent operations");
         for other_op_head in op_heads.into_iter().skip(1) {
             tx.merge_operation(other_op_head);
-            tx.mut_repo().rebase_descendants(user_settings)?;
+            tx.rebase_descendants(user_settings)?;
         }
         let merged_repo = tx.write().leave_unpublished();
         Ok(merged_repo.operation().clone())
@@ -809,7 +809,10 @@ impl MutableRepo {
         )
     }
 
-    pub fn rebase_descendants(&mut self, settings: &UserSettings) -> Result<usize, TreeMergeError> {
+    pub(super) fn rebase_descendants(
+        &mut self,
+        settings: &UserSettings,
+    ) -> Result<usize, TreeMergeError> {
         if !self.has_rewrites() {
             // Optimization
             return Ok(0);

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -691,8 +691,9 @@ pub struct MutableRepo {
     base_repo: Arc<ReadonlyRepo>,
     index: Box<dyn MutableIndex>,
     view: DirtyCell<View>,
-    rewritten_commits: HashMap<CommitId, HashSet<CommitId>>,
-    abandoned_commits: HashSet<CommitId>,
+    // TODO: make not pub
+    pub rewritten_commits: HashMap<CommitId, HashSet<CommitId>>,
+    pub abandoned_commits: HashSet<CommitId>,
 }
 
 impl MutableRepo {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -691,9 +691,11 @@ pub struct MutableRepo {
     base_repo: Arc<ReadonlyRepo>,
     index: Box<dyn MutableIndex>,
     view: DirtyCell<View>,
+    rewritten_commits: HashMap<CommitId, HashSet<CommitId>>,
+    abandoned_commits: HashSet<CommitId>,
     // TODO: make not pub
-    pub rewritten_commits: HashMap<CommitId, HashSet<CommitId>>,
-    pub abandoned_commits: HashSet<CommitId>,
+    pub rewritten_descendants: HashMap<CommitId, HashSet<CommitId>>,
+    pub abandoned_descendants: HashSet<CommitId>,
 }
 
 impl MutableRepo {
@@ -710,6 +712,8 @@ impl MutableRepo {
             view: DirtyCell::with_clean(mut_view),
             rewritten_commits: Default::default(),
             abandoned_commits: Default::default(),
+            rewritten_descendants: Default::default(),
+            abandoned_descendants: Default::default(),
         }
     }
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -663,7 +663,7 @@ impl RepoLoader {
         let mut tx = base_repo.start_transaction(user_settings, "resolve concurrent operations");
         for other_op_head in op_heads.into_iter().skip(1) {
             tx.merge_operation(other_op_head);
-            tx.rebase_descendants(user_settings)?;
+            let _ = tx.rebase_descendants(user_settings)?; // @nocommit
         }
         let merged_repo = tx.write().leave_unpublished();
         Ok(merged_repo.operation().clone())

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -24,6 +24,7 @@ use crate::op_store::OperationMetadata;
 use crate::operation::Operation;
 use crate::repo::{MutableRepo, ReadonlyRepo, Repo, RepoLoader};
 use crate::settings::UserSettings;
+use crate::tree::TreeMergeError;
 use crate::view::View;
 
 pub struct Transaction {
@@ -68,6 +69,11 @@ impl Transaction {
 
     pub fn mut_repo(&mut self) -> &mut MutableRepo {
         &mut self.mut_repo
+    }
+
+    pub fn rebase_descendants(&mut self, settings: &UserSettings) -> Result<usize, TreeMergeError> {
+        // TODO: schedule things so that `finish` calls the Git post-rewrite hook if necessary.
+        self.mut_repo.rebase_descendants(settings)
     }
 
     pub fn merge_operation(&mut self, other_op: Operation) {

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -27,6 +27,9 @@ use crate::settings::UserSettings;
 use crate::tree::TreeMergeError;
 use crate::view::View;
 
+#[must_use]
+pub struct RebasedDescendants {}
+
 pub struct Transaction {
     mut_repo: MutableRepo,
     parent_ops: Vec<Operation>,
@@ -71,9 +74,13 @@ impl Transaction {
         &mut self.mut_repo
     }
 
-    pub fn rebase_descendants(&mut self, settings: &UserSettings) -> Result<usize, TreeMergeError> {
+    pub fn rebase_descendants(
+        &mut self,
+        settings: &UserSettings,
+    ) -> Result<(usize, RebasedDescendants), TreeMergeError> {
         // TODO: schedule things so that `finish` calls the Git post-rewrite hook if necessary.
-        self.mut_repo.rebase_descendants(settings)
+        let num_rebased = self.mut_repo.rebase_descendants(settings)?;
+        Ok((num_rebased, RebasedDescendants {}))
     }
 
     pub fn merge_operation(&mut self, other_op: Operation) {

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -148,7 +148,7 @@ fn test_rewrite(use_git: bool) {
         .set_tree(rewritten_tree.id().clone())
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     tx.commit();
     assert_eq!(rewritten_commit.parents(), vec![store.root_commit()]);
     assert_eq!(

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -148,7 +148,7 @@ fn test_rewrite(use_git: bool) {
         .set_tree(rewritten_tree.id().clone())
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     tx.commit();
     assert_eq!(rewritten_commit.parents(), vec![store.root_commit()]);
     assert_eq!(

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -96,7 +96,7 @@ fn test_import_refs() {
     let git_repo = get_git_repo(repo);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
     let view = repo.view();
 
@@ -192,7 +192,7 @@ fn test_import_refs_reimport() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! {
@@ -219,7 +219,7 @@ fn test_import_refs_reimport() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let view = repo.view();
@@ -275,7 +275,7 @@ fn test_import_refs_reimport_head_removed() {
     let commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let commit_id = jj_id(&commit);
     // Test the setup
     assert!(tx.mut_repo().view().heads().contains(&commit_id));
@@ -283,7 +283,7 @@ fn test_import_refs_reimport_head_removed() {
     // Remove the head and re-import
     tx.mut_repo().remove_head(&commit_id);
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(&commit_id));
 }
 
@@ -302,7 +302,7 @@ fn test_import_refs_reimport_git_head_counts() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
 
     // Delete the branch and re-import. The commit should still be there since HEAD
     // points to it
@@ -312,7 +312,7 @@ fn test_import_refs_reimport_git_head_counts() {
         .delete()
         .unwrap();
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(&jj_id(&commit)));
 }
 
@@ -333,7 +333,7 @@ fn test_import_refs_reimport_git_head_without_ref() {
 
     // Import HEAD.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 
@@ -345,7 +345,7 @@ fn test_import_refs_reimport_git_head_without_ref() {
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 }
@@ -370,7 +370,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
 
     // Import HEAD and main.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 
@@ -382,7 +382,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
 
     // Reimport HEAD and main, which abandons the old main branch.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 }
@@ -415,7 +415,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! {
@@ -456,7 +456,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let view = repo.view();
@@ -504,7 +504,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! {
@@ -555,7 +555,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let view = repo.view();
@@ -611,7 +611,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
 
     // Import HEAD and main.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 
@@ -620,7 +620,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 }
@@ -638,7 +638,7 @@ fn test_import_refs_reimport_all_from_root_removed() {
     let commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     // Test the setup
     assert!(tx.mut_repo().view().heads().contains(&jj_id(&commit)));
 
@@ -649,7 +649,7 @@ fn test_import_refs_reimport_all_from_root_removed() {
         .delete()
         .unwrap();
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(&jj_id(&commit)));
 }
 
@@ -686,7 +686,7 @@ fn test_import_some_refs() {
             .unwrap_or(false)
     })
     .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // There are two heads, feature2 and feature4.
@@ -759,7 +759,7 @@ fn test_import_some_refs() {
         get_remote_branch(ref_name) == Some("feature2")
     })
     .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // feature2 and feature4 will still be heads, and all four branches should be
@@ -776,7 +776,7 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten.
-    assert_eq!(tx.rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(tx.rebase_descendants(&settings).unwrap().0, 0);
     let repo = tx.commit();
 
     // feature2 and feature4 should still be the heads, and all three branches
@@ -793,7 +793,7 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(tx.rebase_descendants(&settings).unwrap().0, 0);
     let repo = tx.commit();
 
     // feature2 and feature4 should still be the heads, and both branches
@@ -809,7 +809,7 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(tx.rebase_descendants(&settings).unwrap().0, 0);
     let repo = tx.commit();
 
     // feature2 should now be the only head and only branch.
@@ -882,7 +882,7 @@ fn test_import_refs_empty_git_repo() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &test_data.git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&test_data.settings).unwrap();
+    let _ = tx.rebase_descendants(&test_data.settings).unwrap();
     let repo = tx.commit();
     assert_eq!(*repo.view().heads(), heads_before);
     assert_eq!(repo.view().branches().len(), 0);
@@ -910,7 +910,7 @@ fn test_import_refs_detached_head() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &test_data.git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&test_data.settings).unwrap();
+    let _ = tx.rebase_descendants(&test_data.settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! { jj_id(&commit1) };
@@ -932,7 +932,7 @@ fn test_export_refs_no_detach() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&test_data.settings).unwrap();
+    let _ = tx.rebase_descendants(&test_data.settings).unwrap();
 
     // Do an initial export to make sure `main` is considered
     assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
@@ -963,7 +963,7 @@ fn test_export_refs_branch_changed() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&test_data.settings).unwrap();
+    let _ = tx.rebase_descendants(&test_data.settings).unwrap();
     assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
 
     let new_commit = create_random_commit(tx.mut_repo(), &test_data.settings)
@@ -1002,7 +1002,7 @@ fn test_export_refs_current_branch_changed() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&test_data.settings).unwrap();
+    let _ = tx.rebase_descendants(&test_data.settings).unwrap();
     assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
 
     let new_commit = create_random_commit(tx.mut_repo(), &test_data.settings)
@@ -1039,7 +1039,7 @@ fn test_export_refs_unborn_git_branch() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&test_data.settings).unwrap();
+    let _ = tx.rebase_descendants(&test_data.settings).unwrap();
     assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
 
     let new_commit = write_random_commit(tx.mut_repo(), &test_data.settings);
@@ -1921,7 +1921,7 @@ fn test_bulk_update_extra_on_import_refs() {
     let import_refs = |repo: &Arc<ReadonlyRepo>| {
         let mut tx = repo.start_transaction(&settings, "test");
         git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-        tx.rebase_descendants(&settings).unwrap();
+        let _ = tx.rebase_descendants(&settings).unwrap();
         tx.commit()
     };
 
@@ -1960,7 +1960,7 @@ fn test_rewrite_imported_commit() {
     let git_commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
     let imported_commit = repo.store().get_commit(&jj_id(&git_commit)).unwrap();
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::Permissions;
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Barrier};
 use std::thread;
@@ -2232,17 +2233,4 @@ ignoreThisSection = foo
     };
 
     assert_eq!(result, expected);
-}
-
-#[test]
-fn test_post_rewrite_hook() {
-    let test_data = GitRepoData::create();
-    let git_repo = test_data.git_repo;
-    let commit1 = empty_git_commit(&git_repo, "refs/heads/main", &[]);
-    git_repo.set_head("refs/heads/main").unwrap();
-
-    let abandoned_commits = HashSet::new();
-    let rewritten_commits = HashMap::new();
-    // TODO: how to test?
-    git::invoke_post_rewrite_hook(&git_repo, &abandoned_commits, &rewritten_commits).unwrap();
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fs::Permissions;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Barrier};
 use std::thread;

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Barrier};
 use std::thread;
@@ -2232,4 +2232,17 @@ ignoreThisSection = foo
     };
 
     assert_eq!(result, expected);
+}
+
+#[test]
+fn test_post_rewrite_hook() {
+    let test_data = GitRepoData::create();
+    let git_repo = test_data.git_repo;
+    let commit1 = empty_git_commit(&git_repo, "refs/heads/main", &[]);
+    git_repo.set_head("refs/heads/main").unwrap();
+
+    let abandoned_commits = HashSet::new();
+    let rewritten_commits = HashMap::new();
+    // TODO: how to test?
+    git::invoke_post_rewrite_hook(&git_repo, &abandoned_commits, &rewritten_commits).unwrap();
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -96,7 +96,7 @@ fn test_import_refs() {
     let git_repo = get_git_repo(repo);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
     let view = repo.view();
 
@@ -192,7 +192,7 @@ fn test_import_refs_reimport() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! {
@@ -219,7 +219,7 @@ fn test_import_refs_reimport() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let view = repo.view();
@@ -275,7 +275,7 @@ fn test_import_refs_reimport_head_removed() {
     let commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let commit_id = jj_id(&commit);
     // Test the setup
     assert!(tx.mut_repo().view().heads().contains(&commit_id));
@@ -283,7 +283,7 @@ fn test_import_refs_reimport_head_removed() {
     // Remove the head and re-import
     tx.mut_repo().remove_head(&commit_id);
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(&commit_id));
 }
 
@@ -302,7 +302,7 @@ fn test_import_refs_reimport_git_head_counts() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
 
     // Delete the branch and re-import. The commit should still be there since HEAD
     // points to it
@@ -312,7 +312,7 @@ fn test_import_refs_reimport_git_head_counts() {
         .delete()
         .unwrap();
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(&jj_id(&commit)));
 }
 
@@ -333,7 +333,7 @@ fn test_import_refs_reimport_git_head_without_ref() {
 
     // Import HEAD.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 
@@ -345,7 +345,7 @@ fn test_import_refs_reimport_git_head_without_ref() {
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 }
@@ -370,7 +370,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
 
     // Import HEAD and main.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 
@@ -382,7 +382,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
 
     // Reimport HEAD and main, which abandons the old main branch.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 }
@@ -415,7 +415,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! {
@@ -456,7 +456,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let view = repo.view();
@@ -504,7 +504,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! {
@@ -555,7 +555,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let view = repo.view();
@@ -611,7 +611,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
 
     // Import HEAD and main.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 
@@ -620,7 +620,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(commit1.id()));
     assert!(tx.mut_repo().view().heads().contains(commit2.id()));
 }
@@ -638,7 +638,7 @@ fn test_import_refs_reimport_all_from_root_removed() {
     let commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     // Test the setup
     assert!(tx.mut_repo().view().heads().contains(&jj_id(&commit)));
 
@@ -649,7 +649,7 @@ fn test_import_refs_reimport_all_from_root_removed() {
         .delete()
         .unwrap();
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(&jj_id(&commit)));
 }
 
@@ -686,7 +686,7 @@ fn test_import_some_refs() {
             .unwrap_or(false)
     })
     .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // There are two heads, feature2 and feature4.
@@ -759,7 +759,7 @@ fn test_import_some_refs() {
         get_remote_branch(ref_name) == Some("feature2")
     })
     .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // feature2 and feature4 will still be heads, and all four branches should be
@@ -776,7 +776,7 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten.
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(tx.rebase_descendants(&settings).unwrap(), 0);
     let repo = tx.commit();
 
     // feature2 and feature4 should still be the heads, and all three branches
@@ -793,7 +793,7 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(tx.rebase_descendants(&settings).unwrap(), 0);
     let repo = tx.commit();
 
     // feature2 and feature4 should still be the heads, and both branches
@@ -809,7 +809,7 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(tx.rebase_descendants(&settings).unwrap(), 0);
     let repo = tx.commit();
 
     // feature2 should now be the only head and only branch.
@@ -882,9 +882,7 @@ fn test_import_refs_empty_git_repo() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &test_data.git_repo, &git_settings).unwrap();
-    tx.mut_repo()
-        .rebase_descendants(&test_data.settings)
-        .unwrap();
+    tx.rebase_descendants(&test_data.settings).unwrap();
     let repo = tx.commit();
     assert_eq!(*repo.view().heads(), heads_before);
     assert_eq!(repo.view().branches().len(), 0);
@@ -912,9 +910,7 @@ fn test_import_refs_detached_head() {
         .repo
         .start_transaction(&test_data.settings, "test");
     git::import_refs(tx.mut_repo(), &test_data.git_repo, &git_settings).unwrap();
-    tx.mut_repo()
-        .rebase_descendants(&test_data.settings)
-        .unwrap();
+    tx.rebase_descendants(&test_data.settings).unwrap();
     let repo = tx.commit();
 
     let expected_heads = hashset! { jj_id(&commit1) };
@@ -935,14 +931,13 @@ fn test_export_refs_no_detach() {
     let mut tx = test_data
         .repo
         .start_transaction(&test_data.settings, "test");
-    let mut_repo = tx.mut_repo();
-    git::import_refs(mut_repo, &git_repo, &git_settings).unwrap();
-    mut_repo.rebase_descendants(&test_data.settings).unwrap();
+    git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
+    tx.rebase_descendants(&test_data.settings).unwrap();
 
     // Do an initial export to make sure `main` is considered
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
     assert_eq!(
-        mut_repo.get_git_ref("refs/heads/main"),
+        tx.mut_repo().get_git_ref("refs/heads/main"),
         RefTarget::normal(jj_id(&commit1))
     );
     assert_eq!(git_repo.head().unwrap().name(), Some("refs/heads/main"));
@@ -967,19 +962,19 @@ fn test_export_refs_branch_changed() {
     let mut tx = test_data
         .repo
         .start_transaction(&test_data.settings, "test");
-    let mut_repo = tx.mut_repo();
-    git::import_refs(mut_repo, &git_repo, &git_settings).unwrap();
-    mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
+    tx.rebase_descendants(&test_data.settings).unwrap();
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
 
-    let new_commit = create_random_commit(mut_repo, &test_data.settings)
+    let new_commit = create_random_commit(tx.mut_repo(), &test_data.settings)
         .set_parents(vec![jj_id(&commit)])
         .write()
         .unwrap();
-    mut_repo.set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    tx.mut_repo()
+        .set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
     assert_eq!(
-        mut_repo.get_git_ref("refs/heads/main"),
+        tx.mut_repo().get_git_ref("refs/heads/main"),
         RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
@@ -1006,19 +1001,19 @@ fn test_export_refs_current_branch_changed() {
     let mut tx = test_data
         .repo
         .start_transaction(&test_data.settings, "test");
-    let mut_repo = tx.mut_repo();
-    git::import_refs(mut_repo, &git_repo, &git_settings).unwrap();
-    mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
+    tx.rebase_descendants(&test_data.settings).unwrap();
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
 
-    let new_commit = create_random_commit(mut_repo, &test_data.settings)
+    let new_commit = create_random_commit(tx.mut_repo(), &test_data.settings)
         .set_parents(vec![jj_id(&commit1)])
         .write()
         .unwrap();
-    mut_repo.set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    tx.mut_repo()
+        .set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
     assert_eq!(
-        mut_repo.get_git_ref("refs/heads/main"),
+        tx.mut_repo().get_git_ref("refs/heads/main"),
         RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
@@ -1043,16 +1038,16 @@ fn test_export_refs_unborn_git_branch() {
     let mut tx = test_data
         .repo
         .start_transaction(&test_data.settings, "test");
-    let mut_repo = tx.mut_repo();
-    git::import_refs(mut_repo, &git_repo, &git_settings).unwrap();
-    mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
+    tx.rebase_descendants(&test_data.settings).unwrap();
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
 
-    let new_commit = write_random_commit(mut_repo, &test_data.settings);
-    mut_repo.set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
+    let new_commit = write_random_commit(tx.mut_repo(), &test_data.settings);
+    tx.mut_repo()
+        .set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
+    assert_eq!(git::export_refs(tx.mut_repo(), &git_repo), Ok(vec![]));
     assert_eq!(
-        mut_repo.get_git_ref("refs/heads/main"),
+        tx.mut_repo().get_git_ref("refs/heads/main"),
         RefTarget::normal(new_commit.id().clone())
     );
     assert_eq!(
@@ -1926,7 +1921,7 @@ fn test_bulk_update_extra_on_import_refs() {
     let import_refs = |repo: &Arc<ReadonlyRepo>| {
         let mut tx = repo.start_transaction(&settings, "test");
         git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-        tx.mut_repo().rebase_descendants(&settings).unwrap();
+        tx.rebase_descendants(&settings).unwrap();
         tx.commit()
     };
 
@@ -1965,7 +1960,7 @@ fn test_rewrite_imported_commit() {
     let git_commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction(&settings, "test");
     git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
     let imported_commit = repo.store().get_commit(&jj_id(&git_commit)).unwrap();
 

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -624,7 +624,7 @@ fn test_simplify_conflict_after_resolving_parent(use_git: bool) {
         .write()
         .unwrap();
     let commit_c3 = rebase_commit(&settings, tx.mut_repo(), &commit_c2, &[commit_b3]).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // The conflict should now be resolved.

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -624,7 +624,7 @@ fn test_simplify_conflict_after_resolving_parent(use_git: bool) {
         .write()
         .unwrap();
     let commit_c3 = rebase_commit(&settings, tx.mut_repo(), &commit_c2, &[commit_b3]).unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // The conflict should now be resolved.

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -82,7 +82,7 @@ fn test_checkout_previous_not_empty(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
     tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
@@ -112,7 +112,7 @@ fn test_checkout_previous_empty(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
     tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(!tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
@@ -143,7 +143,7 @@ fn test_checkout_previous_empty_with_description(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
     tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
@@ -175,7 +175,7 @@ fn test_checkout_previous_empty_with_local_branch(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
     tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert!(tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
@@ -213,7 +213,7 @@ fn test_checkout_previous_empty_non_head(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
     tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         *tx.mut_repo().view().heads(),
         hashset! {old_child.id().clone(), new_wc_commit.id().clone()}

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -74,18 +74,16 @@ fn test_checkout_previous_not_empty(use_git: bool) {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let old_wc_commit = write_random_commit(mut_repo, &settings);
+    let old_wc_commit = write_random_commit(tx.mut_repo(), &settings);
     let ws_id = WorkspaceId::default();
-    mut_repo.edit(ws_id.clone(), &old_wc_commit).unwrap();
+    tx.mut_repo().edit(ws_id.clone(), &old_wc_commit).unwrap();
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let new_wc_commit = write_random_commit(mut_repo, &settings);
-    mut_repo.edit(ws_id, &new_wc_commit).unwrap();
-    mut_repo.rebase_descendants(&settings).unwrap();
-    assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
+    let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
+    tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
+    assert!(tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
 #[test_case(false ; "local backend")]
@@ -98,8 +96,8 @@ fn test_checkout_previous_empty(use_git: bool) {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let old_wc_commit = mut_repo
+    let old_wc_commit = tx
+        .mut_repo()
         .new_commit(
             &settings,
             vec![repo.store().root_commit_id().clone()],
@@ -108,15 +106,14 @@ fn test_checkout_previous_empty(use_git: bool) {
         .write()
         .unwrap();
     let ws_id = WorkspaceId::default();
-    mut_repo.edit(ws_id.clone(), &old_wc_commit).unwrap();
+    tx.mut_repo().edit(ws_id.clone(), &old_wc_commit).unwrap();
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let new_wc_commit = write_random_commit(mut_repo, &settings);
-    mut_repo.edit(ws_id, &new_wc_commit).unwrap();
-    mut_repo.rebase_descendants(&settings).unwrap();
-    assert!(!mut_repo.view().heads().contains(old_wc_commit.id()));
+    let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
+    tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
+    assert!(!tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
 #[test_case(false ; "local backend")]
@@ -129,8 +126,8 @@ fn test_checkout_previous_empty_with_description(use_git: bool) {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let old_wc_commit = mut_repo
+    let old_wc_commit = tx
+        .mut_repo()
         .new_commit(
             &settings,
             vec![repo.store().root_commit_id().clone()],
@@ -140,15 +137,14 @@ fn test_checkout_previous_empty_with_description(use_git: bool) {
         .write()
         .unwrap();
     let ws_id = WorkspaceId::default();
-    mut_repo.edit(ws_id.clone(), &old_wc_commit).unwrap();
+    tx.mut_repo().edit(ws_id.clone(), &old_wc_commit).unwrap();
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let new_wc_commit = write_random_commit(mut_repo, &settings);
-    mut_repo.edit(ws_id, &new_wc_commit).unwrap();
-    mut_repo.rebase_descendants(&settings).unwrap();
-    assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
+    let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
+    tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
+    assert!(tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
 #[test_case(false ; "local backend")]
@@ -161,8 +157,8 @@ fn test_checkout_previous_empty_with_local_branch(use_git: bool) {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let old_wc_commit = mut_repo
+    let old_wc_commit = tx
+        .mut_repo()
         .new_commit(
             &settings,
             vec![repo.store().root_commit_id().clone()],
@@ -170,17 +166,17 @@ fn test_checkout_previous_empty_with_local_branch(use_git: bool) {
         )
         .write()
         .unwrap();
-    mut_repo.set_local_branch_target("b", RefTarget::normal(old_wc_commit.id().clone()));
+    tx.mut_repo()
+        .set_local_branch_target("b", RefTarget::normal(old_wc_commit.id().clone()));
     let ws_id = WorkspaceId::default();
-    mut_repo.edit(ws_id.clone(), &old_wc_commit).unwrap();
+    tx.mut_repo().edit(ws_id.clone(), &old_wc_commit).unwrap();
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let new_wc_commit = write_random_commit(mut_repo, &settings);
-    mut_repo.edit(ws_id, &new_wc_commit).unwrap();
-    mut_repo.rebase_descendants(&settings).unwrap();
-    assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
+    let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
+    tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
+    assert!(tx.mut_repo().view().heads().contains(old_wc_commit.id()));
 }
 
 #[test_case(false ; "local backend")]
@@ -215,12 +211,11 @@ fn test_checkout_previous_empty_non_head(use_git: bool) {
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
-    let mut_repo = tx.mut_repo();
-    let new_wc_commit = write_random_commit(mut_repo, &settings);
-    mut_repo.edit(ws_id, &new_wc_commit).unwrap();
-    mut_repo.rebase_descendants(&settings).unwrap();
+    let new_wc_commit = write_random_commit(tx.mut_repo(), &settings);
+    tx.mut_repo().edit(ws_id, &new_wc_commit).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
-        *mut_repo.view().heads(),
+        *tx.mut_repo().view().heads(),
         hashset! {old_child.id().clone(), new_wc_commit.id().clone()}
     );
 }

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -155,14 +155,14 @@ fn test_isolation(use_git: bool) {
         .set_description("rewrite1")
         .write()
         .unwrap();
-    tx1.rebase_descendants(&settings).unwrap();
+    let _ = tx1.rebase_descendants(&settings).unwrap();
     let rewrite2 = tx2
         .mut_repo()
         .rewrite_commit(&settings, &initial)
         .set_description("rewrite2")
         .write()
         .unwrap();
-    tx2.rebase_descendants(&settings).unwrap();
+    let _ = tx2.rebase_descendants(&settings).unwrap();
 
     // Neither transaction has committed yet, so each transaction sees its own
     // commit.

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -944,7 +944,7 @@ fn test_rebase_descendants_basic_branch_update() {
         .rewrite_commit(&settings, &commit_b)
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_b2.id().clone())
@@ -992,7 +992,7 @@ fn test_rebase_descendants_branch_move_two_steps() {
         .rewrite_commit(&settings, &commit_c)
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let heads = tx.mut_repo().view().heads();
     assert_eq!(heads.len(), 1);
     let c3_id = heads.iter().next().unwrap().clone();
@@ -1040,7 +1040,7 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
         .rewrite_commit(&settings, &commit_b)
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_b2.id().clone())
@@ -1085,7 +1085,7 @@ fn test_rebase_descendants_update_branch_after_abandon() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_b.id().clone());
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_a.id().clone())
@@ -1139,7 +1139,7 @@ fn test_rebase_descendants_update_branches_after_divergent_rewrite() {
         .set_description("more different")
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
 
     let target = tx.mut_repo().get_local_branch("main");
     assert!(target.has_conflict());
@@ -1214,7 +1214,7 @@ fn test_rebase_descendants_rewrite_updates_branch_conflict() {
         .set_description("different")
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
 
     let target = tx.mut_repo().get_local_branch("main");
     assert!(target.has_conflict());
@@ -1277,7 +1277,7 @@ fn test_rebase_descendants_rewrite_resolves_branch_conflict() {
         .set_parents(vec![commit_c.id().clone()])
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_b2.id().clone())
@@ -1312,7 +1312,7 @@ fn test_rebase_descendants_branch_delete_modify_abandon() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_b.id().clone());
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     assert_eq!(tx.mut_repo().get_local_branch("main"), RefTarget::absent());
 }
 
@@ -1356,7 +1356,7 @@ fn test_rebase_descendants_update_checkout(use_git: bool) {
         .set_description("C")
         .write()
         .unwrap();
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // Workspaces 1 and 2 had B checked out, so they get updated to C. Workspace 3
@@ -1401,7 +1401,7 @@ fn test_rebase_descendants_update_checkout_abandoned(use_git: bool) {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_b.id().clone());
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // Workspaces 1 and 2 had B checked out, so they get updated to the same new
@@ -1455,7 +1455,7 @@ fn test_rebase_descendants_update_checkout_abandoned_merge(use_git: bool) {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_d.id().clone());
-    tx.rebase_descendants(&settings).unwrap();
+    let _ = tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let new_checkout_id = repo.view().get_wc_commit_id(&workspace_id).unwrap();

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -944,7 +944,7 @@ fn test_rebase_descendants_basic_branch_update() {
         .rewrite_commit(&settings, &commit_b)
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_b2.id().clone())
@@ -992,7 +992,7 @@ fn test_rebase_descendants_branch_move_two_steps() {
         .rewrite_commit(&settings, &commit_c)
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let heads = tx.mut_repo().view().heads();
     assert_eq!(heads.len(), 1);
     let c3_id = heads.iter().next().unwrap().clone();
@@ -1040,7 +1040,7 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
         .rewrite_commit(&settings, &commit_b)
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_b2.id().clone())
@@ -1085,7 +1085,7 @@ fn test_rebase_descendants_update_branch_after_abandon() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_b.id().clone());
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_a.id().clone())
@@ -1139,7 +1139,7 @@ fn test_rebase_descendants_update_branches_after_divergent_rewrite() {
         .set_description("more different")
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
 
     let target = tx.mut_repo().get_local_branch("main");
     assert!(target.has_conflict());
@@ -1214,7 +1214,7 @@ fn test_rebase_descendants_rewrite_updates_branch_conflict() {
         .set_description("different")
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
 
     let target = tx.mut_repo().get_local_branch("main");
     assert!(target.has_conflict());
@@ -1277,7 +1277,7 @@ fn test_rebase_descendants_rewrite_resolves_branch_conflict() {
         .set_parents(vec![commit_c.id().clone()])
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
         RefTarget::normal(commit_b2.id().clone())
@@ -1312,7 +1312,7 @@ fn test_rebase_descendants_branch_delete_modify_abandon() {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_b.id().clone());
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     assert_eq!(tx.mut_repo().get_local_branch("main"), RefTarget::absent());
 }
 
@@ -1356,7 +1356,7 @@ fn test_rebase_descendants_update_checkout(use_git: bool) {
         .set_description("C")
         .write()
         .unwrap();
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // Workspaces 1 and 2 had B checked out, so they get updated to C. Workspace 3
@@ -1401,7 +1401,7 @@ fn test_rebase_descendants_update_checkout_abandoned(use_git: bool) {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_b.id().clone());
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     // Workspaces 1 and 2 had B checked out, so they get updated to the same new
@@ -1455,7 +1455,7 @@ fn test_rebase_descendants_update_checkout_abandoned_merge(use_git: bool) {
 
     let mut tx = repo.start_transaction(&settings, "test");
     tx.mut_repo().record_abandoned_commit(commit_d.id().clone());
-    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    tx.rebase_descendants(&settings).unwrap();
     let repo = tx.commit();
 
     let new_checkout_id = repo.view().get_wc_commit_id(&workspace_id).unwrap();

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -498,7 +498,7 @@ fn test_merge_views_divergent() {
         .set_description("A2")
         .write()
         .unwrap();
-    tx1.rebase_descendants(&settings).unwrap();
+    let _ = tx1.rebase_descendants(&settings).unwrap();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let commit_a3 = tx2
@@ -507,7 +507,7 @@ fn test_merge_views_divergent() {
         .set_description("A3")
         .write()
         .unwrap();
-    tx2.rebase_descendants(&settings).unwrap();
+    let _ = tx2.rebase_descendants(&settings).unwrap();
 
     let repo = commit_transactions(&settings, vec![tx1, tx2]);
 
@@ -543,7 +543,7 @@ fn test_merge_views_child_on_rewritten(child_first: bool) {
         .set_description("A2")
         .write()
         .unwrap();
-    tx2.rebase_descendants(&settings).unwrap();
+    let _ = tx2.rebase_descendants(&settings).unwrap();
 
     let repo = if child_first {
         commit_transactions(&settings, vec![tx1, tx2])
@@ -594,7 +594,7 @@ fn test_merge_views_child_on_rewritten_divergent(on_rewritten: bool, child_first
         .set_description("A4")
         .write()
         .unwrap();
-    tx2.rebase_descendants(&settings).unwrap();
+    let _ = tx2.rebase_descendants(&settings).unwrap();
 
     let repo = if child_first {
         commit_transactions(&settings, vec![tx1, tx2])
@@ -645,7 +645,7 @@ fn test_merge_views_child_on_abandoned(child_first: bool) {
     let mut tx2 = repo.start_transaction(&settings, "test");
     tx2.mut_repo()
         .record_abandoned_commit(commit_b.id().clone());
-    tx2.rebase_descendants(&settings).unwrap();
+    let _ = tx2.rebase_descendants(&settings).unwrap();
 
     let repo = if child_first {
         commit_transactions(&settings, vec![tx1, tx2])

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -498,7 +498,7 @@ fn test_merge_views_divergent() {
         .set_description("A2")
         .write()
         .unwrap();
-    tx1.mut_repo().rebase_descendants(&settings).unwrap();
+    tx1.rebase_descendants(&settings).unwrap();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let commit_a3 = tx2
@@ -507,7 +507,7 @@ fn test_merge_views_divergent() {
         .set_description("A3")
         .write()
         .unwrap();
-    tx2.mut_repo().rebase_descendants(&settings).unwrap();
+    tx2.rebase_descendants(&settings).unwrap();
 
     let repo = commit_transactions(&settings, vec![tx1, tx2]);
 
@@ -543,7 +543,7 @@ fn test_merge_views_child_on_rewritten(child_first: bool) {
         .set_description("A2")
         .write()
         .unwrap();
-    tx2.mut_repo().rebase_descendants(&settings).unwrap();
+    tx2.rebase_descendants(&settings).unwrap();
 
     let repo = if child_first {
         commit_transactions(&settings, vec![tx1, tx2])
@@ -594,7 +594,7 @@ fn test_merge_views_child_on_rewritten_divergent(on_rewritten: bool, child_first
         .set_description("A4")
         .write()
         .unwrap();
-    tx2.mut_repo().rebase_descendants(&settings).unwrap();
+    tx2.rebase_descendants(&settings).unwrap();
 
     let repo = if child_first {
         commit_transactions(&settings, vec![tx1, tx2])
@@ -645,7 +645,7 @@ fn test_merge_views_child_on_abandoned(child_first: bool) {
     let mut tx2 = repo.start_transaction(&settings, "test");
     tx2.mut_repo()
         .record_abandoned_commit(commit_b.id().clone());
-    tx2.mut_repo().rebase_descendants(&settings).unwrap();
+    tx2.rebase_descendants(&settings).unwrap();
 
     let repo = if child_first {
         commit_transactions(&settings, vec![tx1, tx2])

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1192,6 +1192,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
                     &self.user_repo.git_backend().unwrap().git_repo(),
                 )?;
                 print_failed_git_export(ui, &failed_branches)?;
+                // TODO: do we need to invoke the post-rewrite hook here?
             }
 
             self.user_repo = ReadonlyUserRepo::new(tx.commit());
@@ -1256,7 +1257,20 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             let git_repo = self.git_backend().unwrap().git_repo();
             let failed_branches = git::export_refs(tx.mut_repo(), &git_repo)?;
             print_failed_git_export(ui, &failed_branches)?;
-            invoke_post_rewrite_hook(&git_repo, abandoned_commits, rewritten_commits)?;
+
+            let abandoned_commits = &mut_repo.abandoned_descendants;
+            let rewritten_commits = &mut_repo.rewritten_descendants;
+            // let rewritten_commits: std::collections::HashMap<_, _> = rebased
+            //     .into_iter()
+            //     .map(|(lhs, rhs)| {
+            //         let mut set = HashSet::new();
+            //         set.insert(rhs);
+            //         (lhs, set)
+            //     })
+            //     .collect();
+            if !abandoned_commits.is_empty() || !rewritten_commits.is_empty() {
+                invoke_post_rewrite_hook(&git_repo, abandoned_commits, &rewritten_commits)?;
+            }
         }
         let store = tx.mut_repo().store().clone();
         let maybe_old_commit = tx

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1258,8 +1258,8 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             let failed_branches = git::export_refs(tx.mut_repo(), &git_repo)?;
             print_failed_git_export(ui, &failed_branches)?;
 
-            let abandoned_commits = &mut_repo.abandoned_descendants;
-            let rewritten_commits = &mut_repo.rewritten_descendants;
+            let abandoned_commits = tx.mut_repo().abandoned_descendants.clone();
+            let rewritten_commits = tx.mut_repo().rewritten_descendants.clone();
             // let rewritten_commits: std::collections::HashMap<_, _> = rebased
             //     .into_iter()
             //     .map(|(lhs, rhs)| {
@@ -1269,7 +1269,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             //     })
             //     .collect();
             if !abandoned_commits.is_empty() || !rewritten_commits.is_empty() {
-                invoke_post_rewrite_hook(&git_repo, abandoned_commits, &rewritten_commits)?;
+                invoke_post_rewrite_hook(&git_repo, &abandoned_commits, &rewritten_commits)?;
             }
         }
         let store = tx.mut_repo().store().clone();

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -32,7 +32,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use jj_lib::backend::{BackendError, ChangeId, CommitId, ObjectId, TreeId};
 use jj_lib::commit::Commit;
-use jj_lib::git::{GitConfigParseError, GitExportError, GitImportError};
+use jj_lib::git::{GitConfigParseError, GitExportError, GitHookError, GitImportError};
 use jj_lib::git_backend::GitBackend;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::hex_util::to_reverse_hex;
@@ -250,6 +250,12 @@ impl From<GitExportError> for CommandError {
         CommandError::InternalError(format!(
             "Failed to export refs to underlying Git repo: {err}"
         ))
+    }
+}
+
+impl From<GitHookError> for CommandError {
+    fn from(err: GitHookError) -> Self {
+        CommandError::InternalError(format!("Failed to invoke Git hook: {err}"))
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1343,7 +1343,7 @@ Make sure they're ignored, then try again.",
         .rewrite_commit(command.settings(), &wc_commit)
         .set_tree(new_tree_id)
         .write()?;
-    let num_rebased = tx.rebase_descendants(command.settings())?;
+    let (num_rebased, rebased) = tx.rebase_descendants(command.settings())?;
     if num_rebased > 0 {
         writeln!(ui, "Rebased {num_rebased} descendant commits")?;
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1343,7 +1343,7 @@ Make sure they're ignored, then try again.",
         .rewrite_commit(command.settings(), &wc_commit)
         .set_tree(new_tree_id)
         .write()?;
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = tx.rebase_descendants(command.settings())?;
     if num_rebased > 0 {
         writeln!(ui, "Rebased {num_rebased} descendant commits")?;
     }
@@ -2113,7 +2113,7 @@ fn cmd_abandon(
     for commit in &to_abandon {
         tx.mut_repo().record_abandoned_commit(commit.id().clone());
     }
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = tx.rebase_descendants(command.settings())?;
 
     if to_abandon.len() == 1 {
         ui.write("Abandoned commit ")?;
@@ -2290,7 +2290,7 @@ fn cmd_new(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(), C
             }
         }
     }
-    num_rebased += tx.mut_repo().rebase_descendants(command.settings())?;
+    num_rebased += tx.rebase_descendants(command.settings())?;
     if num_rebased > 0 {
         writeln!(ui, "Rebased {num_rebased} descendant commits")?;
     }
@@ -3172,7 +3172,7 @@ fn rebase_descendants(
     for old_commit in old_commits {
         rebase_commit(command.settings(), tx.mut_repo(), old_commit, new_parents)?;
     }
-    let num_rebased = old_commits.len() + tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = old_commits.len() + tx.rebase_descendants(command.settings())?;
     writeln!(ui, "Rebased {num_rebased} commits")?;
     tx.finish(ui)?;
     Ok(())
@@ -3247,7 +3247,7 @@ fn rebase_revision(
         )?;
         num_rebased_descendants += 1;
     }
-    num_rebased_descendants += tx.mut_repo().rebase_descendants(command.settings())?;
+    num_rebased_descendants += tx.rebase_descendants(command.settings())?;
     if num_rebased_descendants > 0 {
         writeln!(
             ui,


### PR DESCRIPTION
Thoughts on the approach? Re #880.

There seem to be several possible places where we could invoke the post-rewrite hook. Originally suggested in #880 was to add it to `Transaction::write`, but that seems a little too late, because we've already cleared out the information about which commits have been rewritten (since it asserts `!mut_repo.has_rewrites()` at that point). On the other hand, it seems like there are several other places where we print a message about having rebased descendant commits, but it looks like not all of those call into `finish_transaction`, so this approach might be incomplete.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
