### PR TITLE
refactor: separate timestamp related utilities in time_util module

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -60,10 +60,11 @@ use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
 use crate::formatter::{Formatter, PlainTextFormatter};
 use crate::graphlog::{AsciiGraphDrawer, Edge};
 use crate::progress::Progress;
-use crate::template_parser::{
-    format_absolute_timestamp, format_duration, format_timestamp_relative_to_now, TemplateParser,
-};
+use crate::template_parser::TemplateParser;
 use crate::templater::Template;
+use crate::time_util::{
+    format_absolute_timestamp, format_duration, format_timestamp_relative_to_now,
+};
 use crate::ui::Ui;
 
 #[derive(clap::Parser, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,5 @@ pub mod merge_tools;
 mod progress;
 pub mod template_parser;
 pub mod templater;
+pub mod time_util;
 pub mod ui;

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{DateTime, FixedOffset, LocalResult, TimeZone, Utc};
 use jujutsu_lib::backend::{CommitId, Signature, Timestamp};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::op_store::WorkspaceId;
@@ -30,6 +29,7 @@ use crate::templater::{
     StringPropertyTemplate, TagProperty, Template, TemplateFunction, TemplateProperty,
     WorkingCopiesProperty,
 };
+use crate::time_util;
 
 #[derive(Parser)]
 #[grammar = "template.pest"]
@@ -95,51 +95,11 @@ impl TemplateProperty<Signature, String> for SignatureEmail {
     }
 }
 
-// TODO: Find a better place for the timestamp functions, e.g. their own module
-fn datetime_from_timestamp(context: &Timestamp) -> Option<DateTime<FixedOffset>> {
-    let utc = match Utc.timestamp_opt(
-        context.timestamp.0.div_euclid(1000),
-        (context.timestamp.0.rem_euclid(1000)) as u32 * 1000000,
-    ) {
-        LocalResult::None => {
-            return None;
-        }
-        LocalResult::Single(x) => x,
-        LocalResult::Ambiguous(y, _z) => y,
-    };
-
-    Some(
-        utc.with_timezone(
-            &FixedOffset::east_opt(context.tz_offset * 60)
-                .unwrap_or_else(|| FixedOffset::east_opt(0).unwrap()),
-        ),
-    )
-}
-
-pub fn format_absolute_timestamp(timestamp: &Timestamp) -> String {
-    match datetime_from_timestamp(timestamp) {
-        Some(datetime) => datetime.format("%Y-%m-%d %H:%M:%S.%3f %:z").to_string(),
-        None => "<out-of-range date>".to_string(),
-    }
-}
-
-pub fn format_duration(from: &Timestamp, to: &Timestamp, format: &timeago::Formatter) -> String {
-    datetime_from_timestamp(from)
-        .zip(datetime_from_timestamp(to))
-        .and_then(|(from, to)| to.signed_duration_since(from).to_std().ok())
-        .map(|duration| format.convert(duration))
-        .unwrap_or_else(|| "<out-of-range date>".to_string())
-}
-
-pub fn format_timestamp_relative_to_now(timestamp: &Timestamp) -> String {
-    format_duration(timestamp, &Timestamp::now(), &timeago::Formatter::new())
-}
-
 struct RelativeTimestampString;
 
 impl TemplateProperty<Timestamp, String> for RelativeTimestampString {
     fn extract(&self, context: &Timestamp) -> String {
-        format_timestamp_relative_to_now(context)
+        time_util::format_timestamp_relative_to_now(context)
     }
 }
 
@@ -340,7 +300,7 @@ fn coerce_to_string<'a, I: 'a>(
         )),
         Property::Timestamp(property) => Box::new(TemplateFunction::new(
             property,
-            Box::new(|timestamp| format_absolute_timestamp(&timestamp)),
+            Box::new(|timestamp| time_util::format_absolute_timestamp(&timestamp)),
         )),
     }
 }

--- a/src/time_util.rs
+++ b/src/time_util.rs
@@ -1,0 +1,41 @@
+use chrono::{DateTime, FixedOffset, LocalResult, TimeZone, Utc};
+use jujutsu_lib::backend::Timestamp;
+
+fn datetime_from_timestamp(context: &Timestamp) -> Option<DateTime<FixedOffset>> {
+    let utc = match Utc.timestamp_opt(
+        context.timestamp.0.div_euclid(1000),
+        (context.timestamp.0.rem_euclid(1000)) as u32 * 1000000,
+    ) {
+        LocalResult::None => {
+            return None;
+        }
+        LocalResult::Single(x) => x,
+        LocalResult::Ambiguous(y, _z) => y,
+    };
+
+    Some(
+        utc.with_timezone(
+            &FixedOffset::east_opt(context.tz_offset * 60)
+                .unwrap_or_else(|| FixedOffset::east_opt(0).unwrap()),
+        ),
+    )
+}
+
+pub fn format_absolute_timestamp(timestamp: &Timestamp) -> String {
+    match datetime_from_timestamp(timestamp) {
+        Some(datetime) => datetime.format("%Y-%m-%d %H:%M:%S.%3f %:z").to_string(),
+        None => "<out-of-range date>".to_string(),
+    }
+}
+
+pub fn format_duration(from: &Timestamp, to: &Timestamp, format: &timeago::Formatter) -> String {
+    datetime_from_timestamp(from)
+        .zip(datetime_from_timestamp(to))
+        .and_then(|(from, to)| to.signed_duration_since(from).to_std().ok())
+        .map(|duration| format.convert(duration))
+        .unwrap_or_else(|| "<out-of-range date>".to_string())
+}
+
+pub fn format_timestamp_relative_to_now(timestamp: &Timestamp) -> String {
+    format_duration(timestamp, &Timestamp::now(), &timeago::Formatter::new())
+}


### PR DESCRIPTION
i acted upon a `TODO` in the code;

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
