### PR TITLE
formatter: rename `underlined` color config to `underline`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -76,7 +76,7 @@ for the foreground color. You can also set the background color, or make the
 text bold or underlined. For that, you need to use a table:
 
 ```toml
-colors.commit_id = { fg = "green", bg = "red", bold = true, underlined = true }
+colors.commit_id = { fg = "green", bg = "red", bold = true, underline = true }
 ```
 
 The key names are called "labels". The above used `commit_id` as label. You can
@@ -87,7 +87,7 @@ this:
 
 ```toml
 colors.commit_id = "green"
-colors."working_copy commit_id" = { underlined = true }
+colors."working_copy commit_id" = { underline = true }
 ```
 
 Parts of the style that are not overridden - such as the foreground color in the

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -13,7 +13,7 @@
 "prefix" = { bold = true}
 "rest" = "bright black"
 "divergent rest" = "red"
-"divergent prefix" = {fg = "red", underlined=true}
+"divergent prefix" = {fg = "red", underline=true}
 
 "email" = "yellow"
 "timestamp" = "cyan"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -355,7 +355,7 @@ fn rules_from_config(config: &config::Config) -> Result<Rules, config::ConfigErr
                         style.bold = Some(*value);
                     }
                 }
-                if let Some(value) = style_table.get("underlined") {
+                if let Some(value) = style_table.get("underline") {
                     if let config::ValueKind::Boolean(value) = &value.kind {
                         style.underlined = Some(*value);
                     }
@@ -598,8 +598,8 @@ mod tests {
         colors.red_fg = { fg = "red" }
         colors.blue_bg = { bg = "blue" }
         colors.bold_font = { bold = true }
-        colors.underlined_text = { underlined = true }
-        colors.multiple = { fg = "green", bg = "yellow", bold = true, underlined = true }
+        colors.underlined_text = { underline = true }
+        colors.multiple = { fg = "green", bg = "yellow", bold = true, underline = true }
         "#,
         );
         let mut output: Vec<u8> = vec![];
@@ -645,7 +645,7 @@ mod tests {
         // Test that we don't lose other attributes when we reset the bold attribute.
         let config = config_from_string(
             r#"
-        colors.not_bold = { fg = "red", bg = "blue", underlined = true }
+        colors.not_bold = { fg = "red", bg = "blue", underline = true }
         colors.bold_font = { bold = true }
         "#,
         );


### PR DESCRIPTION
I keep calling it `underline` by mistake, so that probably means that it's a more natural name for it. We haven't made a release of it yet, so I didn't mention it in the changelog.

I didn't update all variables to also use `underline`, because I felt that `underlined` was usually more natural there, plus crossterm calls it `Attribute::Underlined`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have added tests to cover my changes
