### PR TITLE
Have `jj op log` obey `ui.relative-timestamps` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Per-repository configuration is now read from `.jj/repo/config.toml`.
 
+* The `ui.relative-timestamps` option now also affects `jj op log`.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,12 +22,11 @@ use std::sync::Mutex;
 use std::time::Instant;
 use std::{fs, io};
 
-use chrono::{FixedOffset, LocalResult, TimeZone, Utc};
 use clap::builder::NonEmptyStringValueParser;
 use clap::{ArgGroup, ArgMatches, CommandFactory, FromArgMatches, Subcommand};
 use config::Source;
 use itertools::Itertools;
-use jujutsu_lib::backend::{CommitId, ObjectId, Timestamp, TreeValue};
+use jujutsu_lib::backend::{CommitId, ObjectId, TreeValue};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::dag_walk::topo_order_reverse;
 use jujutsu_lib::git::{GitFetchError, GitRefUpdate};
@@ -61,7 +60,7 @@ use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
 use crate::formatter::{Formatter, PlainTextFormatter};
 use crate::graphlog::{AsciiGraphDrawer, Edge};
 use crate::progress::Progress;
-use crate::template_parser::TemplateParser;
+use crate::template_parser::{format_absolute_timestamp, TemplateParser};
 use crate::templater::Template;
 use crate::ui::Ui;
 
@@ -3340,26 +3339,6 @@ fn cmd_debug(
     Ok(())
 }
 
