### PR TITLE
`jj log`: option to specify preferred id length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   option to `none`. For a presentation that doesn't rely on color, set it to
   `brackets`.
 
+* It is now possible to change the lengths of the ids `jj log` prints with the
+  new `ui.log-id-preferred-length` option.
+
 * `jj print` was renamed to `jj cat`. `jj print` remains as an alias.
   
 * In content that goes to the terminal, the ANSI escape byte (0x1b) is replaced

--- a/docs/config.md
+++ b/docs/config.md
@@ -105,13 +105,25 @@ for some examples of what's possible.
 ui.graph.style = "curved"
 ```
 
-### Shortest unique prefixes for ids
+### Display of commit and change ids
+
 ```toml
 ui.unique-prefixes = "brackets"  # Does not rely on color
 ```
 
 Whether to highlight a unique prefix for commit & change ids. Possible
 values are `styled`, `brackets` and `none` (default: `styled`).
+
+```toml
+ui.log-id-preferred-length = 6
+```
+
+Determines the number of characters displayed for `jj log` for change or commit
+ids. The default is 12. If the `ui.unique-prefixes` option is not set to `none`,
+this option will be ignored if the number of characters it specifies is
+insufficient to print the entire unique prefix of an id.
+
+This option can be convenient to set on a per-repository level.
 
 ### Relative timestamps
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -170,6 +170,13 @@ impl UserSettings {
             .unwrap_or_else(|_| "styled".to_string())
     }
 
+    pub fn log_id_preferred_length(&self) -> Option<usize> {
+        self.config
+            .get_int("ui.log-id-preferred-length")
+            .ok()
+            .and_then(|l| l.try_into().ok())
+    }
+
     pub fn config(&self) -> &config::Config {
         &self.config
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1413,12 +1413,13 @@ fn log_template(settings: &UserSettings) -> String {
     } else {
         "committer.timestamp()"
     };
+    let desired_id_len = settings.log_id_preferred_length().unwrap_or(12);
     // TODO: If/when this logic is relevant in the `lib` crate, make this into
     // and enum similar to `ColorChoice`.
     let prefix_format = match settings.unique_prefixes().as_str() {
-        "brackets" => "shortest_prefix_and_brackets()",
-        "styled" => "shortest_styled_prefix()",
-        _ => "short()",
+        "brackets" => format!("shortest_prefix_and_brackets({desired_id_len})"),
+        "styled" => format!("shortest_styled_prefix({desired_id_len})"),
+        _ => format!("short({desired_id_len})"),
     };
     let default_template = format!(
         r#"

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -86,7 +86,11 @@
                     "enum": ["none", "brackets", "styled"],
                     "description": "How formatter indicates the unique prefix part of a revision or change ID",
                     "default": "styled"
-
+                },
+                "log-id-preferred-length": {
+                    "type": "integer",
+                    "description": "Determines the number of characters displayed for `jj log` for change or commit ids.",
+                    "default": 12
                 },
                 "editor": {
                     "type": "string",

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -83,9 +83,10 @@
                     }
                 },
                 "unique-prefixes": {
-                    "enum": ["none", "brackets"],
+                    "enum": ["none", "brackets", "styled"],
                     "description": "How formatter indicates the unique prefix part of a revision or change ID",
-                    "default": "brackets"
+                    "default": "styled"
+
                 },
                 "editor": {
                     "type": "string",

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -485,10 +485,12 @@ fn parse_commit_or_change_id_method<'a, I: 'a>(
     };
     let property = match name.as_str() {
         "short" => {
-            expect_no_arguments(args_pair)?;
+            let len_property = parse_optional_integer(args_pair)?;
             Property::String(chain_properties(
-                self_property,
-                TemplatePropertyFn(|id: &CommitOrChangeId| id.short()),
+                (self_property, len_property),
+                TemplatePropertyFn(|(id, len): &(CommitOrChangeId, Option<i64>)| {
+                    id.short(len.and_then(|l| l.try_into().ok()).unwrap_or(12))
+                }),
             ))
         }
         "shortest_prefix_and_brackets" => {

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -561,9 +561,9 @@ impl<'a> CommitOrChangeId<'a> {
         hex::encode(&self.id_bytes)
     }
 
-    pub fn short(&self) -> String {
+    pub fn short(&self, total_len: usize) -> String {
         let mut hex = self.hex();
-        hex.truncate(12);
+        hex.truncate(total_len);
         hex
     }
 

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -567,12 +567,14 @@ impl<'a> CommitOrChangeId<'a> {
         hex
     }
 
-    pub fn shortest_prefix_and_brackets(&self) -> String {
+    /// The length of the id printed (not counting the brackets) will be the
+    /// maximum of `total_len` and the length of the shortest unique prefix
+    pub fn shortest_prefix_and_brackets(&self, total_len: i64) -> String {
         let hex = self.hex();
         let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
             &hex,
             self.repo.shortest_unique_id_prefix_len(self.as_bytes()),
-            12 - 2,
+            max(total_len, 0) as usize,
         );
         if rest.is_empty() {
             prefix.to_string()
@@ -581,12 +583,14 @@ impl<'a> CommitOrChangeId<'a> {
         }
     }
 
-    pub fn shortest_styled_prefix(&self) -> IdWithHighlightedPrefix {
+    /// The length of the id printed will be the maximum of `total_len` and the
+    /// length of the shortest unique prefix
+    pub fn shortest_styled_prefix(&self, total_len: i64) -> IdWithHighlightedPrefix {
         let hex = self.hex();
         let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
             &hex,
             self.repo.shortest_unique_id_prefix_len(self.as_bytes()),
-            12,
+            max(total_len, 0) as usize,
         );
         IdWithHighlightedPrefix {
             prefix: prefix.to_string(),

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -79,11 +79,29 @@ fn test_log_default() {
         &["log", "--config-toml", "ui.unique-prefixes='brackets'"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @ f[fdaa62087] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d5]
+    @ f[fdaa62087a2] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d[e54178d59d]
     | (empty) description 1
-    o 9a[45c67d3e] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae]
+    o 9a[45c67d3e96] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae97]
     | add a file
-    o 0[000000000] 1970-01-01 00:00:00.000 +00:00 0[000000000]
+    o 0[00000000000] 1970-01-01 00:00:00.000 +00:00 0[00000000000]
+      (empty) (no description set)
+    "###);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--config-toml",
+            "ui.unique-prefixes='brackets'",
+            "--config-toml",
+            "ui.log-id-preferred-length=2",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ f[f] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9d
+    | (empty) description 1
+    o 9a test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[2]
+    | add a file
+    o 0[0] 1970-01-01 00:00:00.000 +00:00 0[0]
       (empty) (no description set)
     "###);
 
@@ -105,6 +123,25 @@ fn test_log_default() {
     o [1m[38;5;5m0[0m[38;5;8m00000000000[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
       [38;5;2m(empty)[39m (no description set)
     "###);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--color=always",
+            "--config-toml",
+            "ui.unique-prefixes='styled'",
+            "--config-toml",
+            "ui.log-id-preferred-length=1",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ [1m[38;5;13mf[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9d[39m[0m
+    | [1m[38;5;10m(empty)[39m description 1[0m
+    o [1m[38;5;5m9a[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m
+    | add a file
+    o [1m[38;5;5m0[0m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m
+      [38;5;2m(empty)[39m (no description set)
+    "###);
 
     // Test default log output format with prefixes explicitly disabled
     let stdout = test_env.jj_cmd_success(
@@ -117,6 +154,24 @@ fn test_log_default() {
     o 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
     | add a file
     o 000000000000 1970-01-01 00:00:00.000 +00:00 000000000000
+      (empty) (no description set)
+    "###);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "log",
+            "--config-toml",
+            "ui.unique-prefixes='none'",
+            "--config-toml",
+            "ui.log-id-preferred-length=1",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    @ f test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9
+    | (empty) description 1
+    o 9 test.user@example.com 2001-02-03 04:05:08.000 +07:00 4
+    | add a file
+    o 0 1970-01-01 00:00:00.000 +00:00 0
       (empty) (no description set)
     "###);
 


### PR DESCRIPTION
The code is a little messy, so this is partially an RFC.

The new option is `ui.log-id-preferred-length`. Setting it to 6
is quite convenient for the `jj` repo, for example. Picture:

![image](https://user-images.githubusercontent.com/4123047/216535699-ad1e2ac8-73dd-44be-b28a-ebdebc00c63c.png)


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/commands/config-schema.json)
- [x] I have added tests to cover my changes
