### PR TITLE
Add pkg-config to required Linux dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ On most distributions, you'll need to build from source using `cargo` directly.
 
 #### Build using `cargo`
 
-First make sure that you have the `libssl-dev` and `openssl` packages installed
-by running something like this:
+First make sure that you have the `libssl-dev`, `openssl`, and `pkg-config`
+packages installed by running something like this:
 ```shell script
-sudo apt-get install libssl-dev openssl
+sudo apt-get install libssl-dev openssl pkg-config
 ```
 
 Now run:


### PR DESCRIPTION
Without it, cargo started erroring out for me after #970 saying it couldn't find openssl without pkg-config being installed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
