### PR TITLE
gitignore: any character can be backslash-escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the jj repo from a Git repo. They will now be considered as non-existent if
   referenced explicitly instead of crashing.
 
+* Fixed handling of escaped characters in .gitignore (only keep trailing spaces
+  if escaped properly).
+
 ### Contributors
 
 Thanks to the people who made this release happen!


### PR DESCRIPTION
The existing result of `remove_trailing_space(r#"foobar\\ "#)` is `r#"foobar\\ "#` because it thinks that the trailing space is escaped by the preceeding backslash, while in fact it is the second character of the `r#"\\"#` sequence.

Note that in the rest of the `gitignore.rs` file we correctly handle any escaped character already.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [X] I have added tests to cover my changes
