### PR TITLE
cli: do not search ancestor paths specified by -R/--repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Commit description set by `-m`/`--message` is now terminated with a newline
   character, just like descriptions set by editor are.
 
+* The `-R`/`--repository` path must be a valid workspace directory. Its
+  ancestor directories are no longer searched.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -33,22 +33,6 @@ fn test_load_bad_path() {
 }
 
 #[test_case(false ; "local backend")]
-#[test_case(true ; "git backend")]
-fn test_load_from_subdir(use_git: bool) {
-    let settings = testutils::user_settings();
-    let test_workspace = TestWorkspace::init(&settings, use_git);
-    let workspace = &test_workspace.workspace;
-
-    let subdir = workspace.workspace_root().join("dir").join("subdir");
-    std::fs::create_dir_all(subdir.clone()).unwrap();
-    let same_workspace = Workspace::load(&settings, &subdir, &StoreFactories::default());
-    assert!(same_workspace.is_ok());
-    let same_workspace = same_workspace.unwrap();
-    assert_eq!(same_workspace.repo_path(), workspace.repo_path());
-    assert_eq!(same_workspace.workspace_root(), workspace.workspace_root());
-}
-
-#[test_case(false ; "local backend")]
 // #[test_case(true ; "git backend")]
 fn test_init_additional_workspace(use_git: bool) {
     let settings = testutils::user_settings();

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -979,7 +979,11 @@ fn init_workspace_loader(
 ) -> Result<WorkspaceLoader, CommandError> {
     let workspace_path_str = global_args.repository.as_deref().unwrap_or(".");
     let workspace_path = cwd.join(workspace_path_str);
-    WorkspaceLoader::init(&workspace_path).map_err(|err| match err {
+    let workspace_root = workspace_path
+        .ancestors()
+        .find(|path| path.join(".jj").is_dir())
+        .unwrap_or(&workspace_path);
+    WorkspaceLoader::init(workspace_root).map_err(|err| match err {
         WorkspaceLoadError::NoWorkspaceHere(wc_path) => {
             // Prefer user-specified workspace_path_str instead of absolute wc_path.
             let message = format!(r#"There is no jj repo in "{workspace_path_str}""#);

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -111,6 +111,23 @@ fn test_repo_arg_with_git_clone() {
 }
 
 #[test]
+fn test_resolve_workspace_directory() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    let subdir = repo_path.join("dir").join("subdir");
+    std::fs::create_dir_all(&subdir).unwrap();
+
+    // Ancestor of cwd
+    let stdout = test_env.jj_cmd_success(&subdir, &["status"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Parent commit: 000000000000 (no description set)
+    Working copy : 230dd059e1b0 (no description set)
+    The working copy is clean
+    "###);
+}
+
+#[test]
 fn test_no_workspace_directory() {
     let test_env = TestEnvironment::default();
     let repo_path = test_env.env_root().join("repo");

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -125,6 +125,26 @@ fn test_resolve_workspace_directory() {
     Working copy : 230dd059e1b0 (no description set)
     The working copy is clean
     "###);
+
+    // Explicit subdirectory path
+    let stderr = test_env.jj_cmd_failure(&subdir, &["status", "-R", "."]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: There is no jj repo in "."
+    "###);
+
+    // Valid explicit path
+    let stdout = test_env.jj_cmd_success(&subdir, &["status", "-R", "../.."]);
+    insta::assert_snapshot!(stdout, @r###"
+    Parent commit: 000000000000 (no description set)
+    Working copy : 230dd059e1b0 (no description set)
+    The working copy is clean
+    "###);
+
+    // "../../..".ancestors() contains "../..", but it should never be looked up.
+    let stderr = test_env.jj_cmd_failure(&subdir, &["status", "-R", "../../.."]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: There is no jj repo in "../../.."
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
