### PR TITLE
Mark empty commits in jj log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   e.g. `color.error = { bg = "red", bold = true, underline = true }` in your
   `~/.jjconfig.toml`.
 
+* The `empty` condition in templates is true when the commit makes no change to
+  the three compared to its parents.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commits, `jj log` now prints the change id in red and puts `??` after it.
   Previously, it printed the word "divergent".
 
+* `jj log` prefixes commit descriptions with "(empty)" when they contain no
+  change compared to their parents.
+
 ### New features
 
 * The default log format now uses the committer timestamp instead of the author

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -133,7 +133,7 @@ in its `jj log` command:
 ```shell script
 $ jj log
 @ f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00 192b456b024b
-| (no description set)
+| (empty) (no description set)
 o f63e76f175b9 martinvonz@google.com 2021-05-23 22:13:45.000 -07:00 fb563a4c6d26
 | Jujutsu is ready!
 o 6a91b4ba16c7 martinvonz@google.com 2021-05-23 22:08:37.000 -07:00 main 080a9b37ff7e
@@ -159,11 +159,11 @@ example:
 ```shell script
 $ jj log -r '@ | root | branches()'
 @ f39aeb1a0200 martinvonz@google.com 2021-05-23 23:10:27.000 -07:00 192b456b024b
-: (no description set)
+: (empty) (no description set)
 o 6a91b4ba16c7 martinvonz@google.com 2021-05-23 22:08:37.000 -07:00 main 080a9b37ff7e
 : cli: make `jj st` show parent commit before working copy commit
 o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-  (no description set)
