### PR TITLE
Add `--empty-parent` and `--empty-child` to `jj split`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,8 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target commit and its parents.
 
 * jj split gained new `--empty-parent` and `--empty-child` options. They
-  allow inserting an empty parent before or after an empty child after the
-  target commit.
+  allow inserting an empty parent before, or an empty child after the
+  target commit. The non-empty commit will keep the target change id.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `jj split any-non-existent-path` inserts an empty commit between the
   target commit and its parents.
 
+* jj split gained new `--empty-parent` and `--empty-child` options. They
+  allow inserting an empty parent before or after an empty child after the
+  target commit.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -203,8 +203,8 @@ fn test_split_empty_parent() {
     @ 0cffa7997ffe second original child
     | o 48523d946ad2 first original child
     |/  
-    o fdf57e73a939 |target| target_commit
-    o   d043564ef936 (empty)
+    o d043564ef936 |target| target_commit
+    o   fdf57e73a939 (empty)
     |\  
     o | 0757f5ec8418 second original parent
     | o 9a45c67d3e96 first original parent


### PR DESCRIPTION
Following the discussion in #1155, I tried an implementation of `--empty-parent` (`-P`) and `--empty-child` (`-C`) with `jj split`. They do not prompt for a description: the non-empty change keeps the original description and change id. The empty change gets an empty description and a new change id.

The fact that the non-empty commit keeps the change id when using `--empty-parent` differs from what is done with `jj split nonexistent`, but it seems more logical to me. I've done this in a separate commit as to be able to revert it easily if needed.



# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [X] I have added tests to cover my changes
