### PR TITLE
split: allow creation of empty parent or child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Commands that draw an ASCII graph (`jj log`, `jj op log`, `jj obslog`) now
   have different styles available by setting e.g. `ui.graph.style = "curved"`.
 
+* `jj split` accepts creating empty commits when given a path. `jj split .`
+  inserts an empty commit between the target commit and its children if any,
+  and `jj split any-non-existent-path` inserts an empty commit between the
+  target commit and its parents.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2557,6 +2557,7 @@ fn cmd_split(ui: &mut Ui, command: &CommandHelper, args: &SplitArgs) -> Result<(
     let mut tx =
         workspace_command.start_transaction(&format!("split commit {}", commit.id().hex()));
     let base_tree = merge_commit_trees(tx.base_repo().as_repo_ref(), &commit.parents());
+    let interactive = args.paths.is_empty();
     let instructions = format!(
         "\
 You are splitting a commit in two: {}
@@ -2574,10 +2575,10 @@ don't make any changes, then the operation will be aborted.
         &base_tree,
         &commit.tree(),
         &instructions,
-        args.paths.is_empty(),
+        interactive,
         matcher.as_ref(),
     )?;
-    if &tree_id == commit.tree_id() {
+    if &tree_id == commit.tree_id() && interactive {
         ui.write("Nothing changed.\n")?;
     } else {
         let middle_tree = tx

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -26,9 +26,9 @@ fn test_split_by_paths() {
     std::fs::write(repo_path.join("file2"), "foo").unwrap();
     std::fs::write(repo_path.join("file3"), "foo").unwrap();
 
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.short()"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "change_id.short()"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ 9d08ea8cac40
+    @ 9a45c67d3e96
     o 000000000000
     "###);
 
@@ -64,10 +64,10 @@ fn test_split_by_paths() {
     JJ: Lines starting with "JJ: " (like this one) will be removed.
     "###);
 
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.short()"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "change_id.short()"]);
     insta::assert_snapshot!(stdout, @r###"
-    @ 45833353d94e
-    o 5eebce1de3b0
+    @ ffdaa62087a2
+    o 9a45c67d3e96
     o 000000000000
     "###);
 


### PR DESCRIPTION
jj split .           => create an empty child
jj split nonexistent => create an empty parent

That would fix #881.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [X] I have added tests to cover my changes
