### PR TITLE
git fetch: accept several remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `remote_needle` as optional arguments and matches just the branches whose
   name contains `branch_needle` and remote contains `remote_needle`.
 
+* `jj git fetch` accepts repeated `--remote` arguments.
+
 * Default remotes can be configured for the `jj git fetch` and `jj git push`
   operations ("origin" by default) using the `git.fetch` and `git.push`
-  configuration entries.
+  configuration entries. `git.fetch` can be a list if multiple remotes must
+  be fetched from.
 
 * `jj duplicate` can now duplicate multiple changes in one go. This preserves
   any parent-child relationships between them. For example, the entire tree of

--- a/src/commands/config-schema.json
+++ b/src/commands/config-schema.json
@@ -180,6 +180,21 @@
                     "type": "boolean",
                     "description": "Whether jj creates a local branch with the same name when it imports a remote-tracking branch from git. See https://github.com/martinvonz/jj/blob/main/docs/config.md#automatic-local-branch-creation",
                     "default": true
+                },
+                "fetch": {
+                    "description": "The remote(s) from which commits are fetched",
+                    "default": "origin",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 }
             }
         },

--- a/src/commands/config-schema.json
+++ b/src/commands/config-schema.json
@@ -195,6 +195,11 @@
                             }
                         }
                     ]
+                },
+                "push": {
+                    "type": "string",
+                    "description": "The remote to which commits are pushed",
+                    "default": "origin"
                 }
             }
         },

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::path::Path;
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_git_fetch_default_remote() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    add_git_remote(&test_env, &repo_path, "origin");
+
+    test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    origin: 9f01a0e04879 message
+    "###);
+}
+
+#[test]
+fn test_git_fetch_single_remote() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    add_git_remote(&test_env, &repo_path, "rem1");
+
+    test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote", "rem1"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    rem1: 9f01a0e04879 message
+    "###);
+}
+
+#[test]
+fn test_git_fetch_single_remote_from_config() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    add_git_remote(&test_env, &repo_path, "rem1");
+    test_env.add_config(r#"git.fetch = "rem1""#);
+
+    test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    rem1: 9f01a0e04879 message
+    "###);
+}
+
+#[test]
+fn test_git_fetch_nonexistent_remote() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch", "--remote", "rem1"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: No git remote named 'rem1'
+    "###);
+    // No remote should have been fetched as part of the failing transaction
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
+}
+
+#[test]
+fn test_git_fetch_nonexistent_remote_from_config() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.add_config(r#"git.fetch = "rem1""#);
+
+    let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: No git remote named 'rem1'
+    "###);
+    // No remote should have been fetched as part of the failing transaction
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
+}
+
+/// Add a remote containing a branch with the same name
+fn add_git_remote(test_env: &TestEnvironment, repo_path: &Path, remote: &str) {
+    let git_repo_path = test_env.env_root().join(remote);
+    let git_repo = git2::Repository::init(git_repo_path).unwrap();
+    let signature =
+        git2::Signature::new("Some One", "some.one@example.com", &git2::Time::new(0, 0)).unwrap();
+    let mut tree_builder = git_repo.treebuilder(None).unwrap();
+    let file_oid = git_repo.blob(b"content").unwrap();
+    tree_builder
+        .insert("file", file_oid, git2::FileMode::Blob.into())
+        .unwrap();
+    let tree_oid = tree_builder.write().unwrap();
+    let tree = git_repo.find_tree(tree_oid).unwrap();
+    git_repo
+        .commit(
+            Some(&format!("refs/heads/{remote}")),
+            &signature,
+            &signature,
+            "message",
+            &tree,
+            &[],
+        )
+        .unwrap();
+    test_env.jj_cmd_success(
+        repo_path,
+        &["git", "remote", "add", remote, &format!("../{remote}")],
+    );
+}
+
+fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+}


### PR DESCRIPTION
The "--remote" option can be repeated, and the "git.fetch" key is now a list.

This would close #1162. I'm not sure I like the asymetry between the "git.push" configuration key, which is a string, and the "git.fetch" one, which is a list. But I understand the need to fetch from several remotes.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated `config-schema.json`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
