### PR TITLE
cli: respect default value of git core.excludesFile

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -584,6 +584,11 @@ impl WorkspaceCommandHelper {
         if let Ok(excludes_file_str) = self
             .git_config()
             .and_then(|git_config| git_config.get_string("core.excludesFile"))
+            .or_else(|_| {
+                std::env::var("XDG_CONFIG_HOME")
+                    .or_else(|_| std::env::var("HOME"))
+                    .map(|x| format!("{x}/.config/git/ignore"))
+            })
         {
             let excludes_file_path = expand_git_path(excludes_file_str);
             git_ignores = git_ignores.chain_with_file("", excludes_file_path);


### PR DESCRIPTION
Per https://git-scm.com/docs/gitignore:

> Its default value is $XDG_CONFIG_HOME/git/ignore. If $XDG_CONFIG_HOME is either not set or empty, $HOME/.config/git/ignore is used instead.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
