### PR TITLE
workspace: add a root subcommand to print the workspace root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by a "␛" character. That prevents them from interfering with the ANSI escapes
   jj itself writes.
 
+* `jj workspace root` prints the root path of the current workspace.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -70,7 +70,8 @@ directory together is called a "workspace". Each workspace can have a different
 commit checked out.
 
 Having multiple workspaces can be useful for running long-running tests in a one
-while you continue developing in another, for example.
+while you continue developing in another, for example. If needed,
+`jj workspace root` prints the root path of the current workspace.
 
 When you're done using a workspace, use `jj workspace forget` to make the repo
 forget about it. The files can be deleted from disk separately (either before or

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -743,6 +743,7 @@ enum WorkspaceCommands {
     Add(WorkspaceAddArgs),
     Forget(WorkspaceForgetArgs),
     List(WorkspaceListArgs),
+    Root(WorkspaceRootArgs),
     UpdateStale(WorkspaceUpdateStaleArgs),
 }
 
@@ -772,6 +773,10 @@ struct WorkspaceForgetArgs {
 /// List workspaces
 #[derive(clap::Args, Clone, Debug)]
 struct WorkspaceListArgs {}
+
+/// Show the current workspace root directory
+#[derive(clap::Args, Clone, Debug)]
+struct WorkspaceRootArgs {}
 
 /// Update a workspace that has become stale
 ///
@@ -3013,6 +3018,9 @@ fn cmd_workspace(
         WorkspaceCommands::List(command_matches) => {
             cmd_workspace_list(ui, command, command_matches)
         }
+        WorkspaceCommands::Root(command_matches) => {
+            cmd_workspace_root(ui, command, command_matches)
+        }
         WorkspaceCommands::UpdateStale(command_matches) => {
             cmd_workspace_update_stale(ui, command, command_matches)
         }
@@ -3139,6 +3147,24 @@ fn cmd_workspace_list(
         workspace_command.write_commit_summary(ui.stdout_formatter().as_mut(), &commit)?;
         writeln!(ui)?;
     }
+    Ok(())
+}
+
+fn cmd_workspace_root(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &WorkspaceRootArgs,
+) -> Result<(), CommandError> {
+    let workspace_command = command.workspace_helper(ui)?;
+    let root =
+        workspace_command
+            .workspace_root()
+            .to_str()
+            .ok_or_else(|| CommandError::UserError {
+                message: String::from("The workspace root is not valid UTF-8"),
+                hint: None,
+            })?;
+    writeln!(ui, "{root}")?;
     Ok(())
 }
 


### PR DESCRIPTION
I needed to find the root of the current workspace and couldn't find a command to do it. Please disregard if there is already a command which does that.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [X] I have added tests to cover my changes
