### PR TITLE
Allow simultaneous rebasing of duplicate commits, duplicating multiple commits, undo after duplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed handling of escaped characters in .gitignore (only keep trailing spaces
   if escaped properly).
 
+* `jj undo` now works after `jj duplicate`.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj undo` now works after `jj duplicate`.
 
+* `jj duplicate` followed by `jj rebase` of a tree containing both the original
+  and duplicate commit no longer crashes. The fix should also resolve any remaining
+  instances of https://github.com/martinvonz/jj/issues/27.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operations ("origin" by default) using the `git.fetch` and `git.push`
   configuration entries.
 
+* `jj duplicate` can now duplicate multiple changes in one go. This preserves
+  any parent-child relationships between them. For example, the entire tree of
+  descendants of `abc` can be duplicated with `jj duplicate abc:`.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -989,6 +989,7 @@ dependencies = [
  "git2",
  "glob",
  "hex",
+ "indexmap",
  "insta",
  "itertools",
  "jujutsu-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ timeago = { version = "0.4.0", default-features = false }
 thiserror = "1.0.38"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["std", "ansi", "env-filter", "fmt"] }
+indexmap = "1.9.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.139" }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -610,7 +610,9 @@ impl MutableRepo {
     }
 
     pub fn has_changes(&self) -> bool {
-        self.view() != &self.base_repo.view
+        !(self.abandoned_commits.is_empty()
+            && self.rewritten_commits.is_empty()
+            && self.view() == &self.base_repo.view)
     }
 
     pub fn consume(self) -> (MutableIndex, View) {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2038,8 +2038,8 @@ fn cmd_commit(ui: &mut Ui, command: &CommandHelper, args: &CommitArgs) -> Result
 fn resolve_multiple_rewriteable_revsets(
     revision_args: &[RevisionArg],
     workspace_command: &WorkspaceCommandHelper,
-) -> Result<Vec<Commit>, CommandError> {
-    let mut acc = Vec::new();
+) -> Result<IndexSet<Commit>, CommandError> {
+    let mut acc = IndexSet::new();
     for revset in revision_args {
         let revisions = workspace_command.resolve_revset(revset)?;
         workspace_command.check_non_empty(&revisions)?;
@@ -2058,9 +2058,7 @@ fn cmd_duplicate(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let to_duplicate: IndexSet<Commit> =
-        resolve_multiple_rewriteable_revsets(&args.revisions, &workspace_command)?
-            .into_iter()
-            .collect();
+        resolve_multiple_rewriteable_revsets(&args.revisions, &workspace_command)?;
     let mut duplicated_old_to_new: IndexMap<Commit, Commit> = IndexMap::new();
 
     let mut tx = workspace_command

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2041,6 +2041,7 @@ fn cmd_duplicate(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let predecessor = workspace_command.resolve_single_rev(&args.revision)?;
+    workspace_command.check_rewriteable(&predecessor)?;
     let mut tx = workspace_command
         .start_transaction(&format!("duplicate commit {}", predecessor.id().hex()));
     let mut_repo = tx.mut_repo();

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -112,11 +112,8 @@ fn test_rebase_branch_with_merge() {
     // Test abandoning the same commit twice directly
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "b", "b"]);
-    // Note that the same commit is listed twice
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned the following commits:
-      1394f625cbbd b
-      1394f625cbbd b
+    Abandoned commit 1394f625cbbd b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   e
@@ -131,12 +128,10 @@ fn test_rebase_branch_with_merge() {
     // Test abandoning the same commit twice indirectly
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d:", "a:"]);
-    // Note that the same commit is listed twice
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
       5557ece3e631 e
       b7c62f28ed10 d
-      5557ece3e631 e
       1394f625cbbd b
       2443ea76b0b1 a
     Working copy now at: af874bffee6e (no description set)

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -49,17 +49,17 @@ fn test_duplicate() {
     o 000000000000   (no description set)
     "###);
 
-    /* BUG!!! Panics instead of failing! */
-    // let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "root"]);
-    // insta::assert_snapshot!(stderr, @r###"
-    // "###);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "root"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Cannot rewrite the root commit
+    "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created: 3d341b2f2b09 a
+    Created: 2f6dc5a1ffc2 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    o 3d341b2f2b09   a
+    o 2f6dc5a1ffc2   a
     | @   17a00fc21654   c
     | |\  
     | o | d370aee184ba   b
@@ -69,13 +69,13 @@ fn test_duplicate() {
     o 000000000000   (no description set)
     "###);
 
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @r###"
-    Created: 2426bb15bfd6 c
+    Created: 1dd099ea963c c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    o   2426bb15bfd6   c
+    o   1dd099ea963c   c
     |\  
     | | @   17a00fc21654   c
     | | |\  

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -154,10 +154,21 @@ fn test_rebase_duplicates() {
     o 000000000000   (no description set) @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
-    // This is the bug: this should succeed
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Unexpected error from backend: Error: Git commit '29bd36b60e6002f04e03c5077f989c93e3c910e1' already exists with different associated non-Git meta-data
+    let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Rebased 4 commits
+    Working copy now at: 29bd36b60e60 b
+    "###);
+    // Some of the duplicate commits' timestamps were changed a little to make them
+    // have distinct commit ids.
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
+    o b43fe7354758   b @ 2001-02-03 04:05:14.000 +07:00
+    | o 08beb14c3ead   b @ 2001-02-03 04:05:15.000 +07:00
+    |/  
+    | @ 29bd36b60e60   b @ 2001-02-03 04:05:16.000 +07:00
+    |/  
+    o 2f6dc5a1ffc2   a @ 2001-02-03 04:05:16.000 +07:00
+    o 000000000000   (no description set) @ 1970-01-01 00:00:00.000 +00:00
     "###);
 }
 
@@ -172,7 +183,6 @@ fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     )
 }
 
-// The timestamp is relevant for the bugfix
 fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> String {
     test_env.jj_cmd_success(
         repo_path,

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -120,6 +120,47 @@ fn test_undo_after_duplicate() {
     "###);
 }
 
+// https://github.com/martinvonz/jj/issues/694
+#[test]
+fn test_rebase_duplicates() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    create_commit(&test_env, &repo_path, "a", &[]);
+    create_commit(&test_env, &repo_path, "b", &["a"]);
+    // Test the setup
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
+    @ 1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
+    o 2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    o 000000000000   (no description set) @ 1970-01-01 00:00:00.000 +00:00
+    "###);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Created: fdaaf3950f07 b
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Created: 870cf438ccbb b
+    "###);
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
+    o 870cf438ccbb   b @ 2001-02-03 04:05:14.000 +07:00
+    | o fdaaf3950f07   b @ 2001-02-03 04:05:13.000 +07:00
+    |/  
+    | @ 1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
+    |/  
+    o 2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    o 000000000000   (no description set) @ 1970-01-01 00:00:00.000 +00:00
+    "###);
+
+    // This is the bug: this should succeed
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Unexpected error from backend: Error: Git commit '29bd36b60e6002f04e03c5077f989c93e3c910e1' already exists with different associated non-Git meta-data
+    "###);
+}
+
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     test_env.jj_cmd_success(
         repo_path,
@@ -127,6 +168,18 @@ fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
             "log",
             "-T",
             r#"commit_id.short() "   " description.first_line()"#,
+        ],
+    )
+}
+
+// The timestamp is relevant for the bugfix
+fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> String {
+    test_env.jj_cmd_success(
+        repo_path,
+        &[
+            "log",
+            "-T",
+            r#"commit_id.short() "   " description.first_line() " @ " committer.timestamp()"#,
         ],
     )
 }

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
+    if parents.is_empty() {
+        test_env.jj_cmd_success(repo_path, &["new", "root", "-m", name]);
+    } else {
+        let mut args = vec!["new", "-m", name];
+        args.extend(parents);
+        test_env.jj_cmd_success(repo_path, &args);
+    }
+    std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
+    test_env.jj_cmd_success(repo_path, &["branch", "create", name]);
+}
+
+// https://github.com/martinvonz/jj/issues/1050
+#[test]
+fn test_undo_after_duplicate() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    create_commit(&test_env, &repo_path, "a", &[]);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @ 2443ea76b0b1   a
+    o 000000000000   (no description set)
+    "###);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Created: f5cefcbb65a4 a
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    o f5cefcbb65a4   a
+    | @ 2443ea76b0b1   a
+    |/  
+    o 000000000000   (no description set)
+    "###);
+
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @ 2443ea76b0b1   a
+    o 000000000000   (no description set)
+    "###);
+}
+
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+    test_env.jj_cmd_success(
+        repo_path,
+        &[
+            "log",
+            "-T",
+            r#"commit_id.short() "   " description.first_line()"#,
+        ],
+    )
+}


### PR DESCRIPTION
Fixes https://github.com/martinvonz/jj/issues/27, https://github.com/martinvonz/jj/issues/694 and https://github.com/martinvonz/jj/issues/1050

I combined the bugfix PRs with the feature PR into one since they are both ready. If a portion of this PR gets a faster review than the rest, I'll split them again.

Now also includes a minor fix to `jj abandon`: if the same revision is specified several times, it is now only listed once in the output.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] Updated command-line help
- [x] I have added tests to cover my changes
