### PR TITLE
repo: leverage stored index to calculate shortest prefix in commit id space

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -29,7 +29,7 @@ use itertools::Itertools;
 use tempfile::NamedTempFile;
 use thiserror::Error;
 
-use crate::backend::{ChangeId, CommitId, ObjectId};
+use crate::backend::{self, ChangeId, CommitId, ObjectId};
 use crate::commit::Commit;
 use crate::file_util::persist_content_addressed_temp_file;
 #[cfg(not(feature = "map_first_last"))]
@@ -82,6 +82,13 @@ impl<'a> IndexRef<'a> {
         match self {
             IndexRef::Readonly(index) => index.commit_id_to_pos(commit_id),
             IndexRef::Mutable(index) => index.commit_id_to_pos(commit_id),
+        }
+    }
+
+    pub fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize {
+        match self {
+            IndexRef::Readonly(index) => index.shortest_unique_commit_id_prefix_len(commit_id),
+            IndexRef::Mutable(index) => index.shortest_unique_commit_id_prefix_len(commit_id),
         }
     }
 
@@ -618,6 +625,10 @@ impl MutableIndex {
         CompositeIndex(self).commit_id_to_pos(commit_id)
     }
 
+    pub fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize {
+        CompositeIndex(self).shortest_unique_commit_id_prefix_len(commit_id)
+    }
+
     pub fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId> {
         CompositeIndex(self).resolve_prefix(prefix)
     }
