### PR TITLE
`jj abandon`: Report what commit or how many commits were abandoned

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1395,9 +1395,19 @@ pub fn run_ui_editor(settings: &UserSettings, edit_path: &PathBuf) -> Result<(),
     Ok(())
 }
 
+// TODO: Consider basing this function on `write_commit_summary`. It will need
+// more arguments passed to it, but the output will be more consistent.
 pub fn short_commit_description(commit: &Commit) -> String {
     let first_line = commit.description().split('\n').next().unwrap();
-    format!("{} ({})", short_commit_hash(commit.id()), first_line)
+    format!(
+        "{} ({})",
+        short_commit_hash(commit.id()),
+        if first_line.is_empty() {
+            "no description set"
+        } else {
+            first_line
+        }
+    )
 }
 
 pub fn short_commit_hash(commit_id: &CommitId) -> String {

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
+    if parents.is_empty() {
+        test_env.jj_cmd_success(repo_path, &["new", "root", "-m", name]);
+    } else {
+        let mut args = vec!["new", "-m", name];
+        args.extend(parents);
+        test_env.jj_cmd_success(repo_path, &args);
+    }
+    std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
+    test_env.jj_cmd_success(repo_path, &["branch", "create", name]);
+}
+
+#[test]
+fn test_rebase_branch_with_merge() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    create_commit(&test_env, &repo_path, "a", &[]);
+    create_commit(&test_env, &repo_path, "b", &["a"]);
+    create_commit(&test_env, &repo_path, "c", &[]);
+    create_commit(&test_env, &repo_path, "d", &["c"]);
+    create_commit(&test_env, &repo_path, "e", &["a", "d"]);
+    // Test the setup
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @   e
+    |\  
+    o | d
+    o | c
+    | | o b
+    | |/  
+    | o a
+    |/  
+    o 
+    "###);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Rebased 1 descendant commits onto parents of abandoned commits
+    Working copy now at: 11a2e10edf4e e
+    Added 0 files, modified 0 files, removed 1 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @   e
+    |\  
+    o | c d
+    | | o b
+    | |/  
+    | o a
+    |/  
+    o 
+    "###);
+
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["abandon"] /* abandons `e` */);
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy now at: 6b5275139632 (no description set)
+    Added 0 files, modified 0 files, removed 3 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @ 
+    | o d e?
+    | o c
+    | | o b
+    | |/  
+    |/|   
+    o | a e?
+    |/  
+    o 
+    "###);
+
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy now at: e7bb061217d5 (no description set)
+    Added 0 files, modified 0 files, removed 3 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @ 
+    | o b
+    |/  
+    o a e?
+    o c d e?
+    "###);
+}
+
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+    test_env.jj_cmd_success(repo_path, &["log", "-T", "branches"])
+}

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -94,7 +94,10 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned 3 commits. This can be undone with `jj undo` or `jj op restore`.
+    Abandoned the following commits:
+      5557ece3e631 e
+      b7c62f28ed10 d
+      fe2e8e8b50b3 c
     Working copy now at: e7bb061217d5 (no description set)
     Added 0 files, modified 0 files, removed 3 files
     "###);

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -56,6 +56,7 @@ fn test_rebase_branch_with_merge() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d"]);
     insta::assert_snapshot!(stdout, @r###"
+    Abandoned commit b7c62f28ed10 d
     Rebased 1 descendant commits onto parents of abandoned commits
     Working copy now at: 11a2e10edf4e e
     Added 0 files, modified 0 files, removed 1 files
@@ -74,17 +75,18 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon"] /* abandons `e` */);
     insta::assert_snapshot!(stdout, @r###"
+    Abandoned commit 5557ece3e631 e
     Working copy now at: 6b5275139632 (no description set)
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @ 
-    | o d e?
+    | o d e??
     | o c
     | | o b
     | |/  
     |/|   
-    o | a e?
+    o | a e??
     |/  
     o 
     "###);
@@ -92,6 +94,7 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
     insta::assert_snapshot!(stdout, @r###"
+    Abandoned 3 commits. This can be undone with `jj undo` or `jj op restore`.
     Working copy now at: e7bb061217d5 (no description set)
     Added 0 files, modified 0 files, removed 3 files
     "###);
@@ -99,8 +102,8 @@ fn test_rebase_branch_with_merge() {
     @ 
     | o b
     |/  
-    o a e?
-    o c d e?
+    o a e??
+    o c d e??
     "###);
 }
 

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -66,7 +66,7 @@ fn test_checkout_not_single_rev() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@" resolved to more than one revision
     Hint: The revset resolved to these revisions:
-    2f8593712db5 ()
+    2f8593712db5 (no description set)
     5c1afd8b074f (fifth)
     009f88bf7141 (fourth)
     3fa8931e7b89 (third)


### PR DESCRIPTION
There are no tests for `jj abandon` currently. I might add some here or in another PR, but not right now.

# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
