### PR TITLE
Fix `nix run`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       foreachSystem = f: lib.foldl' (attrs: system: lib.recursiveUpdate attrs (f system)) { } systems;
     in
     {
-      overlay = (final: prev: {
+      overlays.default = (final: prev: {
         jujutsu = final.callPackage
           (
             { stdenv
@@ -78,13 +78,15 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ self.overlay ];
+          overlays = [ self.overlays.default ];
         };
       in
       {
-        packages.${system}.jujutsu = pkgs.jujutsu;
-        defaultPackage.${system} = self.packages.${system}.jujutsu;
-        defaultApp.${system} = {
+        packages.${system} = {
+          jujutsu = pkgs.jujutsu;
+          default = self.packages.${system}.jujutsu;
+        };
+        apps.${system}.default = {
           type = "app";
           program = "${pkgs.jujutsu}/bin/jj";
         };


### PR DESCRIPTION
Otherwise nix 2.8 and newer will give this error message:

```
>> nix --version; nix run github:martinvonz/jj
nix (Nix) 2.11.1
error: attribute 'defaultApp.x86_64-linux' should have type 'derivation'
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
