### PR TITLE
templater: add parsing rule for integer literal, add i64 property

### DIFF
--- a/src/template.pest
+++ b/src/template.pest
@@ -32,14 +32,16 @@ function_arguments = {
   | whitespace*
 }
 
-maybe_method = { ("." ~ function)* }
-
 // Note that "x(y)" is a function call but "x (y)" concatenates "x" and "y"
+primary = _{
+  ("(" ~ template ~ ")")
+  | function
+  | identifier
+  | literal
+}
+
 term = {
-  ("(" ~ template ~ ")") ~ maybe_method
-  | function ~ maybe_method
-  | identifier ~ maybe_method
-  | literal ~ maybe_method
+  primary ~ ("." ~ function)*
 }
 
 list = _{

--- a/src/template.pest
+++ b/src/template.pest
@@ -24,7 +24,7 @@ literal_char = @{ !("\"" | "\\") ~ ANY }
 raw_literal = @{ literal_char+ }
 literal = { "\"" ~ (raw_literal | escape)* ~ "\"" }
 
-identifier = @{ (ASCII_ALPHANUMERIC | "_")+ }
+identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 function = { identifier ~ "(" ~ function_arguments ~ ")" }
 function_arguments = {

--- a/src/template.pest
+++ b/src/template.pest
@@ -24,6 +24,11 @@ literal_char = @{ !("\"" | "\\") ~ ANY }
 raw_literal = @{ literal_char+ }
 literal = { "\"" ~ (raw_literal | escape)* ~ "\"" }
 
+integer_literal = {
+  ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
+  | "0"
+}
+
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 function = { identifier ~ "(" ~ function_arguments ~ ")" }
@@ -38,6 +43,7 @@ primary = _{
   | function
   | identifier
   | literal
+  | integer_literal
 }
 
 term = {

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -83,6 +83,16 @@ impl Template<()> for bool {
     }
 }
 
+impl Template<()> for i64 {
+    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
+        write!(formatter, "{self}")
+    }
+
+    fn has_content(&self, _: &()) -> bool {
+        true
+    }
+}
+
 pub struct LabelTemplate<T, L> {
     content: T,
     labels: L,

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -151,6 +151,23 @@ fn test_templater_parse_error() {
       = Method "foo" doesn't exist for type "String"
     "###);
 
+    insta::assert_snapshot!(render_err(r#"10000000000000000000"#), @r###"
+    Error: Failed to parse template:  --> 1:1
+      |
+    1 | 10000000000000000000
+      | ^------------------^
+      |
+      = Invalid integer literal: number too large to fit in target type
+    "###);
+    insta::assert_snapshot!(render_err(r#"42.foo()"#), @r###"
+    Error: Failed to parse template:  --> 1:4
+      |
+    1 | 42.foo()
+      |    ^-^
+      |
+      = Method "foo" doesn't exist for type "Integer"
+    "###);
+
     insta::assert_snapshot!(render_err(r#"("foo" "bar").baz()"#), @r###"
     Error: Failed to parse template:  --> 1:15
       |

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -103,6 +103,9 @@ fn test_templater_parsed_tree() {
 
     // Parenthesized "if" condition
     insta::assert_snapshot!(render(r#"if((divergent), "t", "f")"#), @"f");
+
+    // Parenthesized method chaining
+    insta::assert_snapshot!(render(r#"(commit_id).short()"#), @"000000000000");
 }
 
 #[test]
@@ -146,6 +149,15 @@ fn test_templater_parse_error() {
       |                          ^-^
       |
       = Method "foo" doesn't exist for type "String"
+    "###);
+
+    insta::assert_snapshot!(render_err(r#"("foo" "bar").baz()"#), @r###"
+    Error: Failed to parse template:  --> 1:15
+      |
+    1 | ("foo" "bar").baz()
+      |               ^-^
+      |
+      = Method "baz" doesn't exist for type "Template"
     "###);
 
     insta::assert_snapshot!(render_err(r#"description.contains()"#), @r###"


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/commands/config-schema.json)
- [x] I have added tests to cover my changes
