### PR TITLE
Fix issues with bright color themes, change `(empty)` marker color

### DIFF
--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -24,7 +24,9 @@
 "working_copy" = { bold = true }
 "working_copy commit_id" = "bright blue"
 "working_copy change_id" = "bright magenta"
-"working_copy email" = "bright yellow"
+# We do not use bright yellow because of how it looks on xterm's default theme.
+# https://github.com/martinvonz/jj/issues/528
+"working_copy email" = "yellow"
 "working_copy timestamp" = "bright cyan"
 "working_copy working_copies" = "bright magenta"
 "working_copy branch"  = "bright magenta"
@@ -34,10 +36,9 @@
 "working_copy divergent" =  "bright red"
 "working_copy divergent change_id"="bright red"
 "working_copy conflict" = "bright red"
-"working_copy description" = "bright white"
 "working_copy empty" = "bright green"
 "diff header" = "yellow"
-"diff file_header" = "bright white"
+"diff file_header" = { bold = true }
 "diff hunk_header" = "cyan"
 "diff removed" = "red"
 "diff added" = "green"
@@ -45,10 +46,7 @@
 "op-log id" = "blue"
 "op-log user" = "yellow"
 "op-log time" = "cyan"
-"op-log tags" = "white"
 "op-log head" = { bold = true }
 "op-log head id" = "bright blue"
-"op-log head user" = "bright yellow"
+"op-log head user" = "yellow"  # No bright yellow, see comment above
 "op-log head time" = "bright cyan"
-"op-log head description" = "bright white"
-"op-log head tags" = "bright white"

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -19,7 +19,7 @@
 "divergent" = "red"
 "divergent change_id"="red"
 "conflict" = "red"
-"empty" = "yellow"
+"empty" = "green"
 
 "working_copy" = { bold = true }
 "working_copy commit_id" = "bright blue"
@@ -35,7 +35,7 @@
 "working_copy divergent change_id"="bright red"
 "working_copy conflict" = "bright red"
 "working_copy description" = "bright white"
-"working_copy empty" = "bright yellow"
+"working_copy empty" = "bright green"
 "diff header" = "yellow"
 "diff file_header" = "bright white"
 "diff hunk_header" = "cyan"

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -76,22 +76,22 @@ fn test_log_default() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
     @ [1m[38;5;13mffdaa62087a2[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
-    | [1m[38;5;11m(empty) [38;5;15mdescription 1[39m[0m
+    | [1m[38;5;10m(empty) [38;5;15mdescription 1[39m[0m
     o [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
     | add a file
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
-      [38;5;3m(empty) [39m(no description set)
+      [38;5;2m(empty) [39m(no description set)
     "###);
 
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
     [1m[38;5;13mffdaa62087a2[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
-    [1m[38;5;11m(empty) [38;5;15mdescription 1[39m[0m
+    [1m[38;5;10m(empty) [38;5;15mdescription 1[39m[0m
     [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
     add a file
     [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
-    [38;5;3m(empty) [39m(no description set)
+    [38;5;2m(empty) [39m(no description set)
     "###);
 }
 
@@ -136,6 +136,6 @@ fn test_log_default_divergence() {
     | @ [1m[38;5;9m9a45c67d3e96??[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7a17d52e633c[39m[0m
     |/  [1m[38;5;15mdescription 1[39m[0m
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
-      [38;5;3m(empty) [39m(no description set)
+      [38;5;2m(empty) [39m(no description set)
     "###);
 }

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -75,8 +75,8 @@ fn test_log_default() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ [1m[38;5;13mffdaa62087a2[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
-    | [1m[38;5;10m(empty) [38;5;15mdescription 1[39m[0m
+    @ [1m[38;5;13mffdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
+    | [1m[38;5;10m(empty) [39mdescription 1[0m
     o [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
     | add a file
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
@@ -86,8 +86,8 @@ fn test_log_default() {
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;13mffdaa62087a2[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
-    [1m[38;5;10m(empty) [38;5;15mdescription 1[39m[0m
+    [1m[38;5;13mffdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9de54178d59d[39m[0m
+    [1m[38;5;10m(empty) [39mdescription 1[0m
     [38;5;5m9a45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4291e264ae97[39m
     add a file
     [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
@@ -133,8 +133,8 @@ fn test_log_default_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     o [38;5;1m9a45c67d3e96??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [38;5;4m8979953d4c67[39m
     | description 2
-    | @ [1m[38;5;9m9a45c67d3e96??[39m [38;5;11mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7a17d52e633c[39m[0m
-    |/  [1m[38;5;15mdescription 1[39m[0m
+    | @ [1m[38;5;9m9a45c67d3e96??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7a17d52e633c[39m[0m
+    |/  [1mdescription 1[0m
     o [38;5;5m000000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m000000000000[39m
       [38;5;2m(empty) [39m(no description set)
     "###);


### PR DESCRIPTION
1. The "empty" marker from https://github.com/martinvonz/jj/pull/1034 changes from yellow to green. This is not a major change, but looks a little more orthogonal and clear:

![dark_theme](https://user-images.githubusercontent.com/4123047/212502483-4119fb17-0601-4335-9770-196e36a6bc31.png)


2. Fixes https://github.com/martinvonz/jj/issues/528 by changing bright yellow to yellow.

3. Finally, stop using `white` or `bright white` which are hardly visible on bright themes.

`xterm`'s default theme before:

![before](https://user-images.githubusercontent.com/4123047/212564102-f6e98635-9bde-4392-8b69-5571fdb1303a.png)

After:

![after](https://user-images.githubusercontent.com/4123047/212562387-b89a412e-8689-4bdd-9b25-3f5df1a7d31f.png)

IMO, the goal with this particular theme is to be bearable, not pretty :).

# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- (postponed) I have updated the documentation (README.md, docs/, demos/)
- (not planned) I have added tests to cover my changes
