### PR TITLE
Don't output implicit defaults from "config list"

### DIFF
--- a/tests/test_config_command.rs
+++ b/tests/test_config_command.rs
@@ -39,6 +39,22 @@ fn test_config_list_single() {
 }
 
 #[test]
+fn test_config_list_nonexistent() {
+    let test_env = TestEnvironment::default();
+    let assert = test_env
+        .jj_cmd(
+            test_env.env_root(),
+            &["config", "list", "nonexistent-test-key"],
+        )
+        .assert()
+        .success()
+        .stdout("");
+    insta::assert_snapshot!(common::get_stderr_string(&assert), @r###"
+    No matching config key for nonexistent-test-key
+    "###);
+}
+
+#[test]
 fn test_config_list_table() {
     let test_env = TestEnvironment::default();
     test_env.add_config(
@@ -121,7 +137,10 @@ fn test_config_layer_override_default() {
     let config_key = "merge-tools.vimdiff.program";
 
     // Default
-    let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["config", "list", config_key, "--include-defaults"],
+    );
     insta::assert_snapshot!(stdout, @r###"
     merge-tools.vimdiff.program="vim"
     "###);


### PR DESCRIPTION
Accept an --include-defaults arg to enable including those.

Listing a nonexistent name is no longer an error, but does output a warning to stderr when no config entries match to explain why there's no other output.

This is another "config list" improvement related to #531.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
