### PR TITLE
commands: Implement `next` and `prev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * templates now support additional string methods `.starts_with(x)`, `.ends_with(x)`
   `.remove_prefix(x)`, `.remove_suffix(x)`, and `.substr(start, end)`.
 
+* `jj next` and `jj prev` are added, these allow you to traverse the history
+  in a linear style. For people coming from Sapling and `git-branchles`
+  see [#2126](https://github.com/martinvonz/jj/issues/2126) for 
+  further pending improvements.
+
 ### Fixed bugs
 
 * Fix issues related to .gitignore handling of untracked directories

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -86,6 +86,8 @@ fn test_alias_calls_unknown_command() {
     insta::assert_snapshot!(stderr, @r###"
     error: unrecognized subcommand 'nonexistent'
 
+      tip: a similar subcommand exists: 'next'
+
     Usage: jj [OPTIONS] [COMMAND]
 
     For more information, try '--help'.

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -1,0 +1,228 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_next_simple() {
+    // Move from first => second.
+    // first
+    // |
+    // second
+    // |
+    // third
+    //
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    // Create a simple linear history, which we'll traverse.
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    // Move to `first`
+    test_env.jj_cmd_success(&repo_path, &["new", "@--"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["next"]);
+    insta::assert_snapshot!(
+        stdout,
+        @r###"
+    Working copy now at: royxmykx f039cf03 (empty) (no description set)
+    Parent commit      : kkmpptxz 3fa8931e (empty) third
+    "###
+    );
+}
+
+#[test]
+fn test_next_multiple() {
+    // Move from first => fourth.
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "fourth"]);
+    test_env.jj_cmd_success(&repo_path, &["new", "@---"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["next", "2"]);
+    // We should now be the child of the fourth commit.
+    insta::assert_snapshot!(
+        stdout,
+        @r###"
+    Working copy now at: yqosqzyt 52a2e8c2 (empty) (no description set)
+    Parent commit      : zsuskuln 009f88bf (empty) fourth
+    "###
+    );
+}
+
+#[test]
+fn test_prev_simple() {
+    // Move from third => second.
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["prev"]);
+    // The working copy commit is now a child of "second".
+    insta::assert_snapshot!(
+        stdout,
+        @r###"
+    Working copy now at: mzvwutvl f7a0f876 (empty) (no description set)
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    "###
+    );
+}
+
+#[test]
+fn test_prev_multiple_without_root() {
+    // Move from fourth => second.
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "fourth"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["prev", "2"]);
+    insta::assert_snapshot!(
+        stdout,
+        @r###"
+    Working copy now at: royxmykx 5647d685 (empty) (no description set)
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    "###
+    );
+}
+
+#[test]
+fn test_next_exceeding_history() {
+    // Try to step beyond the current repos history.
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["edit", "-r", "@--"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "3"]);
+    // `jj next` beyond existing history fails.
+    insta::assert_snapshot!(stderr, @r###"
+    Error: No descendant found 3 commits forward
+    "###);
+}
+
+#[test]
+fn test_next_fails_on_branching_children() {
+    // TODO(#2126): Fix this behavior
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    // Create a main branch for this test
+    test_env.jj_cmd_success(&repo_path, &["branch", "set", "main"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    // Create a branching child.
+    test_env.jj_cmd_success(&repo_path, &["branch", "c", "into-the-future"]);
+    test_env.jj_cmd_success(&repo_path, &["co", "into-the-future"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "42"]);
+    test_env.jj_cmd_success(&repo_path, &["co", "main"]);
+    // Make the default branch have two possible children.
+    test_env.jj_cmd_success(&repo_path, &["new", "into-the-future", "@-"]);
+    // Try to advance the working copy commit.
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["next"]);
+    insta::assert_snapshot!(stderr,@r###"
+    Error: Cannot run `jj next` on a merge commit
+    "###);
+}
+
+#[test]
+fn test_prev_fails_on_multiple_parents() {
+    // TODO(#2126): Fix this behavior
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "c", "all-about"]);
+    test_env.jj_cmd_success(&repo_path, &["co", "all-about"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "soname"]);
+    // Create a merge commit, which has two parents.
+    test_env.jj_cmd_success(&repo_path, &["new", "@-", "@--"]);
+    // We have more than one parent, prev fails.
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["prev"]);
+    insta::assert_snapshot!(stderr,@r###"
+    Error: Cannot run `jj prev` on a merge commit
+    "###);
+}
+
+#[test]
+fn test_prev_onto_root_fails() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "fourth"]);
+    // The root commit is before "first".
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "6"]);
+    insta::assert_snapshot!(stderr,@r###"
+    Error: No ancestor found 6 commits back
+    "###);
+}
+
+#[test]
+fn test_prev_editing() {
+    // Edit the third commit.
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "fourth"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["prev", "--edit"]);
+    insta::assert_snapshot!(
+        stdout,
+        @r###"
+    Working copy now at: zsuskuln 009f88bf (empty) fourth
+    Parent commit      : kkmpptxz 3fa8931e (empty) third
+    "###
+    );
+}
+
+#[test]
+fn test_next_editing() {
+    // Edit the second commit.
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "fourth"]);
+    test_env.jj_cmd_success(&repo_path, &["edit", "@--"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["next", "--edit"]);
+    insta::assert_snapshot!(
+        stdout,
+        @r###"
+    Working copy now at: zsuskuln 009f88bf (empty) fourth
+    Parent commit      : kkmpptxz 3fa8931e (empty) third
+    "###
+    );
+}

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -444,6 +444,15 @@ impl RevsetExpression {
         })
     }
 
+    /// Ancestors of `self`, including `self` until `generation` back.
+    pub fn ancestors_at(self: &Rc<RevsetExpression>, generation: u64) -> Rc<RevsetExpression> {
+        Rc::new(RevsetExpression::Ancestors {
+            heads: self.clone(),
+            generation: generation..(generation + 1),
+            is_legacy: false,
+        })
+    }
+
     /// Children of `self`.
     pub fn children(self: &Rc<RevsetExpression>) -> Rc<RevsetExpression> {
         Rc::new(RevsetExpression::Descendants {
@@ -466,6 +475,15 @@ impl RevsetExpression {
             roots: self.clone(),
             generation: GENERATION_RANGE_FULL,
             is_legacy: true,
+        })
+    }
+
+    /// Descendants of `self`, including `self` until `generation` ahead.
+    pub fn descendants_at(self: &Rc<RevsetExpression>, generation: u64) -> Rc<RevsetExpression> {
+        Rc::new(RevsetExpression::Descendants {
+            roots: self.clone(),
+            generation: generation..(generation + 1),
+            is_legacy: false,
         })
     }
 


### PR DESCRIPTION
This is a naive implementation, which cannot deal with multiple children or parents stemming from merges.

For now I'll create a follow-up bug, which someone else can solve. 

Note: I currently gave each command separate a separate argument struct for extensibility. 

Fixes #878

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

- [x] I have updated `CHANGELOG.md`
- [n/a ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
