### PR TITLE
RFC: Remove check that all deletions in a conflict are regular files

### DIFF
--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -150,18 +150,21 @@ pub fn extract_file_conflict_as_single_hunk(
     conflict: &Conflict,
 ) -> Option<ConflictHunk> {
     let file_adds = file_parts(&conflict.adds);
-    let file_removes = file_parts(&conflict.removes);
-    if file_adds.len() != conflict.adds.len() || file_removes.len() != conflict.removes.len() {
+    if file_adds.len() != conflict.adds.len() {
         return None;
     }
     let added_content = file_adds
         .iter()
         .map(|part| get_file_contents(store, path, part))
         .collect_vec();
-    let removed_content = file_removes
+    let file_removes = file_parts(&conflict.removes);
+    let mut removed_content = file_removes
         .iter()
         .map(|part| get_file_contents(store, path, part))
         .collect_vec();
+    // If some of the removes are not regular files, we pretend those were empty
+    // files.
+    removed_content.resize(conflict.removes.len(), vec![]);
 
     Some(ConflictHunk {
         removes: removed_content,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2454,10 +2454,7 @@ fn print_conflicted_paths(
                 if deletions > 1 { "s" } else { "" }
             ));
         }
-        // TODO: We might decide it's OK for `jj resolve` to ignore special files in the
-        // `removes` of a conflict (see e.g. https://github.com/martinvonz/jj/pull/978). In
-        // that case, `conflict.removes` should be removed below.
-        for object in itertools::chain(conflict.adds.iter(), conflict.removes.iter()) {
+        for object in conflict.adds.iter() {
             seen_objects.insert(
                 match object.value {
                     TreeValue::File {


### PR DESCRIPTION
I think the user doesn't really care about them, and it should be safe to treat them as empty files. WDYT?

Note that there are no tests for this functionality, as it should only matter rarely.