### PR TITLE
Add a `config edit` command to open jj config in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj git push` now accepts multiple `--branch`/`--change` arguments
 
-* `jj config list` command prints values from config (with other subcommands
-  coming soon).
+* `jj config list` command prints values from config and `config edit` opens
+  the config in an editor.
 
 * `jj debug config-schema` command prints out JSON schema for the jj TOML config
   file format.

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,7 +104,7 @@ impl LayeredConfigs {
     }
 }
 
-fn config_path() -> Result<Option<PathBuf>, ConfigError> {
+pub fn config_path() -> Result<Option<PathBuf>, ConfigError> {
     if let Ok(config_path) = env::var("JJ_CONFIG") {
         // TODO: We should probably support colon-separated (std::env::split_paths)
         // paths here

--- a/testing/fake-editor.rs
+++ b/testing/fake-editor.rs
@@ -58,8 +58,18 @@ fn main() {
                     exit(1)
                 }
             }
+            ["expectpath"] => {
+                let actual = args.file.to_str().unwrap();
+                if actual != payload {
+                    eprintln!("fake-editor: Unexpected path.\n");
+                    eprintln!("EXPECTED: <{payload}>\nRECEIVED: <{actual}>");
+                    exit(1)
+                }
+            }
             ["write"] => {
-                fs::write(&args.file, payload).unwrap();
+                fs::write(&args.file, payload).unwrap_or_else(|_| {
+                    panic!("Failed to write file {}", args.file.to_str().unwrap())
+                });
             }
             _ => {
                 eprintln!("fake-editor: unexpected command: {command}");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -111,6 +111,10 @@ impl TestEnvironment {
         &self.home_dir
     }
 
+    pub fn config_dir(&self) -> &PathBuf {
+        &self.config_dir
+    }
+
     pub fn add_config(&self, content: &[u8]) {
         // Concatenating two valid TOML files does not (generally) result in a valid
         // TOML file, so we use create a new file every time instead.


### PR DESCRIPTION
Part of #531 to define the overall `config` command.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
