### PR TITLE
build: don't use vendored OpenSSL by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
         target: ${{ matrix.target }}
     - name: Build release binary
       run: cargo build --target ${{ matrix.target }} --verbose --release
+    - name: (re-)Build release binary with vendored OpenSSL
+      if: matrix.os != 'ubuntu-20.04' && matrix.os != 'macos-11'
+      run: cargo build --target ${{ matrix.target }} --verbose --release --features vendored-openssl
     - name: Build archive
       shell: bash
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,5 +75,5 @@ test-case = "2.2.2"
 testutils = { path = "lib/testutils" }
 
 [features]
-default = ["vendored-openssl", "jujutsu-lib/legacy-thrift"]
+default = ["jujutsu-lib/legacy-thrift"]
 vendored-openssl = ["git2/vendored-openssl", "jujutsu-lib/vendored-openssl"]

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
 
 Run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
+cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu --features vendored-openssl
 ```
 
 


### PR DESCRIPTION
I added support for using a vendored OpenSSL in dbadbd68c022. That was in order to get the musl binary to work. However, it shouldn't be needed on most platforms, and we've had a few reports of issues caused by it. Let's disable it by default and enable it specifically when building the musl binary instead.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
