### PR TITLE
Allow `jj git push` to push multiple branches/changes at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj log --summary --patch` now shows both summary and diff outputs.
 
+* `jj git push` now accepts multiple `--branch`/`--change` arguments
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export
@@ -28,6 +30,7 @@ Thanks to the people who made this release happen!
  * Martin von Zweigbergk (@martinvonz)
  * Danny Hooper (hooper@google.com)
  * Yuya Nishihara (@yuja)
+ * Ilya Grigoriev (@ilyagr)
 
 ## [0.6.1] - 2022-12-05
 

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -108,7 +108,7 @@ fn find_pair_to_remove(
     None
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct BranchPushUpdate {
     pub old_target: Option<CommitId>,
     pub new_target: Option<CommitId>,

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -168,6 +168,25 @@ fn test_git_push_multiple() {
       Add branch my-branch to afc3e612e744
     Dry-run requested, not pushing.
     "###);
+    // Dry run requesting two specific branches twice
+    let stdout = test_env.jj_cmd_success(
+        &workspace_root,
+        &[
+            "git",
+            "push",
+            "-b=branch1",
+            "-b=my-branch",
+            "-b=branch1",
+            "-b=my-branch",
+            "--dry-run",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Branch changes to push to origin:
+      Delete branch branch1 from 828a683493c6
+      Add branch my-branch to afc3e612e744
+    Dry-run requested, not pushing.
+    "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     Branch changes to push to origin:
@@ -213,6 +232,16 @@ fn test_git_push_changes() {
     Branch changes to push to origin:
       Force branch push-<CHANGE_ID> from ccebc2439094 to 1624f122b2b1
       Add branch push-<CHANGE_ID> to 0a736fed65c0
+    "###);
+    // specifying the same change twice doesn't break things
+    std::fs::write(workspace_root.join("file"), "modified3").unwrap();
+    let stdout = test_env.jj_cmd_success(
+        &workspace_root,
+        &["git", "push", "--change", "@", "--change", "@"],
+    );
+    insta::assert_snapshot!(replace_changeid(&stdout), @r###"
+    Branch changes to push to origin:
+      Force branch push-<CHANGE_ID> from 1624f122b2b1 to bae35833f32d
     "###);
 }
 


### PR DESCRIPTION
Also creates a short arg `-b` for `--branch`.

I haven't tried to make the code very pretty, but I got tests to pass.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] Only command-line help is planned for documentation
- [x] I have added tests to cover my changes