+  (empty) (no description set)
 ```
 
 The `000000000000` commit is a virtual commit that's called the "root commit".
@@ -254,7 +254,7 @@ Rebased 1 descendant commits
 Working copy now at: e659edc4a9fc (no description set)
 $ jj log
 @ 461f38324592 martinvonz@google.com 2021-05-26 12:53:08.000 -07:00 e659edc4a9fc
-| (no description set)
+| (empty) (no description set)
 | o 8e6178b84ffb martinvonz@google.com 2021-05-26 12:39:35.000 -07:00 69dbcf76642a
 |/  C
 o 5548374c0794 martinvonz@google.com 2021-05-26 12:39:30.000 -07:00 576d647acf36

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1615,6 +1615,7 @@ fn log_template(settings: &UserSettings) -> String {
             " " commit_id.short()
             if(conflict, label("conflict", " conflict"))
             "\n"
+            if(empty, label("empty", "(empty) "))
             description.first_line()
             "\n""#,
     );

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -19,6 +19,7 @@
 "divergent" = "red"
 "divergent change_id"="red"
 "conflict" = "red"
+"empty" = "yellow"
 
 "working_copy" = { bold = true }
 "working_copy commit_id" = "bright blue"
@@ -34,6 +35,7 @@
 "working_copy divergent change_id"="bright red"
 "working_copy conflict" = "bright red"
 "working_copy description" = "bright white"
+"working_copy empty" = "bright yellow"
 "diff header" = "yellow"
 "diff file_header" = "bright white"
 "diff hunk_header" = "cyan"

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -25,7 +25,7 @@ use crate::formatter::PlainTextFormatter;
 use crate::templater::{
     AuthorProperty, BranchProperty, ChangeIdProperty, CommitIdKeyword, CommitterProperty,
     ConditionalTemplate, ConflictProperty, ConstantTemplateProperty, DescriptionProperty,
-    DivergentProperty, DynamicLabelTemplate, GitRefsProperty, IsGitHeadProperty,
+    DivergentProperty, DynamicLabelTemplate, EmptyProperty, GitRefsProperty, IsGitHeadProperty,
     IsWorkingCopyProperty, LabelTemplate, ListTemplate, LiteralTemplate, SignatureTimestamp,
     StringPropertyTemplate, TagProperty, Template, TemplateFunction, TemplateProperty,
     WorkingCopiesProperty,
@@ -316,6 +316,7 @@ fn parse_commit_keyword<'a>(
         "is_git_head" => Property::Boolean(Box::new(IsGitHeadProperty::new(repo))),
         "divergent" => Property::Boolean(Box::new(DivergentProperty::new(repo))),
         "conflict" => Property::Boolean(Box::new(ConflictProperty)),
+        "empty" => Property::Boolean(Box::new(EmptyProperty { repo })),
         name => panic!("unexpected identifier: {name}"),
     };
     PropertyAndLabels(property, vec![pair.as_str().to_string()])

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -23,6 +23,7 @@ use jujutsu_lib::commit::Commit;
 use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::RepoRef;
 use jujutsu_lib::revset::RevsetExpression;
+use jujutsu_lib::rewrite::merge_commit_trees;
 
 use crate::formatter::Formatter;
 
@@ -441,5 +442,15 @@ pub struct SignatureTimestamp;
 impl TemplateProperty<Signature, Timestamp> for SignatureTimestamp {
     fn extract(&self, context: &Signature) -> Timestamp {
         context.timestamp.clone()
+    }
+}
+
+pub struct EmptyProperty<'a> {
+    pub repo: RepoRef<'a>,
+}
+
+impl TemplateProperty<Commit, bool> for EmptyProperty<'_> {
+    fn extract(&self, context: &Commit) -> bool {
+        context.tree().id() == merge_commit_trees(self.repo, &context.parents()).id()
     }
 }

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -132,7 +132,7 @@ fn test_alias_cannot_override_builtin() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
     insta::assert_snapshot!(stdout, @r###"
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
 }
 

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -65,33 +65,33 @@ fn test_log_default() {
     // Test default log output format
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log"]), @r###"
     @ ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
-    | description 1
+    | (empty) description 1
     o 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
     | add a file
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
     @ [1m[38;5;13mffdaa62087a2[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
-    | [1m[38;5;15mdescription 1[39m[0m
+    | [1m[38;5;11m(empty) [38;5;15mdescription 1[39m[0m
     o [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
     | add a file
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
-      (no description set)
+      [38;5;3m(empty) [39m(no description set)
     "###);
 
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
     [1m[38;5;13mffdaa62087a2[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
-    [1m[38;5;15mdescription 1[39m[0m
+    [1m[38;5;11m(empty) [38;5;15mdescription 1[39m[0m
     [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
     add a file
     [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
-    (no description set)
+    [38;5;3m(empty) [39m(no description set)
     "###);
 }
 
@@ -109,7 +109,7 @@ fn test_log_default_divergence() {
     @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
     | description 1
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
 
     // Create divergence
@@ -125,7 +125,7 @@ fn test_log_default_divergence() {
     | @ 9a45c67d3e96?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
     |/  description 1
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
 
     // Color
@@ -136,6 +136,6 @@ fn test_log_default_divergence() {
     | @ [1m[38;5;9m9a45c67d3e96??[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7a17d52e633c[39m[0m
     |/  [1m[38;5;15mdescription 1[39m[0m
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
-      (no description set)
+      [38;5;3m(empty) [39m(no description set)
     "###);
 }

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -41,7 +41,7 @@ fn test_obslog_with_or_without_diff() {
     o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     | my description
     o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
-      my description
+      (empty) my description
     "###);
 
     // There should be no diff caused by the rebase because it was a pure rebase
@@ -65,7 +65,7 @@ fn test_obslog_with_or_without_diff() {
     | Added regular file file2:
     |         1: foo
     o  test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
-      my description
+      (empty) my description
     "###);
 
     // Test `--no-graph`
@@ -78,7 +78,7 @@ fn test_obslog_with_or_without_diff() {
      test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     my description
      test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
-    my description
+    (empty) my description
     "###);
 
     // Test `--git` format, and that it implies `-p`
@@ -115,7 +115,7 @@ fn test_obslog_with_or_without_diff() {
     @@ -1,0 +1,1 @@
     +foo
      test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
-    my description
+    (empty) my description
     "###);
 }
 
@@ -146,16 +146,16 @@ fn test_obslog_squash() {
     | | Added regular file file1:
     | |         1: foo
     o |  test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
-    | | first
+    | | (empty) first
     o |  test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
-     /  (no description set)
+     /  (empty) (no description set)
     o  test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
     | second
     | Modified regular file file1:
     |    1    1: foo
     |         2: bar
     o  test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
-      second
+      (empty) second
     "###);
 }
 

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -162,13 +162,13 @@ fn test_alias() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root & syntax-error"]);
@@ -264,7 +264,7 @@ fn test_bad_alias_decl() {
         .success();
     insta::assert_snapshot!(get_stdout_string(&assert), @r###"
     o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
-      (no description set)
+      (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_stderr_string(&assert), @r###"
     Failed to load "revset-aliases."bad"":  --> 1:1


### PR DESCRIPTION
The tests are covered by existing ones.

I have chosen yellow as the "(empty)" marker color, maybe you would prefer another one.

Fix #1028.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [X] I have added tests to cover my changes
