### PR TITLE
working_copy: write tree_state file on init

### DIFF
--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1035,12 +1035,14 @@ impl WorkingCopy {
             .open(state_path.join("checkout"))
             .unwrap();
         file.write_all(&proto.encode_to_vec()).unwrap();
+        let tree_state =
+            TreeState::init(store.clone(), working_copy_path.clone(), state_path.clone());
         WorkingCopy {
             store,
             working_copy_path,
             state_path,
             checkout_state: OnceCell::new(),
-            tree_state: OnceCell::new(),
+            tree_state: OnceCell::with_value(tree_state),
         }
     }
 


### PR DESCRIPTION
I don't think there's a good reason not to write the `.jj/working_copy/tree_state` file on init. Being able to assume that the file exists means that we won't need the store object to to lazily load the `TreeState` object. Well, except that `TreeState` keeps an `Arc<Store>`, but I'm trying to change that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
