### PR TITLE
repo: inline single-caller, and surprising, `Commit::is_empty()`

### DIFF
--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -117,12 +117,6 @@ impl Commit {
         &self.data
     }
 
-    pub fn is_empty(&self) -> bool {
-        let parents = self.parents();
-        // TODO: Perhaps the root commit should also be considered empty.
-        parents.len() == 1 && parents[0].tree_id() == self.tree_id()
-    }
-
     pub fn description(&self) -> &str {
         &self.data.description
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -835,7 +835,8 @@ impl MutableRepo {
                 .store()
                 .get_commit(&wc_commit_id)
                 .map_err(EditCommitError::WorkingCopyCommitNotFound)?;
-            if wc_commit.is_empty()
+            if wc_commit.parent_ids().len() == 1
+                && wc_commit.parents()[0].tree_id() == wc_commit.tree_id()
                 && wc_commit.description().is_empty()
                 && self.view().heads().contains(wc_commit.id())
             {


### PR DESCRIPTION
I would expect `Commit::is_empty()` to check if the commit is empty in our usual sense, i.e. that there are no changes compared to the auto-merged parents. However, it would return `false` for any merge commit (and for the root commit). Since we only use it in one place, let's inline it there. The use there does seem reasonable, because it's about abandoning an "uninteresting" working-copy commit.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
