### PR TITLE
Fix random seed in all tests that use `testutils::user_settings`

### DIFF
--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -25,7 +25,6 @@ use jujutsu_lib::revset::{
     self, optimize, parse, resolve_symbol, RevsetAliasesMap, RevsetError, RevsetExpression,
     RevsetWorkspaceContext,
 };
-use jujutsu_lib::settings::UserSettings;
 use jujutsu_lib::workspace::Workspace;
 use test_case::test_case;
 use testutils::{
@@ -47,14 +46,6 @@ fn test_resolve_symbol_root(use_git: bool) {
 #[test]
 fn test_resolve_symbol_commit_id() {
     let settings = testutils::user_settings();
-    // Stabilize change ids so they won't make commit id prefixes ambiguous
-    let config = config::Config::builder()
-        .add_source(settings.config().clone())
-        .set_override("debug.randomness-seed", "42")
-        .unwrap()
-        .build()
-        .unwrap();
-    let settings = UserSettings::from_config(config);
     // Test only with git so we can get predictable commit ids
     let test_repo = TestRepo::init(true);
     let repo = &test_repo.repo;

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -61,14 +61,16 @@ pub fn new_temp_dir() -> TempDir {
 
 pub fn user_settings() -> UserSettings {
     let config = config::Config::builder()
-        .set_override("user.name", "Test User")
-        .unwrap()
-        .set_override("user.email", "test.user@example.com")
-        .unwrap()
-        .set_override("operation.hostname", "host.example.com")
-        .unwrap()
-        .set_override("operation.username", "test-username")
-        .unwrap()
+        .add_source(config::File::from_str(
+            r#"
+                user.name = "Test User"
+                user.email = "test.user@example.com"
+                operation.username = "test-username"
+                operation.hostname = "host.example.com"
+                debug.randomness-seed = "42"
+           "#,
+            config::FileFormat::Toml,
+        ))
         .build()
         .unwrap();
     UserSettings::from_config(config)


### PR DESCRIPTION
This doesn't change any tests, but could prevent change ids randomly matching commit id prefixes from causing tests to fail in the future.

Follows up on bbd49cdf29, https://github.com/martinvonz/jj/issues/1024 and https://github.com/martinvonz/jj/pull/1033.

@yuja , let me know if you have any concerns.