### PR TITLE
`contributing.md`: Add a link to the "Comprehensive Rust" course

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,6 +57,14 @@ This project follows [Google's Open Source Community
 Guidelines](https://opensource.google/conduct/).
 
 
+## Learning Rust
+
+In addition to the [Rust Book](https://doc.rust-lang.org/book/) and the other
+excellent resources at https://www.rust-lang.org/learn, we recommend the
+["Comprehensive Rust" mini-course](https://google.github.io/comprehensive-rust/)
+for an overview, especially if you are familiar with C++.
+
+
 ## Setting up a development environment
 
 To develop `jj`, the mandatory steps are simply


### PR DESCRIPTION
This is something I wish I had when I first contributed to `jj`.

Let me know if you disagree with the "we recommend" part. It's a big claim, I don't want to include it if it doesn't feel right to somebody.