### PR TITLE
Have `jj log` hightlight unique prefixes, `BTree`-based implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   any parent-child relationships between them. For example, the entire tree of
   descendants of `abc` can be duplicated with `jj duplicate abc:`.
 
+* Setting the new `ui.unique-prefixes` option to `brackets` makes `jj log`
+  highlight the shortest unique prefix of every commit and change id.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   any parent-child relationships between them. For example, the entire tree of
   descendants of `abc` can be duplicated with `jj duplicate abc:`.
 
-* Setting the new `ui.unique-prefixes` option to `brackets` makes `jj log`
-  highlight the shortest unique prefix of every commit and change id.
+* `jj log` now highlights the shortest unique prefix of every commit and change id
+  with brackets. To disable, set the new `ui.unique-prefixes` option to `none`
 
 ### Fixed bugs
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -48,10 +48,10 @@ This setting overrides the `NO_COLOR` environment variable (if set).
 
 ### Shortest unique prefixes for ids
 
-    ui.unique-prefixes = "brackets"  # E.g. `1e74d[6a8f51]`
+    ui.unique-prefixes = "none"
 
 Whether to highlight a unique prefix for commit & change ids. Possible
-values are `brackets` and `none` (default: `none`).
+values are `brackets` and `none` (default: `brackets`).
 
 ### Relative timestamps
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,13 @@ This setting overrides the `NO_COLOR` environment variable (if set).
 
     ui.color = "never" # Turn off color
 
