### PR TITLE
style: do not dereference self to perform pattern-matching

### DIFF
--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -230,25 +230,25 @@ pub enum TreeValue {
 impl ContentHash for TreeValue {
     fn hash(&self, state: &mut impl digest::Update) {
         use TreeValue::*;
-        match *self {
-            File { ref id, executable } => {
+        match self {
+            File { id, executable } => {
                 state.update(&0u32.to_le_bytes());
                 id.hash(state);
                 executable.hash(state);
             }
-            Symlink(ref id) => {
+            Symlink(id) => {
                 state.update(&1u32.to_le_bytes());
                 id.hash(state);
             }
-            Tree(ref id) => {
+            Tree(id) => {
                 state.update(&2u32.to_le_bytes());
                 id.hash(state);
             }
-            GitSubmodule(ref id) => {
+            GitSubmodule(id) => {
                 state.update(&3u32.to_le_bytes());
                 id.hash(state);
             }
-            Conflict(ref id) => {
+            Conflict(id) => {
                 state.update(&4u32.to_le_bytes());
                 id.hash(state);
             }

--- a/lib/src/content_hash.rs
+++ b/lib/src/content_hash.rs
@@ -71,9 +71,9 @@ impl ContentHash for String {
 
 impl<T: ContentHash> ContentHash for Option<T> {
     fn hash(&self, state: &mut impl digest::Update) {
-        match *self {
+        match self {
             None => state.update(&[0]),
-            Some(ref x) => {
+            Some(x) => {
                 state.update(&[1]);
                 x.hash(state)
             }

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -125,15 +125,12 @@ pub enum RefTarget {
 impl ContentHash for RefTarget {
     fn hash(&self, state: &mut impl digest::Update) {
         use RefTarget::*;
-        match *self {
-            Normal(ref id) => {
+        match self {
+            Normal(id) => {
                 state.update(&0u32.to_le_bytes());
                 id.hash(state);
             }
-            Conflict {
-                ref removes,
-                ref adds,
-            } => {
+            Conflict { removes, adds } => {
                 state.update(&1u32.to_le_bytes());
                 removes.hash(state);
                 adds.hash(state);

--- a/lib/src/simple_op_store_model.rs
+++ b/lib/src/simple_op_store_model.rs
@@ -181,13 +181,13 @@ impl TSerializable for RefTarget {
   fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> thrift::Result<()> {
     let struct_ident = TStructIdentifier::new("RefTarget");
     o_prot.write_struct_begin(&struct_ident)?;
-    match *self {
-      RefTarget::CommitId(ref f) => {
+    match self {
+      RefTarget::CommitId(f) => {
         o_prot.write_field_begin(&TFieldIdentifier::new("commit_id", TType::String, 1))?;
         o_prot.write_bytes(f)?;
         o_prot.write_field_end()?;
       },
-      RefTarget::Conflict(ref f) => {
+      RefTarget::Conflict(f) => {
         o_prot.write_field_begin(&TFieldIdentifier::new("conflict", TType::Struct, 2))?;
         f.write_to_out_protocol(o_prot)?;
         o_prot.write_field_end()?;


### PR DESCRIPTION
Dereferencing `self` as `*self` in order to perform patten-matching using `ref` is unnecessary and will be done automatically by the compiler (match ergonomics, introduced in Rust 1.26).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
