### PR TITLE
cli: don't print error about broken pipe

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -2022,9 +2022,7 @@ pub fn handle_command_result(
             }
         }
         Err(CommandError::BrokenPipe) => {
-            // It's unlikely this write() would succeed, but try anyway to either
-            // print error message or raise new io::Error.
-            writeln!(ui.error(), "Error: Broken pipe")?;
+            // A broken pipe is not an error, but a signal to exit gracefully.
             Ok(ExitCode::from(BROKEN_PIPE_EXIT_CODE))
         }
         Err(CommandError::InternalError(message)) => {


### PR DESCRIPTION
`jj log | head` consistently prints "Error: Broken pipe" for me. I don't know how the output gets printed after the pipe has been closed, but neither `git` nor `hg` prints an error, so I think we shouldn't either.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
