### PR TITLE
commit: add alias `ci` for cvs/svn/hg muscle memory havers

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -366,7 +366,7 @@ struct DescribeArgs {
 
 /// Update the description and create a new change on top.
 #[derive(clap::Args, Clone, Debug)]
-#[command(hide = true)]
+#[command(hide = true, visible_aliases=&["ci"])]
 struct CommitArgs {
     /// The change description to use (don't open editor)
     #[arg(long, short)]


### PR DESCRIPTION
As far as I can tell it won't hurt anyone to have this alias exist, but will help those of us with old muscle memory.
