### PR TITLE
Make the `??` for conflicted branches red & `FormattedString` demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `ui.relative-timestamps` option now also affects `jj op log`.
 
 * Background colors, bold text, and underlining are now supported. You can set
-  e.g. `color.error = { bg = "red", bold = true, underline = true }` in your
+  e.g. `color.error = { bg = "red", bold = true, underlined = true }` in your
   `~/.jjconfig.toml`.
 
 * The `empty` condition in templates is true when the commit makes no change to

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -13,6 +13,7 @@
 "working_copies" = "magenta"
 "branch" = "magenta"
 "branches" = "magenta"
+"branches divergent" = "red"
 "tags" = "magenta"
 "git_refs" = "magenta"
 "git_head" = "magenta"

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -353,6 +353,10 @@ fn parse_boolean_commit_property<'a>(
                 property,
                 Box::new(|string| !string.is_empty()),
             )),
+            Property::FormattedString(property) => Box::new(TemplateFunction::new(
+                property,
+                Box::new(|string| !string.is_empty()),
+            )),
             _ => panic!("cannot yet use this as boolean: {pair:?}"),
         },
         _ => panic!("cannot yet use this as boolean: {pair:?}"),

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -98,7 +98,6 @@ impl TemplateProperty<Timestamp, String> for RelativeTimestampString {
 
 enum Property<'a, I> {
     String(Box<dyn TemplateProperty<I, String> + 'a>),
-    #[allow(dead_code)] // TODO: remove exception. `branches` property will have this type shortly
     FormattedString(Box<dyn TemplateProperty<I, FormattedString> + 'a>),
     Boolean(Box<dyn TemplateProperty<I, bool> + 'a>),
     CommitOrChangeId(
@@ -293,7 +292,7 @@ fn parse_commit_keyword<'a>(
             repo,
             workspace_id: workspace_id.clone(),
         })),
-        "branches" => Property::String(Box::new(BranchProperty { repo })),
+        "branches" => Property::FormattedString(Box::new(BranchProperty { repo })),
         "tags" => Property::String(Box::new(TagProperty { repo })),
         "git_refs" => Property::String(Box::new(GitRefsProperty { repo })),
         "is_git_head" => Property::Boolean(Box::new(IsGitHeadProperty::new(repo))),

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -227,6 +227,16 @@ impl From<FormattedString> for String {
         String::from_utf8_lossy(&result).to_string()
     }
 }
+pub struct FormattedStringPropertyTemplate<'a, C> {
+    pub property: Box<dyn TemplateProperty<C, FormattedString> + 'a>,
+}
+
+impl<'a, C> Template<C> for FormattedStringPropertyTemplate<'a, C> {
+    fn format(&self, context: &C, formatter: &mut dyn Formatter) -> io::Result<()> {
+        let text = self.property.extract(context);
+        text.format(formatter)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -195,6 +195,14 @@ impl FormattedString {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        match self {
+            FormattedString::Plain(s) => s.is_empty(),
+            FormattedString::Labeled { str, .. } => str.is_empty(),
+            FormattedString::Concat(strs) => strs.iter().all(|s| s.is_empty()),
+        }
+    }
+
     pub fn concat(strings: Vec<FormattedString>) -> Self {
         Self::Concat(strings)
     }

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -152,9 +152,9 @@ fn test_log_default_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    o [38;5;1m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:11.000 +07:00[39m [38;5;5mbranch??[39m [38;5;4m5[e6d1ab31e][39m
+    o [38;5;1m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:11.000 +07:00[39m [38;5;5mbranch[38;5;1m??[39m [38;5;4m5[e6d1ab31e][39m
     | description 2
-    | @ [1m[38;5;9m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mbranch??[39m [38;5;12me[b166f7c60][39m[0m
+    | @ [1m[38;5;9m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mbranch[38;5;1m??[39m [38;5;12me[b166f7c60][39m[0m
     |/  [1mdescription 1[0m
     o [38;5;5m0[000000000][39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m0[000000000][39m
       [38;5;2m(empty) [39m(no description set)

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -122,11 +122,12 @@ fn test_log_default_divergence() {
     let repo_path = test_env.env_root().join("repo");
 
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["branch", "c", "branch"]);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description 1"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
-    @ 9[a45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 7[a17d52e63]
+    @ 9[a45c67d3e] test.user@example.com 2001-02-03 04:05:09.000 +07:00 branch e[b166f7c60]
     | description 1
     o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
       (empty) (no description set)
@@ -140,9 +141,9 @@ fn test_log_default_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    o 9[a45c67d3e]?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8[979953d4c]
+    o 9[a45c67d3e]?? test.user@example.com 2001-02-03 04:05:11.000 +07:00 branch?? 5[e6d1ab31e]
     | description 2
-    | @ 9[a45c67d3e]?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7[a17d52e63]
+    | @ 9[a45c67d3e]?? test.user@example.com 2001-02-03 04:05:09.000 +07:00 branch?? e[b166f7c60]
     |/  description 1
     o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
       (empty) (no description set)
@@ -151,9 +152,9 @@ fn test_log_default_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    o [38;5;1m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [38;5;4m8[979953d4c][39m
+    o [38;5;1m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:11.000 +07:00[39m [38;5;5mbranch??[39m [38;5;4m5[e6d1ab31e][39m
     | description 2
-    | @ [1m[38;5;9m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[a17d52e63][39m[0m
+    | @ [1m[38;5;9m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mbranch??[39m [38;5;12me[b166f7c60][39m[0m
     |/  [1mdescription 1[0m
     o [38;5;5m0[000000000][39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m0[000000000][39m
       [38;5;2m(empty) [39m(no description set)


### PR DESCRIPTION
This adds a minor feature but mainly creates and demonstrates `FormattedString` functionality.

This same functionality will be used to highlight id prefixes with color.
See https://github.com/martinvonz/jj/pull/1100. In principle, that PR only depends
on the first ~4 commits of this one.

In terms of the minor feature, this commit allows much fancier coloring for branches,
but I haven't decided on a color scheme that's an improvement. We should also avoid
creating a color soup.

It's also possible to make the entire name of the divergent branch red,
but it seems unnecessary. Magenta + red looks good.

If I remember correctly, the FormattedString approach was the one originally recommended to
me by @martinvonz .

# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
