### PR TITLE
cli: add a way to add custom global flags

### DIFF
--- a/examples/custom-global-flag/main.rs
+++ b/examples/custom-global-flag/main.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use jujutsu::cli_util::{CliRunner, CommandError};
+use jujutsu::ui::Ui;
+
+#[derive(clap::Args, Clone, Debug)]
+struct CustomGlobalArgs {
+    /// Show a greeting before each command
+    #[arg(long, global = true)]
+    greet: bool,
+}
+
+fn process_before(ui: &mut Ui, custom_global_args: CustomGlobalArgs) -> Result<(), CommandError> {
+    if custom_global_args.greet {
+        writeln!(ui, "Hello!")?;
+    }
+    Ok(())
+}
+
+fn main() {
+    CliRunner::init()
+        .add_global_args(process_before)
+        .run_and_exit();
+}


### PR DESCRIPTION
Our internal build at Google needs a custom global flag, which lets the user pass flags into C++ code we use for our custom backends. This provides a way of achieving that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