@@ -768,6 +779,46 @@ impl<'a> CompositeIndex<'a> {
     pub fn commit_id_to_pos(&self, commit_id: &CommitId) -> Option<IndexPosition> {
         self.ancestor_index_segments()
             .find_map(|segment| segment.segment_commit_id_to_pos(commit_id))
+    }
+
+    /// Suppose the given `commit_id` exists, returns the minimum prefix length
+    /// to disambiguate it. The length to be returned is a number of hexadecimal
+    /// digits.
+    ///
+    /// If the given `commit_id` doesn't exist, this will return the prefix
+    /// length that never matches with any commit ids.
+    pub fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize {
+        let (prev_id, next_id) = self.resolve_neighbor_commit_ids(commit_id);
+        itertools::chain(prev_id, next_id)
+            .map(|id| backend::common_hex_len(commit_id.as_bytes(), id.as_bytes()) + 1)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Suppose the given `commit_id` exists, returns the previous and next
+    /// commit ids in lexicographical order.
+    fn resolve_neighbor_commit_ids(
+        &self,
+        commit_id: &CommitId,
+    ) -> (Option<CommitId>, Option<CommitId>) {
+        self.ancestor_index_segments()
+            .map(|segment| {
+                let num_parent_commits = segment.segment_num_parent_commits();
+                let to_local_pos = |pos: IndexPosition| pos.0 - num_parent_commits;
+                let (prev_pos, next_pos) =
+                    segment.segment_commit_id_to_neighbor_positions(commit_id);
+                (
+                    prev_pos.map(|p| segment.segment_commit_id(to_local_pos(p))),
+                    next_pos.map(|p| segment.segment_commit_id(to_local_pos(p))),
+                )
+            })
+            .reduce(|(acc_prev_id, acc_next_id), (prev_id, next_id)| {
+                (
+                    acc_prev_id.into_iter().chain(prev_id).max(),
+                    acc_next_id.into_iter().chain(next_id).min(),
+                )
+            })
+            .unwrap()
     }
 
     pub fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId> {
@@ -1578,6 +1629,10 @@ impl ReadonlyIndex {
         CompositeIndex(self).commit_id_to_pos(commit_id)
     }
 
+    pub fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize {
+        CompositeIndex(self).shortest_unique_commit_id_prefix_len(commit_id)
+    }
+
     pub fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId> {
         CompositeIndex(self).resolve_prefix(prefix)
     }
@@ -2084,6 +2139,104 @@ mod tests {
         assert_eq!(
             index.segment_commit_id_to_neighbor_positions(&CommitId::from_hex("ffffff")),
             (Some(IndexPosition(4)), None),
+        );
+
+        // Global lookup, commit_id exists. id_0 < id_1 < id_5 < id_3 < id_2 < id_4
+        let composite_index = CompositeIndex(&index);
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&id_0),
+            (None, Some(id_1.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&id_1),
+            (Some(id_0.clone()), Some(id_5.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&id_5),
+            (Some(id_1.clone()), Some(id_3.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&id_3),
+            (Some(id_5.clone()), Some(id_2.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&id_2),
+            (Some(id_3.clone()), Some(id_4.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&id_4),
+            (Some(id_2.clone()), None),
+        );
+
+        // Global lookup, commit_id doesn't exist. id_0 < id_1 < id_5 < id_3 < id_2 <
+        // id_4
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&CommitId::from_hex("000000")),
+            (None, Some(id_0.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&CommitId::from_hex("010000")),
+            (Some(id_1.clone()), Some(id_5.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&CommitId::from_hex("033334")),
+            (Some(id_5.clone()), Some(id_3.clone())),
+        );
+        assert_eq!(
+            composite_index.resolve_neighbor_commit_ids(&CommitId::from_hex("ffffff")),
+            (Some(id_4.clone()), None),
+        );
+    }
+
+    #[test]
+    fn shortest_unique_commit_id_prefix() {
+        let temp_dir = testutils::new_temp_dir();
+        let mut new_change_id = change_id_generator();
+        let mut index = MutableIndex::full(3);
+
+        // Create some commits with different various common prefixes.
+        let id_0 = CommitId::from_hex("000001");
+        let id_1 = CommitId::from_hex("009999");
+        let id_2 = CommitId::from_hex("055488");
+        index.add_commit_data(id_0.clone(), new_change_id(), &[]);
+        index.add_commit_data(id_1.clone(), new_change_id(), &[]);
+        index.add_commit_data(id_2.clone(), new_change_id(), &[]);
+
+        // Write the first three commits to one file and build the remainder on top.
+        let initial_file = index.save_in(temp_dir.path().to_owned()).unwrap();
+        index = MutableIndex::incremental(initial_file);
+
+        let id_3 = CommitId::from_hex("055444");
+        let id_4 = CommitId::from_hex("055555");
+        let id_5 = CommitId::from_hex("033333");
+        index.add_commit_data(id_3.clone(), new_change_id(), &[]);
+        index.add_commit_data(id_4.clone(), new_change_id(), &[]);
+        index.add_commit_data(id_5.clone(), new_change_id(), &[]);
+
+        // Public API: calculate shortest unique prefix len with known commit_id
+        assert_eq!(index.shortest_unique_commit_id_prefix_len(&id_0), 3);
+        assert_eq!(index.shortest_unique_commit_id_prefix_len(&id_1), 3);
+        assert_eq!(index.shortest_unique_commit_id_prefix_len(&id_2), 5);
+        assert_eq!(index.shortest_unique_commit_id_prefix_len(&id_3), 5);
+        assert_eq!(index.shortest_unique_commit_id_prefix_len(&id_4), 4);
+        assert_eq!(index.shortest_unique_commit_id_prefix_len(&id_5), 2);
+
+        // Public API: calculate shortest unique prefix len with unknown commit_id
+        assert_eq!(
+            index.shortest_unique_commit_id_prefix_len(&CommitId::from_hex("000002")),
+            6
+        );
+        assert_eq!(
+            index.shortest_unique_commit_id_prefix_len(&CommitId::from_hex("010000")),
+            2
+        );
+        assert_eq!(
+            index.shortest_unique_commit_id_prefix_len(&CommitId::from_hex("033334")),
+            6
+        );
+        assert_eq!(
+            index.shortest_unique_commit_id_prefix_len(&CommitId::from_hex("ffffff")),
+            1
         );
     }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
