### PR TITLE
index: do not build hex string to test prefix match, use .as_bytes()

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -282,18 +282,18 @@ impl HexPrefix {
         self.0.as_str()
     }
 
-    pub fn bytes_prefixes(&self) -> (CommitId, CommitId) {
+    pub fn bytes_prefixes<Q: ObjectId>(&self) -> (Q, Q) {
         if self.0.len() % 2 == 0 {
             let bytes = hex::decode(&self.0).unwrap();
-            (CommitId::new(bytes.clone()), CommitId::new(bytes))
+            (Q::new(bytes.clone()), Q::new(bytes))
         } else {
             let min_bytes = hex::decode(self.0.clone() + "0").unwrap();
             let prefix = min_bytes[0..min_bytes.len() - 1].to_vec();
-            (CommitId::new(prefix), CommitId::new(min_bytes))
+            (Q::new(prefix), Q::new(min_bytes))
         }
     }
 
-    pub fn matches(&self, id: &CommitId) -> bool {
+    pub fn matches<Q: ObjectId>(&self, id: &Q) -> bool {
         id.hex().starts_with(&self.0)
     }
 }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -105,7 +105,7 @@ fn resolve_short_commit_id(
     repo: RepoRef,
     symbol: &str,
 ) -> Result<Option<Vec<CommitId>>, RevsetError> {
-    if let Some(prefix) = HexPrefix::new(symbol.to_owned()) {
+    if let Some(prefix) = HexPrefix::new(symbol) {
         match repo.index().resolve_prefix(&prefix) {
             PrefixResolution::NoMatch => Ok(None),
             PrefixResolution::AmbiguousMatch => {
@@ -122,7 +122,7 @@ fn resolve_change_id(
     repo: RepoRef,
     change_id_prefix: &str,
 ) -> Result<Option<Vec<CommitId>>, RevsetError> {
-    if let Some(hex_prefix) = HexPrefix::new(change_id_prefix.to_owned()) {
+    if let Some(hex_prefix) = HexPrefix::new(change_id_prefix) {
         let mut found_change_id = None;
         let mut commit_ids = vec![];
         // TODO: Create a persistent lookup from change id to (visible?) commit ids.

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -128,7 +128,7 @@ fn resolve_change_id(
         // TODO: Create a persistent lookup from change id to (visible?) commit ids.
         for index_entry in RevsetExpression::all().evaluate(repo, None).unwrap().iter() {
             let change_id = index_entry.change_id();
-            if change_id.hex().starts_with(hex_prefix.hex()) {
+            if hex_prefix.matches(&change_id) {
                 if let Some(previous_change_id) = found_change_id.replace(change_id.clone()) {
                     if previous_change_id != change_id {
                         return Err(RevsetError::AmbiguousIdPrefix(change_id_prefix.to_owned()));


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
