### PR TITLE
diff summary: add a newline before the summary to help hard-wrapping tools

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2119,9 +2119,9 @@ fn combine_messages(
             source.description().to_string()
         } else {
             let combined = "JJ: Enter a description for the combined commit.\n".to_string()
-                + "JJ: Description from the destination commit:\n"
+                + "JJ: Description from the destination commit:\n\n"
                 + destination.description()
-                + "\nJJ: Description from the source commit:\n"
+                + "\n\nJJ: Description from the source commit:\n\n"
                 + source.description();
             edit_description(ui, repo, &combined)?
         }
@@ -2579,7 +2579,7 @@ fn diff_summary_to_description(bytes: &[u8]) -> String {
         "Summary diffs and repo paths must always be valid UTF8.",
         // Double-check this assumption for diffs that include file content.
     );
-    "JJ: This commit contains the following changes:\n".to_owned()
+    "\nJJ: This commit contains the following changes:\n".to_owned()
         + &textwrap::indent(text, "JJ:     ")
 }
 

--- a/tests/test_commit_command.rs
+++ b/tests/test_commit_command.rs
@@ -67,6 +67,7 @@ fn test_commit_with_editor() {
         std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
     add files
 
+
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:     A file2

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -370,15 +370,20 @@ fn test_move_description() {
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
     destination
 
+
+
     source
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter a description for the combined commit.
     JJ: Description from the destination commit:
+
     destination
 
+
     JJ: Description from the source commit:
+
     source
 
     JJ: Lines starting with "JJ: " (like this one) will be removed.

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -48,6 +48,7 @@ fn test_split_by_paths() {
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter commit description for the first part (parent).
 
+
     JJ: This commit contains the following changes:
     JJ:     A file2
 
@@ -56,6 +57,7 @@ fn test_split_by_paths() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
     JJ: Enter commit description for the second part (child).
+
 
     JJ: This commit contains the following changes:
     JJ:     A file1

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -286,15 +286,20 @@ fn test_squash_description() {
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
     destination
 
+
+
     source
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter a description for the combined commit.
     JJ: Description from the destination commit:
+
     destination
 
+
     JJ: Description from the source commit:
+
     source
 
     JJ: Lines starting with "JJ: " (like this one) will be removed.

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -252,15 +252,20 @@ fn test_unsquash_description() {
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
     destination
 
+
+
     source
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter a description for the combined commit.
     JJ: Description from the destination commit:
+
     destination
 
+
     JJ: Description from the source commit:
+
     source
 
     JJ: Lines starting with "JJ: " (like this one) will be removed.


### PR DESCRIPTION
Without this change, using VSCode to hard-wrap the commit message does the wrong thing and rewraps the `JJ: ` lines into the body of the draft log message. I haven't tested vim or emacs hard-wrapping logic but my memory of both of those is that it would behave mostly the same. An extra newline here shouldn't hurt anyone, so let's just add it.

Gave the same behavior to other commit editors (I hope.)
