### PR TITLE
Add "jj debug config-schema" command to output JSON schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj config list` command prints values from config (with other subcommands
   coming soon).
 
+* `jj debug config-schema` command prints out JSON schema for the jj TOML config
+  file format.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "regex",
  "similar",
  "yaml-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ libc = { version = "0.2.139" }
 assert_cmd = "2.0.7"
 criterion = "0.4.0"
 criterion_bencher_compat = "0.4.0"
-insta = "1.23.0"
+insta = { version = "1.23.0", features = ["filters"] }
 predicates = "2.1.5"
 regex = "1.7.0"
 test-case = "2.2.2"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -999,6 +999,7 @@ struct GitExportArgs {}
 enum DebugCommands {
     Completion(DebugCompletionArgs),
     Mangen(DebugMangenArgs),
+    ConfigSchema(DebugConfigSchemaArgs),
     #[command(name = "resolverev")]
     ResolveRev(DebugResolveRevArgs),
     #[command(name = "workingcopy")]
@@ -1042,6 +1043,10 @@ struct DebugCompletionArgs {
 /// Print a ROFF (manpage)
 #[derive(clap::Args, Clone, Debug)]
 struct DebugMangenArgs {}
+
+/// Print the JSON schema for the jj TOML config format.
+#[derive(clap::Args, Clone, Debug)]
+struct DebugConfigSchemaArgs {}
 
 /// Resolve a revision identifier to its full ID
 #[derive(clap::Args, Clone, Debug)]
@@ -3173,6 +3178,11 @@ fn cmd_debug(
             let man = clap_mangen::Man::new(command.app().clone());
             man.render(&mut buf)?;
             ui.stdout_formatter().write_all(&buf)?;
+        }
+        DebugCommands::ConfigSchema(_config_schema_matches) => {
+            // TODO(#879): Consider generating entire schema dynamically vs. static file.
+            let buf = include_bytes!("config-schema.json");
+            ui.stdout_formatter().write_all(buf)?;
         }
         DebugCommands::ResolveRev(resolve_matches) => {
             let workspace_command = command.workspace_helper(ui)?;

--- a/tests/test_debug_command.rs
+++ b/tests/test_debug_command.rs
@@ -1,0 +1,64 @@
+// Copyright 2022 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use insta::assert_snapshot;
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_debug_config_schema() {
+    let test_env = TestEnvironment::default();
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["debug", "config-schema"]);
+    // Validate partial snapshot, redacting any lines nested 2+ indent levels.
+    insta::with_settings!({filters => vec![(r"(?m)(^        .*$\r?\n)+", "        [...]\n")]}, {
+        assert_snapshot!(stdout, @r###"
+        {
+            "$schema": "http://json-schema.org/draft-07/schema",
+            "title": "Jujutsu config",
+            "type": "object",
+            "description": "User configuration for Jujutsu VCS. See https://github.com/martinvonz/jj/blob/main/docs/config.md for details",
+            "properties": {
+                [...]
+            }
+        }
+        "###)
+    });
+}
+
+#[test]
+fn test_debug_index() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let workspace_path = test_env.env_root().join("repo");
+    let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
+    insta::with_settings!(
+    {filters => vec![
+        (r"    Name: [0-9a-z]+", "    Name: [hash]"),
+    ]},
+    {
+        assert_snapshot!(stdout, @r###"
+        Number of commits: 2
+        Number of merges: 0
+        Max generation number: 1
+        Number of heads: 1
+        Number of changes: 2
+        Stats per level:
+          Level 0:
+            Number of commits: 2
+            Name: [hash]
+        "###)
+    });
+}


### PR DESCRIPTION
Extends TOML/JSON schema changes from #966 to allow jj to output the schema directly. Context in #879.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
