### PR TITLE
templater: eliminate redundant empty literals, fix handling of parens

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2918,7 +2918,7 @@ fn cmd_debug(
                 crate::template_parser::Rule::template,
                 &template_matches.template,
             );
-            writeln!(ui, "{parse:?}")?;
+            writeln!(ui, "{parse:#?}")?;
         }
         DebugCommands::Index(_index_matches) => {
             let workspace_command = command.workspace_helper(ui)?;

--- a/src/template.pest
+++ b/src/template.pest
@@ -36,14 +36,12 @@ term = {
   | function ~ maybe_method
   | identifier ~ maybe_method
   | literal ~ maybe_method
-  | ""
 }
 
-list = {
+list = _{
   term ~ (whitespace+ ~ term)+
 }
 
 template = {
-  list
-  | term
+  whitespace* ~ (list | term | "") ~ whitespace*
 }

--- a/src/template.pest
+++ b/src/template.pest
@@ -17,7 +17,7 @@
 // predecessors % ("predecessor: " commit_id)
 // parents % (commit_id " is a parent of " super.commit_id)
 
-whitespace = { " " | "\n" }
+whitespace = _{ " " | "\n" }
 
 escape = @{ "\\" ~ ("n" | "\"" | "\\") }
 literal_char = @{ !("\"" | "\\") ~ ANY }

--- a/src/template.pest
+++ b/src/template.pest
@@ -32,7 +32,7 @@ maybe_method = { ("." ~ function)* }
 
 // Note that "x(y)" is a function call but "x (y)" concatenates "x" and "y"
 term = {
-  ("(" ~ term ~ ")") ~ maybe_method
+  ("(" ~ template ~ ")") ~ maybe_method
   | function ~ maybe_method
   | identifier ~ maybe_method
   | literal ~ maybe_method
@@ -40,8 +40,7 @@ term = {
 }
 
 list = {
-  ("(" ~ list ~ ")")
-  | term ~ (whitespace+ ~ term)+
+  term ~ (whitespace+ ~ term)+
 }
 
 template = {

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -349,6 +349,7 @@ fn parse_commit_term<'a>(
                     name => panic!("function {name} not implemented"),
                 }
             }
+            Rule::template => parse_commit_template_rule(repo, workspace_id, expr),
             other => panic!("unexpected term: {other:?}"),
         }
     }

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -374,7 +374,7 @@ fn parse_commit_template_rule<'a>(
             }
             Box::new(ListTemplate(formatters))
         }
-        _ => Box::new(Literal(String::new())),
+        other => panic!("unexpected template rule: {other:?}"),
     }
 }
 

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -298,11 +298,8 @@ fn parse_commit_term<'a>(
                 match name {
                     "label" => {
                         let label_pair = inner.next().unwrap();
-                        let label_template = parse_commit_template_rule(
-                            repo,
-                            workspace_id,
-                            label_pair.into_inner().next().unwrap(),
-                        );
+                        let label_template =
+                            parse_commit_template_rule(repo, workspace_id, label_pair);
                         let arg_template = match inner.next() {
                             None => panic!("label() requires two arguments"),
                             Some(pair) => pair,

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -83,6 +83,36 @@ fn test_templater_parsed_tree() {
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
 
+    // Empty
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@-", "-T", r#"  "#]);
+    insta::assert_snapshot!(stdout, @"");
+
+    // Single term with whitespace
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--no-graph",
+            "-r@-",
+            "-T",
+            r#"  commit_id.short()  "#,
+        ],
+    );
+    insta::assert_snapshot!(stdout, @"000000000000");
+
+    // Multiple terms
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--no-graph",
+            "-r@-",
+            "-T",
+            r#"  commit_id.short()  empty "#,
+        ],
+    );
+    insta::assert_snapshot!(stdout, @"000000000000true");
+
     // Parenthesized single term
     let stdout = test_env.jj_cmd_success(
         &repo_path,

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -76,3 +76,30 @@ fn test_templater_branches() {
     o 000000000000 
     "###);
 }
+
+#[test]
+fn test_templater_parsed_tree() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // Parenthesized single term
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["log", "--no-graph", "-r@-", "-T", r#"(commit_id.short())"#],
+    );
+    insta::assert_snapshot!(stdout, @"000000000000");
+
+    // Parenthesized multiple terms and concatenation
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--no-graph",
+            "-r@-",
+            "-T",
+            r#"(commit_id.short() " ") empty"#,
+        ],
+    );
+    insta::assert_snapshot!(stdout, @"000000000000 true");
+}


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
