### PR TITLE
config: allow configuration of git remotes for fetch and push operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `remote_needle` as optional arguments and matches just the branches whose
   name contains `branch_needle` and remote contains `remote_needle`.
 
+* Default remotes can be configured for the `jj git fetch` and `jj git push`
+  operations ("origin" by default) using the `git.fetch` and `git.push`
+  configuration entries.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/docs/github.md
+++ b/docs/github.md
@@ -126,3 +126,21 @@ For a detailed overview, how Jujutsu handles conflicts, revisit the [tutorial][t
 [http-auth]: https://github.com/martinvonz/jj/issues/469 
 [tut]: tutorial.md#Conflicts
 [stacked]: https://jg.gg/2018/09/29/stacked-diffs-versus-pull-requests/
+
+## Using several remotes
+
+It is common to use several remotes when contributing to a shared repository. For example,
+"upstream" can designate the remote where the changes will be merged through a pull-request
+while "origin" is your private fork of the project. In this case, you might want to
+`jj git fetch` from "upstream" and to `jj git push` to "origin".
+
+You can configure the default remotes to fetch from and push to in your configuration file
+(for example `.jj/repo/config.toml`):
+
+```toml
+[git]
+fetch = "upstream"
+push = "origin"
+```
+
+The default for both `git.fetch` and `git.push` is "origin".

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,15 +151,15 @@ fn env_base() -> config::Config {
 pub fn default_config() -> config::Config {
     // Syntax error in default config isn't a user error. That's why defaults are
     // loaded by separate builder.
+    macro_rules! from_toml {
+        ($file:literal) => {
+            config::File::from_str(include_str!($file), config::FileFormat::Toml)
+        };
+    }
     config::Config::builder()
-        .add_source(config::File::from_str(
-            include_str!("config/colors.toml"),
-            config::FileFormat::Toml,
-        ))
-        .add_source(config::File::from_str(
-            include_str!("config/merge_tools.toml"),
-            config::FileFormat::Toml,
-        ))
+        .add_source(from_toml!("config/colors.toml"))
+        .add_source(from_toml!("config/merge_tools.toml"))
+        .add_source(from_toml!("config/git.toml"))
         .build()
         .unwrap()
 }

--- a/src/config/git.toml
+++ b/src/config/git.toml
@@ -1,0 +1,3 @@
+[git]
+push = "origin"
+fetch = "origin"


### PR DESCRIPTION
The `git.fetch` and `git.push` keys can be used in the configuration file for the default to use in `jj git fetch` and `jj git push` operations.

By defaut, "origin" is used in both cases.

For example when developing for this repository I only fetch from "upstream" (martinvonz/jj) and only push to "origin" (samueltardieu/jj). Being able to write this in my configuration file makes it easier.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
