### PR TITLE
cli: report no updates to current branch

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -645,6 +645,9 @@ fn cmd_git_push(
                         );
                     }
                 }
+                if branches.is_empty() {
+                    return Err(user_error("No current branch."));
+                }
                 for (branch_name, branch_target) in branches {
                     if !seen_branches.insert(branch_name.clone()) {
                         continue;
@@ -660,9 +663,6 @@ fn cmd_git_push(
                     }
                 }
             }
-        }
-        if branch_updates.is_empty() {
-            return Err(user_error("No current branch."));
         }
         tx = workspace_command.start_transaction(&format!(
             "push current branch(es) to git remote {}",

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -130,6 +130,16 @@ fn test_git_push_no_current_branch() {
 }
 
 #[test]
+fn test_git_push_current_branch_unchanged() {
+    let (test_env, workspace_root) = set_up();
+    test_env.jj_cmd_success(&workspace_root, &["co", "branch1"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+}
+
+#[test]
 fn test_git_push_multiple() {
     let (test_env, workspace_root) = set_up();
     test_env.jj_cmd_success(&workspace_root, &["branch", "delete", "branch1"]);


### PR DESCRIPTION
Fix a bug where `jj git push` would print "No current branch." when there is a current branch but it is unchanged. We were conflating the two because we print the message when no updates were performed, instead of only when no branches were found.
