### PR TITLE
style: make normalize_output() take a &str instead of a String

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -84,7 +84,7 @@ impl TestEnvironment {
     /// Run a `jj` command, check that it was successful, and return its stdout
     pub fn jj_cmd_success(&self, current_dir: &Path, args: &[&str]) -> String {
         let assert = self.jj_cmd(current_dir, args).assert().success().stderr("");
-        self.normalize_output(get_stdout_string(&assert))
+        self.normalize_output(&get_stdout_string(&assert))
     }
 
     /// Run a `jj` command, check that it failed with code 1, and return its
@@ -92,7 +92,7 @@ impl TestEnvironment {
     #[must_use]
     pub fn jj_cmd_failure(&self, current_dir: &Path, args: &[&str]) -> String {
         let assert = self.jj_cmd(current_dir, args).assert().code(1).stdout("");
-        self.normalize_output(get_stderr_string(&assert))
+        self.normalize_output(&get_stderr_string(&assert))
     }
 
     /// Run a `jj` command and check that it failed with code 2 (for invalid
@@ -100,7 +100,7 @@ impl TestEnvironment {
     #[must_use]
     pub fn jj_cmd_cli_error(&self, current_dir: &Path, args: &[&str]) -> String {
         let assert = self.jj_cmd(current_dir, args).assert().code(2).stdout("");
-        self.normalize_output(get_stderr_string(&assert))
+        self.normalize_output(&get_stderr_string(&assert))
     }
 
     pub fn env_root(&self) -> &Path {
@@ -182,7 +182,7 @@ impl TestEnvironment {
         edit_script
     }
 
-    pub fn normalize_output(&self, text: String) -> String {
+    pub fn normalize_output(&self, text: &str) -> String {
         let text = text.replace("jj.exe", "jj");
         let regex = Regex::new(&format!(
             r"{}(\S+)",


### PR DESCRIPTION
I noticed it while considering using this function. I ended up not using it but the change makes a cleaner interface.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
