### PR TITLE
nix: remove .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake


### PR DESCRIPTION
The flake currently has some odd behavior, such as copying .jj and target/, and treating the jj src as an input to the dev shell. This avoids making life rough for direnv users while those are outstanding.