### PR TITLE
templater: add concat() and infix concatenation operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `format_time_range()` template alias instead. For details, see
   [the documentation](docs/config.md).
 
+* Implicit concatenation of template expressions has been disabled. Use
+  `++` operator, `concat()`, or `separate()` function instead.
+  Example: `description ++ "\n"`
+
 ### New features
 
 * `jj git push --deleted` will remove all locally deleted branches from the remote.

--- a/docs/config.md
+++ b/docs/config.md
@@ -147,7 +147,7 @@ Can be customized by the `format_short_id()` template alias.
 # Just the shortest possible unique prefix
 'format_short_id(id)' = 'id.shortest()'
 # Show unique prefix and the rest surrounded by brackets
-'format_short_id(id)' = 'id.shortest(12).prefix() "[" id.shortest(12).rest() "]"'
+'format_short_id(id)' = 'id.shortest(12).prefix() ++ "[" ++ id.shortest(12).rest() ++ "]"'
 # Always show 12 characters
 'format_short_id(id)' = 'id.short(12)'
 ```
@@ -178,7 +178,7 @@ will need to modify the `format_time_range()` template alias.
 
 ```toml
 [template-aliases]
-'format_time_range(time_range)' = 'time_range.start() " - " time_range.end()'
+'format_time_range(time_range)' = 'time_range.start() ++ " - " ++ time_range.end()'
 ```
 
 ### Author format

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -1,7 +1,9 @@
 [templates]
 commit_summary = '''
-format_short_commit_id(commit_id) " "
-if(description, description.first_line(), description_placeholder)
+separate(" ",
+  format_short_commit_id(commit_id),
+  if(description, description.first_line(), description_placeholder),
+)
 '''
 
 log = '''
@@ -20,8 +22,10 @@ label(if(current_working_copy, "working_copy"),
     if(conflict, label("conflict", "conflict")),
   )
   "\n"
-  if(empty, label("empty", "(empty)") " ")
-  if(description, description.first_line(), description_placeholder)
+  separate(" ",
+    if(empty, label("empty", "(empty)")),
+    if(description, description.first_line(), description_placeholder),
+  )
   "\n"
 )
 '''

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -8,38 +8,39 @@ separate(" ",
 
 log = '''
 label(if(current_working_copy, "working_copy"),
-  separate(" ",
-    if(divergent,
-      label("divergent", format_short_change_id(change_id) "??"),
-      format_short_change_id(change_id)),
-    format_short_signature(author),
-    format_timestamp(committer.timestamp()),
-    branches,
-    tags,
-    working_copies,
-    git_head,
-    format_short_commit_id(commit_id),
-    if(conflict, label("conflict", "conflict")),
-  )
-  "\n"
-  separate(" ",
-    if(empty, label("empty", "(empty)")),
-    if(description, description.first_line(), description_placeholder),
-  )
-  "\n"
+  concat(
+    separate(" ",
+      if(divergent,
+        label("divergent", format_short_change_id(change_id) "??"),
+        format_short_change_id(change_id)),
+      format_short_signature(author),
+      format_timestamp(committer.timestamp()),
+      branches,
+      tags,
+      working_copies,
+      git_head,
+      format_short_commit_id(commit_id),
+      if(conflict, label("conflict", "conflict")),
+    ) "\n",
+    separate(" ",
+      if(empty, label("empty", "(empty)")),
+      if(description, description.first_line(), description_placeholder),
+    ) "\n",
+  ),
 )
 '''
 
 op_log = '''
 label(if(current_operation, "current_operation"),
-  separate(" ",
-    id.short(),
-    user,
-    format_time_range(time),
-  )
-  "\n"
-  description.first_line() "\n"
-  tags
+  concat(
+    separate(" ",
+      id.short(),
+      user,
+      format_time_range(time),
+    ) "\n",
+    description.first_line() "\n",
+    tags,
+  ),
 )
 '''
 
@@ -61,11 +62,13 @@ show = 'show'
 # TODO: Add branches, tags, etc
 # TODO: Indent the description like Git does
 'show' = '''
-"Commit ID: " commit_id "\n"
-"Change ID: " change_id "\n"
-"Author: " author " (" format_timestamp(author.timestamp()) ")\n"
-"Committer: " committer " (" format_timestamp(committer.timestamp()) ")\n"
-"\n"
-if(description, description, description_placeholder "\n")
-"\n"
+concat(
+  "Commit ID: " commit_id "\n",
+  "Change ID: " change_id "\n",
+  "Author: " author " (" format_timestamp(author.timestamp()) ")\n",
+  "Committer: " committer " (" format_timestamp(committer.timestamp()) ")\n",
+  "\n",
+  if(description, description, description_placeholder "\n"),
+  "\n",
+)
 '''

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -11,7 +11,7 @@ label(if(current_working_copy, "working_copy"),
   concat(
     separate(" ",
       if(divergent,
-        label("divergent", format_short_change_id(change_id) "??"),
+        label("divergent", format_short_change_id(change_id) ++ "??"),
         format_short_change_id(change_id)),
       format_short_signature(author),
       format_timestamp(committer.timestamp()),
@@ -21,11 +21,11 @@ label(if(current_working_copy, "working_copy"),
       git_head,
       format_short_commit_id(commit_id),
       if(conflict, label("conflict", "conflict")),
-    ) "\n",
+    ) ++ "\n",
     separate(" ",
       if(empty, label("empty", "(empty)")),
       if(description, description.first_line(), description_placeholder),
-    ) "\n",
+    ) ++ "\n",
   ),
 )
 '''
@@ -37,8 +37,8 @@ label(if(current_operation, "current_operation"),
       id.short(),
       user,
       format_time_range(time),
-    ) "\n",
-    description.first_line() "\n",
+    ) ++ "\n",
+    description.first_line() ++ "\n",
     tags,
   ),
 )
@@ -56,19 +56,19 @@ show = 'show'
 'format_short_commit_id(id)' = 'format_short_id(id)'
 'format_short_signature(signature)' = 'signature.email()'
 'format_time_range(time_range)' = '''
-  time_range.start().ago() label("time", ", lasted ") time_range.duration()'''
+  time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp'
 
 # TODO: Add branches, tags, etc
 # TODO: Indent the description like Git does
 'show' = '''
 concat(
-  "Commit ID: " commit_id "\n",
-  "Change ID: " change_id "\n",
-  "Author: " author " (" format_timestamp(author.timestamp()) ")\n",
-  "Committer: " committer " (" format_timestamp(committer.timestamp()) ")\n",
+  "Commit ID: " ++ commit_id ++ "\n",
+  "Change ID: " ++ change_id ++ "\n",
+  "Author: " ++ author ++ " (" ++ format_timestamp(author.timestamp()) ++ ")\n",
+  "Committer: " ++ committer ++ " (" ++ format_timestamp(committer.timestamp()) ++ ")\n",
   "\n",
-  if(description, description, description_placeholder "\n"),
+  if(description, description, description_placeholder ++ "\n"),
   "\n",
 )
 '''

--- a/src/template.pest
+++ b/src/template.pest
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // Example:
-// "commit: " short(commit_id) "\n"
-// predecessors % ("predecessor: " commit_id)
-// parents % (commit_id " is a parent of " super.commit_id)
+// "commit: " ++ short(commit_id) ++ "\n"
+// predecessors % ("predecessor: " ++ commit_id)
+// parents % (commit_id ++ " is a parent of " ++ super.commit_id)
 
 whitespace = _{ " " | "\n" }
 
@@ -41,7 +41,6 @@ formal_parameters = {
   | ""
 }
 
-// Note that "x(y)" is a function call but "x (y)" concatenates "x" and "y"
 primary = _{
   ("(" ~ whitespace* ~ template ~ whitespace* ~ ")")
   | function
@@ -55,7 +54,7 @@ term = {
 }
 
 list = _{
-  term ~ (whitespace+ ~ term)+
+  term ~ (whitespace* ~ "++" ~ whitespace* ~ term)+
 }
 
 template = { list | term }

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -1068,6 +1068,15 @@ fn build_global_function<'a, L: TemplateLanguage<'a>>(
             ));
             Expression::Template(template)
         }
+        "concat" => {
+            let contents = function
+                .args
+                .iter()
+                .map(|node| build_expression(language, node).map(|x| x.into_template()))
+                .try_collect()?;
+            let template = Box::new(ListTemplate(contents));
+            Expression::Template(template)
+        }
         "separate" => {
             let ([separator_node], content_nodes) = expect_some_arguments(function)?;
             let separator = build_expression(language, separator_node)?.into_template();

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -102,5 +102,6 @@ fn test_branch_forget_glob() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    test_env.jj_cmd_success(cwd, &["log", "-T", r#"branches " " commit_id.short()"#])
+    let template = r#"branches " " commit_id.short()"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -102,6 +102,6 @@ fn test_branch_forget_glob() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"branches " " commit_id.short()"#;
+    let template = r#"branches ++ " " ++ commit_id.short()"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -100,5 +100,6 @@ fn test_checkout_not_single_rev() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    test_env.jj_cmd_success(cwd, &["log", "-T", r#"commit_id " " description"#])
+    let template = r#"commit_id " " description"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -100,6 +100,6 @@ fn test_checkout_not_single_rev() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"commit_id " " description"#;
+    let template = r#"commit_id ++ " " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_commit_command.rs
+++ b/tests/test_commit_command.rs
@@ -89,5 +89,6 @@ fn test_commit_without_working_copy() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    test_env.jj_cmd_success(cwd, &["log", "-T", r#"commit_id.short() " " description"#])
+    let template = r#"commit_id.short() " " description"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_commit_command.rs
+++ b/tests/test_commit_command.rs
@@ -89,6 +89,6 @@ fn test_commit_without_working_copy() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"commit_id.short() " " description"#;
+    let template = r#"commit_id.short() ++ " " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -43,15 +43,8 @@ fn test_log_author_timestamp_ago() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
 
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &[
-            "log",
-            "--no-graph",
-            "-T",
-            r#"author.timestamp().ago() "\\n""#,
-        ],
-    );
+    let template = r#"author.timestamp().ago() "\n""#;
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T", template]);
     let line_re = Regex::new(r"[0-9]+ years ago").unwrap();
     assert!(
         stdout.lines().all(|x| line_re.is_match(x)),
@@ -184,7 +177,7 @@ fn test_log_customize_short_id() {
         &[
             "log",
             "--config-toml",
-            &format!("{decl}='id.shortest(5).prefix().upper() \"_\" id.shortest(5).rest()'"),
+            &format!(r#"{decl}='id.shortest(5).prefix().upper() "_" id.shortest(5).rest()'"#),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -43,7 +43,7 @@ fn test_log_author_timestamp_ago() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
 
-    let template = r#"author.timestamp().ago() "\n""#;
+    let template = r#"author.timestamp().ago() ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T", template]);
     let line_re = Regex::new(r"[0-9]+ years ago").unwrap();
     assert!(
@@ -177,7 +177,7 @@ fn test_log_customize_short_id() {
         &[
             "log",
             "--config-toml",
-            &format!(r#"{decl}='id.shortest(5).prefix().upper() "_" id.shortest(5).rest()'"#),
+            &format!(r#"{decl}='id.shortest(5).prefix().upper() ++ "_" ++ id.shortest(5).rest()'"#),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use crate::common::TestEnvironment;
 
 pub mod common;
@@ -69,8 +71,7 @@ fn test_concurrent_operations_auto_rebase() {
     );
 
     // We should be informed about the concurrent modification
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id \" \" description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
     o  3f06323826b4a293a9ee6d24cc0e07ad2961b5d5 new child
@@ -101,8 +102,7 @@ fn test_concurrent_operations_wc_modified() {
     std::fs::write(repo_path.join("file"), "modified\n").unwrap();
 
     // We should be informed about the concurrent modification
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id \" \" description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     Concurrent modification detected, resolving automatically.
     @  4eb0610031b7cd148ff9f729a673a3f815033170 new child1
     │ o  4b20e61d23ee7d7c4d5e61e11e97c26e716f9c30 new child2
@@ -135,4 +135,9 @@ fn test_concurrent_operations_wc_modified() {
     o  add workspace 'default'
     o  initialize repo
     "###);
+}
+
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+    let template = r#"commit_id " " description"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -138,6 +138,6 @@ fn test_concurrent_operations_wc_modified() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"commit_id " " description"#;
+    let template = r#"commit_id ++ " " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -322,23 +322,12 @@ fn test_rebase_duplicates() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(
-        repo_path,
-        &[
-            "log",
-            "-T",
-            r#"commit_id.short() "   " description.first_line()"#,
-        ],
-    )
+    let template = r#"commit_id.short() "   " description.first_line()"#;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
 fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(
-        repo_path,
-        &[
-            "log",
-            "-T",
-            r#"commit_id.short() "   " description.first_line() " @ " committer.timestamp()"#,
-        ],
-    )
+    let template =
+        r#"commit_id.short() "   " description.first_line() " @ " committer.timestamp()"#;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -322,12 +322,13 @@ fn test_rebase_duplicates() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let template = r#"commit_id.short() "   " description.first_line()"#;
+    let template = r#"commit_id.short() ++ "   " ++ description.first_line()"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
 fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let template =
-        r#"commit_id.short() "   " description.first_line() " @ " committer.timestamp()"#;
+    let template = r###"
+    commit_id.short() ++ "   " ++ description.first_line() ++ " @ " ++ committer.timestamp()
+    "###;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -109,7 +109,8 @@ fn read_file(path: &Path) -> String {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    test_env.jj_cmd_success(cwd, &["log", "-T", r#"commit_id.short() " " description"#])
+    let template = r#"commit_id.short() " " description"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 
 #[test]

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -109,7 +109,7 @@ fn read_file(path: &Path) -> String {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"commit_id.short() " " description"#;
+    let template = r#"commit_id.short() ++ " " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -292,28 +292,28 @@ fn test_git_colocated_squash_undo() {
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     o  qpvuntsmwlqt 2f376ea1478c A master !divergence!
     │ @  rlvkpnrzqnoo 8f71e3b6a3be
-    │ o  qpvuntsmwlqt a86754f975f9 A  !divergence!
+    │ o  qpvuntsmwlqt a86754f975f9 A !divergence!
     ├─╯
     o  zzzzzzzzzzzz 000000000000
     "###);
 }
 
 fn get_log_output_divergence(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(
-        repo_path,
-        &[
-            "log",
-            "-T",
-            r#"change_id.short() " " commit_id.short() " " description.first_line() " " branches if(divergent, " !divergence!")"#,
-        ],
+    let template = r###"
+    separate(" ",
+      change_id.short(),
+      commit_id.short(),
+      description.first_line(),
+      branches,
+      if(divergent, "!divergence!"),
     )
+    "###;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
 fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
-    test_env.jj_cmd_success(
-        workspace_root,
-        &["log", "-T", "commit_id \" \" branches", "-r=all()"],
-    )
+    let template = r#"commit_id " " branches"#;
+    test_env.jj_cmd_success(workspace_root, &["log", "-T", template, "-r=all()"])
 }
 
 #[test]

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -312,7 +312,7 @@ fn get_log_output_divergence(test_env: &TestEnvironment, repo_path: &Path) -> St
 }
 
 fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
-    let template = r#"commit_id " " branches"#;
+    let template = r#"commit_id ++ " " ++ branches"#;
     test_env.jj_cmd_success(workspace_root, &["log", "-T", template, "-r=all()"])
 }
 

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -64,7 +64,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
 }
 
 fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
-    let template = r#"commit_id.short() " " description.first_line() " " branches"#;
+    let template = r#"commit_id.short() ++ " " ++ description.first_line() ++ " " ++ branches"#;
     test_env.jj_cmd_success(workspace_root, &["log", "-T", template, "-r", "all()"])
 }
 

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -64,16 +64,8 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
 }
 
 fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
-    test_env.jj_cmd_success(
-        workspace_root,
-        &[
-            "log",
-            "-T",
-            r#"commit_id.short() " " description.first_line() " " branches"#,
-            "-r",
-            "all()",
-        ],
-    )
+    let template = r#"commit_id.short() " " description.first_line() " " branches"#;
+    test_env.jj_cmd_success(workspace_root, &["log", "-T", template, "-r", "all()"])
 }
 
 #[test]

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -297,7 +297,7 @@ fn test_log_shortest_accessors() {
     test_env.add_config(
         r###"
         [template-aliases]
-        'format_id(id)' = 'id.shortest(12).prefix() "[" id.shortest(12).rest() "]"'
+        'format_id(id)' = 'id.shortest(12).prefix() ++ "[" ++ id.shortest(12).rest() ++ "]"'
         "###,
     );
 
@@ -305,7 +305,7 @@ fn test_log_shortest_accessors() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "initial"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "c", "original"]);
     insta::assert_snapshot!(
-        render("original", r#"format_id(change_id) " " format_id(commit_id)"#),
+        render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
         @"q[pvuntsmwlqt] b[a1a30916d29]");
 
     // Create a chain of 10 commits
@@ -319,11 +319,11 @@ fn test_log_shortest_accessors() {
     }
 
     insta::assert_snapshot!(
-        render("original", r#"format_id(change_id) " " format_id(commit_id)"#),
+        render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
         @"qpv[untsmwlqt] ba1[a30916d29]");
 
     insta::assert_snapshot!(
-        render(":@", r#"change_id.shortest() " " commit_id.shortest() "\n""#),
+        render(":@", r#"change_id.shortest() ++ " " ++ commit_id.shortest() ++ "\n""#),
         @r###"
     wq 03
     km f7
@@ -339,7 +339,7 @@ fn test_log_shortest_accessors() {
     "###);
 
     insta::assert_snapshot!(
-        render(":@", r#"format_id(change_id) " " format_id(commit_id) "\n""#),
+        render(":@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
         @r###"
     wq[nwkozpkust] 03[f51310b83e]
     km[kuslswpqwq] f7[7fb1909080]
@@ -494,7 +494,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     test_env.add_config(
         r###"
         [template-aliases]
-        'format_id(id)' = 'id.shortest(12).prefix() "[" id.shortest(12).rest() "]"'
+        'format_id(id)' = 'id.shortest(12).prefix() ++ "[" ++ id.shortest(12).rest() ++ "]"'
         "###,
     );
 
@@ -609,7 +609,7 @@ fn test_log_divergence() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
-    let template = r#"description.first_line() if(divergent, " !divergence!")"#;
+    let template = r#"description.first_line() ++ if(divergent, " !divergence!")"#;
 
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description 1"]);

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -320,7 +320,8 @@ fn test_move_partial() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    test_env.jj_cmd_success(cwd, &["log", "-T", r#"commit_id.short() " " branches"#])
+    let template = r#"commit_id.short() " " branches"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 
 #[test]

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -320,7 +320,7 @@ fn test_move_partial() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"commit_id.short() " " branches"#;
+    let template = r#"commit_id.short() ++ " " ++ branches"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 

--- a/tests/test_new_command.rs
+++ b/tests/test_new_command.rs
@@ -299,7 +299,7 @@ fn test_new_insert_before_no_loop() {
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    let template = r#"commit_id.short() " " if(description, description, "root")"#;
+    let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @    7705d353bf5d F
@@ -403,7 +403,7 @@ fn setup_before_insertion(test_env: &TestEnvironment, repo_path: &Path) {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let template = r#"commit_id " " description"#;
+    let template = r#"commit_id ++ " " ++ description"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 

--- a/tests/test_new_command.rs
+++ b/tests/test_new_command.rs
@@ -299,14 +299,8 @@ fn test_new_insert_before_no_loop() {
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &[
-            "log",
-            "-T",
-            r#"commit_id.short() " " if(description, description, "root")"#,
-        ],
-    );
+    let template = r#"commit_id.short() " " if(description, description, "root")"#;
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @    7705d353bf5d F
     ├─╮
@@ -409,12 +403,11 @@ fn setup_before_insertion(test_env: &TestEnvironment, repo_path: &Path) {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["log", "-T", "commit_id \" \" description"])
+    let template = r#"commit_id " " description"#;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
 fn get_short_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(
-        repo_path,
-        &["log", "-T", r#"if(description, description, "root")"#],
-    )
+    let template = r#"if(description, description, "root")"#;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -135,13 +135,13 @@ fn test_op_log_template() {
     let repo_path = test_env.env_root().join("repo");
     let render = |template| test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
 
-    insta::assert_snapshot!(render(r#"id "\n""#), @r###"
+    insta::assert_snapshot!(render(r#"id ++ "\n""#), @r###"
     @  a99a3fd5c51e8f7ccb9ae2f9fb749612a23f0a7cf25d8c644f36c35c077449ce3c66f49d098a5a704ca5e47089a7f019563a5b8cbc7d451619e0f90c82241ceb
     o  56b94dfc38e7d54340377f566e96ab97dc6163ea7841daf49fb2e1d1ceb27e26274db1245835a1a421fb9d06e6e0fe1e4f4aa1b0258c6e86df676ad9111d0dab
     "###);
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
-                                time.start(), time.end(), time.duration()) "\n""#), @r###"
+                                time.start(), time.end(), time.duration()) ++ "\n""#), @r###"
     @  a99a3 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     o  56b94 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     "###);

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -136,6 +136,6 @@ fn test_split_by_paths() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"change_id.short() " " empty"#;
+    let template = r#"change_id.short() ++ " " ++ empty"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -233,7 +233,7 @@ fn test_squash_partial() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let template = r#"commit_id.short() " " branches"#;
+    let template = r#"commit_id.short() ++ " " ++ branches"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -233,10 +233,8 @@ fn test_squash_partial() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(
-        repo_path,
-        &["log", "-T", r#"commit_id.short() " " branches"#],
-    )
+    let template = r#"commit_id.short() " " branches"#;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
 #[test]

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -63,10 +63,8 @@ fn test_templater_branches() {
     test_env.jj_cmd_success(&origin_path, &["git", "export"]);
     test_env.jj_cmd_success(&workspace_root, &["git", "fetch"]);
 
-    let output = test_env.jj_cmd_success(
-        &workspace_root,
-        &["log", "-T", r#"commit_id.short() " " branches"#],
-    );
+    let template = r#"commit_id.short() " " branches"#;
+    let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
     o  b1bb3766d584 branch3??
     │ @  a5b4d15489cc branch2* new-branch

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -336,6 +336,20 @@ fn test_templater_label_function() {
 }
 
 #[test]
+fn test_templater_concat_function() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    let render = |template| get_colored_template_output(&test_env, &repo_path, "@-", template);
+
+    insta::assert_snapshot!(render(r#"concat()"#), @"");
+    insta::assert_snapshot!(render(r#"concat(author, empty)"#), @" <>[38;5;2mtrue[39m");
+    insta::assert_snapshot!(
+        render(r#"concat(label("error", ""), label("warning", "a"), "b")"#),
+        @"[38;5;3ma[39mb");
+}
+
+#[test]
 fn test_templater_separate_function() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -199,7 +199,7 @@ fn test_unsquash_partial() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let template = r#"commit_id.short() " " branches"#;
+    let template = r#"commit_id.short() ++ " " ++ branches"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -199,10 +199,8 @@ fn test_unsquash_partial() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(
-        repo_path,
-        &["log", "-T", r#"commit_id.short() " " branches"#],
-    )
+    let template = r#"commit_id.short() " " branches"#;
+    test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
 #[test]

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -342,7 +342,7 @@ fn test_list_workspaces_template() {
     test_env.jj_cmd_success(test_env.env_root(), &["init", "--git", "main"]);
     test_env.add_config(
         r#"
-        templates.commit_summary = """commit_id.short() " " description.first_line()
+        templates.commit_summary = """commit_id.short() ++ " " ++ description.first_line() ++
                                       if(current_working_copy, " (current)")"""
         "#,
     );

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -406,17 +406,12 @@ fn test_workspaces_root() {
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
-    test_env.jj_cmd_success(
-        cwd,
-        &[
-            "log",
-            "-T",
-            r#"separate(" ",
-                 commit_id,
-                 working_copies,
-                 if(divergent, "(divergent)"))"#,
-            "-r",
-            "all()",
-        ],
+    let template = r###"
+    separate(" ",
+      commit_id,
+      working_copies,
+      if(divergent, "(divergent)"),
     )
+    "###;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template, "-r", "all()"])
 }


### PR DESCRIPTION
~This basically makes the template syntax more Mercurial-like.  The main difference is that the top-level node isn't a string, but an expression.~

The goal is to eliminate the implicit concatenation rule: `"foo" "bar"`.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
