### PR TITLE
No crash for unreachable commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `-R`/`--repository` path must be a valid workspace directory. Its
   ancestor directories are no longer searched.
 
+* Fixed a crash when trying to access a commit that's never been imported into
+  the jj repo from a Git repo. They will now be considered as non-existent if
+  referenced explicitly instead of crashing.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -91,8 +91,9 @@ fn resolve_full_commit_id(
         }
         let commit_id = CommitId::new(binary_commit_id);
         match repo.store().get_commit(&commit_id) {
-            Ok(_) => Ok(Some(vec![commit_id])),
-            Err(BackendError::ObjectNotFound { .. }) => Ok(None),
+            // Only recognize a commit if we have indexed it
+            Ok(_) if repo.index().entry_by_id(&commit_id).is_some() => Ok(Some(vec![commit_id])),
+            Ok(_) | Err(BackendError::ObjectNotFound { .. }) => Ok(None),
             Err(err) => Err(RevsetError::StoreError(err)),
         }
     } else {


### PR DESCRIPTION
This is a partial fix to #814: the crash will no longer happen since the commit id unknown to jj will be considered non-existent.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [X] I have added tests to cover my changes
