### PR TITLE
build: set MSRV for main program as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
 categories = ["command-line-utilities", "development-tools"]
 default-run = "jj"
+rust-version = "1.60"
 
 [[bin]]
 name = "jj"


### PR DESCRIPTION
Since we build the binary for the lib MSRV in the CI, it makes sense to also set the MSRV on the binary. It *may* help utilities such as dependabot which could avoid suggesting upgrades that are not supported by our MSRV.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
