### PR TITLE
templater: add generic wrappers for Option<TemplateProperty>

### DIFF
--- a/src/templater.rs
+++ b/src/templater.rs
@@ -210,6 +210,14 @@ impl<C, P: TemplateProperty<C> + ?Sized> TemplateProperty<C> for Box<P> {
     }
 }
 
+impl<C, P: TemplateProperty<C>> TemplateProperty<C> for Option<P> {
+    type Output = Option<P::Output>;
+
+    fn extract(&self, context: &C) -> Self::Output {
+        self.as_ref().map(|property| property.extract(context))
+    }
+}
+
 // Implement TemplateProperty for tuples
 macro_rules! tuple_impls {
     ($( ( $($n:tt $T:ident),+ ) )+) => {


### PR DESCRIPTION
Option<P> allows us to embed optional argument property in tuple.

    let maybe_arg = maybe_pair.map(|pair| parse(...))?;
    chain_properties((self, maybe_arg), |_: &(Context, Option<_>)| ...)

For one optional argument, we can instead switch the property functions:

    if let Some(pair) = maybe_pair {
        let arg = pair.map(|pair| parse(...))?;
        chain_properties((self, arg), |_: &(Context, _)| ...)
    } else {
        chain_properties(self, |_: &Context| ...)
    }

If we have various combinations of optional arguments, using Option<P> would be better.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
