### PR TITLE
lib: replace protobuf crate with prost

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,20 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+  check-protos:
+    name: Check protos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - uses: dtolnay/rust-toolchain@e645b0cf01249a964ec099494d38d2da0f0b349f
+        with:
+          toolchain: stable
+      - run: sudo apt update && sudo apt-get -y install protobuf-compiler
+      - name: Generate Rust code from .proto files
+        run: cargo run -p gen-protos
+      - name: Check for uncommitted changes
+        run: git diff --exit-code
+
   rustfmt:
     name: Check formatting
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +568,13 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "gen-protos"
+version = "0.1.0"
+dependencies = [
+ "prost-build",
 ]
 
 [[package]]
@@ -830,8 +843,7 @@ dependencies = [
  "once_cell",
  "pest",
  "pest_derive",
- "protobuf",
- "protobuf-codegen",
+ "prost",
  "rand",
  "regex",
  "serde_json",
@@ -983,6 +995,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.36.1",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nom"
@@ -1181,6 +1199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,55 +1328,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "3.2.0"
+name = "prost"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
+checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
 dependencies = [
  "bytes",
- "once_cell",
- "protobuf-support",
- "thiserror",
+ "prost-derive",
 ]
 
 [[package]]
-name = "protobuf-codegen"
-version = "3.2.0"
+name = "prost-build"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd418ac3c91caa4032d37cb80ff0d44e2ebe637b2fb243b6234bf89cdac4901"
+checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
 dependencies = [
- "anyhow",
- "once_cell",
- "protobuf",
- "protobuf-parse",
- "regex",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "protobuf-parse"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d39b14605eaa1f6a340aec7f320b34064feb26c93aec35d6a9a2272a8ddfa49"
-dependencies = [
- "anyhow",
- "indexmap",
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
  "log",
- "protobuf",
- "protobuf-support",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
  "tempfile",
- "thiserror",
  "which",
 ]
 
 [[package]]
-name = "protobuf-support"
-version = "3.2.0"
+name = "prost-derive"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d4d7b8601c814cfb36bcebb79f0e61e45e1e93640cf778837833bbed05c372"
+checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
 dependencies = [
- "thiserror",
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ name = "diff_bench"
 harness = false
 
 [workspace]
-members = ["lib", "lib/testutils"]
+members = ["lib", "lib/testutils", "lib/gen-protos"]
 
 [dependencies]
 chrono = { version = "0.4.23", default-features = false, features = ["std", "clock"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,6 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-protobuf-codegen = "3.2.0"
 version_check = "0.9.4"
 
 [dependencies]
@@ -32,7 +31,6 @@ maplit = "1.0.2"
 once_cell = "1.16.0"
 pest = "2.5.1"
 pest_derive = "2.5.1"
-protobuf = { version = "3.0.1", features = ["with-bytes"] }
 regex = "1.7.0"
 serde_json = "1.0.91"
 tempfile = "3.3.0"
@@ -42,6 +40,7 @@ uuid = { version = "1.2.2", features = ["v4"] }
 whoami = "1.2.3"
 zstd = "0.12.1"
 tracing = "0.1.37"
+prost = "0.11.5"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -12,24 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn main() {
-    let input = &[
-        "src/protos/op_store.proto",
-        "src/protos/store.proto",
-        "src/protos/working_copy.proto",
-    ];
-    protobuf_codegen::Codegen::new()
-        .pure()
-        .inputs(input)
-        .include("src/protos")
-        .cargo_out_dir("protos")
-        .run_from_script();
+fn main() -> std::io::Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
-    for file in input {
-        println!("cargo:rerun-if-changed={file}");
-    }
 
     if let Some(true) = version_check::supports_feature("map_first_last") {
         println!("cargo:rustc-cfg=feature=\"map_first_last\"");
     }
+
+    Ok(())
 }

--- a/lib/gen-protos/Cargo.toml
+++ b/lib/gen-protos/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gen-protos"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+prost-build = "0.11.5"

--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -1,0 +1,34 @@
+// Copyright 2022 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Result;
+use std::path::Path;
+
+fn main() -> Result<()> {
+    let input = ["op_store.proto", "store.proto", "working_copy.proto"];
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let protos_dir = root.join("src").join("protos");
+
+    prost_build::Config::new()
+        .out_dir(&protos_dir)
+        .include_file("mod.rs")
+        .compile_protos(
+            &input
+                .into_iter()
+                .map(|x| protos_dir.join(x))
+                .collect::<Vec<_>>(),
+            &[protos_dir],
+        )
+}

--- a/lib/src/protos/mod.rs
+++ b/lib/src/protos/mod.rs
@@ -1,15 +1,9 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
+pub mod op_store {
+    include!("op_store.rs");
+}
+pub mod store {
+    include!("store.rs");
+}
+pub mod working_copy {
+    include!("working_copy.rs");
+}

--- a/lib/src/protos/op_store.rs
+++ b/lib/src/protos/op_store.rs
@@ -1,0 +1,132 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RefConflict {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub removes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub adds: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RefTarget {
+    #[prost(oneof = "ref_target::Value", tags = "1, 2")]
+    pub value: ::core::option::Option<ref_target::Value>,
+}
+/// Nested message and enum types in `RefTarget`.
+pub mod ref_target {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(bytes, tag = "1")]
+        CommitId(::prost::alloc::vec::Vec<u8>),
+        #[prost(message, tag = "2")]
+        Conflict(super::RefConflict),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoteBranch {
+    #[prost(string, tag = "1")]
+    pub remote_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub target: ::core::option::Option<RefTarget>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Branch {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Unset if the branch has been deleted locally.
+    #[prost(message, optional, tag = "2")]
+    pub local_target: ::core::option::Option<RefTarget>,
+    /// TODO: How would we support renaming remotes while having undo work? If
+    /// the remote name is stored in config, it's going to become a mess if the
+    /// remote is renamed but the configs are left unchanged. Should each remote
+    /// be identified (here and in configs) by a UUID?
+    #[prost(message, repeated, tag = "3")]
+    pub remote_branches: ::prost::alloc::vec::Vec<RemoteBranch>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GitRef {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// This field is just for historical reasons (before we had the RefTarget
+    /// type). New GitRefs have (only) the target field.
+    /// TODO: Delete support for the old format.
+    #[prost(bytes = "vec", tag = "2")]
+    pub commit_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub target: ::core::option::Option<RefTarget>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Tag {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub target: ::core::option::Option<RefTarget>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct View {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub head_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "4")]
+    pub public_head_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[deprecated]
+    #[prost(bytes = "vec", tag = "2")]
+    pub wc_commit_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(map = "string, bytes", tag = "8")]
+    pub wc_commit_ids: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::vec::Vec<u8>,
+    >,
+    #[prost(message, repeated, tag = "5")]
+    pub branches: ::prost::alloc::vec::Vec<Branch>,
+    #[prost(message, repeated, tag = "6")]
+    pub tags: ::prost::alloc::vec::Vec<Tag>,
+    /// Only a subset of the refs. For example, does not include refs/notes/.
+    #[prost(message, repeated, tag = "3")]
+    pub git_refs: ::prost::alloc::vec::Vec<GitRef>,
+    #[prost(bytes = "vec", tag = "7")]
+    pub git_head: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(bytes = "vec", tag = "1")]
+    pub view_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub parents: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(message, optional, tag = "3")]
+    pub metadata: ::core::option::Option<OperationMetadata>,
+}
+/// TODO: Share with store.proto? Do we even need the timezone here?
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Timestamp {
+    #[prost(int64, tag = "1")]
+    pub millis_since_epoch: i64,
+    #[prost(int32, tag = "2")]
+    pub tz_offset: i32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OperationMetadata {
+    #[prost(message, optional, tag = "1")]
+    pub start_time: ::core::option::Option<Timestamp>,
+    #[prost(message, optional, tag = "2")]
+    pub end_time: ::core::option::Option<Timestamp>,
+    #[prost(string, tag = "3")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub hostname: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub username: ::prost::alloc::string::String,
+    #[prost(map = "string, string", tag = "6")]
+    pub tags: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+}

--- a/lib/src/protos/store.rs
+++ b/lib/src/protos/store.rs
@@ -1,0 +1,108 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TreeValue {
+    #[prost(oneof = "tree_value::Value", tags = "2, 3, 4, 5")]
+    pub value: ::core::option::Option<tree_value::Value>,
+}
+/// Nested message and enum types in `TreeValue`.
+pub mod tree_value {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct File {
+        #[prost(bytes = "vec", tag = "1")]
+        pub id: ::prost::alloc::vec::Vec<u8>,
+        #[prost(bool, tag = "2")]
+        pub executable: bool,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(message, tag = "2")]
+        File(File),
+        #[prost(bytes, tag = "3")]
+        SymlinkId(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag = "4")]
+        TreeId(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag = "5")]
+        ConflictId(::prost::alloc::vec::Vec<u8>),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Tree {
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<tree::Entry>,
+}
+/// Nested message and enum types in `Tree`.
+pub mod tree {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Entry {
+        #[prost(string, tag = "1")]
+        pub name: ::prost::alloc::string::String,
+        #[prost(message, optional, tag = "2")]
+        pub value: ::core::option::Option<super::TreeValue>,
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Commit {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub parents: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub predecessors: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub root_tree: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub change_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag = "5")]
+    pub description: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "6")]
+    pub author: ::core::option::Option<commit::Signature>,
+    #[prost(message, optional, tag = "7")]
+    pub committer: ::core::option::Option<commit::Signature>,
+    #[deprecated]
+    #[prost(bool, tag = "8")]
+    pub is_open: bool,
+    #[deprecated]
+    #[prost(bool, tag = "9")]
+    pub is_pruned: bool,
+}
+/// Nested message and enum types in `Commit`.
+pub mod commit {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Timestamp {
+        #[prost(int64, tag = "1")]
+        pub millis_since_epoch: i64,
+        #[prost(int32, tag = "2")]
+        pub tz_offset: i32,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Signature {
+        #[prost(string, tag = "1")]
+        pub name: ::prost::alloc::string::String,
+        #[prost(string, tag = "2")]
+        pub email: ::prost::alloc::string::String,
+        #[prost(message, optional, tag = "3")]
+        pub timestamp: ::core::option::Option<Timestamp>,
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Conflict {
+    #[prost(message, repeated, tag = "1")]
+    pub removes: ::prost::alloc::vec::Vec<conflict::Part>,
+    #[prost(message, repeated, tag = "2")]
+    pub adds: ::prost::alloc::vec::Vec<conflict::Part>,
+}
+/// Nested message and enum types in `Conflict`.
+pub mod conflict {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Part {
+        #[prost(message, optional, tag = "1")]
+        pub content: ::core::option::Option<super::TreeValue>,
+    }
+}

--- a/lib/src/protos/working_copy.rs
+++ b/lib/src/protos/working_copy.rs
@@ -1,0 +1,85 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileState {
+    #[prost(int64, tag = "1")]
+    pub mtime_millis_since_epoch: i64,
+    #[prost(uint64, tag = "2")]
+    pub size: u64,
+    #[prost(enumeration = "FileType", tag = "3")]
+    pub file_type: i32,
+    /// Set only if file_type is Conflict
+    #[prost(bytes = "vec", tag = "4")]
+    pub conflict_id: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SparsePatterns {
+    #[prost(string, repeated, tag = "1")]
+    pub prefixes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TreeState {
+    #[prost(bytes = "vec", tag = "1")]
+    pub tree_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(map = "string, message", tag = "2")]
+    pub file_states: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        FileState,
+    >,
+    #[prost(message, optional, tag = "3")]
+    pub sparse_patterns: ::core::option::Option<SparsePatterns>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Checkout {
+    /// The operation at which the working copy was updated.
+    #[prost(bytes = "vec", tag = "2")]
+    pub operation_id: ::prost::alloc::vec::Vec<u8>,
+    /// An identifier for this workspace. It is used for looking up the current
+    /// checkout in the repo view. Currently a human-readable name.
+    /// TODO: Is it better to make this a UUID and a have map that to a name in
+    /// config? That way users can rename a workspace.
+    #[prost(string, tag = "3")]
+    pub workspace_id: ::prost::alloc::string::String,
+    /// The checked-out commit, which can be viewed as a cache of the working-copy
+    /// commit ID recorded in `operation_id`'s operation. No longer used.
+    /// TODO: Delete this mid 2022 or so
+    #[prost(bytes = "vec", tag = "1")]
+    pub commit_id: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum FileType {
+    Normal = 0,
+    Symlink = 1,
+    Executable = 2,
+    Conflict = 3,
+    GitSubmodule = 4,
+}
+impl FileType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            FileType::Normal => "Normal",
+            FileType::Symlink => "Symlink",
+            FileType::Executable => "Executable",
+            FileType::Conflict => "Conflict",
+            FileType::GitSubmodule => "GitSubmodule",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Normal" => Some(Self::Normal),
+            "Symlink" => Some(Self::Symlink),
+            "Executable" => Some(Self::Executable),
+            "Conflict" => Some(Self::Conflict),
+            "GitSubmodule" => Some(Self::GitSubmodule),
+            _ => None,
+        }
+    }
+}

--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -39,10 +39,14 @@ impl RepoPathComponent {
 
 impl From<&str> for RepoPathComponent {
     fn from(value: &str) -> Self {
+        RepoPathComponent::from(value.to_owned())
+    }
+}
+
+impl From<String> for RepoPathComponent {
+    fn from(value: String) -> Self {
         assert!(!value.contains('/'));
-        RepoPathComponent {
-            value: value.to_owned(),
-        }
+        RepoPathComponent { value }
     }
 }
 


### PR DESCRIPTION
Prost is a far more conformant implementation (https://github.com/stepancheg/rust-protobuf/pull/661 vs. https://github.com/tokio-rs/prost/blob/master/conformance/failing_tests.txt) and appears to be more actively maintained (no commits in protobuf since September, PRs not being reviewed).

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
