### PR TITLE
`jj resolve --list`: Add descriptions of conflict complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj debug config-schema` command prints out JSON schema for the jj TOML config
   file format.
 
+* `jj resolve --list` can now describe the complexity of conflicts.
+
 * `jj resolve` now notifies the user of remaining conflicts, if any, on success.
   This can be prevented by the new `--quiet` option.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2397,7 +2397,7 @@ fn cmd_resolve(
         )));
     }
     if args.list {
-        return print_conflicted_files(
+        return print_conflicted_paths(
             &conflicts,
             ui.stdout_formatter().as_mut(),
             &workspace_command,
@@ -2423,7 +2423,7 @@ fn cmd_resolve(
         let new_conflicts = new_tree.conflicts_matching(&EverythingMatcher);
         if !new_conflicts.is_empty() {
             ui.write("After this operation, some files at this revision still have conflicts:\n")?;
-            print_conflicted_files(
+            print_conflicted_paths(
                 &new_conflicts,
                 ui.stdout_formatter().as_mut(),
                 &workspace_command,
@@ -2433,7 +2433,7 @@ fn cmd_resolve(
     Ok(())
 }
 
-fn print_conflicted_files(
+fn print_conflicted_paths(
     conflicts: &[(RepoPath, jujutsu_lib::backend::ConflictId)],
     formatter: &mut dyn Formatter,
     workspace_command: &WorkspaceCommandHelper,


### PR DESCRIPTION
The descriptions focus on adds, not the deletions. The deletions are used
to compute the number of deleted files that must be sides of the conflict.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes

------------------------------------

This is based on top of #975. I am pretty happy with the English of the descriptions. It might be nice to have prettier alignment, though.

There could also be a `--short` option that says the same thing more compactly, e.g. "txt, txt" or "dir, exe" for 2-sided conflicts.

On the other hand, I don't run into conflicts this complex often enough to know what is useful here.