### PR TITLE
config: add and parse `ui.log_author_format` in the default template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its children.
 
 * `author`/`committer` templates now support `.username()`, which leaves out the
-domain information of `.email()`.
+  domain information of `.email()`.
+
+* It is now possible to change the author format of `jj log` with the new
+  `ui.log_author_format` option.
 
 ### Fixed bugs
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -141,6 +141,20 @@ ui.relative-timestamps = true
 False by default, but setting to true will change timestamps to be rendered
 as `x days/hours/seconds ago` instead of being rendered as a full timestamp.
 
+### Author format
+
+```toml
+ui.log_author_format = 'username'
+```
+
+Supported values are,
+
+- `none` for no author information,
+- `full` for both the name and email,
+- `name` for just the name,
+- `username` for username part of the email,
+- (default) `email` (or any other gibberish for that matter) for the full email.
+
 ## Pager
 
 The default pager is can be set via `ui.pager` or the `PAGER` environment

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -170,6 +170,12 @@ impl UserSettings {
             .unwrap_or_else(|_| "styled".to_string())
     }
 
+    pub fn log_author_format(&self) -> String {
+        self.config
+            .get_string("ui.log-author-format")
+            .unwrap_or_else(|_| "email".to_owned())
+    }
+
     pub fn log_id_preferred_length(&self) -> Option<usize> {
         self.config
             .get_int("ui.log-id-preferred-length")

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1435,6 +1435,14 @@ fn log_template(settings: &UserSettings) -> String {
         "styled" => format!("shortest({desired_id_len})"),
         _ => format!("short({desired_id_len})"),
     };
+    let author_template = match settings.log_author_format().as_str() {
+        "none" => None,
+        "full" => Some("author"),
+        "name" => Some("author.name()"),
+        "username" => Some("author.username()"),
+        _ => Some("author.email()"),
+    }
+    .map_or("".to_owned(), |t| t.to_owned() + ",");
     let default_template = format!(
         r#"
             label(if(current_working_copy, "working_copy"),
@@ -1442,7 +1450,7 @@ fn log_template(settings: &UserSettings) -> String {
                 if(divergent,
                   label("divergent", change_id.{prefix_format} "??"),
                   change_id.{prefix_format}),
-                author.email(),
+                {author_template}
                 {committer_timestamp},
                 branches,
                 tags,

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -63,7 +63,11 @@
                 },
                 "color": {
                     "description": "Whether to colorize command output",
-                    "enum": ["always", "never", "auto"],
+                    "enum": [
+                        "always",
+                        "never",
+                        "auto"
+                    ],
                     "default": "auto"
                 },
                 "pager": {
@@ -77,7 +81,11 @@
                     "properties": {
                         "format": {
                             "description": "The diff format to use",
-                            "enum": ["color-words", "git", "summary"],
+                            "enum": [
+                                "color-words",
+                                "git",
+                                "summary"
+                            ],
                             "default": "color-words"
                         }
                     }
@@ -88,15 +96,36 @@
                     "properties": {
                         "style": {
                             "description": "Style of connectors/markings used to render the graph. See https://github.com/martinvonz/jj/blob/main/docs/config.md#graph-style",
-                            "enum": ["legacy", "curved", "square", "ascii", "ascii-large"],
+                            "enum": [
+                                "legacy",
+                                "curved",
+                                "square",
+                                "ascii",
+                                "ascii-large"
+                            ],
                             "default": "legacy"
                         }
                     }
                 },
                 "unique-prefixes": {
-                    "enum": ["none", "brackets", "styled"],
+                    "enum": [
+                        "none",
+                        "brackets",
+                        "styled"
+                    ],
                     "description": "How formatter indicates the unique prefix part of a revision or change ID",
                     "default": "styled"
+                },
+                "log-author-format": {
+                    "enum": [
+                        "none",
+                        "full",
+                        "name",
+                        "username",
+                        "email"
+                    ],
+                    "default": "email",
+                    "description": "Determines how author information is displayed in `jj log`"
                 },
                 "log-id-preferred-length": {
                     "type": "integer",
@@ -162,8 +191,12 @@
             },
             "propertyNames": {
                 "oneOf": [
-                    { "$ref": "#/properties/colors/definitions/basicFormatterLabels" },
-                    { "type": "string" }
+                    {
+                        "$ref": "#/properties/colors/definitions/basicFormatterLabels"
+                    },
+                    {
+                        "type": "string"
+                    }
                 ]
             },
             "additionalProperties": {
@@ -175,8 +208,12 @@
                     {
                         "type": "object",
                         "properties": {
-                            "fg": { "$ref": "#/properties/colors/definitions/colors" },
-                            "bg": { "$ref": "#/properties/colors/definitions/colors" },
+                            "fg": {
+                                "$ref": "#/properties/colors/definitions/colors"
+                            },
+                            "bg": {
+                                "$ref": "#/properties/colors/definitions/colors"
+                            },
                             "bold": {
                                 "type": "boolean"
                             },

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -574,6 +574,105 @@ fn test_log_shortest_length_parameter() {
 }
 
 #[test]
+fn test_log_author_format_in_default_template() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "--revisions=@"]),
+        @r###"
+        @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "--config-toml=ui.log-author-format=''",
+                "log",
+                "--revisions=@",
+            ],
+        ),
+        @r###"
+        @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "--config-toml=ui.log-author-format='gibberish'",
+                "log",
+                "--revisions=@",
+            ],
+        ),
+        @r###"
+        @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "--config-toml=ui.log-author-format='email'",
+                "log",
+                "--revisions=@",
+            ],
+        ),
+        @r###"
+        @ 9a45c67d3e96 test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "--config-toml=ui.log-author-format='none'",
+                "log",
+                "--revisions=@",
+            ],
+        ),
+        @r###"
+        @ 9a45c67d3e96 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "--config-toml=ui.log-author-format='name'",
+                "log",
+                "--revisions=@"
+            ],
+        ),
+        @r###"
+        @ 9a45c67d3e96 Test User 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(
+            &repo_path,
+            &[
+                "--config-toml=ui.log-author-format='username'",
+                "log",
+                "--revisions=@"
+            ],
+        ),
+        @r###"
+        @ 9a45c67d3e96 test.user 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+        ~ (empty) (no description set)
+        "###
+    );
+}
+
+#[test]
 fn test_log_divergence() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
Supported values are,

- `none` for no author information,
- `full` for both the name and email,
- `name` for just the name,
- `username` for username part of the email,
- (default) `email` (or any other gibberish for that matter) for the full email.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
