### PR TITLE
readme: add `--locked` to `cargo install` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ sudo apt-get install libssl-dev openssl pkg-config
 
 Now run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
+cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujutsu
 ```
 
 
@@ -226,7 +226,7 @@ export PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl@3/lib/pkgconfig"
 
 Now run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
+cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujutsu
 ```
 
 
@@ -234,7 +234,7 @@ cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu
 
 Run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --bin jj jujutsu --features vendored-openssl
+cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujutsu --features vendored-openssl
 ```
 
 


### PR DESCRIPTION
Our installation instructions don't currently work with Rust < 1.64 because `clap` updated their MSRV to 1.64, and `cargo install` without `--locked` bypasses `Cargo.lock` and selects the version of `clap` that needs Rust 1.64.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
