### PR TITLE
git fetch: prune old branch names before adding new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix the output of `jj debug completion --help` by reversing fish and zsh text.
 
+* Fixed edge case in `jj git fetch` when a pruned branch is a prefix of another
+  branch.
+
 ### Contributors
 
 Thanks to the people who made this release happen!

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -364,10 +364,10 @@ pub fn fetch(
     let refspec: &[&str] = &[];
     tracing::debug!("remote.download");
     remote.download(refspec, Some(&mut fetch_options))?;
-    tracing::debug!("remote.update_tips");
-    remote.update_tips(None, false, git2::AutotagOption::Unspecified, None)?;
     tracing::debug!("remote.prune");
     remote.prune(None)?;
+    tracing::debug!("remote.update_tips");
+    remote.update_tips(None, false, git2::AutotagOption::Unspecified, None)?;
     // TODO: We could make it optional to get the default branch since we only care
     // about it on clone.
     let mut default_branch = None;

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -144,8 +144,10 @@ fn test_git_fetch_prune_before_updating_tips() {
         .rename("origin/subname", false)
         .unwrap();
 
-    // Exhibit bug: origin will prevent origin/subname from being created
-    let _ = test_env.jj_cmd_failure(&repo_path, &["git", "fetch"]);
+    test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    origin/subname: 9f01a0e04879 message
+    "###);
 }
 
 /// Add a remote containing a branch with the same name


### PR DESCRIPTION
I have verified that the new test fails before this patch is installed.

This allows a remote to remove a branch "foo" and create a branch "foo/bar". Otherwise, git2 attempts to create the "foo/bar" file t store the head of the branch before removing the "foo" one.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [X] I have added tests to cover my changes
