### PR TITLE
`author`/`committer` templates: add a `username` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj new --insert-after` inserts the new commit between the target commit and
   its children.
 
+* `author`/`committer` templates now support `.username()`, which leaves out the
+domain information of `.email()`.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -360,6 +360,14 @@ fn expect_arguments<const N: usize, const M: usize>(
     }
 }
 
+fn split_email(email: &str) -> (&str, Option<&str>) {
+    if let Some((username, rest)) = email.split_once('@') {
+        (username, Some(rest))
+    } else {
+        (email, None)
+    }
+}
+
 fn parse_method_chain<'a, I: 'a>(
     input_property: PropertyAndLabels<'a, I>,
     method_pairs: Pairs<Rule>,
@@ -554,6 +562,16 @@ fn parse_signature_method<'a, I: 'a>(
             Property::String(chain_properties(
                 self_property,
                 TemplatePropertyFn(|signature: &Signature| signature.email.clone()),
+            ))
+        }
+        "username" => {
+            expect_no_arguments(args_pair)?;
+            Property::String(chain_properties(
+                self_property,
+                TemplatePropertyFn(|signature: &Signature| {
+                    let (username, _) = split_email(&signature.email);
+                    username.to_owned()
+                }),
             ))
         }
         "timestamp" => {


### PR DESCRIPTION
I haven't used a proper email address parser as I'm not really sure if it's worth the extra dependency and effort -- thoughts?

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
