### PR TITLE
fix: update cargo install command in readme to specify jujutsu crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ export PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl@3/lib/pkgconfig"
 
 Now run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --bin jj
+cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
 ```
 
 
@@ -231,7 +231,7 @@ cargo install --git https://github.com/martinvonz/jj.git --bin jj
 
 Run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --bin jj
+cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
 ```
 
 


### PR DESCRIPTION
Seems two spots in the README were missed by https://github.com/martinvonz/jj/commit/cc40740fa2bb15ec70799692353c8cad2ffe8f5b from #947.

When not specifying the crate, we get the following error:
```
error: multiple packages with binaries found: gen-protos, jujutsu. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify which to install.
```