### PR TITLE
repo: load correct `OpHeadsStore` depending on repo's type

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -463,7 +463,8 @@ impl RepoLoader {
         let store = Store::new(store_factories.load_backend(&repo_path.join("store")));
         let repo_settings = user_settings.with_repo(repo_path).unwrap();
         let op_store = Arc::from(store_factories.load_op_store(&repo_path.join("op_store")));
-        let op_heads_store = Arc::new(SimpleOpHeadsStore::load(&repo_path.join("op_heads")));
+        let op_heads_store =
+            Arc::from(store_factories.load_op_heads_store(&repo_path.join("op_heads")));
         let index_store = Arc::new(IndexStore::load(repo_path.join("index")));
         Self {
             repo_path: repo_path.to_path_buf(),


### PR DESCRIPTION
We forgot to actually call `StoreFactories::load_op_heads_store()` to load the right type of `OpHeadsStore` depending on the contents of `.jj/repo/op_heads/type`. That shouldn't have any effect yet since we only have one type so far, and there are no out-of-tree types yet either (clearly, since they would not work).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
