### PR TITLE
revset: parse keyword arguments, accept remote_branches(remote=needle)

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -90,8 +90,8 @@ revsets (expressions) as arguments.
   `branches(push)` would match the branches `push-123` and `repushed` but not
   the branch `main`. If a branch is in a conflicted state, all its possible
   targets are included.
-* `remote_branches([branch_needle[, remote_needle]])`: All remote branch
-  targets across all remotes. If just the `branch_needle` is specified,
+* `remote_branches([branch_needle[, [remote=]remote_needle]])`: All remote
+  branch targets across all remotes. If just the `branch_needle` is specified,
   branches whose name contains the given string across all remotes are
   selected. If both `branch_needle` and `remote_needle` are specified, the
   selection is further restricted to just the remotes whose name contains
@@ -151,7 +151,7 @@ jj log -r 'remote_branches()..'
 Show commits not on `origin` (if you have other remotes like `fork`):
 
 ```
-jj log -r 'remote_branches("", origin)..'
+jj log -r 'remote_branches(remote=origin)..'
 ```
 
 Show all ancestors of the working copy (almost like plain `git log`)

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -48,21 +48,17 @@ infix_op = _{ union_op | intersection_op | difference_op | compat_add_op | compa
 
 function_name = @{ (ASCII_ALPHANUMERIC | "_")+ }
 function_arguments = {
-  whitespace* ~ expression ~ whitespace*
-  ~ ("," ~ whitespace* ~ expression ~ whitespace*)*
-  ~ ("," ~ whitespace*)?
-  | whitespace*
+  expression ~ (whitespace* ~ "," ~ whitespace* ~ expression)* ~ (whitespace* ~ ",")?
+  | ""
 }
 formal_parameters = {
-  whitespace* ~ identifier ~ whitespace*
-  ~ ("," ~ whitespace* ~ identifier ~ whitespace*)*
-  ~ ("," ~ whitespace*)?
-  | whitespace*
+  identifier ~ (whitespace* ~ "," ~ whitespace* ~ identifier)* ~ (whitespace* ~ ",")?
+  | ""
 }
 
 primary = {
-  function_name ~ "(" ~ function_arguments ~ ")"
-  | "(" ~ expression ~ ")"
+  function_name ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")"
+  | "(" ~ whitespace* ~ expression ~ whitespace* ~ ")"
   | symbol
 }
 
@@ -76,14 +72,14 @@ range_expression = _{
 }
 
 expression = {
-  whitespace* ~ (negate_op ~ whitespace*)* ~ range_expression ~ whitespace*
-  ~ (infix_op ~ whitespace* ~ (negate_op ~ whitespace*)* ~ range_expression ~ whitespace*)*
+  (negate_op ~ whitespace*)* ~ range_expression
+  ~ (whitespace* ~ infix_op ~ whitespace* ~ (negate_op ~ whitespace*)* ~ range_expression)*
 }
 
-program = _{ SOI ~ expression ~ EOI }
+program = _{ SOI ~ whitespace* ~ expression ~ whitespace* ~ EOI }
 
 alias_declaration_part = _{
-  function_name ~ "(" ~ formal_parameters ~ ")"
+  function_name ~ "(" ~ whitespace* ~ formal_parameters ~ whitespace* ~ ")"
   | identifier
 }
 alias_declaration = _{

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -47,8 +47,10 @@ compat_sub_op = { "-" }
 infix_op = _{ union_op | intersection_op | difference_op | compat_add_op | compat_sub_op }
 
 function_name = @{ (ASCII_ALPHANUMERIC | "_")+ }
+keyword_argument = { identifier ~ whitespace* ~ "=" ~ whitespace* ~ expression }
+argument = _{ keyword_argument | expression }
 function_arguments = {
-  expression ~ (whitespace* ~ "," ~ whitespace* ~ expression)* ~ (whitespace* ~ ",")?
+  argument ~ (whitespace* ~ "," ~ whitespace* ~ argument)* ~ (whitespace* ~ ",")?
   | ""
 }
 formal_parameters = {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2367,6 +2367,7 @@ mod tests {
         assert_eq!(parse("(@)-"), Ok(wc_symbol.parents()));
         // Space is allowed around expressions
         assert_eq!(parse(" :@ "), Ok(wc_symbol.ancestors()));
+        assert_eq!(parse("( :@ )"), Ok(wc_symbol.ancestors()));
         // Space is not allowed around prefix operators
         assert_eq!(parse(" : @ "), Err(RevsetParseErrorKind::SyntaxError));
         // Incomplete parse

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -76,7 +76,7 @@ fn test_bad_function_call() {
     1 | parents()
       |         ^
       |
-      = Invalid arguments to revset function "parents": Expected 1 argument
+      = Invalid arguments to revset function "parents": Expected 1 arguments
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "parents(foo, bar)"]);
@@ -86,7 +86,7 @@ fn test_bad_function_call() {
     1 | parents(foo, bar)
       |         ^------^
       |
-      = Invalid arguments to revset function "parents": Expected 1 argument
+      = Invalid arguments to revset function "parents": Expected 1 arguments
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "heads(foo, bar)"]);
@@ -96,7 +96,7 @@ fn test_bad_function_call() {
     1 | heads(foo, bar)
       |       ^------^
       |
-      = Invalid arguments to revset function "heads": Expected 0 or 1 arguments
+      = Invalid arguments to revset function "heads": Expected 0 to 1 arguments
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "file()"]);

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -138,6 +138,50 @@ fn test_bad_function_call() {
       |
       = Revset function "whatever" doesn't exist
     "###);
+
+    let stderr = test_env.jj_cmd_failure(
+        &repo_path,
+        &["log", "-r", "remote_branches(a, b, remote=c)"],
+    );
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset:  --> 1:23
+      |
+    1 | remote_branches(a, b, remote=c)
+      |                       ^------^
+      |
+      = Invalid arguments to revset function "remote_branches": Got multiple values for keyword "remote"
+    "###);
+
+    let stderr =
+        test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_branches(remote=a, b)"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset:  --> 1:27
+      |
+    1 | remote_branches(remote=a, b)
+      |                           ^
+      |
+      = Invalid arguments to revset function "remote_branches": Positional argument follows keyword argument
+    "###);
+
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_branches(=foo)"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset:  --> 1:17
+      |
+    1 | remote_branches(=foo)
+      |                 ^---
+      |
+      = expected identifier or expression
+    "###);
+
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_branches(remote=)"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset:  --> 1:24
+      |
+    1 | remote_branches(remote=)
+      |                        ^---
+      |
+      = expected expression
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
