### PR TITLE
cmd `jj log`: Move `divergent` label next to the change id

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1477,13 +1477,13 @@ fn log_template(settings: &UserSettings) -> String {
     let default_template = format!(
         r#"
             change_id.short()
+            if(divergent, label("divergent", " divergent"))
             " " author.email()
             " " label("timestamp", {committer_timestamp})
             if(branches, " " branches)
             if(tags, " " tags)
             if(working_copies, " " working_copies)
             if(is_git_head, label("git_head", " HEAD@git"))
-            if(divergent, label("divergent", " divergent"))
             " " commit_id.short()
             if(conflict, label("conflict", " conflict"))
             "\n"


### PR DESCRIPTION
The divergent label is most relevant when the user is about to refer to a commit by its change id.

It's also good to put it far from the `conflicts` label, to reduce confusion between very different concepts that have similar names.

Finally, I think it is a feature rather than a bug that the `divergent` label now upsets the alignment of different lines of `jj log`.

--------

I think this doesn't change any of the screenshots in the repo. If it does, we could consider bundling this with other changes to `jj log` output.
