### PR TITLE
cli: rename `print` to `cat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj log` now highlights the shortest unique prefix of every commit and change id
   with brackets. To disable, set the new `ui.unique-prefixes` option to `none`
 
+* `jj print` was renamed to `jj cat`. `jj print` remains as an alias.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -77,7 +77,8 @@ enum Commands {
     Checkout(CheckoutArgs),
     Untrack(UntrackArgs),
     Files(FilesArgs),
-    Print(PrintArgs),
+    #[command(alias = "print")]
+    Cat(CatArgs),
     Diff(DiffArgs),
     Show(ShowArgs),
     Status(StatusArgs),
@@ -229,7 +230,7 @@ struct FilesArgs {
 
 /// Print contents of a file in a revision
 #[derive(clap::Args, Clone, Debug)]
-struct PrintArgs {
+struct CatArgs {
     /// The revision to get the file contents from
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,
@@ -1382,7 +1383,7 @@ fn cmd_files(ui: &mut Ui, command: &CommandHelper, args: &FilesArgs) -> Result<(
     Ok(())
 }
 
-fn cmd_print(ui: &mut Ui, command: &CommandHelper, args: &PrintArgs) -> Result<(), CommandError> {
+fn cmd_cat(ui: &mut Ui, command: &CommandHelper, args: &CatArgs) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let path = workspace_command.parse_file_path(&args.path)?;
@@ -4603,7 +4604,7 @@ pub fn run_command(
         Commands::Checkout(sub_args) => cmd_checkout(ui, command_helper, sub_args),
         Commands::Untrack(sub_args) => cmd_untrack(ui, command_helper, sub_args),
         Commands::Files(sub_args) => cmd_files(ui, command_helper, sub_args),
-        Commands::Print(sub_args) => cmd_print(ui, command_helper, sub_args),
+        Commands::Cat(sub_args) => cmd_cat(ui, command_helper, sub_args),
         Commands::Diff(sub_args) => cmd_diff(ui, command_helper, sub_args),
         Commands::Show(sub_args) => cmd_show(ui, command_helper, sub_args),
         Commands::Status(sub_args) => cmd_status(ui, command_helper, sub_args),

--- a/tests/test_cat_command.rs
+++ b/tests/test_cat_command.rs
@@ -17,7 +17,7 @@ use crate::common::TestEnvironment;
 pub mod common;
 
 #[test]
-fn test_print() {
+fn test_cat() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
@@ -28,28 +28,43 @@ fn test_print() {
     std::fs::create_dir(repo_path.join("dir")).unwrap();
     std::fs::write(repo_path.join("dir").join("file2"), "c\n").unwrap();
 
-    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "@-"]);
+    // Can print the contents of a file in a commit
+    let stdout = test_env.jj_cmd_success(&repo_path, &["cat", "file1", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
+
+    // Defaults to printing the working-copy version
+    let stdout = test_env.jj_cmd_success(&repo_path, &["cat", "file1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    b
+    "###);
+
+    // `print` is an alias for `cat`
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
+
+    // Can print a file in a subdirectory
     let subdir_file = if cfg!(unix) {
         "dir/file2"
     } else {
         "dir\\file2"
     };
-    let stdout = test_env.jj_cmd_success(&repo_path, &["print", subdir_file]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["cat", subdir_file]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["print", "nonexistent"]);
+
+    // Error if the path doesn't exist
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["cat", "nonexistent"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: No such path
     "###);
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["print", "dir"]);
+
+    // Error if the path is not a file
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["cat", "dir"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Path exists but is not a file
     "###);
@@ -58,7 +73,7 @@ fn test_print() {
     test_env.jj_cmd_success(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "@", "-d", "@--"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["cat", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     <<<<<<<
     %%%%%%%


### PR DESCRIPTION
`jj cat` better matches `hg cat` and, of course, `cat`. I apparently called it `jj print` when I added it in 7a013a59ae98 because I haven't found `hg cat` useful for actually concatenating files. That's still true, and I don't know if we will ever bother to teach `jj cat` to actually concatenate files, but I think the familiarity of `cat` is more important.

For reference, Git calls it `git show <rev>:<file>`.

I kept `print` as an alias and added a test for it. I also documented the test better.

By the way, I've considered adding a command for writing from stdin directly to a specific commit. If we ever do, it might make sense to call that command `write` (e.g. `echo foo | jj write -r @- README.md`). Then it would make sense to add `read` as an alias to `cat`. I'm not sure that's a good idea, but let's leave that for later anyway.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
