### PR TITLE
Add ui.graph.style into config schema

### DIFF
--- a/src/commands/config-schema.json
+++ b/src/commands/config-schema.json
@@ -71,6 +71,17 @@
                     "description": "Pager to use for displaying command output",
                     "default": "less -FRX"
                 },
+                "graph": {
+                    "type": "object",
+                    "description": "Options for rendering revision graphs from jj log etc",
+                    "properties": {
+                        "style": {
+                            "description": "Style of connectors/markings used to render the graph. See https://github.com/martinvonz/jj/blob/main/docs/config.md#graph-style",
+                            "enum": ["legacy", "curved", "square", "ascii", "ascii-large"],
+                            "default": "legacy"
+                        }
+                    }
+                },
                 "editor": {
                     "type": "string",
                     "description": "Editor to use for commands that involve editing text"


### PR DESCRIPTION
This config option was recently added in #1051 (and later renamed from .format to .style), but never added to the schema.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes