### PR TITLE
templater: reorganize shortest*() methods

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1424,7 +1424,7 @@ fn log_template(settings: &UserSettings) -> String {
     // TODO: If/when this logic is relevant in the `lib` crate, make this into
     // and enum similar to `ColorChoice`.
     let prefix_format = match settings.unique_prefixes().as_str() {
-        "brackets" => format!("shortest_prefix_and_brackets({desired_id_len})"),
+        "brackets" => format!("shortest({desired_id_len}).with_brackets()"),
         "styled" => format!("shortest({desired_id_len})"),
         _ => format!("short({desired_id_len})"),
     };

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1425,7 +1425,7 @@ fn log_template(settings: &UserSettings) -> String {
     // and enum similar to `ColorChoice`.
     let prefix_format = match settings.unique_prefixes().as_str() {
         "brackets" => format!("shortest_prefix_and_brackets({desired_id_len})"),
-        "styled" => format!("shortest_styled_prefix({desired_id_len})"),
+        "styled" => format!("shortest({desired_id_len})"),
         _ => format!("short({desired_id_len})"),
     };
     let default_template = format!(

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -495,7 +495,7 @@ fn parse_commit_or_change_id_method<'a, I: 'a>(
             Property::ShortestIdPrefix(chain_properties(
                 (self_property, len_property),
                 TemplatePropertyFn(|(id, len): &(CommitOrChangeId, Option<i64>)| {
-                    id.shortest(len.unwrap_or(0))
+                    id.shortest(len.and_then(|l| l.try_into().ok()).unwrap_or(0))
                 }),
             ))
         }

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -585,14 +585,14 @@ impl<'a> CommitOrChangeId<'a> {
 
     /// The length of the id printed will be the maximum of `total_len` and the
     /// length of the shortest unique prefix
-    pub fn shortest_styled_prefix(&self, total_len: i64) -> IdWithHighlightedPrefix {
+    pub fn shortest(&self, total_len: i64) -> ShortestIdPrefix {
         let hex = self.hex();
         let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
             &hex,
             self.repo.shortest_unique_id_prefix_len(self.as_bytes()),
             max(total_len, 0) as usize,
         );
-        IdWithHighlightedPrefix {
+        ShortestIdPrefix {
             prefix: prefix.to_string(),
             rest: rest.to_string(),
         }
@@ -655,12 +655,12 @@ mod tests {
     }
 }
 
-pub struct IdWithHighlightedPrefix {
+pub struct ShortestIdPrefix {
     prefix: String,
     rest: String,
 }
 
-impl Template<()> for IdWithHighlightedPrefix {
+impl Template<()> for ShortestIdPrefix {
     fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
         formatter.with_label("prefix", |fmt| fmt.write_str(&self.prefix))?;
         formatter.with_label("rest", |fmt| fmt.write_str(&self.rest))

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -567,22 +567,6 @@ impl<'a> CommitOrChangeId<'a> {
         hex
     }
 
-    /// The length of the id printed (not counting the brackets) will be the
-    /// maximum of `total_len` and the length of the shortest unique prefix
-    pub fn shortest_prefix_and_brackets(&self, total_len: i64) -> String {
-        let hex = self.hex();
-        let (prefix, rest) = extract_entire_prefix_and_trimmed_tail(
-            &hex,
-            self.repo.shortest_unique_id_prefix_len(self.as_bytes()),
-            max(total_len, 0) as usize,
-        );
-        if rest.is_empty() {
-            prefix.to_string()
-        } else {
-            format!("{prefix}[{rest}]")
-        }
-    }
-
     /// The length of the id printed will be the maximum of `total_len` and the
     /// length of the shortest unique prefix
     pub fn shortest(&self, total_len: i64) -> ShortestIdPrefix {
@@ -658,6 +642,16 @@ mod tests {
 pub struct ShortestIdPrefix {
     prefix: String,
     rest: String,
+}
+
+impl ShortestIdPrefix {
+    pub fn with_brackets(&self) -> String {
+        if self.rest.is_empty() {
+            self.prefix.clone()
+        } else {
+            format!("{}[{}]", self.prefix, self.rest)
+        }
+    }
 }
 
 impl Template<()> for ShortestIdPrefix {

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -292,8 +292,8 @@ fn test_log_prefix_highlight_brackets() {
     fn prefix_format(len: Option<usize>) -> String {
         format!(
             r#"
-      "Change " change_id.shortest_prefix_and_brackets({0}) " " description.first_line()
-      " " commit_id.shortest_prefix_and_brackets({0}) " " branches
+      "Change " change_id.shortest({0}).with_brackets() " " description.first_line()
+      " " commit_id.shortest({0}).with_brackets() " " branches
     "#,
             len.map(|l| l.to_string()).unwrap_or(String::default())
         )
@@ -508,8 +508,8 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     let repo_path = test_env.env_root().join("repo");
 
     let prefix_format = r#"
-      "Change " change_id.shortest_prefix_and_brackets(12) " " description.first_line()
-      " " commit_id.shortest_prefix_and_brackets(12) " " branches
+      "Change " change_id.shortest(12).with_brackets() " " description.first_line()
+      " " commit_id.shortest(12).with_brackets() " " branches
     "#;
 
     std::fs::write(repo_path.join("file"), "original file\n").unwrap();

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -386,8 +386,8 @@ fn test_log_prefix_highlight_styled() {
     fn prefix_format(len: Option<usize>) -> String {
         format!(
             r#"
-      "Change " change_id.shortest_styled_prefix({0}) " " description.first_line()
-      " " commit_id.shortest_styled_prefix({0}) " " branches
+      "Change " change_id.shortest({0}) " " description.first_line()
+      " " commit_id.shortest({0}) " " branches
     "#,
             len.map(|l| l.to_string()).unwrap_or(String::default())
         )

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -556,6 +556,24 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
 }
 
 #[test]
+fn test_log_shortest_length_parameter() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(0)"]), @r###"
+    @ 2
+    o 0
+    "###);
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(100)"]), @r###"
+    @ 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    o 0000000000000000000000000000000000000000
+    "###);
+}
+
+#[test]
 fn test_log_divergence() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
