### PR TITLE
`jj resolve`: Add debug information to EmptyOrUnchanged error

### DIFF
--- a/tests/test_diffedit_command.rs
+++ b/tests/test_diffedit_command.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use regex::Regex;
-
 use crate::common::TestEnvironment;
 
 pub mod common;
@@ -52,10 +50,8 @@ fn test_diffedit() {
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit"]);
-    insta::assert_snapshot!(Regex::new(r"Details: [^\n]+").unwrap().replace(&stderr, "Details: <OS-Dependent>"), @r###"
-    Error: Failed to edit diff: Tool exited with a non-zero code.
-     Details: <OS-Dependent>
+    insta::assert_snapshot!(&test_env.jj_cmd_failure(&repo_path, &["diffedit"]), @r###"
+    Error: Failed to edit diff: Tool exited with a non-zero code (run with --verbose to see the exact invocation). Exit code: 1.
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -202,10 +198,8 @@ fn test_diffedit_old_restore_interactive_tests() {
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit", "--from", "@-"]);
-    insta::assert_snapshot!(Regex::new(r"Details: [^\n]+").unwrap().replace(&stderr, "Details: <OS-Dependent>"), @r###"
-    Error: Failed to edit diff: Tool exited with a non-zero code.
-     Details: <OS-Dependent>
+    insta::assert_snapshot!(&test_env.jj_cmd_failure(&repo_path, &["diffedit", "--from", "@-"]), @r###"
+    Error: Failed to edit diff: Tool exited with a non-zero code (run with --verbose to see the exact invocation). Exit code: 1.
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -275,17 +275,15 @@ fn check_resolve_produces_input_file(
     std::fs::write(editor_script, format!("expect\n{expected_content}")).unwrap();
 
     let merge_arg_config = format!(r#"merge-tools.fake-editor.merge-args = ["${role}"]"#);
-    let error =
-        test_env.jj_cmd_failure(repo_path, &["resolve", "--config-toml", &merge_arg_config]);
     // This error means that fake-editor exited successfully but did not modify the
     // output file.
     // We cannot use `insta::assert_snapshot!` here after insta 1.22 due to
     // https://github.com/mitsuhiko/insta/commit/745b45b. Hopefully, this will again become possible
     // in the future. See also https://github.com/mitsuhiko/insta/issues/313.
     assert_eq!(
-        error,
+        &test_env.jj_cmd_failure(repo_path, &["resolve", "--config-toml", &merge_arg_config]),
         "Error: Failed to use external tool to resolve: The output file is either unchanged or \
-         empty after the editor quit.\n"
+         empty after the editor quit (run with --verbose to see the exact invocation).\n"
     );
 }
 


### PR DESCRIPTION
This would have made it a bit easier to  debug a problem somebody had on Discord.


# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
