### PR TITLE
refactor: return ExitCode from CliRunner::run()

### DIFF
--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -60,11 +60,11 @@ fn run_custom_command(
     }
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
     CliRunner::init()
         .set_store_factories(create_store_factories())
         .add_subcommand(run_custom_command)
-        .run_and_exit();
+        .run()
 }
 
 /// A commit backend that's extremely similar to the Git backend

--- a/examples/custom-command/main.rs
+++ b/examples/custom-command/main.rs
@@ -54,8 +54,6 @@ fn run_custom_command(
     }
 }
 
-fn main() {
-    CliRunner::init()
-        .add_subcommand(run_custom_command)
-        .run_and_exit();
+fn main() -> std::process::ExitCode {
+    CliRunner::init().add_subcommand(run_custom_command).run()
 }

--- a/examples/custom-global-flag/main.rs
+++ b/examples/custom-global-flag/main.rs
@@ -29,8 +29,6 @@ fn process_before(ui: &mut Ui, custom_global_args: CustomGlobalArgs) -> Result<(
     Ok(())
 }
 
-fn main() {
-    CliRunner::init()
-        .add_global_args(process_before)
-        .run_and_exit();
+fn main() -> std::process::ExitCode {
+    CliRunner::init().add_global_args(process_before).run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,6 @@
 
 use jujutsu::cli_util::CliRunner;
 
-fn main() {
-    CliRunner::init().run_and_exit();
+fn main() -> std::process::ExitCode {
+    CliRunner::init().run()
 }


### PR DESCRIPTION
`CliRunner::run()` has been renamed from `CliRunner::run_and_exit()` and returns an `ExitCode` which can be returned from `main()`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
