### PR TITLE
reimplement random ChangeId generator without using UUID

### DIFF
--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -155,10 +155,7 @@ impl UserSettings {
 pub struct JJRng(Mutex<ChaCha20Rng>);
 impl JJRng {
     pub fn new_change_id(&self) -> ChangeId {
-        let mut random_bytes: [u8; 16] = self.gen();
-        // TODO: make it fully random
-        random_bytes[6] = (random_bytes[6] & 0x0f) | ((4 as u8) << 4); // Version: 4
-        random_bytes[8] = (random_bytes[8] & 0x3f) | 0x80; // Variant::RFC4122
+        let random_bytes: [u8; 16] = self.gen();
         ChangeId::new(random_bytes.into())
     }
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -155,13 +155,11 @@ impl UserSettings {
 pub struct JJRng(Mutex<ChaCha20Rng>);
 impl JJRng {
     pub fn new_change_id(&self) -> ChangeId {
-        let random_bytes = self.gen();
-        // The `uuid` crate is used merely to specify the number of random bytes (16)
-        ChangeId::from_bytes(
-            uuid::Builder::from_random_bytes(random_bytes)
-                .into_uuid()
-                .as_bytes(),
-        )
+        let mut random_bytes: [u8; 16] = self.gen();
+        // TODO: make it fully random
+        random_bytes[6] = (random_bytes[6] & 0x0f) | ((4 as u8) << 4); // Version: 4
+        random_bytes[8] = (random_bytes[8] & 0x3f) | 0x80; // Variant::RFC4122
+        ChangeId::new(random_bytes.into())
     }
 
     /// Wraps Rng::gen but only requires an immutable reference. Can be made

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -246,14 +246,14 @@ fn test_git_push_existing_long_branch() {
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
     test_env.jj_cmd_success(
         &workspace_root,
-        &["branch", "create", "push-19b790168e7347a7ba98deae21e807c0"],
+        &["branch", "create", "push-19b790168e73f7a73a98deae21e807c0"],
     );
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--change=@"]);
 
     insta::assert_snapshot!(stdout, @r###"
     Branch changes to push to origin:
-      Add branch push-19b790168e7347a7ba98deae21e807c0 to fa16a14170fb
+      Add branch push-19b790168e73f7a73a98deae21e807c0 to fa16a14170fb
     "###);
 }
 


### PR DESCRIPTION
`create_no_gc_ref()` is the last remaining dependency on UUID.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
