### PR TITLE
tests: make fake editor scripts initially empty

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -156,6 +156,7 @@ impl TestEnvironment {
             .as_bytes(),
         );
         let edit_script = self.env_root().join("edit_script");
+        std::fs::write(&edit_script, "").unwrap();
         self.add_env_var("EDIT_SCRIPT", edit_script.to_str().unwrap());
         edit_script
     }
@@ -178,6 +179,7 @@ impl TestEnvironment {
             .as_bytes(),
         );
         let edit_script = self.env_root().join("diff_edit_script");
+        std::fs::write(&edit_script, "").unwrap();
         self.add_env_var("DIFF_EDIT_SCRIPT", edit_script.to_str().unwrap());
         edit_script
     }

--- a/tests/test_diffedit_command.rs
+++ b/tests/test_diffedit_command.rs
@@ -184,7 +184,6 @@ fn test_diffedit_old_restore_interactive_tests() {
     let edit_script = test_env.set_up_fake_diff_editor();
 
     // Nothing happens if we make no changes
-    std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
     Nothing changed.

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -198,7 +198,6 @@ fn test_move_partial() {
     let edit_script = test_env.set_up_fake_diff_editor();
 
     // If we don't make any changes in the diff-editor, the whole change is moved
-    std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy now at: 71b69e433fbc (no description set)

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -153,7 +153,6 @@ fn test_squash_partial() {
     // If we don't make any changes in the diff-editor, the whole change is moved
     // into the parent
     let edit_script = test_env.set_up_fake_diff_editor();
-    std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -151,7 +151,6 @@ fn test_unsquash_partial() {
     // If we don't make any changes in the diff-editor, the whole change is moved
     // from the parent
     let edit_script = test_env.set_up_fake_diff_editor();
-    std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
@@ -170,7 +169,7 @@ fn test_unsquash_partial() {
 
     // Can unsquash only some changes in interactive mode
     test_env.jj_cmd_success(&repo_path, &["undo"]);
-    std::fs::write(&edit_script, "reset file1").unwrap();
+    std::fs::write(edit_script, "reset file1").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy now at: a8e8fded1021 (no description set)


### PR DESCRIPTION
I would expect `set_up_fake_[diff_]editor()` to create an empty script but it turns out they didn't even create the files. That means that the caller needs to write an empty script to them if they want the fake editors to not do anything. Let's instead write the empty scripts, for a less surprising behavior.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
