### PR TITLE
init: provide more info when init fails

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -137,8 +137,21 @@ impl From<BackendError> for CommandError {
 }
 
 impl From<WorkspaceInitError> for CommandError {
-    fn from(_: WorkspaceInitError) -> Self {
-        user_error("The target repo already exists")
+    fn from(err: WorkspaceInitError) -> Self {
+        match err {
+            WorkspaceInitError::DestinationExists(_) => {
+                user_error("The target repo already exists")
+            }
+            WorkspaceInitError::NonUnicodePath => {
+                user_error("The target repo path contains non-unicode characters")
+            }
+            WorkspaceInitError::CheckOutCommit(err) => CommandError::InternalError(format!(
+                "Failed to check out the initial commit: {err}"
+            )),
+            WorkspaceInitError::Path(err) => {
+                CommandError::InternalError(format!("Failed to access the repository: {err}"))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
We classified all errors from initialization as "The target repo already exists". That's incorrect when the error came from the backend.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/commands/config-schema.json)
- [ ] I have added tests to cover my changes
