### PR TITLE
`jj resolve --list` and `jj status`: make conflict output colorful + clippy

### DIFF
--- a/lib/src/tree_builder.rs
+++ b/lib/src/tree_builder.rs
@@ -84,8 +84,7 @@ impl TreeBuilder {
         // Write trees level by level, starting with trees without children.
         let store = self.store.as_ref();
         loop {
-            let mut dirs_to_write: HashSet<RepoPath> =
-                trees_to_write.keys().cloned().into_iter().collect();
+            let mut dirs_to_write: HashSet<RepoPath> = trees_to_write.keys().cloned().collect();
 
             for dir in trees_to_write.keys() {
                 if let Some(parent) = dir.parent() {

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1670,7 +1670,7 @@ pub fn handle_command_result(ui: &mut Ui, result: Result<(), CommandError>) -> i
         Err(CommandError::UserError { message, hint }) => {
             ui.write_error(&format!("Error: {message}\n")).unwrap();
             if let Some(hint) = hint {
-                ui.write_hint(&format!("Hint: {hint}\n")).unwrap();
+                ui.write_hint(format!("Hint: {hint}\n")).unwrap();
             }
             1
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2484,7 +2484,7 @@ fn print_conflicted_paths(
 
         writeln!(
             formatter,
-            "{}: {msg}",
+            "{}\t{msg}",
             &workspace_command.format_file_path(repo_path)
         )?;
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1539,9 +1539,7 @@ fn cmd_status(
             formatter.with_label("conflict", |formatter| {
                 writeln!(formatter, "There are unresolved conflicts at these paths:")
             })?;
-            for (path, _) in conflicts {
-                writeln!(formatter, "{}", &workspace_command.format_file_path(&path))?;
-            }
+            print_conflicted_paths(&conflicts, &tree, formatter, &workspace_command)?
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1708,7 +1708,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
     if let (None, [only_path]) = (&args.revisions, args.paths.as_slice()) {
         if only_path == "." && workspace_command.parse_file_path(only_path)?.is_root() {
             // For users of e.g. Mercurial, where `.` indicates the current commit.
-            ui.write_warn(&format!(
+            ui.write_warn(format!(
                 "warning: The argument {only_path:?} is being interpreted as a path, but this is \
                  often not useful because all non-empty commits touch '.'.  If you meant to show \
                  the working copy commit, pass -r '@' instead.\n"
@@ -1716,7 +1716,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
         } else if revset.is_empty()
             && revset::parse(only_path, &RevsetAliasesMap::new(), None).is_ok()
         {
-            ui.write_warn(&format!(
+            ui.write_warn(format!(
                 "warning: The argument {only_path:?} is being interpreted as a path. To specify a \
                  revset, pass -r {only_path:?} instead.\n"
             ))?;

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -3,6 +3,9 @@
 "warning" = "yellow"
 "hint" = "blue"
 
+"conflict_description" = "yellow"
+"conflict_description difficult" = "red"
+
 "commit_id" = "blue"
 "change_id" = "magenta"
 "author" = "yellow"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,7 +146,7 @@ impl Ui {
                         self.output = new_output;
                     }
                     Err(e) => {
-                        self.write_warn(&format!(
+                        self.write_warn(format!(
                             "Failed to spawn pager '{cmd}': {e}\n",
                             cmd = self.pager_cmd,
                         ))

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -375,6 +375,11 @@ fn test_too_many_parents() {
     create_commit(&test_env, &repo_path, "conflict", &["a", "b", "c"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @"file	3-sided conflict");
+    // Test warning color
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
+    @r###"
+    file	[33m[31m3-sided[33m conflict[0m
+    "###);
 
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
@@ -502,6 +507,11 @@ fn test_description_with_dir_and_deletion() {
     @r###"
     file	3-sided conflict including 1 deletion and a directory
     "###);
+    // Test warning color. The deletion is fine, so it's not highlighted
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
+    @r###"
+    file	[33m[31m3-sided[33m conflict including 1 deletion and [31ma directory[33m[0m
+    "###);
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
     Error: Failed to use external tool to resolve: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
@@ -579,6 +589,12 @@ fn test_multiple_conflicts() {
     file1	2-sided conflict
     file2	2-sided conflict
     "###);
+    // Test colors
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
+    @r###"
+    file1	[33m2-sided conflict[0m
+    file2	[33m2-sided conflict[0m
+    "###);
 
     let editor_script = test_env.set_up_fake_editor();
 
@@ -586,7 +602,7 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution file2\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "file2"]), @r###"
-    Working copy now at: 06cafc2b5489 conflict
+    Working copy now at: 5b4465fc6c31 conflict
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     file1	2-sided conflict
@@ -610,7 +626,7 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution file2\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "--quiet", "file2"]), @r###"
-    Working copy now at: 02326c070aa4 conflict
+    Working copy now at: afb1b8512e98 conflict
     Added 0 files, modified 1 files, removed 0 files
     "###);
 

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -63,9 +63,7 @@ fn test_resolution() {
         o 
         "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file: 2-sided conflict
-    "###);
+    @"file	2-sided conflict");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -184,7 +182,7 @@ conflict
     Working copy now at: 0bb40c908c8b conflict
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
-    file: 2-sided conflict
+    file	2-sided conflict
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
@@ -209,9 +207,7 @@ conflict
        7    7: >>>>>>>
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file: 2-sided conflict
-    "###);
+    @"file	2-sided conflict");
 
     // Check that if merge tool leaves conflict markers in output file but
     // `merge-tool-edits-conflict-markers=false` or is not specified,
@@ -310,9 +306,7 @@ fn test_normal_conflict_input_files() {
         o 
         "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file: 2-sided conflict
-    "###);
+    @"file	2-sided conflict");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -351,9 +345,7 @@ fn test_baseless_conflict_input_files() {
         o 
         "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file: 2-sided conflict
-    "###);
+    @"file	2-sided conflict");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -382,9 +374,7 @@ fn test_too_many_parents() {
     create_commit(&test_env, &repo_path, "c", &["base"], &[("file", "c\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b", "c"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file: 3-sided conflict
-    "###);
+    @"file	3-sided conflict");
 
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
@@ -416,7 +406,7 @@ fn test_edit_delete_conflict_input_files() {
         "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
-    file: 2-sided conflict including 1 deletion
+    file	2-sided conflict including 1 deletion
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
@@ -461,7 +451,7 @@ fn test_file_vs_dir() {
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
-    file: 2-sided conflict including a directory
+    file	2-sided conflict including a directory
     "###);
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
@@ -510,7 +500,7 @@ fn test_description_with_dir_and_deletion() {
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
-    file: 3-sided conflict including 1 deletion and a directory
+    file	3-sided conflict including 1 deletion and a directory
     "###);
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
@@ -586,8 +576,8 @@ fn test_multiple_conflicts() {
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
-    file1: 2-sided conflict
-    file2: 2-sided conflict
+    file1	2-sided conflict
+    file2	2-sided conflict
     "###);
 
     let editor_script = test_env.set_up_fake_editor();
@@ -599,7 +589,7 @@ fn test_multiple_conflicts() {
     Working copy now at: 06cafc2b5489 conflict
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
-    file1: 2-sided conflict
+    file1	2-sided conflict
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
     @r###"
@@ -613,9 +603,7 @@ fn test_multiple_conflicts() {
        7     : >>>>>>>
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file1: 2-sided conflict
-    "###);
+    @"file1	2-sided conflict");
 
     // Repeat the above with the `--quiet` option.
     test_env.jj_cmd_success(&repo_path, &["undo"]);
@@ -649,9 +637,7 @@ fn test_multiple_conflicts() {
        7     : >>>>>>>
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file2: 2-sided conflict
-    "###);
+    @"file2	2-sided conflict");
     std::fs::write(
         &editor_script,
         "expect\n\0write\nsecond resolution for auto-chosen file\n",


### PR DESCRIPTION
`jj status` now looks like this:

![image](https://user-images.githubusercontent.com/4123047/211169647-773b2e08-dade-4aa4-9a60-f3a3e7c08084.png)


# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
