### PR TITLE
matchers: remove .to_vec() from PrefixMatcher::matches() loop

### DIFF
--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -101,9 +101,9 @@ pub struct FilesMatcher {
 }
 
 impl FilesMatcher {
-    pub fn new(files: HashSet<RepoPath>) -> Self {
+    pub fn new(files: &[RepoPath]) -> Self {
         let mut dirs = Dirs::new();
-        for f in &files {
+        for f in files {
             dirs.add_file(f);
         }
         FilesMatcher { dirs }
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_filesmatcher_empty() {
-        let m = FilesMatcher::new(hashset! {});
+        let m = FilesMatcher::new(&[]);
         assert!(!m.matches(&RepoPath::from_internal_string("file")));
         assert!(!m.matches(&RepoPath::from_internal_string("dir/file")));
         assert_eq!(m.visit(&RepoPath::root()), Visit::Nothing);
@@ -393,12 +393,12 @@ mod tests {
 
     #[test]
     fn test_filesmatcher_nonempty() {
-        let m = FilesMatcher::new(hashset! {
+        let m = FilesMatcher::new(&[
             RepoPath::from_internal_string("dir1/subdir1/file1"),
             RepoPath::from_internal_string("dir1/subdir1/file2"),
             RepoPath::from_internal_string("dir1/subdir2/file3"),
             RepoPath::from_internal_string("file4"),
-        });
+        ]);
 
         assert!(!m.matches(&RepoPath::from_internal_string("dir1")));
         assert!(!m.matches(&RepoPath::from_internal_string("dir1/subdir1")));

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -97,7 +97,6 @@ impl Matcher for EverythingMatcher {
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct FilesMatcher {
-    files: HashSet<RepoPath>,
     dirs: Dirs,
 }
 
@@ -107,13 +106,13 @@ impl FilesMatcher {
         for f in &files {
             dirs.add_file(f);
         }
-        FilesMatcher { files, dirs }
+        FilesMatcher { dirs }
     }
 }
 
 impl Matcher for FilesMatcher {
     fn matches(&self, file: &RepoPath) -> bool {
-        self.files.contains(file)
+        self.dirs.get(file).map(|sub| sub.is_file).unwrap_or(false)
     }
 
     fn visit(&self, dir: &RepoPath) -> Visit {
@@ -400,6 +399,12 @@ mod tests {
             RepoPath::from_internal_string("dir1/subdir2/file3"),
             RepoPath::from_internal_string("file4"),
         });
+
+        assert!(!m.matches(&RepoPath::from_internal_string("dir1")));
+        assert!(!m.matches(&RepoPath::from_internal_string("dir1/subdir1")));
+        assert!(m.matches(&RepoPath::from_internal_string("dir1/subdir1/file1")));
+        assert!(m.matches(&RepoPath::from_internal_string("dir1/subdir1/file2")));
+        assert!(!m.matches(&RepoPath::from_internal_string("dir1/subdir1/file3")));
 
         assert_eq!(
             m.visit(&RepoPath::root()),

--- a/lib/tests/test_diff_summary.rs
+++ b/lib/tests/test_diff_summary.rs
@@ -15,7 +15,6 @@
 use jujutsu_lib::matchers::{EverythingMatcher, FilesMatcher};
 use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::tree::DiffSummary;
-use maplit::hashset;
 use test_case::test_case;
 use testutils::TestRepo;
 
@@ -165,7 +164,7 @@ fn test_matcher_dir_file_transition(use_git: bool) {
     let tree1 = testutils::create_tree(repo, &[(&a_path, "before")]);
     let tree2 = testutils::create_tree(repo, &[(&a_a_path, "after")]);
 
-    let matcher = FilesMatcher::new(hashset! {a_path.clone()});
+    let matcher = FilesMatcher::new(&[a_path.clone()]);
     assert_eq!(
         tree1.diff_summary(&tree2, &matcher),
         DiffSummary {
@@ -183,7 +182,7 @@ fn test_matcher_dir_file_transition(use_git: bool) {
         }
     );
 
-    let matcher = FilesMatcher::new(hashset! {a_a_path.clone()});
+    let matcher = FilesMatcher::new(&[a_a_path.clone()]);
     assert_eq!(
         tree1.diff_summary(&tree2, &matcher),
         DiffSummary {
@@ -201,7 +200,7 @@ fn test_matcher_dir_file_transition(use_git: bool) {
         }
     );
 
-    let matcher = FilesMatcher::new(hashset! {a_path.clone(), a_a_path.clone()});
+    let matcher = FilesMatcher::new(&[a_path.clone(), a_a_path.clone()]);
     assert_eq!(
         tree1.diff_summary(&tree2, &matcher),
         DiffSummary {
@@ -246,7 +245,7 @@ fn test_matcher_normal_cases(use_git: bool) {
         ],
     );
 
-    let matcher = FilesMatcher::new(hashset! {a_path.clone(), z_path.clone()});
+    let matcher = FilesMatcher::new(&[a_path.clone(), z_path.clone()]);
     assert_eq!(
         tree1.diff_summary(&tree2, &matcher),
         DiffSummary {
@@ -264,7 +263,7 @@ fn test_matcher_normal_cases(use_git: bool) {
         }
     );
 
-    let matcher = FilesMatcher::new(hashset! {dir1_a_path.clone(), dir2_b_path.clone()});
+    let matcher = FilesMatcher::new(&[dir1_a_path.clone(), dir2_b_path.clone()]);
     assert_eq!(
         tree1.diff_summary(&tree2, &matcher),
         DiffSummary {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1950,7 +1950,7 @@ fn test_filter_by_diff(use_git: bool) {
     // matcher API:
     let resolve = |file_path: &RepoPath| -> Vec<CommitId> {
         let repo_ref = mut_repo.as_repo_ref();
-        let matcher = FilesMatcher::new([file_path.clone()].into());
+        let matcher = FilesMatcher::new(&[file_path.clone()]);
         let candidates = RevsetExpression::all().evaluate(repo_ref, None).unwrap();
         let commit_ids = revset::filter_by_diff(repo_ref, &matcher as &dyn Matcher, candidates)
             .iter()


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
