### PR TITLE
index_store: don't look up whole commit when only id is needed

### DIFF
--- a/lib/src/index_store.rs
+++ b/lib/src/index_store.rs
@@ -214,10 +214,14 @@ fn topo_order_earlier_first(
     let mut visited = in_parent_file;
     while let Some(commit) = commits.pop() {
         let mut waiting_for_earlier_commit = false;
-        for earlier in commit.parents().iter().chain(commit.predecessors().iter()) {
-            if !visited.contains(earlier.id()) {
+        for earlier in commit
+            .parent_ids()
+            .iter()
+            .chain(commit.predecessor_ids().iter())
+        {
+            if !visited.contains(earlier) {
                 waiting
-                    .entry(earlier.id().clone())
+                    .entry(earlier.clone())
                     .or_insert_with(Vec::new)
                     .push(commit.clone());
                 waiting_for_earlier_commit = true;


### PR DESCRIPTION
When building an initial index from an existing Git repo, for example, we walk parents and predecessors to find all commits to index. Part of that code was looking up the whole parent and predecessor commits even though it only needed the ids. I don't know if this has a measurable impact on performance, but it's not really any more complex to just get the ids anyway.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