+### Shortest unique prefixes for ids
+
+    ui.unique-prefixes = "brackets"  # E.g. `1e74d[6a8f51]`
+
+Whether to highlight a unique prefix for commit & change ids. Possible
+values are `brackets` and `none` (default: `none`).
+
 ### Relative timestamps
 
     ui.relative-timestamps = true

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -143,6 +143,12 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
+    pub fn unique_prefixes(&self) -> String {
+        self.config
+            .get_string("ui.unique-prefixes")
+            .unwrap_or_default()
+    }
+
     pub fn config(&self) -> &config::Config {
         &self.config
     }

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -146,7 +146,7 @@ impl UserSettings {
     pub fn unique_prefixes(&self) -> String {
         self.config
             .get_string("ui.unique-prefixes")
-            .unwrap_or_default()
+            .unwrap_or_else(|_| "brackets".to_string())
     }
 
     pub fn config(&self) -> &config::Config {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1590,18 +1590,24 @@ fn log_template(settings: &UserSettings) -> String {
     } else {
         "committer.timestamp()"
     };
+    // TODO: If/when this logic is relevant in the `lib` crate, make this into
+    // and enum similar to `ColorChoice`.
+    let prefix_format = match settings.unique_prefixes().as_str() {
+        "brackets" => "short_prefix_and_brackets()",
+        _ => "short()",
+    };
     let default_template = format!(
         r#"
             if(divergent,
-              label("divergent", change_id.short() "??"),
-              change_id.short())
+              label("divergent", change_id.{prefix_format} "??"),
+              change_id.{prefix_format})
             " " author.email()
             " " {committer_timestamp}
             if(branches, " " branches)
             if(tags, " " tags)
             if(working_copies, " " working_copies)
             if(is_git_head, label("git_head", " HEAD@git"))
-            " " commit_id.short()
+            " " commit_id.{prefix_format}
             if(conflict, label("conflict", " conflict"))
             "\n"
             if(empty, label("empty", "(empty) "))

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -23,7 +23,7 @@ use pest_derive::Parser;
 use crate::formatter::PlainTextFormatter;
 use crate::templater::{
     AuthorProperty, BranchProperty, CommitOrChangeId, CommitOrChangeIdKeyword,
-    CommitOrChangeIdShortest, CommitterProperty, ConditionalTemplate, ConflictProperty,
+    CommitOrChangeIdShort, CommitterProperty, ConditionalTemplate, ConflictProperty,
     ConstantTemplateProperty, DescriptionProperty, DivergentProperty, DynamicLabelTemplate,
     EmptyProperty, GitRefsProperty, IsGitHeadProperty, IsWorkingCopyProperty, LabelTemplate,
     ListTemplate, LiteralTemplate, SignatureTimestamp, StringPropertyTemplate, TagProperty,
@@ -208,7 +208,7 @@ fn parse_commit_or_chain_id_method<'a>(
     // TODO: validate arguments
 
     let this_function = match name.as_str() {
-        "short" => Property::String(Box::new(CommitOrChangeIdShortest)),
+        "short" => Property::String(Box::new(CommitOrChangeIdShort)),
         name => panic!("no such commit ID method: {name}"),
     };
     let chain_method = inner.last().unwrap();

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -23,11 +23,12 @@ use pest_derive::Parser;
 use crate::formatter::PlainTextFormatter;
 use crate::templater::{
     AuthorProperty, BranchProperty, CommitOrChangeId, CommitOrChangeIdKeyword,
-    CommitOrChangeIdShort, CommitterProperty, ConditionalTemplate, ConflictProperty,
-    ConstantTemplateProperty, DescriptionProperty, DivergentProperty, DynamicLabelTemplate,
-    EmptyProperty, GitRefsProperty, IsGitHeadProperty, IsWorkingCopyProperty, LabelTemplate,
-    ListTemplate, LiteralTemplate, SignatureTimestamp, StringPropertyTemplate, TagProperty,
-    Template, TemplateFunction, TemplateProperty, WorkingCopiesProperty,
+    CommitOrChangeIdShort, CommitOrChangeIdShortPrefixAndBrackets, CommitterProperty,
+    ConditionalTemplate, ConflictProperty, ConstantTemplateProperty, DescriptionProperty,
+    DivergentProperty, DynamicLabelTemplate, EmptyProperty, GitRefsProperty, IsGitHeadProperty,
+    IsWorkingCopyProperty, LabelTemplate, ListTemplate, LiteralTemplate, SignatureTimestamp,
+    StringPropertyTemplate, TagProperty, Template, TemplateFunction, TemplateProperty,
+    WorkingCopiesProperty,
 };
 use crate::time_util;
 
@@ -215,6 +216,9 @@ fn parse_commit_or_chain_id_method<'a>(
 
     let this_function = match name.as_str() {
         "short" => Property::String(Box::new(CommitOrChangeIdShort { repo })),
+        "short_prefix_and_brackets" => {
+            Property::String(Box::new(CommitOrChangeIdShortPrefixAndBrackets { repo }))
+        }
         name => panic!("no such commit ID method: {name}"),
     };
     let chain_method = inner.last().unwrap();

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -103,6 +103,41 @@ impl TemplateProperty<Timestamp, String> for RelativeTimestampString {
     }
 }
 
+enum Property<'a, I> {
+    String(Box<dyn TemplateProperty<I, String> + 'a>),
+    Boolean(Box<dyn TemplateProperty<I, bool> + 'a>),
+    CommitId(Box<dyn TemplateProperty<I, CommitId> + 'a>),
+    Signature(Box<dyn TemplateProperty<I, Signature> + 'a>),
+    Timestamp(Box<dyn TemplateProperty<I, Timestamp> + 'a>),
+}
+
+impl<'a, I: 'a> Property<'a, I> {
+    fn after<C: 'a>(self, first: Box<dyn TemplateProperty<C, I> + 'a>) -> Property<'a, C> {
+        match self {
+            Property::String(property) => Property::String(Box::new(TemplateFunction::new(
+                first,
+                Box::new(move |value| property.extract(&value)),
+            ))),
+            Property::Boolean(property) => Property::Boolean(Box::new(TemplateFunction::new(
+                first,
+                Box::new(move |value| property.extract(&value)),
+            ))),
+            Property::CommitId(property) => Property::CommitId(Box::new(TemplateFunction::new(
+                first,
+                Box::new(move |value| property.extract(&value)),
+            ))),
+            Property::Signature(property) => Property::Signature(Box::new(TemplateFunction::new(
+                first,
+                Box::new(move |value| property.extract(&value)),
+            ))),
+            Property::Timestamp(property) => Property::Timestamp(Box::new(TemplateFunction::new(
+                first,
+                Box::new(move |value| property.extract(&value)),
+            ))),
+        }
+    }
+}
+
 fn parse_method_chain<'a, I: 'a>(
     pair: Pair<Rule>,
     input_property: Property<'a, I>,
@@ -214,41 +249,6 @@ fn parse_timestamp_method<'a>(method: Pair<Rule>) -> PropertyAndLabels<'a, Times
     };
     let chain_method = inner.last().unwrap();
     parse_method_chain(chain_method, this_function)
-}
-
-enum Property<'a, I> {
-    String(Box<dyn TemplateProperty<I, String> + 'a>),
-    Boolean(Box<dyn TemplateProperty<I, bool> + 'a>),
-    CommitId(Box<dyn TemplateProperty<I, CommitId> + 'a>),
-    Signature(Box<dyn TemplateProperty<I, Signature> + 'a>),
-    Timestamp(Box<dyn TemplateProperty<I, Timestamp> + 'a>),
-}
-
-impl<'a, I: 'a> Property<'a, I> {
-    fn after<C: 'a>(self, first: Box<dyn TemplateProperty<C, I> + 'a>) -> Property<'a, C> {
-        match self {
-            Property::String(property) => Property::String(Box::new(TemplateFunction::new(
-                first,
-                Box::new(move |value| property.extract(&value)),
-            ))),
-            Property::Boolean(property) => Property::Boolean(Box::new(TemplateFunction::new(
-                first,
-                Box::new(move |value| property.extract(&value)),
-            ))),
-            Property::CommitId(property) => Property::CommitId(Box::new(TemplateFunction::new(
-                first,
-                Box::new(move |value| property.extract(&value)),
-            ))),
-            Property::Signature(property) => Property::Signature(Box::new(TemplateFunction::new(
-                first,
-                Box::new(move |value| property.extract(&value)),
-            ))),
-            Property::Timestamp(property) => Property::Timestamp(Box::new(TemplateFunction::new(
-                first,
-                Box::new(move |value| property.extract(&value)),
-            ))),
-        }
-    }
 }
 
 struct PropertyAndLabels<'a, C>(Property<'a, C>, Vec<String>);

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -441,16 +441,16 @@ impl CommitOrChangeIdKeyword {
         commit_or_change_id.hex()
     }
 
-    pub fn shortest_format(commit_or_change_id: CommitOrChangeId) -> String {
+    pub fn short_format(commit_or_change_id: CommitOrChangeId) -> String {
         commit_or_change_id.hex()[..12].to_string()
     }
 }
 
-pub struct CommitOrChangeIdShortest;
+pub struct CommitOrChangeIdShort;
 
-impl TemplateProperty<CommitOrChangeId, String> for CommitOrChangeIdShortest {
+impl TemplateProperty<CommitOrChangeId, String> for CommitOrChangeIdShort {
     fn extract(&self, context: &CommitOrChangeId) -> String {
-        CommitOrChangeIdKeyword::shortest_format(context.clone())
+        CommitOrChangeIdKeyword::short_format(context.clone())
     }
 }
 

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -446,9 +446,11 @@ impl CommitOrChangeIdKeyword {
     }
 }
 
-pub struct CommitOrChangeIdShort;
+pub struct CommitOrChangeIdShort<'a> {
+    pub repo: RepoRef<'a>,
+}
 
-impl TemplateProperty<CommitOrChangeId, String> for CommitOrChangeIdShort {
+impl TemplateProperty<CommitOrChangeId, String> for CommitOrChangeIdShort<'_> {
     fn extract(&self, context: &CommitOrChangeId) -> String {
         CommitOrChangeIdKeyword::short_format(context.clone())
     }

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -444,6 +444,25 @@ impl CommitOrChangeIdKeyword {
     pub fn short_format(commit_or_change_id: CommitOrChangeId) -> String {
         commit_or_change_id.hex()[..12].to_string()
     }
+    pub fn short_prefix_and_brackets_format(
+        commit_or_change_id: CommitOrChangeId,
+        repo: RepoRef,
+    ) -> String {
+        highlight_shortest_prefix(&commit_or_change_id.hex(), 12, repo)
+    }
+}
+
+fn highlight_shortest_prefix(hex: &str, total_len: usize, repo: RepoRef) -> String {
+    let prefix_len = repo.base_repo().shortest_unique_prefix_length(hex);
+    if prefix_len < total_len - 1 {
+        format!(
+            "{}[{}]",
+            &hex[0..prefix_len],
+            &hex[prefix_len..total_len - 1]
+        )
+    } else {
+        hex[0..total_len].to_string()
+    }
 }
 
 pub struct CommitOrChangeIdShort<'a> {
@@ -453,6 +472,16 @@ pub struct CommitOrChangeIdShort<'a> {
 impl TemplateProperty<CommitOrChangeId, String> for CommitOrChangeIdShort<'_> {
     fn extract(&self, context: &CommitOrChangeId) -> String {
         CommitOrChangeIdKeyword::short_format(context.clone())
+    }
+}
+
+pub struct CommitOrChangeIdShortPrefixAndBrackets<'a> {
+    pub repo: RepoRef<'a>,
+}
+
+impl TemplateProperty<CommitOrChangeId, String> for CommitOrChangeIdShortPrefixAndBrackets<'_> {
+    fn extract(&self, context: &CommitOrChangeId) -> String {
+        CommitOrChangeIdKeyword::short_prefix_and_brackets_format(context.clone(), self.repo)
     }
 }
 

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -72,6 +72,26 @@ fn test_log_default() {
       (empty) (no description set)
     "###);
 
+    // Test default log output format with bracket prefixes
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "--config-toml", "ui.unique-prefixes='brackets'"]), @r###"
+    @ f[fdaa62087a] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d59]
+    | (empty) description 1
+    o 9a[45c67d3e9] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae9]
+    | add a file
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
+      (empty) (no description set)
+    "###);
+
+    // Test default log output format with prefixes explicitly disabled
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "--config-toml", "ui.unique-prefixes='none'"]), @r###"
+    @ ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
+    | (empty) description 1
+    o 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
+    | add a file
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
+      (empty) (no description set)
+    "###);
+
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -64,9 +64,9 @@ fn test_log_default() {
 
     // Test default log output format
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log"]), @r###"
-    @ ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
+    @ f[fdaa62087a] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d59]
     | (empty) description 1
