### PR TITLE
let branches and remote_branches revset functions take arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `empty` condition in templates is true when the commit makes no change to
   the three compared to its parents.
 
+* `branches([needle])` revset function now takes `needle` as an optional
+  argument and matches just the branches whose name contains `needle`.
+
+* `remote_branches([branch_needle[, remote_needle]])` now takes `branch_needle`
+  and `remote_needle` as optional arguments and matches just the branches whose
+  name contains `branch_needle` and remote contains `remote_needle`.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export
@@ -91,11 +98,11 @@ No changes, only changed to a released version of the `thrift` crate dependency.
 
 * Adjusted precedence of revset union/intersection/difference operators.
   `x | y & z` is now equivalent to `x | (y & z)`.
-  
+
 * Support for open commits has been dropped. The `ui.enable-open-commits` config
   that was added in 0.5.0 is no longer respected. The `jj open/close` commands
   have been deleted.
-  
+
 * `jj commit` is now a separate command from `jj close` (which no longer
   exists). The behavior has changed slightly. It now always asks for a
   description, even if there already was a description set. It now also only
@@ -153,7 +160,7 @@ No changes, only changed to a released version of the `thrift` crate dependency.
   revset.
 
 * The new global flag `-v/--verbose` will turn on debug logging to give
-  some additional insight into what is happening behind the scenes. 
+  some additional insight into what is happening behind the scenes.
   Note: This is not comprehensively supported by all operations yet.
 
 * `jj log`, `jj show`, and `jj obslog` now all support showing relative
@@ -165,7 +172,7 @@ No changes, only changed to a released version of the `thrift` crate dependency.
   This typically occurred when running in a working copy colocated with Git
   (created by running `jj init --git-dir=.`).
   [#463](https://github.com/martinvonz/jj/issues/463)
-  
+
 * When exporting branches to Git, we used to fail if some branches could not be
   exported (e.g. because Git doesn't allow a branch called `main` and another
   branch called `main/sub`). We now print a warning about these branches
@@ -417,7 +424,7 @@ No changes (just trying to get automated GitHub release to work).
   has a non-empty description.
 
 * All commands now consistently snapshot the working copy (it was missing from
-  e.g. `jj undo` and `jj merge` before). 
+  e.g. `jj undo` and `jj merge` before).
 
 ## [0.4.0] - 2022-04-02
 

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1355,6 +1355,20 @@ fn test_evaluate_expression_branches(use_git: bool) {
         resolve_commit_ids(mut_repo.as_repo_ref(), "branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
     );
+    // Can get branches with matching names
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "branches(branch1)"),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "branches(branch)"),
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    // Can silently resolve to an empty set if there's no matches
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "branches(branch3)"),
+        vec![]
+    );
     // Two branches pointing to the same commit does not result in a duplicate in
     // the revset
     mut_repo.set_local_branch(
@@ -1425,6 +1439,52 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
     assert_eq!(
         resolve_commit_ids(mut_repo.as_repo_ref(), "remote_branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    // Can get branches with matching names
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "remote_branches(branch1)"),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "remote_branches(branch)"),
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    // Can get branches from matching remotes
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), r#"remote_branches("", origin)"#),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), r#"remote_branches("", ri)"#),
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    // Can get branches with matching names from matching remotes
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "remote_branches(branch1, ri)"),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            r#"remote_branches(branch, private)"#
+        ),
+        vec![commit2.id().clone()]
+    );
+    // Can silently resolve to an empty set if there's no matches
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), "remote_branches(branch3)"),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo.as_repo_ref(), r#"remote_branches("", upstream)"#),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo.as_repo_ref(),
+            r#"remote_branches(branch1, private)"#
+        ),
+        vec![]
     );
     // Two branches pointing to the same commit does not result in a duplicate in
     // the revset


### PR DESCRIPTION
- branches has the signature `branches([needle])`, meaning the needle is optional (`branches()` is equivalent to `branches("")`) and it matches all branches whose name contains needle as a substring
- remote_branches has the signature `remote_branches([branch_needle[, remote_needle]])`, meaning it can be called with no arguments, or one argument (in which case, it's similar to branches), or two arguments where the first argument matches branch names and the second argument matches remote names (similar to branches, `remote_branches()`, `remote_branches("")` and `remote_branches("", "")` are all equivalent)

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
