### PR TITLE
Highlight unique prefix for each id by showing the rest of it in gray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   any parent-child relationships between them. For example, the entire tree of
   descendants of `abc` can be duplicated with `jj duplicate abc:`.
 
-* `jj log` now highlights the shortest unique prefix of every commit and change id
-  with brackets. To disable, set the new `ui.unique-prefixes` option to `none`
+* `jj log` now highlights the shortest unique prefix of every commit and change
+  id and shows the rest in gray. To disable, set the new `ui.unique-prefixes`
+  option to `none`. For a presentation that doesn't rely on color, set it to
+  `brackets`.
 
 * `jj print` was renamed to `jj cat`. `jj print` remains as an alias.
   

--- a/docs/config.md
+++ b/docs/config.md
@@ -106,13 +106,12 @@ ui.graph.style = "curved"
 ```
 
 ### Shortest unique prefixes for ids
-
 ```toml
-ui.unique-prefixes = "none"
+ui.unique-prefixes = "brackets"  # Does not rely on color
 ```
 
-Whether to highlight a unique prefix for commit & change ids. Possible values
-are `brackets` and `none` (default: `brackets`).
+Whether to highlight a unique prefix for commit & change ids. Possible
+values are `styled`, `brackets` and `none` (default: `styled`).
 
 ### Relative timestamps
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -167,7 +167,7 @@ impl UserSettings {
     pub fn unique_prefixes(&self) -> String {
         self.config
             .get_string("ui.unique-prefixes")
-            .unwrap_or_else(|_| "brackets".to_string())
+            .unwrap_or_else(|_| "styled".to_string())
     }
 
     pub fn config(&self) -> &config::Config {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1379,6 +1379,7 @@ fn log_template(settings: &UserSettings) -> String {
     // and enum similar to `ColorChoice`.
     let prefix_format = match settings.unique_prefixes().as_str() {
         "brackets" => "shortest_prefix_and_brackets()",
+        "styled" => "shortest_styled_prefix()",
         _ => "short()",
     };
     let default_template = format!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1378,7 +1378,7 @@ fn log_template(settings: &UserSettings) -> String {
     // TODO: If/when this logic is relevant in the `lib` crate, make this into
     // and enum similar to `ColorChoice`.
     let prefix_format = match settings.unique_prefixes().as_str() {
-        "brackets" => "short_prefix_and_brackets()",
+        "brackets" => "shortest_prefix_and_brackets()",
         _ => "short()",
     };
     let default_template = format!(

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -8,6 +8,13 @@
 
 "commit_id" = "blue"
 "change_id" = "magenta"
+
+# Unique prefixes and the rest for change & commit ids
+"prefix" = { bold = true}
+"rest" = "bright black"
+"divergent rest" = "red"
+"divergent prefix" = {fg = "red", underlined=true}
+
 "email" = "yellow"
 "timestamp" = "cyan"
 "working_copies" = "magenta"

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -24,7 +24,7 @@ use pest_derive::Parser;
 use crate::formatter::PlainTextFormatter;
 use crate::templater::{
     AuthorProperty, BranchProperty, ChangeIdProperty, CommitIdProperty, CommitOrChangeId,
-    CommitOrChangeIdShort, CommitOrChangeIdShortPrefixAndBrackets, CommitterProperty,
+    CommitOrChangeIdShort, CommitOrChangeIdShortestPrefixAndBrackets, CommitterProperty,
     ConditionalTemplate, ConflictProperty, DescriptionProperty, DivergentProperty,
     DynamicLabelTemplate, EmptyProperty, FormattablePropertyTemplate, GitHeadProperty,
     GitRefsProperty, IsWorkingCopyProperty, LabelTemplate, ListTemplate, Literal,
@@ -192,8 +192,8 @@ fn parse_commit_or_change_id_method<'a>(
     // TODO: validate arguments
     match name.as_str() {
         "short" => Property::String(Box::new(CommitOrChangeIdShort)),
-        "short_prefix_and_brackets" => {
-            Property::String(Box::new(CommitOrChangeIdShortPrefixAndBrackets))
+        "shortest_prefix_and_brackets" => {
+            Property::String(Box::new(CommitOrChangeIdShortestPrefixAndBrackets))
         }
         name => panic!("no such commit ID method: {name}"),
     }

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -561,6 +561,38 @@ mod tests {
     }
 }
 
+pub struct IdWithHighlightedPrefix {
+    prefix: String,
+    rest: String,
+}
+
+impl Template<()> for IdWithHighlightedPrefix {
+    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
+        formatter.with_label("prefix", |fmt| fmt.write_str(&self.prefix))?;
+        formatter.with_label("rest", |fmt| fmt.write_str(&self.rest))
+    }
+}
+
+pub struct HighlightPrefix;
+impl TemplateProperty<CommitOrChangeId<'_>> for HighlightPrefix {
+    type Output = IdWithHighlightedPrefix;
+
+    fn extract(&self, context: &CommitOrChangeId) -> Self::Output {
+        let hex = context.hex();
+        let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
+            &hex,
+            context
+                .repo
+                .shortest_unique_id_prefix_len(context.as_bytes()),
+            12,
+        );
+        IdWithHighlightedPrefix {
+            prefix: prefix.to_string(),
+            rest: rest.to_string(),
+        }
+    }
+}
+
 pub struct CommitOrChangeIdShort;
 
 impl TemplateProperty<CommitOrChangeId<'_>> for CommitOrChangeIdShort {

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -494,8 +494,18 @@ impl CommitOrChangeId<'_> {
         hex
     }
 
-    pub fn shortest_prefix_and_brackets(&self) -> String {
-        highlight_shortest_prefix_brackets(self, 12)
+    fn shortest_prefix_and_brackets(&self) -> String {
+        let hex = self.hex();
+        let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
+            &hex,
+            self.repo.shortest_unique_id_prefix_len(self.as_bytes()),
+            12 - 2,
+        );
+        if rest.is_empty() {
+            prefix.to_string()
+        } else {
+            format!("{prefix}[{rest}]")
+        }
     }
 }
 
@@ -548,20 +558,6 @@ mod tests {
             "",
         )
         "###);
-    }
-}
-
-fn highlight_shortest_prefix_brackets(id: &CommitOrChangeId, total_len: usize) -> String {
-    let hex = id.hex();
-    let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
-        &hex,
-        id.repo.shortest_unique_id_prefix_len(id.as_bytes()),
-        total_len - 2,
-    );
-    if rest.is_empty() {
-        prefix.to_string()
-    } else {
-        format!("{prefix}[{rest}]")
     }
 }
 

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -494,7 +494,7 @@ impl CommitOrChangeId<'_> {
         hex
     }
 
-    pub fn short_prefix_and_brackets(&self) -> String {
+    pub fn shortest_prefix_and_brackets(&self) -> String {
         highlight_shortest_prefix_brackets(self, 12)
     }
 }
@@ -575,13 +575,13 @@ impl TemplateProperty<CommitOrChangeId<'_>> for CommitOrChangeIdShort {
     }
 }
 
-pub struct CommitOrChangeIdShortPrefixAndBrackets;
+pub struct CommitOrChangeIdShortestPrefixAndBrackets;
 
-impl TemplateProperty<CommitOrChangeId<'_>> for CommitOrChangeIdShortPrefixAndBrackets {
+impl TemplateProperty<CommitOrChangeId<'_>> for CommitOrChangeIdShortestPrefixAndBrackets {
     type Output = String;
 
     fn extract(&self, context: &CommitOrChangeId) -> Self::Output {
-        context.short_prefix_and_brackets()
+        context.shortest_prefix_and_brackets()
     }
 }
 

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -135,7 +135,7 @@ fn test_alias_cannot_override_builtin() {
     // Alias should be ignored
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
     insta::assert_snapshot!(stdout, @r###"
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
 }

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -65,11 +65,11 @@ fn test_log_default() {
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ f[fdaa62087] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d5]
+    @ ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
     | (empty) description 1
-    o 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae]
+    o 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
     | add a file
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
 
@@ -123,22 +123,22 @@ fn test_log_default() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ [1m[38;5;13mf[fdaa62087][39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[e54178d5][39m[0m
+    @ [1m[38;5;13mf[38;5;8mfdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[38;5;8me54178d59d[39m[0m
     | [1m[38;5;10m(empty) [39mdescription 1[0m
-    o [38;5;5m9a[45c67d3e][39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4[291e264ae][39m
+    o [1m[38;5;5m9a[0m[38;5;8m45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
     | add a file
-    o [38;5;5m0[000000000][39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m0[000000000][39m
+    o [1m[38;5;5m0[0m[38;5;8m00000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
       [38;5;2m(empty) [39m(no description set)
     "###);
 
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;13mf[fdaa62087][39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[e54178d5][39m[0m
+    [1m[38;5;13mf[38;5;8mfdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[38;5;8me54178d59d[39m[0m
     [1m[38;5;10m(empty) [39mdescription 1[0m
-    [38;5;5m9a[45c67d3e][39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [38;5;4m4[291e264ae][39m
+    [1m[38;5;5m9a[0m[38;5;8m45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
     add a file
-    [38;5;5m0[000000000][39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m0[000000000][39m
+    [1m[38;5;5m0[0m[38;5;8m00000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
     [38;5;2m(empty) [39m(no description set)
     "###);
 }
@@ -154,9 +154,9 @@ fn test_log_default_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
-    @ 9[a45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 7[a17d52e63]
+    @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
     | description 1
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
 
@@ -168,22 +168,22 @@ fn test_log_default_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    o 9[a45c67d3e]?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8[979953d4c]
+    o 9a45c67d3e96?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d4c67
     | description 2
-    | @ 9[a45c67d3e]?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7[a17d52e63]
+    | @ 9a45c67d3e96?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
     |/  description 1
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    o [38;5;1m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [38;5;4m8[979953d4c][39m
+    o [1m[4m[38;5;1m9[0m[38;5;1ma45c67d3e96??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [1m[38;5;4m8[0m[38;5;8m979953d4c67[39m
     | description 2
-    | @ [1m[38;5;9m9[a45c67d3e]??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[a17d52e63][39m[0m
+    | @ [1m[4m[38;5;1m9[24ma45c67d3e96[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e633c[39m[0m
     |/  [1mdescription 1[0m
-    o [38;5;5m0[000000000][39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m0[000000000][39m
+    o [1m[38;5;5m0[0m[38;5;8m00000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
       [38;5;2m(empty) [39m(no description set)
     "###);
 }
@@ -199,11 +199,11 @@ fn test_log_git_head() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ [1m[38;5;13m8[e4fac809c][39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[0aaf4754c][39m[0m
+    @ [1m[38;5;13m8[38;5;8me4fac809cbb[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[38;5;8m0aaf4754c1e[39m[0m
     | [1minitial[0m
-    o [38;5;5m9[a45c67d3e][39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;5mHEAD@git[39m [38;5;4m23[0dd059e1][39m
+    o [1m[38;5;5m9[0m[38;5;8ma45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;5mHEAD@git[39m [1m[38;5;4m23[0m[38;5;8m0dd059e1b0[39m
     | [38;5;2m(empty) [39m(no description set)
-    o [38;5;5m0[000000000][39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [38;5;4m0[000000000][39m
+    o [1m[38;5;5m0[0m[38;5;8m00000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
       [38;5;2m(empty) [39m(no description set)
     "###);
 }

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -82,6 +82,25 @@ fn test_log_default() {
       (empty) (no description set)
     "###);
 
+    // Test default log output format with styled prefixes and color
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--color=always",
+            "--config-toml",
+            "ui.unique-prefixes='styled'",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ [1m[38;5;13mf[38;5;8mfdaa62087a2[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[38;5;8me54178d59d[39m[0m
+    | [1m[38;5;10m(empty) [39mdescription 1[0m
+    o [1m[38;5;5m9a[0m[38;5;8m45c67d3e96[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
+    | add a file
+    o [1m[38;5;5m0[0m[38;5;8m00000000000[39m  [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+      [38;5;2m(empty) [39m(no description set)
+    "###);
+
     // Test default log output format with prefixes explicitly disabled
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "--config-toml", "ui.unique-prefixes='none'"]), @r###"
     @ ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -63,7 +63,8 @@ fn test_log_default() {
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "my-branch"]);
 
     // Test default log output format
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log"]), @r###"
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
+    insta::assert_snapshot!(stdout, @r###"
     @ f[fdaa62087] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d5]
     | (empty) description 1
     o 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae]
@@ -73,7 +74,11 @@ fn test_log_default() {
     "###);
 
     // Test default log output format with bracket prefixes
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "--config-toml", "ui.unique-prefixes='brackets'"]), @r###"
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "--config-toml", "ui.unique-prefixes='brackets'"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
     @ f[fdaa62087] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d5]
     | (empty) description 1
     o 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae]
@@ -102,7 +107,11 @@ fn test_log_default() {
     "###);
 
     // Test default log output format with prefixes explicitly disabled
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "--config-toml", "ui.unique-prefixes='none'"]), @r###"
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "--config-toml", "ui.unique-prefixes='none'"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
     @ ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
     | (empty) description 1
     o 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -107,7 +107,7 @@ fn test_init_git_external() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o d[3866db7e3] git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8[d698d4a8e]
+    o d3866db7e30a git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
     ~ My commit message
     "###);
 }
@@ -150,7 +150,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o d[3866db7e3] git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8[d698d4a8e]
+    o d3866db7e30a git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
     ~ My commit message
     "###);
 }

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -294,8 +294,8 @@ fn test_log_prefix_highlight() {
     let repo_path = test_env.env_root().join("repo");
 
     let prefix_format = r#"
-      "Change " change_id.short_prefix_and_brackets() " " description.first_line()
-      " " commit_id.short_prefix_and_brackets() " " branches
+      "Change " change_id.shortest_prefix_and_brackets() " " description.first_line()
+      " " commit_id.shortest_prefix_and_brackets() " " branches
     "#;
 
     std::fs::write(repo_path.join("file"), "original file\n").unwrap();
@@ -345,8 +345,8 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     let repo_path = test_env.env_root().join("repo");
 
     let prefix_format = r#"
-      "Change " change_id.short_prefix_and_brackets() " " description.first_line()
-      " " commit_id.short_prefix_and_brackets() " " branches
+      "Change " change_id.shortest_prefix_and_brackets() " " description.first_line()
+      " " commit_id.shortest_prefix_and_brackets() " " branches
     "#;
 
     std::fs::write(repo_path.join("file"), "original file\n").unwrap();

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -30,13 +30,13 @@ fn test_obslog_with_or_without_diff() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ 8[e4fac809c] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad360]
+    @ 8e4fac809cbb test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     | my description
-    o 8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af6] conflict
+    o 8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     | my description
-    o 8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb5]
+    o 8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     | my description
-    o 8[e4fac809c] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae0]
+    o 8e4fac809cbb test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
       (empty) my description
     "###);
 
@@ -44,43 +44,43 @@ fn test_obslog_with_or_without_diff() {
     // (even even though it resulted in a conflict).
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ 8[e4fac809c] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad360]
+    @ 8e4fac809cbb test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     | my description
     | Resolved conflict in file1:
     |    1    1: <<<<<<<resolved
     |    2     : %%%%%%%
     |    3     : +bar
     |    4     : >>>>>>>
-    o 8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af6] conflict
+    o 8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     | my description
-    o 8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb5]
+    o 8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     | my description
     | Modified regular file file1:
     |    1    1: foo
     |         2: bar
     | Added regular file file2:
     |         1: foo
-    o 8[e4fac809c] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae0]
+    o 8e4fac809cbb test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
       (empty) my description
     "###);
 
     // Test `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad360]
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     my description
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af6] conflict
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     my description
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb5]
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     my description
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae0]
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
     (empty) my description
     "###);
 
     // Test `--git` format, and that it implies `-p`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:10.000 +07:00 66[b42ad360]
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     my description
     diff --git a/file1 b/file1
     index e155302a24...2ab19ae607 100644
