### PR TITLE
protobuf: remove ignored call to `out_dir()`

### DIFF
--- a/lib/build.rs
+++ b/lib/build.rs
@@ -12,16 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-
 fn main() {
-    let out_dir = format!("{}/protos", std::env::var("OUT_DIR").unwrap());
-
-    if Path::new(&out_dir).exists() {
-        std::fs::remove_dir_all(&out_dir).unwrap();
-    }
-    std::fs::create_dir(&out_dir).unwrap();
-
     let input = &[
         "src/protos/op_store.proto",
         "src/protos/store.proto",
@@ -29,7 +20,6 @@ fn main() {
     ];
     protobuf_codegen::Codegen::new()
         .pure()
-        .out_dir(out_dir)
         .inputs(input)
         .include("src/protos")
         .cargo_out_dir("protos")


### PR DESCRIPTION
Since we call `cargo_out_dir()` - which is the preferred way of using `protobuf_codegen::Codegen` in `build.rs` - our call to `out_dir()` has no effect.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
