### PR TITLE
ui `jj resolve`: List remaining conflicts (if any) on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj debug config-schema` command prints out JSON schema for the jj TOML config
   file format.
 
+* `jj resolve` now notifies the user of remaining conflicts, if any, on success.
+  This can be prevented by the new `--quiet` option.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -183,6 +183,8 @@ conflict
         @r###"
     Working copy now at: 0bb40c908c8b conflict
     Added 0 files, modified 1 files, removed 0 files
+    After this operation, some files at this revision still have conflicts:
+    file
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
@@ -537,6 +539,8 @@ fn test_multiple_conflicts() {
     test_env.jj_cmd_success(&repo_path, &["resolve", "file2"]), @r###"
     Working copy now at: 06cafc2b5489 conflict
     Added 0 files, modified 1 files, removed 0 files
+    After this operation, some files at this revision still have conflicts:
+    file1
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
@@ -552,6 +556,15 @@ fn test_multiple_conflicts() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
     file1
+    "###);
+
+    // Repeat the above with the `--quiet` option.
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    std::fs::write(&editor_script, "expect\n\0write\nresolution file2\n").unwrap();
+    insta::assert_snapshot!(
+    test_env.jj_cmd_success(&repo_path, &["resolve", "--quiet", "file2"]), @r###"
+    Working copy now at: 02326c070aa4 conflict
+    Added 0 files, modified 1 files, removed 0 files
     "###);
 
     // For the rest of the test, we call `jj resolve` several times in a row to

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -85,7 +85,11 @@ fn test_resolution() {
         ["dump editor0", "write\nresolution\n"].join("\0"),
     )
     .unwrap();
-    test_env.jj_cmd_success(&repo_path, &["resolve"]);
+    insta::assert_snapshot!(
+    test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
+    Working copy now at: e069f0736a79 conflict
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     "###);
@@ -167,14 +171,19 @@ conflict
         .join("\0"),
     )
     .unwrap();
-    test_env.jj_cmd_success(
-        &repo_path,
-        &[
-            "resolve",
-            "--config-toml",
-            "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
-        ],
-    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "resolve",
+                "--config-toml",
+                "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
+            ],
+        ),
+        @r###"
+    Working copy now at: 0bb40c908c8b conflict
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
     <<<<<<<
@@ -225,7 +234,11 @@ conflict
         .join("\0"),
     )
     .unwrap();
-    test_env.jj_cmd_success(&repo_path, &["resolve"]);
+    insta::assert_snapshot!(
+    test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
+    Working copy now at: 95418cb82ab1 conflict
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor3")).unwrap(), @r###"
     "###);
@@ -520,7 +533,11 @@ fn test_multiple_conflicts() {
 
     // Check that we can manually pick which of the conflicts to resolve first
     std::fs::write(&editor_script, "expect\n\0write\nresolution file2\n").unwrap();
-    test_env.jj_cmd_success(&repo_path, &["resolve", "file2"]);
+    insta::assert_snapshot!(
+    test_env.jj_cmd_success(&repo_path, &["resolve", "file2"]), @r###"
+    Working copy now at: 06cafc2b5489 conflict
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
     Resolved conflict in file2:


### PR DESCRIPTION
This can be prevented by the new `--quiet` option.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
