### PR TITLE
cli: avoid a closure in `op log` code for printing timestamp

### DIFF
--- a/src/commands/operation.rs
+++ b/src/commands/operation.rs
@@ -71,27 +71,23 @@ fn cmd_op_log(
                 metadata.hostname
             )?;
             formatter.write_str(" ")?;
-            formatter.with_label("time", |formatter| {
-                formatter.write_str(
-                    &(if self.relative_timestamps {
-                        let mut f = timeago::Formatter::new();
-                        f.min_unit(timeago::TimeUnit::Microseconds).ago("");
-                        let mut duration =
-                            format_duration(&metadata.start_time, &metadata.end_time, &f);
-                        if duration == "now" {
-                            duration = "less than a microsecond".to_string()
-                        }
-                        let start = format_timestamp_relative_to_now(&metadata.start_time);
-                        format!("{start}, lasted {duration}",)
-                    } else {
-                        format!(
-                            "{} - {}",
-                            format_absolute_timestamp(&metadata.start_time),
-                            format_absolute_timestamp(&metadata.end_time)
-                        )
-                    }),
-                )
-            })?;
+            if self.relative_timestamps {
+                let mut f = timeago::Formatter::new();
+                f.min_unit(timeago::TimeUnit::Microseconds).ago("");
+                let mut duration = format_duration(&metadata.start_time, &metadata.end_time, &f);
+                if duration == "now" {
+                    duration = "less than a microsecond".to_string()
+                }
+                let start = format_timestamp_relative_to_now(&metadata.start_time);
+                write!(formatter.labeled("time"), "{start}, lasted {duration}")?;
+            } else {
+                write!(
+                    formatter.labeled("time"),
+                    "{} - {}",
+                    format_absolute_timestamp(&metadata.start_time),
+                    format_absolute_timestamp(&metadata.end_time)
+                )?;
+            }
             formatter.write_str("\n")?;
             write!(
                 formatter.labeled("description"),


### PR DESCRIPTION
I find it easier to read the code without the closure and the extra indentation. Instead, leverage `formatter.labeled()`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