-// TODO: Move this somewhere where it can be reused by
-// `template_parser::SignatureTimestamp`.
-fn format_timestamp(timestamp: &Timestamp) -> String {
-    let utc = match Utc.timestamp_opt(
-        timestamp.timestamp.0.div_euclid(1000),
-        (timestamp.timestamp.0.rem_euclid(1000)) as u32 * 1000000,
-    ) {
-        LocalResult::None => {
-            return "<out-of-range date>".to_string();
-        }
-        LocalResult::Single(x) => x,
-        LocalResult::Ambiguous(y, _z) => y,
-    };
-    let datetime = utc.with_timezone(
-        &FixedOffset::east_opt(timestamp.tz_offset * 60)
-            .unwrap_or_else(|| FixedOffset::east_opt(0).unwrap()),
-    );
-    datetime.format("%Y-%m-%d %H:%M:%S.%3f %:z").to_string()
-}
-
 fn cmd_op_log(
     ui: &mut Ui,
     command: &CommandHelper,
@@ -3386,8 +3365,8 @@ fn cmd_op_log(
             formatter.with_label("time", |formatter| {
                 formatter.write_str(&format!(
                     "{} - {}",
-                    format_timestamp(&metadata.start_time),
-                    format_timestamp(&metadata.end_time)
+                    format_absolute_timestamp(&metadata.start_time),
+                    format_absolute_timestamp(&metadata.end_time)
                 ))
             })?;
             formatter.write_str("\n")?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,7 +26,7 @@ use clap::builder::NonEmptyStringValueParser;
 use clap::{ArgGroup, ArgMatches, CommandFactory, FromArgMatches, Subcommand};
 use config::Source;
 use itertools::Itertools;
-use jujutsu_lib::backend::{CommitId, ObjectId, TreeValue};
+use jujutsu_lib::backend::{CommitId, ObjectId, Timestamp, TreeValue};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::dag_walk::topo_order_reverse;
 use jujutsu_lib::git::{GitFetchError, GitRefUpdate};
@@ -60,7 +60,9 @@ use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
 use crate::formatter::{Formatter, PlainTextFormatter};
 use crate::graphlog::{AsciiGraphDrawer, Edge};
 use crate::progress::Progress;
-use crate::template_parser::{format_absolute_timestamp, TemplateParser};
+use crate::template_parser::{
+    format_absolute_timestamp, format_timestamp_relative_to_now, TemplateParser,
+};
 use crate::templater::Template;
 use crate::ui::Ui;
 
@@ -3351,7 +3353,18 @@ fn cmd_op_log(
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let mut formatter = formatter.as_mut();
-    struct OpTemplate;
+    struct OpTemplate {
+        relative_timestamps: bool,
+    }
+    impl OpTemplate {
+        fn format_timestamp(&self, timestamp: &Timestamp) -> String {
+            if self.relative_timestamps {
+                format_timestamp_relative_to_now(timestamp)
+            } else {
+                format_absolute_timestamp(timestamp)
+            }
+        }
+    }
     impl Template<Operation> for OpTemplate {
         fn format(&self, op: &Operation, formatter: &mut dyn Formatter) -> io::Result<()> {
             // TODO: Make this templated
@@ -3365,8 +3378,8 @@ fn cmd_op_log(
             formatter.with_label("time", |formatter| {
                 formatter.write_str(&format!(
                     "{} - {}",
-                    format_absolute_timestamp(&metadata.start_time),
-                    format_absolute_timestamp(&metadata.end_time)
+                    self.format_timestamp(&metadata.start_time),
+                    self.format_timestamp(&metadata.end_time)
                 ))
             })?;
             formatter.write_str("\n")?;
@@ -3381,7 +3394,9 @@ fn cmd_op_log(
             Ok(())
         }
     }
-    let template = OpTemplate;
+    let template = OpTemplate {
+        relative_timestamps: command.settings().relative_timestamps(),
+    };
 
     let mut graph = AsciiGraphDrawer::new(&mut formatter);
     for op in topo_order_reverse(

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -123,18 +123,16 @@ pub fn format_absolute_timestamp(timestamp: &Timestamp) -> String {
     }
 }
 
-pub fn format_timestamp_relative_to_now(timestamp: &Timestamp) -> String {
-    datetime_from_timestamp(timestamp)
-        .and_then(|datetime| {
-            let now = chrono::Local::now();
-
-            now.signed_duration_since(datetime).to_std().ok()
-        })
-        .map(|duration| {
-            let f = timeago::Formatter::new();
-            f.convert(duration)
-        })
+pub fn format_duration(from: &Timestamp, to: &Timestamp, format: &timeago::Formatter) -> String {
+    datetime_from_timestamp(from)
+        .zip(datetime_from_timestamp(to))
+        .and_then(|(from, to)| to.signed_duration_since(from).to_std().ok())
+        .map(|duration| format.convert(duration))
         .unwrap_or_else(|| "<out-of-range date>".to_string())
+}
+
+pub fn format_timestamp_relative_to_now(timestamp: &Timestamp) -> String {
+    format_duration(timestamp, &Timestamp::now(), &timeago::Formatter::new())
 }
 
 struct RelativeTimestampString;

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -44,12 +44,12 @@ fn test_op_log() {
     );
     let regex = Regex::new(r"\d\d years").unwrap();
     insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r###"
-    @ 45108169c0f8 test-username@host.example.com NN years ago - NN years ago
+    @ 45108169c0f8 test-username@host.example.com NN years ago, lasted less than a microsecond
     | describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     | args: jj describe -m 'description 0'
-    o a99a3fd5c51e test-username@host.example.com NN years ago - NN years ago
+    o a99a3fd5c51e test-username@host.example.com NN years ago, lasted less than a microsecond
     | add workspace 'default'
-    o 56b94dfc38e7 test-username@host.example.com NN years ago - NN years ago
+    o 56b94dfc38e7 test-username@host.example.com NN years ago, lasted less than a microsecond
       initialize repo
     "###);
     let add_workspace_id = "a99a3fd5c51e";

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -14,6 +14,8 @@
 
 use std::path::Path;
 
+use regex::Regex;
+
 use crate::common::TestEnvironment;
 
 pub mod common;
@@ -33,6 +35,21 @@ fn test_op_log() {
     o a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     | add workspace 'default'
     o 56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+      initialize repo
+    "###);
+    // Test op log with relative dates
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["op", "log", "--config-toml", "ui.relative-timestamps=true"],
+    );
+    let regex = Regex::new(r"\d\d years").unwrap();
+    insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r###"
+    @ 45108169c0f8 test-username@host.example.com NN years ago - NN years ago
+    | describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    | args: jj describe -m 'description 0'
+    o a99a3fd5c51e test-username@host.example.com NN years ago - NN years ago
+    | add workspace 'default'
+    o 56b94dfc38e7 test-username@host.example.com NN years ago - NN years ago
       initialize repo
     "###);
     let add_workspace_id = "a99a3fd5c51e";


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (the docs work as is) I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
