### PR TITLE
Update `Cargo.lock` to make `cargo-deny` CI happy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"


### PR DESCRIPTION
See https://github.com/martinvonz/jj/actions/runs/3920774270/jobs/6702590941

Hopefully, this will pass the `cargo-deny` check

I just ran `cargo update -p bumpalo`. 
