### PR TITLE
cleanup: update more "checkout" to "working-copy commit" and similar

### DIFF
--- a/lib/src/protos/working_copy.proto
+++ b/lib/src/protos/working_copy.proto
@@ -46,7 +46,7 @@ message Checkout {
   // The operation at which the working copy was updated.
   bytes operation_id = 2;
   // An identifier for this workspace. It is used for looking up the current
-  // checkout in the repo view. Currently a human-readable name.
+  // working-copy commit in the repo view. Currently a human-readable name.
   // TODO: Is it better to make this a UUID and a have map that to a name in
   // config? That way users can rename a workspace.
   string workspace_id = 3;

--- a/lib/src/protos/working_copy.rs
+++ b/lib/src/protos/working_copy.rs
@@ -37,7 +37,7 @@ pub struct Checkout {
     #[prost(bytes = "vec", tag = "2")]
     pub operation_id: ::prost::alloc::vec::Vec<u8>,
     /// An identifier for this workspace. It is used for looking up the current
-    /// checkout in the repo view. Currently a human-readable name.
+    /// working-copy commit in the repo view. Currently a human-readable name.
     /// TODO: Is it better to make this a UUID and a have map that to a name in
     /// config? That way users can rename a workspace.
     #[prost(string, tag = "3")]

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -779,7 +779,7 @@ impl MutableRepo {
                 && wc_commit.description().is_empty()
                 && self.view().heads().contains(wc_commit.id())
             {
-                // Abandon the checkout we're leaving if it's empty and a head commit
+                // Abandon the working-copy commit we're leaving if it's empty and a head commit
                 self.record_abandoned_commit(wc_commit_id);
             }
         }
@@ -946,31 +946,31 @@ impl MutableRepo {
     }
 
     fn merge_view(&mut self, base: &View, other: &View) {
-        // Merge checkouts. If there's a conflict, we keep the self side.
-        for (workspace_id, base_checkout) in base.wc_commit_ids() {
-            let self_checkout = self.view().get_wc_commit_id(workspace_id);
-            let other_checkout = other.get_wc_commit_id(workspace_id);
-            if other_checkout == Some(base_checkout) || other_checkout == self_checkout {
+        // Merge working-copy commits. If there's a conflict, we keep the self side.
+        for (workspace_id, base_wc_commit) in base.wc_commit_ids() {
+            let self_wc_commit = self.view().get_wc_commit_id(workspace_id);
+            let other_wc_commit = other.get_wc_commit_id(workspace_id);
+            if other_wc_commit == Some(base_wc_commit) || other_wc_commit == self_wc_commit {
                 // The other side didn't change or both sides changed in the
                 // same way.
-            } else if let Some(other_checkout) = other_checkout {
-                if self_checkout == Some(base_checkout) {
+            } else if let Some(other_wc_commit) = other_wc_commit {
+                if self_wc_commit == Some(base_wc_commit) {
                     self.view_mut()
-                        .set_wc_commit(workspace_id.clone(), other_checkout.clone());
+                        .set_wc_commit(workspace_id.clone(), other_wc_commit.clone());
                 }
             } else {
                 // The other side removed the workspace. We want to remove it even if the self
-                // side changed the checkout.
+                // side changed the working-copy commit.
                 self.view_mut().remove_wc_commit(workspace_id);
             }
         }
-        for (workspace_id, other_checkout) in other.wc_commit_ids() {
+        for (workspace_id, other_wc_commit) in other.wc_commit_ids() {
             if self.view().get_wc_commit_id(workspace_id).is_none()
                 && base.get_wc_commit_id(workspace_id).is_none()
             {
                 // The other side added the workspace.
                 self.view_mut()
-                    .set_wc_commit(workspace_id.clone(), other_checkout.clone());
+                    .set_wc_commit(workspace_id.clone(), other_wc_commit.clone());
             }
         }
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -297,7 +297,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         new_commit_ids: Vec<CommitId>,
         edit: bool,
     ) -> Result<(), BackendError> {
-        // We arbitrarily pick a new checkout among the candidates.
+        // We arbitrarily pick a new working-copy commit among the candidates.
         self.update_wc_commits(&old_commit_id, &new_commit_ids[0], edit)?;
 
         if let Some(branch_names) = self.branches.get(&old_commit_id).cloned() {

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -293,9 +293,9 @@ pub enum SnapshotError {
 
 #[derive(Debug, Error)]
 pub enum CheckoutError {
-    // The current checkout was deleted, maybe by an overly aggressive GC that happened while
-    // the current process was running.
-    #[error("Current checkout not found: {source}")]
+    // The current working-copy commit was deleted, maybe by an overly aggressive GC that happened
+    // while the current process was running.
+    #[error("Current working-copy commit not found: {source}")]
     SourceNotFound {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -333,9 +333,9 @@ fn suppress_file_exists_error(orig_err: CheckoutError) -> Result<(), CheckoutErr
 
 #[derive(Debug, Error)]
 pub enum ResetError {
-    // The current checkout was deleted, maybe by an overly aggressive GC that happened while
-    // the current process was running.
-    #[error("Current checkout not found: {source}")]
+    // The current working-copy commit was deleted, maybe by an overly aggressive GC that happened
+    // while the current process was running.
+    #[error("Current working-copy commit not found: {source}")]
     SourceNotFound {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -1167,9 +1167,10 @@ impl WorkingCopy {
         new_tree: &Tree,
     ) -> Result<CheckoutStats, CheckoutError> {
         let mut locked_wc = self.start_mutation();
-        // Check if the current checkout has changed on disk compared to what the caller
-        // expected. It's safe to check out another commit regardless, but it's
-        // probably not what  the caller wanted, so we let them know.
+        // Check if the current working-copy commit has changed on disk compared to what
+        // the caller expected. It's safe to check out another commit
+        // regardless, but it's probably not what  the caller wanted, so we let
+        // them know.
         if let Some(old_tree_id) = old_tree_id {
             if *old_tree_id != locked_wc.old_tree_id {
                 locked_wc.discard();

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -63,11 +63,11 @@ fn test_commit_parallel(use_git: bool) {
         thread.join().ok().unwrap();
     }
     let repo = repo.reload_at_head(&settings).unwrap();
-    // One commit per thread plus the commit from the initial checkout on top of the
-    // root commit
+    // One commit per thread plus the commit from the initial working-copy on top of
+    // the root commit
     assert_eq!(repo.view().heads().len(), num_threads + 1);
 
-    // One addition operation for initializing the repo, one for checking out the
+    // One additional operation for initializing the repo, one for checking out the
     // initial commit.
     assert_eq!(count_non_merge_operations(&repo), num_threads + 2);
 }
@@ -98,8 +98,8 @@ fn test_commit_parallel_instances(use_git: bool) {
     for thread in threads {
         thread.join().ok().unwrap();
     }
-    // One commit per thread plus the commit from the initial checkout on top of the
-    // root commit
+    // One commit per thread plus the commit from the initial working-copy commit on
+    // top of the root commit
     let repo = ReadonlyRepo::load_at_head(&settings, repo.repo_path(), &StoreFactories::default())
         .unwrap();
     assert_eq!(repo.view().heads().len(), num_threads + 1);

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -108,7 +108,7 @@ fn test_init_no_config_set(use_git: bool) {
 #[test_case(false ; "local backend")]
 #[test_case(true ; "git backend")]
 fn test_init_checkout(use_git: bool) {
-    // Test the contents of the checkout after init
+    // Test the contents of the working-copy commit after init
     let settings = testutils::user_settings();
     let test_workspace = TestWorkspace::init(&settings, use_git);
     let repo = &test_workspace.repo;

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -514,7 +514,7 @@ fn test_evaluate_expression_root_and_checkout(use_git: bool) {
         vec![root_commit.id().clone()]
     );
 
-    // Can find the current checkout
+    // Can find the current working-copy commit
     mut_repo
         .set_wc_commit(WorkspaceId::default(), commit1.id().clone())
         .unwrap();
@@ -673,7 +673,7 @@ fn test_evaluate_expression_parents(use_git: bool) {
     // The root commit has no parents
     assert_eq!(resolve_commit_ids(mut_repo.as_repo_ref(), "root-"), vec![]);
 
-    // Can find parents of the current checkout
+    // Can find parents of the current working-copy commit
     mut_repo
         .set_wc_commit(WorkspaceId::default(), commit2.id().clone())
         .unwrap();

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -223,8 +223,8 @@ fn test_merge_views_checkout() {
 
     let repo = repo.reload_at_head(&settings).unwrap();
 
-    // We currently arbitrarily pick the first transaction's checkout (first by
-    // transaction end time).
+    // We currently arbitrarily pick the first transaction's working-copy commit
+    // (first by transaction end time).
     assert_eq!(repo.view().get_wc_commit_id(&ws1_id), Some(commit2.id()));
     assert_eq!(repo.view().get_wc_commit_id(&ws2_id), Some(commit2.id()));
     assert_eq!(repo.view().get_wc_commit_id(&ws3_id), Some(commit3.id()));

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -617,7 +617,7 @@ fn cmd_git_push(
             None => {
                 return Err(user_error("Nothing checked out in this workspace"));
             }
-            Some(checkout) => {
+            Some(wc_commit) => {
                 fn find_branches_targeting<'a>(
                     view: &'a View,
                     target: &RefTarget,
@@ -633,11 +633,11 @@ fn cmd_git_push(
                 // Search for branches targeting @
                 let mut branches = find_branches_targeting(
                     workspace_command.repo().view(),
-                    &RefTarget::Normal(checkout.clone()),
+                    &RefTarget::Normal(wc_commit.clone()),
                 );
                 if branches.is_empty() {
                     // Try @- instead if it has exactly one parent, such as after `jj squash`
-                    let commit = workspace_command.repo().store().get_commit(checkout)?;
+                    let commit = workspace_command.repo().store().get_commit(wc_commit)?;
                     if let [parent] = commit.parent_ids() {
                         branches = find_branches_targeting(
                             workspace_command.repo().view(),

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -44,8 +44,8 @@ fn test_workspaces_add_second_workspace() {
     Added 1 files, modified 0 files, removed 0 files
     "###);
 
-    // Can see the checkout in each workspace in the log output. The "@" node in the
-    // graph indicates the current workspace's checkout.
+    // Can see the working-copy commit in each workspace in the log output. The "@"
+    // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     o 397eac932ad3c349b2659fd2eb035a4dd3da4193 second@
     | @ e0e6d5672858dc9a57ec5b772b7c4f3270ed0223 default@


### PR DESCRIPTION
I've preferred "working-copy commit" over "checkout" for a while because I think it's clearer, but there were lots of places still using "checkout". I've left "checkout" in places where it refers to the action of updating the working copy or the working-cop commit.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
