### PR TITLE
`jj rebase` and `jj new`: Allow revsets with multiple commits with new `--allow-large-revsets` argument 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Command arguments to `ui.diff-editor`/`ui.merge-editor` can now be specified
   inline without referring to `[merge-tools]` table.
 
+* `jj rebase` now accepts a new `--allow-large-revsets` argument that allows the
+  revset in the `-d` argument to expand to several revisions. For example,
+  `jj rebase -s B -d B- -d C` now works even if `B` is a merge commit.
+
+* `jj new` now also accepts a `--allow-large-revsets` argument that behaves
+  similarly to `jj rebase --allow-large-revsets`.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1412,15 +1412,20 @@ pub fn resolve_multiple_nonempty_revsets(
 pub fn resolve_base_revs(
     workspace_command: &WorkspaceCommandHelper,
     revisions: &[RevisionArg],
+    allow_plural_revsets: bool,
 ) -> Result<IndexSet<Commit>, CommandError> {
     let mut commits = IndexSet::new();
-    for revision_str in revisions {
-        let commit = workspace_command.resolve_single_rev(revision_str)?;
-        let commit_hash = short_commit_hash(commit.id());
-        if !commits.insert(commit) {
-            return Err(user_error(format!(
-                r#"More than one revset resolved to revision {commit_hash}"#,
-            )));
+    if allow_plural_revsets {
+        commits = resolve_multiple_nonempty_revsets(revisions, workspace_command)?;
+    } else {
+        for revision_str in revisions {
+            let commit = workspace_command.resolve_single_rev(revision_str)?;
+            let commit_hash = short_commit_hash(commit.id());
+            if !commits.insert(commit) {
+                return Err(user_error(format!(
+                    r#"More than one revset resolved to revision {commit_hash}"#,
+                )));
+            }
         }
     }
 

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1431,26 +1431,6 @@ pub fn resolve_mutliple_nonempty_revsets_flag_guarded(
     }
 }
 
-/// Resolves revsets into revisions to rebase onto. These revisions don't have
-/// to be rewriteable.
-pub fn resolve_destination_revs(
-    workspace_command: &WorkspaceCommandHelper,
-    revisions: &[RevisionArg],
-    allow_plural_revsets: bool,
-) -> Result<IndexSet<Commit>, CommandError> {
-    let commits = resolve_mutliple_nonempty_revsets_flag_guarded(
-        workspace_command,
-        revisions,
-        allow_plural_revsets,
-    )?;
-    let root_commit_id = workspace_command.repo().store().root_commit_id();
-    if commits.len() >= 2 && commits.iter().any(|c| c.id() == root_commit_id) {
-        Err(user_error("Cannot merge with root revision"))
-    } else {
-        Ok(commits)
-    }
-}
-
 pub fn update_working_copy(
     ui: &mut Ui,
     repo: &Arc<ReadonlyRepo>,

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -738,14 +738,15 @@ impl WorkspaceCommandHelper {
         match (iter.next(), iter.next()) {
             (Some(commit), None) => Ok(commit?),
             (None, _) => Err(user_error(format!(
-                "Revset \"{revision_str}\" didn't resolve to any revisions"
+                r#"Revset "{revision_str}" didn't resolve to any revisions"#
             ))),
             (Some(commit0), Some(commit1)) => {
                 let mut iter = [commit0, commit1].into_iter().chain(iter);
                 let commits: Vec<_> = iter.by_ref().take(5).try_collect()?;
                 let elided = iter.next().is_some();
                 let hint = format!(
-                    "The revset resolved to these revisions:\n{commits}{ellipsis}",
+                    r#"The revset "{revision_str}" resolved to these revisions:{eol}{commits}{ellipsis}"#,
+                    eol = "\n",
                     commits = commits
                         .iter()
                         .map(|c| self.format_commit_summary(c))
@@ -753,7 +754,7 @@ impl WorkspaceCommandHelper {
                     ellipsis = elided.then(|| "\n...").unwrap_or_default()
                 );
                 Err(user_error_with_hint(
-                    format!("Revset \"{revision_str}\" resolved to more than one revision"),
+                    format!(r#"Revset "{revision_str}" resolved to more than one revision"#),
                     hint,
                 ))
             }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1396,7 +1396,7 @@ fn load_revset_aliases(
     Ok(aliases_map)
 }
 
-pub fn resolve_multiple_rewritable_revsets(
+pub fn resolve_multiple_nonempty_revsets(
     revision_args: &[RevisionArg],
     workspace_command: &WorkspaceCommandHelper,
 ) -> Result<IndexSet<Commit>, CommandError> {
@@ -1404,9 +1404,6 @@ pub fn resolve_multiple_rewritable_revsets(
     for revset in revision_args {
         let revisions = workspace_command.resolve_revset(revset)?;
         workspace_command.check_non_empty(&revisions)?;
-        for commit in &revisions {
-            workspace_command.check_rewritable(commit)?;
-        }
         acc.extend(revisions);
     }
     Ok(acc)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1996,7 +1996,9 @@ fn cmd_new(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(), C
         !args.revisions.is_empty(),
         "expected a non-empty list from clap"
     );
-    let commits = resolve_base_revs(&workspace_command, &args.revisions)?;
+    let commits = resolve_base_revs(&workspace_command, &args.revisions)?
+        .into_iter()
+        .collect_vec();
     let parent_ids = commits.iter().map(|c| c.id().clone()).collect();
     let mut tx = workspace_command.start_transaction("new empty commit");
     let merged_tree = merge_commit_trees(tx.base_repo().as_repo_ref(), &commits);
@@ -2685,7 +2687,9 @@ fn cmd_merge(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(),
 
 fn cmd_rebase(ui: &mut Ui, command: &CommandHelper, args: &RebaseArgs) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let new_parents = resolve_base_revs(&workspace_command, &args.destination)?;
+    let new_parents = resolve_base_revs(&workspace_command, &args.destination)?
+        .into_iter()
+        .collect_vec();
     if let Some(rev_str) = &args.revision {
         rebase_revision(ui, command, &mut workspace_command, &new_parents, rev_str)?;
     } else if let Some(source_str) = &args.source {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,10 +45,10 @@ use maplit::{hashmap, hashset};
 use pest::Parser;
 
 use crate::cli_util::{
-    self, check_stale_working_copy, print_checkout_stats, resolve_destination_revs,
-    resolve_multiple_nonempty_revsets, run_ui_editor, serialize_config_value, short_commit_hash,
-    user_error, user_error_with_hint, Args, CommandError, CommandHelper, DescriptionArg,
-    RevisionArg, WorkspaceCommandHelper, DESCRIPTION_PLACEHOLDER_TEMPLATE,
+    self, check_stale_working_copy, print_checkout_stats, resolve_multiple_nonempty_revsets,
+    resolve_mutliple_nonempty_revsets_flag_guarded, run_ui_editor, serialize_config_value,
+    short_commit_hash, user_error, user_error_with_hint, Args, CommandError, CommandHelper,
+    DescriptionArg, RevisionArg, WorkspaceCommandHelper, DESCRIPTION_PLACEHOLDER_TEMPLATE,
 };
 use crate::config::{config_path, AnnotatedValue, ConfigSource};
 use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
@@ -1994,6 +1994,26 @@ fn cmd_edit(ui: &mut Ui, command: &CommandHelper, args: &EditArgs) -> Result<(),
         tx.finish(ui)?;
     }
     Ok(())
+}
+
+/// Resolves revsets into revisions to rebase onto. These revisions don't have
+/// to be rewriteable.
+fn resolve_destination_revs(
+    workspace_command: &WorkspaceCommandHelper,
+    revisions: &[RevisionArg],
+    allow_plural_revsets: bool,
+) -> Result<IndexSet<Commit>, CommandError> {
+    let commits = resolve_mutliple_nonempty_revsets_flag_guarded(
+        workspace_command,
+        revisions,
+        allow_plural_revsets,
+    )?;
+    let root_commit_id = workspace_command.repo().store().root_commit_id();
+    if commits.len() >= 2 && commits.iter().any(|c| c.id() == root_commit_id) {
+        Err(user_error("Cannot merge with root revision"))
+    } else {
+        Ok(commits)
+    }
 }
 
 fn cmd_new(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(), CommandError> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,10 +45,10 @@ use maplit::{hashmap, hashset};
 use pest::Parser;
 
 use crate::cli_util::{
-    self, check_stale_working_copy, print_checkout_stats, resolve_base_revs, run_ui_editor,
-    serialize_config_value, short_commit_hash, user_error, user_error_with_hint, Args,
-    CommandError, CommandHelper, DescriptionArg, RevisionArg, WorkspaceCommandHelper,
-    DESCRIPTION_PLACEHOLDER_TEMPLATE,
+    self, check_stale_working_copy, print_checkout_stats, resolve_base_revs,
+    resolve_multiple_rewritable_revsets, run_ui_editor, serialize_config_value, short_commit_hash,
+    user_error, user_error_with_hint, Args, CommandError, CommandHelper, DescriptionArg,
+    RevisionArg, WorkspaceCommandHelper, DESCRIPTION_PLACEHOLDER_TEMPLATE,
 };
 use crate::config::{config_path, AnnotatedValue, ConfigSource};
 use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
@@ -1860,22 +1860,6 @@ fn cmd_commit(ui: &mut Ui, command: &CommandHelper, args: &CommitArgs) -> Result
     }
     tx.finish(ui)?;
     Ok(())
-}
-
-fn resolve_multiple_rewritable_revsets(
-    revision_args: &[RevisionArg],
-    workspace_command: &WorkspaceCommandHelper,
-) -> Result<IndexSet<Commit>, CommandError> {
-    let mut acc = IndexSet::new();
-    for revset in revision_args {
-        let revisions = workspace_command.resolve_revset(revset)?;
-        workspace_command.check_non_empty(&revisions)?;
-        for commit in &revisions {
-            workspace_command.check_rewritable(commit)?;
-        }
-        acc.extend(revisions);
-    }
-    Ok(acc)
 }
 
 fn cmd_duplicate(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,7 +46,7 @@ use pest::Parser;
 
 use crate::cli_util::{
     self, check_stale_working_copy, print_checkout_stats, resolve_base_revs,
-    resolve_multiple_rewritable_revsets, run_ui_editor, serialize_config_value, short_commit_hash,
+    resolve_multiple_nonempty_revsets, run_ui_editor, serialize_config_value, short_commit_hash,
     user_error, user_error_with_hint, Args, CommandError, CommandHelper, DescriptionArg,
     RevisionArg, WorkspaceCommandHelper, DESCRIPTION_PLACEHOLDER_TEMPLATE,
 };
@@ -1869,7 +1869,11 @@ fn cmd_duplicate(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let to_duplicate: IndexSet<Commit> =
-        resolve_multiple_rewritable_revsets(&args.revisions, &workspace_command)?;
+        resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command)?;
+    to_duplicate
+        .iter()
+        .map(|commit| workspace_command.check_rewritable(commit))
+        .try_collect()?;
     let mut duplicated_old_to_new: IndexMap<Commit, Commit> = IndexMap::new();
 
     let mut tx = workspace_command
@@ -1922,7 +1926,11 @@ fn cmd_abandon(
     args: &AbandonArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let to_abandon = resolve_multiple_rewritable_revsets(&args.revisions, &workspace_command)?;
+    let to_abandon = resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command)?;
+    to_abandon
+        .iter()
+        .map(|commit| workspace_command.check_rewritable(commit))
+        .try_collect()?;
     let transaction_description = if to_abandon.len() == 1 {
         format!("abandon commit {}", to_abandon[0].id().hex())
     } else {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,7 +45,7 @@ use maplit::{hashmap, hashset};
 use pest::Parser;
 
 use crate::cli_util::{
-    self, check_stale_working_copy, print_checkout_stats, resolve_base_revs,
+    self, check_stale_working_copy, print_checkout_stats, resolve_destination_revs,
     resolve_multiple_nonempty_revsets, run_ui_editor, serialize_config_value, short_commit_hash,
     user_error, user_error_with_hint, Args, CommandError, CommandHelper, DescriptionArg,
     RevisionArg, WorkspaceCommandHelper, DESCRIPTION_PLACEHOLDER_TEMPLATE,
@@ -2002,7 +2002,7 @@ fn cmd_new(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(), C
         !args.revisions.is_empty(),
         "expected a non-empty list from clap"
     );
-    let commits = resolve_base_revs(
+    let commits = resolve_destination_revs(
         &workspace_command,
         &args.revisions,
         args.allow_large_revsets,
@@ -2697,7 +2697,7 @@ fn cmd_merge(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(),
 
 fn cmd_rebase(ui: &mut Ui, command: &CommandHelper, args: &RebaseArgs) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let new_parents = resolve_base_revs(
+    let new_parents = resolve_destination_revs(
         &workspace_command,
         &args.destination,
         args.allow_large_revsets,

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -65,7 +65,7 @@ fn test_checkout_not_single_rev() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "root..@"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@" resolved to more than one revision
-    Hint: The revset resolved to these revisions:
+    Hint: The revset "root..@" resolved to these revisions:
     2f8593712db5 (no description set)
     5c1afd8b074f fifth
     009f88bf7141 fourth
@@ -77,7 +77,7 @@ fn test_checkout_not_single_rev() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "root..@-"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@-" resolved to more than one revision
-    Hint: The revset resolved to these revisions:
+    Hint: The revset "root..@-" resolved to these revisions:
     5c1afd8b074f fifth
     009f88bf7141 fourth
     3fa8931e7b89 third
@@ -88,7 +88,7 @@ fn test_checkout_not_single_rev() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "@-|@--"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "@-|@--" resolved to more than one revision
-    Hint: The revset resolved to these revisions:
+    Hint: The revset "@-|@--" resolved to these revisions:
     5c1afd8b074f fifth
     009f88bf7141 fourth
     "###);

--- a/tests/test_new_command.rs
+++ b/tests/test_new_command.rs
@@ -96,7 +96,7 @@ fn test_new_merge() {
     // merge with non-unique revisions
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "@", "200e"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Revset "@" and "200e" resolved to the same revision 200ed1a14c8a
+    Error: More than one revset resolved to revision 200ed1a14c8a
     "###);
 
     // merge with root

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -320,6 +320,7 @@ fn test_rebase_multiple_destinations() {
     Hint: The revset "b|c" resolved to these revisions:
     fe2e8e8b50b3 c
     d370aee184ba b
+    If this was intentional, specify the `--allow-large-revsets` argument
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -324,7 +324,7 @@ fn test_rebase_multiple_destinations() {
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Revset "b" and "b" resolved to the same revision d370aee184ba
+    Error: More than one revset resolved to revision d370aee184ba
     "###);
 
     let stderr =

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -314,6 +314,19 @@ fn test_rebase_multiple_destinations() {
     o 
     "###);
 
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b|c"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Revset "b|c" resolved to more than one revision
+    Hint: The revset "b|c" resolved to these revisions:
+    fe2e8e8b50b3 c
+    d370aee184ba b
+    "###);
+
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Revset "b" and "b" resolved to the same revision d370aee184ba
+    "###);
+
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "root"]);
     insta::assert_snapshot!(stderr, @r###"


### PR DESCRIPTION
Eventually, we should be able to rely on `jj op restore` and the ~`--multi`~ (**Update:** `--allow-large-revsets`)
argument should likely be removed. This is a temporary measure until we figure
out https://github.com/martinvonz/jj/issues/922 and the like.

Fixes https://github.com/martinvonz/jj/issues/571

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- (N/A) I have updated the config schema (src/commands/config-schema.json)
- [x] I have added tests to cover my changes
