### PR TITLE
backend: implement equality for commits and trees

### DIFF
--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -138,7 +138,7 @@ content_hash! {
 }
 
 content_hash! {
-    #[derive(Debug, Clone)]
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct Commit {
         pub parents: Vec<CommitId>,
         pub predecessors: Vec<CommitId>,
@@ -291,7 +291,7 @@ impl<'a> Iterator for TreeEntriesNonRecursiveIterator<'a> {
 }
 
 content_hash! {
-    #[derive(Default, Debug, Clone)]
+    #[derive(Default, PartialEq, Eq, Debug, Clone)]
     pub struct Tree {
         entries: BTreeMap<RepoPathComponent, TreeValue>,
     }


### PR DESCRIPTION
It can be useful in tests to be able to compare two commits or trees. Most other structs already implement equality.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
