### PR TITLE
cli: fix typo in "rewriteable"

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -817,7 +817,7 @@ impl WorkspaceCommandHelper {
         )
     }
 
-    pub fn check_rewriteable(&self, commit: &Commit) -> Result<(), CommandError> {
+    pub fn check_rewritable(&self, commit: &Commit) -> Result<(), CommandError> {
         if commit.id() == self.repo.store().root_commit_id() {
             return Err(user_error("Cannot rewrite the root commit"));
         }


### PR DESCRIPTION
It's apparently spelled without the second "e".

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/commands/config-schema.json)
- [ ] I have added tests to cover my changes
