### PR TITLE
cli: make hints cyan instead of blue

### DIFF
--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -1,7 +1,7 @@
 [colors]
 "error" = "red"
 "warning" = "yellow"
-"hint" = "blue"
+"hint" = "cyan"
 
 "conflict_description" = "yellow"
 "conflict_description difficult" = "red"


### PR DESCRIPTION
It's hard to read dark blue on black, at least with iTerm2's default color scheme. Cyan makes it much more readable. That's the color `cargo` uses. We could also consider coloring only the "Hint:" part like `cargo` does. For errors, `cargo` colors the "Error:" part red and uses bold/bright white for select parts of the message.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/commands/config-schema.json)
- [ ] I have added tests to cover my changes
