### PR TITLE
Add `--insert-after` and `--insert-before` to `jj new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj new` now also accepts a `--allow-large-revsets` argument that behaves
   similarly to `jj rebase --allow-large-revsets`.
 
+* `jj new --insert-before` inserts the new commit between the target commit and
+  its parents.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj new --insert-before` inserts the new commit between the target commit and
   its parents.
 
+* `jj new --insert-after` inserts the new commit between the target commit and
+  its children.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export


### PR DESCRIPTION
I probably missed helper functions that would have made the code prettier. The discussion is in #1155.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
