### PR TITLE
cli: remove unnecessary (?) `ArgAction::Append` in `$[clap]`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,7 +25,7 @@ use std::{fs, io};
 
 use chrono::{FixedOffset, LocalResult, TimeZone, Utc};
 use clap::builder::NonEmptyStringValueParser;
-use clap::{ArgAction, ArgGroup, ArgMatches, CommandFactory, FromArgMatches, Subcommand};
+use clap::{ArgGroup, ArgMatches, CommandFactory, FromArgMatches, Subcommand};
 use itertools::Itertools;
 use jujutsu_lib::backend::{CommitId, Timestamp, TreeValue};
 use jujutsu_lib::commit::Commit;
@@ -715,7 +715,7 @@ enum BranchSubcommand {
         names: Vec<String>,
 
         /// A glob pattern indicating branches to forget.
-        #[arg(action(ArgAction::Append), long = "glob")]
+        #[arg(long)]
         glob: Vec<String>,
     },
 


### PR DESCRIPTION
I think "append" is the default for `Vec`-type fields.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
