### PR TITLE
cli: add transaction wrapper to prevent WorkspaceCommandHelper API misuse

### DIFF
--- a/examples/custom-command/main.rs
+++ b/examples/custom-command/main.rs
@@ -43,7 +43,7 @@ fn run_custom_command(
                 .rewrite_commit(command_helper.settings(), &commit)
                 .set_description("Frobnicated!")
                 .write()?;
-            workspace_command.finish_transaction(ui, tx)?;
+            tx.finish(ui)?;
             writeln!(
                 ui,
                 "Frobnicated revision: {}",

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -153,7 +153,7 @@ pub fn cmd_branch(
                     RefTarget::Normal(target_commit.id().clone()),
                 );
             }
-            workspace_command.finish_transaction(ui, tx)?;
+            tx.finish(ui)?;
         }
 
         BranchSubcommand::Set {
@@ -196,7 +196,7 @@ pub fn cmd_branch(
                     RefTarget::Normal(target_commit.id().clone()),
                 );
             }
-            workspace_command.finish_transaction(ui, tx)?;
+            tx.finish(ui)?;
         }
 
         BranchSubcommand::Delete { names } => {
@@ -206,7 +206,7 @@ pub fn cmd_branch(
             for branch_name in names {
                 tx.mut_repo().remove_local_branch(branch_name);
             }
-            workspace_command.finish_transaction(ui, tx)?;
+            tx.finish(ui)?;
         }
 
         BranchSubcommand::Forget { names, glob } => {
@@ -218,7 +218,7 @@ pub fn cmd_branch(
             for branch_name in names {
                 tx.mut_repo().remove_branch(&branch_name);
             }
-            workspace_command.finish_transaction(ui, tx)?;
+            tx.finish(ui)?;
         }
 
         BranchSubcommand::List => {

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -612,7 +612,7 @@ fn cmd_git_push(
         match workspace_command
             .repo()
             .view()
-            .get_wc_commit_id(&workspace_command.workspace_id())
+            .get_wc_commit_id(workspace_command.workspace_id())
         {
             None => {
                 return Err(user_error("Nothing checked out in this workspace"));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1243,7 +1243,7 @@ fn cmd_show(ui: &mut Ui, command: &CommandHelper, args: &ShowArgs) -> Result<(),
     );
     let template = crate::template_parser::parse_commit_template(
         workspace_command.repo().as_repo_ref(),
-        &workspace_command.workspace_id(),
+        workspace_command.workspace_id(),
         &template_string,
     );
     ui.request_pager();
@@ -1269,7 +1269,7 @@ fn cmd_status(
     let repo = workspace_command.repo();
     let maybe_checkout_id = repo
         .view()
-        .get_wc_commit_id(&workspace_command.workspace_id());
+        .get_wc_commit_id(workspace_command.workspace_id());
     let maybe_checkout = maybe_checkout_id
         .map(|id| repo.store().get_commit(id))
         .transpose()?;
@@ -1409,7 +1409,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
         workspace_command.parse_revset(args.revisions.as_deref().unwrap_or(&default_revset))?;
     let repo = workspace_command.repo();
     let workspace_id = workspace_command.workspace_id();
-    let checkout_id = repo.view().get_wc_commit_id(&workspace_id);
+    let checkout_id = repo.view().get_wc_commit_id(workspace_id);
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     let revset = workspace_command.evaluate_revset(&revset_expression)?;
     let revset = if !args.paths.is_empty() {
@@ -1428,7 +1428,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
     };
     let template = crate::template_parser::parse_commit_template(
         repo.as_repo_ref(),
-        &workspace_id,
+        workspace_id,
         &template_string,
     );
     let format_commit_template = |commit: &Commit, formatter: &mut dyn Formatter| {
@@ -1561,7 +1561,7 @@ fn cmd_obslog(ui: &mut Ui, command: &CommandHelper, args: &ObslogArgs) -> Result
     let wc_commit_id = workspace_command
         .repo()
         .view()
-        .get_wc_commit_id(&workspace_id);
+        .get_wc_commit_id(workspace_id);
 
     let diff_formats =
         diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch);
@@ -1572,7 +1572,7 @@ fn cmd_obslog(ui: &mut Ui, command: &CommandHelper, args: &ObslogArgs) -> Result
     };
     let template = crate::template_parser::parse_commit_template(
         workspace_command.repo().as_repo_ref(),
-        &workspace_id,
+        workspace_id,
         &template_string,
     );
 
@@ -1786,7 +1786,7 @@ fn cmd_commit(ui: &mut Ui, command: &CommandHelper, args: &CommitArgs) -> Result
     let commit_id = workspace_command
         .repo()
         .view()
-        .get_wc_commit_id(&workspace_command.workspace_id())
+        .get_wc_commit_id(workspace_command.workspace_id())
         .ok_or_else(|| user_error("This command requires a working copy"))?;
     let commit = workspace_command.repo().store().get_commit(commit_id)?;
     let description = if let Some(message) = &args.message {
@@ -1943,11 +1943,10 @@ fn cmd_edit(ui: &mut Ui, command: &CommandHelper, args: &EditArgs) -> Result<(),
     let mut workspace_command = command.workspace_helper(ui)?;
     let new_commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewriteable(&new_commit)?;
-    let workspace_id = workspace_command.workspace_id();
     if workspace_command
         .repo()
         .view()
-        .get_wc_commit_id(&workspace_id)
+        .get_wc_commit_id(workspace_command.workspace_id())
         == Some(new_commit.id())
     {
         ui.write("Already editing that commit\n")?;
@@ -3048,7 +3047,7 @@ fn cmd_workspace_add(
     let new_wc_commit = if let Some(old_checkout_id) = tx
         .base_repo()
         .view()
-        .get_wc_commit_id(&old_workspace_command.workspace_id())
+        .get_wc_commit_id(old_workspace_command.workspace_id())
     {
         tx.base_repo()
             .store()
@@ -3073,7 +3072,7 @@ fn cmd_workspace_forget(
     let workspace_id = if let Some(workspace_str) = &args.workspace {
         WorkspaceId::new(workspace_str.to_string())
     } else {
-        workspace_command.workspace_id()
+        workspace_command.workspace_id().to_owned()
     };
     if workspace_command
         .repo()

--- a/src/commands/operation.rs
+++ b/src/commands/operation.rs
@@ -166,7 +166,7 @@ pub fn cmd_op_undo(
     let bad_repo = repo_loader.load_at(&bad_op);
     let parent_repo = repo_loader.load_at(&parent_ops[0]);
     tx.mut_repo().merge(&bad_repo, &parent_repo);
-    workspace_command.finish_transaction(ui, tx)?;
+    tx.finish(ui)?;
 
     Ok(())
 }
@@ -181,7 +181,7 @@ fn cmd_op_restore(
     let mut tx = workspace_command
         .start_transaction(&format!("restore to operation {}", target_op.id().hex()));
     tx.mut_repo().set_view(target_op.view().take_store_view());
-    workspace_command.finish_transaction(ui, tx)?;
+    tx.finish(ui)?;
 
     Ok(())
 }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
