### PR TITLE
cleanup: remove an unnecessary borrow reported by Clippy 1.66

### DIFF
--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -60,7 +60,7 @@ fn upgrade_from_thrift(store_path: &Path) -> std::io::Result<()> {
     // Find the current operation head(s) of the operation log
     let op_heads_store_path = repo_path.join("op_heads");
     let mut old_op_heads = HashSet::new();
-    for entry in fs::read_dir(&op_heads_store_path)? {
+    for entry in fs::read_dir(op_heads_store_path)? {
         let basename = entry?.file_name();
         let op_id_str = basename.to_str().unwrap();
         if let Ok(op_id_bytes) = hex::decode(op_id_str) {

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -45,7 +45,7 @@ fn merge_directories(left: &Path, base: &Path, right: &Path, output: &Path) {
         if child_left.is_dir() {
             sub_dirs.push(base_name.to_os_string());
         } else {
-            std::fs::copy(&child_left, &child_output).unwrap();
+            std::fs::copy(&child_left, child_output).unwrap();
         }
     }
     // Walk the base and find files removed in the right side, then remove them in
@@ -75,7 +75,7 @@ fn merge_directories(left: &Path, base: &Path, right: &Path, output: &Path) {
         } else if !child_base.exists() {
             // This overwrites the left side if that's been written. That's fine, since the
             // point of the test is that it should be okay for either side to win.
-            std::fs::copy(&child_right, &child_output).unwrap();
+            std::fs::copy(&child_right, child_output).unwrap();
         }
     }
     // Do the merge in subdirectories

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -401,6 +401,8 @@ fn test_snapshot_racy_timestamps(use_git: bool) {
     let wc = test_workspace.workspace.working_copy_mut();
     for i in 0..100 {
         {
+            // https://github.com/rust-lang/rust-clippy/issues/9778
+            #[allow(clippy::needless_borrow)]
             let mut file = OpenOptions::new()
                 .create(true)
                 .write(true)


### PR DESCRIPTION
Interestingly, the nightly release doesn't complain about this.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
