### PR TITLE
`resolve --list`: account for deletions of special files

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2454,7 +2454,10 @@ fn print_conflicted_paths(
                 if deletions > 1 { "s" } else { "" }
             ));
         }
-        for object in conflict.adds.iter() {
+        // TODO: We might decide it's OK for `jj resolve` to ignore special files in the
+        // `removes` of a conflict (see e.g. https://github.com/martinvonz/jj/pull/978). In
+        // that case, `conflict.removes` should be removed below.
+        for object in itertools::chain(conflict.adds.iter(), conflict.removes.iter()) {
             seen_objects.insert(
                 match object.value {
                     TreeValue::File {


### PR DESCRIPTION
This will match `jj`'s behavior of being unable to resolve such conflicts or to show readable diffs of them, in the pre-#978 state.

This is a fixup of 621293d7c6.

# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- (not planned)  I have updated the documentation (README.md, docs/, demos/)
- (may happen as part of #978) I have added tests to cover my changes
