### PR TITLE
templater: remove string.short() method

### DIFF
--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -56,14 +56,6 @@ fn parse_string_literal(pair: Pair<Rule>) -> String {
     result
 }
 
-struct StringShort;
-
-impl TemplateProperty<String, String> for StringShort {
-    fn extract(&self, context: &String) -> String {
-        context.chars().take(12).collect()
-    }
-}
-
 struct StringFirstLine;
 
 impl TemplateProperty<String, String> for StringFirstLine {
@@ -188,7 +180,6 @@ fn parse_string_method<'a>(method: Pair<Rule>) -> PropertyAndLabels<'a, String> 
     // TODO: validate arguments
 
     let this_function = match name.as_str() {
-        "short" => Property::String(Box::new(StringShort)),
         "first_line" => Property::String(Box::new(StringFirstLine)),
         name => panic!("no such string method: {name}"),
     };


### PR DESCRIPTION
I think this is a remainder of 68ad712e123e "Templater: Combine Change and Commit id templates." It doesn't make sense that description.short() prints the first 12 characters.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