@@ -92,9 +92,9 @@ fn test_obslog_with_or_without_diff() {
     -+bar
     ->>>>>>>
     +resolved
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 af[536e5af6] conflict
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     my description
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:09.000 +07:00 6f[bba7bcb5]
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -110,7 +110,7 @@ fn test_obslog_with_or_without_diff() {
     +++ b/file2
     @@ -1,0 +1,1 @@
     +foo
-    8[e4fac809c] test.user@example.com 2001-02-03 04:05:08.000 +07:00 e[ac0d0dae0]
+    8e4fac809cbb test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
     (empty) my description
     "###);
 }
@@ -132,25 +132,25 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    o   9a[45c67d3e] test.user@example.com 2001-02-03 04:05:10.000 +07:00 27[e721a5ba]
+    o   9a45c67d3e96 test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5ba72
     |\  squashed
     | | Modified regular file file1:
     | |    1    1: foo
     | |         2: bar
-    o | 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:09.000 +07:00 97[64e503e1]
+    o | 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
     | | first
     | | Added regular file file1:
     | |         1: foo
-    o | 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 6[9542c1984]
+    o | 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     | | (empty) first
-    o | 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:07.000 +07:00 23[0dd059e1]
+    o | 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
      /  (empty) (no description set)
-    o ff[daa62087] test.user@example.com 2001-02-03 04:05:10.000 +07:00 f[09a38899f]
+    o ffdaa62087a2 test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
     | second
     | Modified regular file file1:
     |    1    1: foo
     |         2: bar
-    o ff[daa62087] test.user@example.com 2001-02-03 04:05:09.000 +07:00 5[799653697]
+    o ffdaa62087a2 test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
       (empty) second
     "###);
 }

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -161,13 +161,13 @@ fn test_alias() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
 
@@ -263,7 +263,7 @@ fn test_bad_alias_decl() {
         .assert()
         .success();
     insta::assert_snapshot!(get_stdout_string(&assert), @r###"
-    o 0[000000000]  1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 000000000000  1970-01-01 00:00:00.000 +00:00 000000000000
       (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_stderr_string(&assert), @r###"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4123047/213904951-caccef87-3636-45b1-b503-86a4271f0cc8.png)

## Updates

The above screenshot is now slightly out of date. It's affected by a (no longer present) bug where the ids ended up 10 characters long instead of 12.

This is now rebased on top of @yuja's work. Thanks Yuya, working with the templater is so much more pleasant now!

Some of this is preparation for making the length of the short prefix configurable. I think this would work neatly
with the now-existing support for per-repository settings. 

It should also be quite doable to highlight prefixes in messages outside `jj log` (e.g. in output of `jj duplicate`).

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