-    o 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
+    o 9a[45c67d3e9] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae9]
     | add a file
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
@@ -95,9 +95,9 @@ fn test_log_default() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ [1m[38;5;13mffdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
+    @ [1m[38;5;13mf[fdaa62087a][39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[e54178d59][39m[0m
     | [1m[38;5;10m(empty) [39mdescription 1[0m
-    o [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
+    o [38;5;5m9a[45c67d3e9][39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4[291e264ae9][39m
     | add a file
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
       [38;5;2m(empty) [39m(no description set)
@@ -106,9 +106,9 @@ fn test_log_default() {
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;13mffdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
+    [1m[38;5;13mf[fdaa62087a][39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[e54178d59][39m[0m
     [1m[38;5;10m(empty) [39mdescription 1[0m
-    [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
+    [38;5;5m9a[45c67d3e9][39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4[291e264ae9][39m
     add a file
     [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
     [38;5;2m(empty) [39m(no description set)
@@ -126,7 +126,7 @@ fn test_log_default_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
-    @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
+    @ 9[a45c67d3e9] test.user@example.com 2001-02-03 04:05:08.000 +07:00 7[a17d52e633]
     | description 1
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
@@ -140,9 +140,9 @@ fn test_log_default_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    o 9a45c67d3e96?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d4c67
+    o 9[a45c67d3e9]?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8[979953d4c6]
     | description 2
-    | @ 9a45c67d3e96?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
+    | @ 9[a45c67d3e9]?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7[a17d52e633]
     |/  description 1
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
@@ -151,9 +151,9 @@ fn test_log_default_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    o [38;5;1m9a45c67d3e96??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [38;5;4m8979953d4c67[39m
+    o [38;5;1m9[a45c67d3e9]??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [38;5;4m8[979953d4c6][39m
     | description 2
-    | @ [1m[38;5;9m9a45c67d3e96??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7a17d52e633c[39m[0m
+    | @ [1m[38;5;9m9[a45c67d3e9]??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[a17d52e633][39m[0m
     |/  [1mdescription 1[0m
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
       [38;5;2m(empty) [39m(no description set)

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -107,7 +107,7 @@ fn test_init_git_external() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o d3866db7e30a git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
+    o d[3866db7e30] git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8[d698d4a8ee]
     ~ My commit message
     "###);
 }
@@ -150,7 +150,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o d3866db7e30a git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
+    o d[3866db7e30] git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8[d698d4a8ee]
     ~ My commit message
     "###);
 }

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -288,6 +288,113 @@ fn test_log_with_or_without_diff() {
 }
 
 #[test]
+fn test_log_prefix_highlight() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let prefix_format = r#"
+      "Change " change_id.short_prefix_and_brackets() " " description.first_line()
+      " " commit_id.short_prefix_and_brackets() " " branches
+    "#;
+
+    std::fs::write(repo_path.join("file"), "original file\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "initial"]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "c", "original"]);
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", prefix_format]),
+        @r###"
+    @ Change 9[a45c67d3e9] initial b[a1a30916d2] original
+    ~ 
+    "###
+    );
+    for i in 1..50 {
+        test_env.jj_cmd_success(&repo_path, &["new", "-m", &format!("commit{i}")]);
+        std::fs::write(repo_path.join("file"), format!("file {i}\n")).unwrap();
+    }
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", prefix_format]),
+        @r###"
+    o Change 9a4[5c67d3e9] initial ba1[a30916d2] original
+    ~ 
+    "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-----------..@", "-T", prefix_format]),
+        @r###"
+    @ Change 4c9[32da8013] commit49 d8[3437a2cef] 
+    o Change 0d[58f15eaba] commit48 f3[abb4ea0ac] 
+    o Change fc[e6c2c5912] commit47 38e[891bea27] 
+    o Change d5[1defcac30] commit46 1c[04d947707] 
+    o Change 4f[13b1391d6] commit45 747[24ae22b1] 
+    o Change 6a[de2950a04] commit44 c7a[a67cf7bb] 
+    o Change 06c[482e452d] commit43 8e[c99dfcb6c] 
+    o Change 392[beeb018e] commit42 8f0[e60411b7] 
+    o Change a1[b73d3ff91] commit41 71[d6937a66c] 
+    o Change 708[8f461291] commit40 db[572049026] 
+    o Change c49[f7f006c7] commit39 d94[54fec8a6] 
+    ~ 
+    "###
+    );
+}
+
+#[test]
+fn test_log_prefix_highlight_counts_hidden_commits() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let prefix_format = r#"
+      "Change " change_id.short_prefix_and_brackets() " " description.first_line()
+      " " commit_id.short_prefix_and_brackets() " " branches
+    "#;
+
+    std::fs::write(repo_path.join("file"), "original file\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "initial"]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "c", "original"]);
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
+        @r###"
+    @ Change 9[a45c67d3e9] initial b[a1a30916d2] original
+    o Change 000000000000 (no description set) 000000000000 
+    "###
+    );
+    for i in 1..100 {
+        test_env.jj_cmd_success(&repo_path, &["describe", "-m", &format!("commit{i}")]);
+        std::fs::write(repo_path.join("file"), format!("file {i}\n")).unwrap();
+    }
+    // The first commit still exists. Its unique prefix became longer.
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "ba1", "-T", prefix_format]),
+        @r###"
+    o Change 9a4[5c67d3e9] initial ba1[a30916d2] 
+    ~ 
+    "###
+    );
+    // The first commit is no longer visible
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
+        @r###"
+    @ Change 9a4[5c67d3e9] commit99 de[3177d2acf] original
+    o Change 000000000000 (no description set) 000000000000 
+    "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_failure(&repo_path, &["log", "-r", "d", "-T", prefix_format]),
+        @r###"
+    Error: Commit or change id prefix "d" is ambiguous
+    "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-r", "de", "-T", prefix_format]),
+        @r###"
+    @ Change 9a4[5c67d3e9] commit99 de[3177d2acf] original
+    ~ 
+    "###
+    );
+}
+
+#[test]
 fn test_log_divergence() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -34,13 +34,13 @@ fn test_obslog_with_or_without_diff() {
 
     let stdout = get_log_output(&test_env, &repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    @ 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad3607]
     | my description
-    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    o 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af67] conflict
     | my description
-    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    o 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb59]
     | my description
-    o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    o 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae08]
       (empty) my description
     "###);
 
@@ -48,43 +48,43 @@ fn test_obslog_with_or_without_diff() {
     // (even even though it resulted in a conflict).
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "-p"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    @ 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad3607]
     | my description
     | Resolved conflict in file1:
     |    1    1: <<<<<<<resolved
     |    2     : %%%%%%%
     |    3     : +bar
     |    4     : >>>>>>>
-    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    o 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af67] conflict
     | my description
-    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    o 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb59]
     | my description
     | Modified regular file file1:
     |    1    1: foo
     |         2: bar
     | Added regular file file2:
     |         1: foo
-    o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    o 8[e4fac809cb] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae08]
       (empty) my description
     "###);
 
     // Test `--no-graph`
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-     test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad3607]
     my description
-     test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af67] conflict
     my description
-     test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb59]
     my description
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae08]
     (empty) my description
     "###);
 
     // Test `--git` format, and that it implies `-p`
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "--no-graph", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
-     test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad3607]
     my description
     diff --git a/file1 b/file1
     index e155302a24...2ab19ae607 100644
@@ -96,9 +96,9 @@ fn test_obslog_with_or_without_diff() {
     -+bar
     ->>>>>>>
     +resolved
-     test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af67] conflict
     my description
-     test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb59]
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -114,7 +114,7 @@ fn test_obslog_with_or_without_diff() {
     +++ b/file2
     @@ -1,0 +1,1 @@
     +foo
-     test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    8[e4fac809cb] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae08]
     (empty) my description
     "###);
 }
@@ -136,25 +136,25 @@ fn test_obslog_squash() {
 
     let stdout = get_log_output(&test_env, &repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o    test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5ba72
+    o   9a[45c67d3e9] test.user@example.com 2001-02-03 04:05:10.000 +07:00 27[e721a5ba7]
     |\  squashed
     | | Modified regular file file1:
     | |    1    1: foo
     | |         2: bar
-    o |  test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
+    o | 9a[45c67d3e9] test.user@example.com 2001-02-03 04:05:09.000 +07:00 97[64e503e1a]
     | | first
     | | Added regular file file1:
     | |         1: foo
-    o |  test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    o | 9a[45c67d3e9] test.user@example.com 2001-02-03 04:05:08.000 +07:00 6[9542c1984c]
     | | (empty) first
-    o |  test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    o | 9a[45c67d3e9] test.user@example.com 2001-02-03 04:05:07.000 +07:00 23[0dd059e1b]
      /  (empty) (no description set)
-    o  test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
+    o ff[daa62087a] test.user@example.com 2001-02-03 04:05:10.000 +07:00 f[09a38899f2]
     | second
     | Modified regular file file1:
     |    1    1: foo
     |         2: bar
-    o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
+    o ff[daa62087a] test.user@example.com 2001-02-03 04:05:09.000 +07:00 5[7996536970]
       (empty) second
     "###);
 }


### PR DESCRIPTION
This makes it possible to set `ui.unique-prefixes="underscore"` and make `jj` highlight the unique prefix of each ID as follows:

![screenshot](https://user-images.githubusercontent.com/4123047/212502483-4119fb17-0601-4335-9770-196e36a6bc31.png)

There are some more thoughts in the commit descriptions.

## Possible future directions

### UI

We should make use of https://github.com/martinvonz/jj/pull/962 and make it possible to mark the prefix with underline & color. The current underscore highlight is still useful for tests, at least. I'm not sure how urgent this is.

In fact, I have a **question**: I cautiously kept the default at no highlighting, mainly since the underscores mess up copying and pasting. Was this over-cautious?

### Use this index in other areas

The IdIndex created in this PR could immediately be used to find divergent commits and to look up commits by prefix replacing these functions.

https://github.com/martinvonz/jj/blob/50321f851f4ce0f484fcd029b4d04581ad356d64/lib/src/revset.rs#L104-L147

I think we should do it, mainly to make it much harder for these parts of `jj` to disagree about what prefix resolves to what change/commit. Let me know if you have concerns.

### Combine IdIndex with the normal Index

They overlap in  functionality. Implementing this properly should be able to speed up the loading of the IdIndex immensely. However, this is a big change that intimidates me a little.

This could use `fst` or https://sapling-scm.com/docs/internals/indexedlog/ (which I just discovered from @arxanas 's writing. It seems to be designed specifically for this purpose, but also seems to be GPL).

### Performance

- Performance issues should only be noticeable on large repos (I tried https://github.com/torvalds/linux). This BTree-based index should be fast enough for repositories the size of Git. Even the naive implementation is fast enough for `jj`.

- There is a draft trie implementation of IdIndex in https://github.com/martinvonz/jj/pull/1041. It's a little more complicated, but 5x faster when measuring the speed of computing prefix for each id. It's similar to this implementation by other measures of performance.

- I have a benchmark to compare different implementations of `IdIndex` that I might add to this PR or submit separately.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
