### PR TITLE
Fix output of `jj debug completion --help`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and duplicate commit no longer crashes. The fix should also resolve any remaining
   instances of https://github.com/martinvonz/jj/issues/27.
 
+* Fix the output of `jj debug completion --help` by reversing fish and zsh text.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -833,17 +833,17 @@ struct DebugCompletionArgs {
     ///
     /// Apply it by running this:
     ///
-    /// autoload -U compinit
-    /// compinit
-    /// source <(jj debug completion --zsh | sed '$d')  # remove the last line
-    /// compdef _jj jj
+    /// jj debug completion --fish | source
     #[arg(long, verbatim_doc_comment)]
     fish: bool,
     /// Print a completion script for Zsh
     ///
     /// Apply it by running this:
     ///
-    /// jj debug completion --fish | source
+    /// autoload -U compinit
+    /// compinit
+    /// source <(jj debug completion --zsh | sed '$d')  # remove the last line
+    /// compdef _jj jj
     #[arg(long, verbatim_doc_comment)]
     zsh: bool,
 }


### PR DESCRIPTION
The help strings for fish and zsh were inverted.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
