### PR TITLE
op_heads_store: simplify the OpHeadsStore trait through refactoring

### DIFF
--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -16,54 +16,32 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use itertools::Itertools;
 use thiserror::Error;
 
 use crate::dag_walk;
 use crate::op_store::{OpStore, OperationId};
 use crate::operation::Operation;
 
-pub enum OpHeads {
-    /// There's a single latest operation. This is the normal case.
-    Single(Operation),
-    /// There are multiple latest operations, which means there has been
-    /// concurrent operations. These need to be resolved.
-    Unresolved {
-        locked_op_heads: LockedOpHeads,
-        op_heads: Vec<Operation>,
-    },
-}
-
 #[derive(Debug, Error, PartialEq, Eq)]
-pub enum OpHeadResolutionError {
+pub enum OpHeadResolutionError<E> {
     #[error("Operation log has no heads")]
     NoHeads,
+    #[error("Op resolution error: {0}")]
+    Err(E),
 }
 
-pub trait LockedOpHeadsResolver {
-    fn finish(&self, new_op: &Operation);
-}
-
-// Represents a mutually exclusive lock on the OpHeadsStore in local systems.
-pub struct LockedOpHeads {
-    resolver: Box<dyn LockedOpHeadsResolver>,
-}
-
-impl LockedOpHeads {
-    pub fn new(resolver: Box<dyn LockedOpHeadsResolver>) -> Self {
-        LockedOpHeads { resolver }
-    }
-
-    pub fn finish(self, new_op: &Operation) {
-        self.resolver.finish(new_op);
+impl<E> From<E> for OpHeadResolutionError<E> {
+    fn from(e: E) -> Self {
+        OpHeadResolutionError::Err(e)
     }
 }
 
-/// Manages the very set of current heads of the operation log.
-///
-/// Implementations should use Arc<> internally, as the lock() and
-/// get_heads() return values which might outlive the original object. When Rust
-/// makes it possible for a Trait method to reference &Arc<Self>, this can be
-/// simplified.
+pub trait OpHeadsStoreLock<'a> {
+    fn promote_new_op(&self, new_op: &Operation);
+}
+
+/// Manages the set of current heads of the operation log.
 pub trait OpHeadsStore: Send + Sync + Debug {
     fn name(&self) -> &str;
 
@@ -73,13 +51,11 @@ pub trait OpHeadsStore: Send + Sync + Debug {
 
     fn get_op_heads(&self) -> Vec<OperationId>;
 
-    fn lock(&self) -> LockedOpHeads;
-
-    fn get_heads(&self, op_store: &Arc<dyn OpStore>) -> Result<OpHeads, OpHeadResolutionError>;
+    fn lock<'a>(&'a self) -> Box<dyn OpHeadsStoreLock<'a> + 'a>;
 
     /// Removes operations in the input that are ancestors of other operations
     /// in the input. The ancestors are removed both from the list and from
-    /// disk.
+    /// storage.
     fn handle_ancestor_ops(&self, op_heads: Vec<Operation>) -> Vec<Operation> {
         let op_head_ids_before: HashSet<_> = op_heads.iter().map(|op| op.id().clone()).collect();
         let neighbors_fn = |op: &Operation| op.parents();
@@ -91,5 +67,72 @@ pub trait OpHeadsStore: Send + Sync + Debug {
             self.remove_op_head(removed_op_head);
         }
         op_heads.into_iter().collect()
+    }
+}
+
+// Given an OpHeadsStore, fetch and resolve its op heads down to one under a
+// lock.
+//
+// This routine is defined outside the trait because it must support generics.
+pub fn resolve_op_heads<E>(
+    op_heads_store: &dyn OpHeadsStore,
+    op_store: &Arc<dyn OpStore>,
+    resolver: impl FnOnce(Vec<Operation>) -> Result<Operation, E>,
+) -> Result<Operation, OpHeadResolutionError<E>> {
+    let mut op_heads = op_heads_store.get_op_heads();
+
+    // TODO: De-duplicate this 'simple-resolution' code.
+    if op_heads.is_empty() {
+        return Err(OpHeadResolutionError::NoHeads);
+    }
+
+    if op_heads.len() == 1 {
+        let operation_id = op_heads.pop().unwrap();
+        let operation = op_store.read_operation(&operation_id).unwrap();
+        return Ok(Operation::new(op_store.clone(), operation_id, operation));
+    }
+
+    // There are multiple heads. We take a lock, then check if there are still
+    // multiple heads (it's likely that another process was in the process of
+    // deleting on of them). If there are still multiple heads, we attempt to
+    // merge all the views into one. We then write that view and a corresponding
+    // operation to the op-store.
+    // Note that the locking isn't necessary for correctness; we take the lock
+    // only to prevent other concurrent processes from doing the same work (and
+    // producing another set of divergent heads).
+    let lock = op_heads_store.lock();
+    let op_head_ids = op_heads_store.get_op_heads();
+
+    if op_head_ids.is_empty() {
+        return Err(OpHeadResolutionError::NoHeads);
+    }
+
+    if op_head_ids.len() == 1 {
+        let op_head_id = op_head_ids[0].clone();
+        let op_head = op_store.read_operation(&op_head_id).unwrap();
+        return Ok(Operation::new(op_store.clone(), op_head_id, op_head));
+    }
+
+    let op_heads = op_head_ids
+        .iter()
+        .map(|op_id: &OperationId| {
+            let data = op_store.read_operation(op_id).unwrap();
+            Operation::new(op_store.clone(), op_id.clone(), data)
+        })
+        .collect_vec();
+    let mut op_heads = op_heads_store.handle_ancestor_ops(op_heads);
+
+    // Return without creating a merge operation
+    if op_heads.len() == 1 {
+        return Ok(op_heads.pop().unwrap());
+    }
+
+    op_heads.sort_by_key(|op| op.store_operation().metadata.end_time.timestamp.clone());
+    match resolver(op_heads) {
+        Ok(new_op) => {
+            lock.promote_new_op(&new_op);
+            Ok(new_op)
+        }
+        Err(e) => Err(OpHeadResolutionError::Err(e)),
     }
 }

--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 
 use thiserror::Error;
 
+use crate::dag_walk;
 use crate::op_store::{OpStore, OperationId};
 use crate::operation::Operation;
 
@@ -74,4 +76,20 @@ pub trait OpHeadsStore: Send + Sync + Debug {
     fn lock(&self) -> LockedOpHeads;
 
     fn get_heads(&self, op_store: &Arc<dyn OpStore>) -> Result<OpHeads, OpHeadResolutionError>;
+
+    /// Removes operations in the input that are ancestors of other operations
+    /// in the input. The ancestors are removed both from the list and from
+    /// disk.
+    fn handle_ancestor_ops(&self, op_heads: Vec<Operation>) -> Vec<Operation> {
+        let op_head_ids_before: HashSet<_> = op_heads.iter().map(|op| op.id().clone()).collect();
+        let neighbors_fn = |op: &Operation| op.parents();
+        // Remove ancestors so we don't create merge operation with an operation and its
+        // ancestor
+        let op_heads = dag_walk::heads(op_heads, &neighbors_fn, &|op: &Operation| op.id().clone());
+        let op_head_ids_after: HashSet<_> = op_heads.iter().map(|op| op.id().clone()).collect();
+        for removed_op_head in op_head_ids_before.difference(&op_head_ids_after) {
+            self.remove_op_head(removed_op_head);
+        }
+        op_heads.into_iter().collect()
+    }
 }

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -178,7 +178,7 @@ impl UnpublishedOperation {
         self.repo_loader
             .op_heads_store()
             .lock()
-            .finish(&data.operation);
+            .promote_new_op(&data.operation);
         let repo = self
             .repo_loader
             .create_from(data.operation, data.view, data.index);

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -112,8 +112,7 @@ fn test_bad_locking_children(use_git: bool) {
         Workspace::load(&settings, machine1_root.path(), &StoreFactories::default()).unwrap();
     let machine1_repo = machine1_workspace
         .repo_loader()
-        .load_at_head()
-        .resolve(&settings)
+        .load_at_head(&settings)
         .unwrap();
     let mut machine1_tx = machine1_repo.start_transaction(&settings, "test");
     let child1 = create_random_commit(machine1_tx.mut_repo(), &settings)
@@ -129,8 +128,7 @@ fn test_bad_locking_children(use_git: bool) {
         Workspace::load(&settings, machine2_root.path(), &StoreFactories::default()).unwrap();
     let machine2_repo = machine2_workspace
         .repo_loader()
-        .load_at_head()
-        .resolve(&settings)
+        .load_at_head(&settings)
         .unwrap();
     let mut machine2_tx = machine2_repo.start_transaction(&settings, "test");
     let child2 = create_random_commit(machine2_tx.mut_repo(), &settings)
@@ -152,8 +150,7 @@ fn test_bad_locking_children(use_git: bool) {
         Workspace::load(&settings, merged_path.path(), &StoreFactories::default()).unwrap();
     let merged_repo = merged_workspace
         .repo_loader()
-        .load_at_head()
-        .resolve(&settings)
+        .load_at_head(&settings)
         .unwrap();
     assert!(merged_repo.view().heads().contains(child1.id()));
     assert!(merged_repo.view().heads().contains(child2.id()));

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -34,7 +34,7 @@ fn test_load_at_operation(use_git: bool) {
     // If we load the repo at head, we should not see the commit since it was
     // removed
     let loader = RepoLoader::init(&settings, repo.repo_path(), &StoreFactories::default());
-    let head_repo = loader.load_at_head().resolve(&settings).unwrap();
+    let head_repo = loader.load_at_head(&settings).unwrap();
     assert!(!head_repo.view().heads().contains(commit.id()));
 
     // If we load the repo at the previous operation, we should see the commit since

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -438,7 +438,7 @@ fn commit_transactions(settings: &UserSettings, txs: Vec<Transaction>) -> Arc<Re
         op_ids.push(tx.commit().op_id().clone());
         std::thread::sleep(std::time::Duration::from_millis(1));
     }
-    let repo = repo_loader.load_at_head().resolve(settings).unwrap();
+    let repo = repo_loader.load_at_head(settings).unwrap();
     // Test the setup. The assumption here is that the parent order matches the
     // order in which they were merged (which currently matches the transaction
     // commit order), so we want to know make sure they appear in a certain

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3148,8 +3148,7 @@ fn cmd_workspace_update_stale(
     command: &CommandHelper,
     _args: &WorkspaceUpdateStaleArgs,
 ) -> Result<(), CommandError> {
-    let workspace = command.load_workspace()?;
-    let mut workspace_command = command.resolve_operation(ui, workspace)?;
+    let mut workspace_command = command.workspace_helper_no_snapshot(ui)?;
     let repo = workspace_command.repo().clone();
     let (mut locked_wc, desired_wc_commit) =
         workspace_command.unsafe_start_working_copy_mutation()?;


### PR DESCRIPTION
This PR refactors OpHeadsStore into a trait with no LockedOpHeads, and instead a free templated function for resolving conflicts given an externally provided resolver.  It simplifies the internal Arc<> story as well as a bunch of call sites.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
