### PR TITLE
cli: remove config knobs to customize log/show output, suggest template aliases instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,8 +155,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `author`/`committer` templates now support `.username()`, which leaves out the
   domain information of `.email()`.
 
-* It is now possible to change the author format of `jj log` with the new
-  `ui.log-author-format` option.
+* It is now possible to change the author format of `jj log` with the
+  `format_short_signature()` template alias. For details, see
+  [the documentation](docs/config.md).
 
 * Added support for template aliases. New symbols and functions can be
   configured by `template-aliases.<name> = <expression>`. Be aware that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,11 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   descendants of `abc` can be duplicated with `jj duplicate abc:`.
 
 * `jj log` now highlights the shortest unique prefix of every commit and change
-  id and shows the rest in gray. To disable, set the new `ui.unique-prefixes`
-  option to `none`.
-
-* It is now possible to change the lengths of the ids `jj log` prints with the
-  new `ui.log-id-preferred-length` option.
+  id and shows the rest in gray. To customize the length and style, use the
+  `format_short_id()` template alias. For details, see
+  [the documentation](docs/config.md).
 
 * `jj print` was renamed to `jj cat`. `jj print` remains as an alias.
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,8 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj log` now highlights the shortest unique prefix of every commit and change
   id and shows the rest in gray. To disable, set the new `ui.unique-prefixes`
-  option to `none`. For a presentation that doesn't rely on color, set it to
-  `brackets`.
+  option to `none`.
 
 * It is now possible to change the lengths of the ids `jj log` prints with the
   new `ui.log-id-preferred-length` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `label(if(current_working_copy, "working_copy"), ...)` to label the
   working-copy entry.
 
+* `jj log` and `jj show` no longer respect `ui.relative-timestamps = true`.
+  Use the `format_timestamp()` template alias instead. For details, see
+  [the documentation](docs/config.md).
+
 * The global `--no-commit-working-copy` is now called `--ignore-working-copy`.
 
 * The `diff.format` config option is now called `ui.diff.format`. The old name
@@ -81,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Per-repository configuration is now read from `.jj/repo/config.toml`.
 
-* The `ui.relative-timestamps` option now also affects `jj op log`.
+* The `ui.relative-timestamps` option now affects `jj op log`.
 
 * Background colors, bold text, and underlining are now supported. You can set
   e.g. `color.error = { bg = "red", bold = true, underline = true }` in your

--- a/docs/config.md
+++ b/docs/config.md
@@ -114,46 +114,45 @@ ui.graph.style = "square"
 
 ### Display of commit and change ids
 
-```toml
-ui.unique-prefixes = "brackets"  # Does not rely on color
-```
-
-Whether to highlight a unique prefix for commit & change ids. Possible
-values are `styled`, `brackets` and `none` (default: `styled`).
+Can be customized by the `format_short_id()` template alias.
 
 ```toml
-ui.log-id-preferred-length = 6
+[template-aliases]
+# Highlight unique prefix and show at least 12 characters (default)
+'format_short_id(id)' = 'id.shortest(12)'
+# Just the shortest possible unique prefix
+'format_short_id(id)' = 'id.shortest()'
+# Show unique prefix and the rest surrounded by brackets
+'format_short_id(id)' = 'id.shortest(12).prefix() "[" id.shortest(12).rest() "]"'
+# Always show 12 characters
+'format_short_id(id)' = 'id.short(12)'
 ```
-
-Determines the number of characters displayed for `jj log` for change or commit
-ids. The default is 12. If the `ui.unique-prefixes` option is not set to `none`,
-this option will be ignored if the number of characters it specifies is
-insufficient to print the entire unique prefix of an id.
-
-This option can be convenient to set on a per-repository level.
 
 ### Relative timestamps
 
-```toml
-ui.relative-timestamps = true
-```
+Can be customized by the `format_timestamp()` template alias.
 
-False by default, but setting to true will change timestamps to be rendered
-as `x days/hours/seconds ago` instead of being rendered as a full timestamp.
+```toml
+[template-aliases]
+# Full timestamp in ISO 8601 format (default)
+'format_timestamp(timestamp)' = 'timestamp'
+# Relative timestamp rendered as "x days/hours/seconds ago"
+'format_timestamp(timestamp)' = 'timestamp.ago()'
+```
 
 ### Author format
 
+Can be customized by the `format_short_signature()` template alias.
+
 ```toml
-ui.log-author-format = 'username'
+[template-aliases]
+# Full email address (default)
+'format_short_signature(signature)' = 'signature.email()'
+# Both name and email address
+'format_short_signature(signature)' = 'signature'
+# Username part of the email address
+'format_short_signature(signature)' = 'signature.username()'
 ```
-
-Supported values are,
-
-- `none` for no author information,
-- `full` for both the name and email,
-- `name` for just the name,
-- `username` for username part of the email,
-- (default) `email` (or any other gibberish for that matter) for the full email.
 
 ## Pager
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -164,12 +164,6 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
-    pub fn log_author_format(&self) -> String {
-        self.config
-            .get_string("ui.log-author-format")
-            .unwrap_or_else(|_| "email".to_owned())
-    }
-
     pub fn config(&self) -> &config::Config {
         &self.config
     }

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -164,23 +164,10 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
-    pub fn unique_prefixes(&self) -> String {
-        self.config
-            .get_string("ui.unique-prefixes")
-            .unwrap_or_else(|_| "styled".to_string())
-    }
-
     pub fn log_author_format(&self) -> String {
         self.config
             .get_string("ui.log-author-format")
             .unwrap_or_else(|_| "email".to_owned())
-    }
-
-    pub fn log_id_preferred_length(&self) -> Option<usize> {
-        self.config
-            .get_int("ui.log-id-preferred-length")
-            .ok()
-            .and_then(|l| l.try_into().ok())
     }
 
     pub fn config(&self) -> &config::Config {

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1557,17 +1557,6 @@ fn load_template_aliases(
         .insert("format_timestamp(timestamp)", timestamp_template)
         .unwrap();
 
-    let desired_id_len = settings.log_id_preferred_length().unwrap_or(12);
-    // TODO: If/when this logic is relevant in the `lib` crate, make this into
-    // and enum similar to `ColorChoice`.
-    let id_template = match settings.unique_prefixes().as_str() {
-        "styled" => format!("id.shortest({desired_id_len})"),
-        _ => format!("id.short({desired_id_len})"),
-    };
-    aliases_map
-        .insert("format_short_id(id)", id_template)
-        .unwrap();
-
     let signature_template = match settings.log_author_format().as_str() {
         "none" => r#""""#,
         "full" => "signature",

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1561,7 +1561,6 @@ fn load_template_aliases(
     // TODO: If/when this logic is relevant in the `lib` crate, make this into
     // and enum similar to `ColorChoice`.
     let id_template = match settings.unique_prefixes().as_str() {
-        "brackets" => format!("id.shortest({desired_id_len}).with_brackets()"),
         "styled" => format!("id.shortest({desired_id_len})"),
         _ => format!("id.short({desired_id_len})"),
     };

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1544,21 +1544,6 @@ fn load_template_aliases(
 ) -> Result<TemplateAliasesMap, CommandError> {
     const TABLE_KEY: &str = "template-aliases";
     let mut aliases_map = TemplateAliasesMap::new();
-
-    // TODO: Reorganize default template aliases and config knobs:
-    // - remove these configs and let user override aliases?
-    // - separate namespace or config section for these "default" aliases? but how?
-    let signature_template = match settings.log_author_format().as_str() {
-        "none" => r#""""#,
-        "full" => "signature",
-        "name" => "signature.name()",
-        "username" => "signature.username()",
-        _ => "signature.email()",
-    };
-    aliases_map
-        .insert("format_short_signature(signature)", signature_template)
-        .unwrap();
-
     let table = settings.config().get_table(TABLE_KEY)?;
     for (decl, value) in table.into_iter().sorted_by(|a, b| a.0.cmp(&b.0)) {
         let r = value

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1548,15 +1548,6 @@ fn load_template_aliases(
     // TODO: Reorganize default template aliases and config knobs:
     // - remove these configs and let user override aliases?
     // - separate namespace or config section for these "default" aliases? but how?
-    let timestamp_template = if settings.relative_timestamps() {
-        "timestamp.ago()"
-    } else {
-        "timestamp"
-    };
-    aliases_map
-        .insert("format_timestamp(timestamp)", timestamp_template)
-        .unwrap();
-
     let signature_template = match settings.log_author_format().as_str() {
         "none" => r#""""#,
         "full" => "signature",

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -107,17 +107,6 @@
                         }
                     }
                 },
-                "log-author-format": {
-                    "enum": [
-                        "none",
-                        "full",
-                        "name",
-                        "username",
-                        "email"
-                    ],
-                    "default": "email",
-                    "description": "Determines how author information is displayed in `jj log`"
-                },
                 "editor": {
                     "type": "string",
                     "description": "Editor to use for commands that involve editing text"

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -107,14 +107,6 @@
                         }
                     }
                 },
-                "unique-prefixes": {
-                    "enum": [
-                        "none",
-                        "styled"
-                    ],
-                    "description": "How formatter indicates the unique prefix part of a revision or change ID",
-                    "default": "styled"
-                },
                 "log-author-format": {
                     "enum": [
                         "none",
@@ -125,11 +117,6 @@
                     ],
                     "default": "email",
                     "description": "Determines how author information is displayed in `jj log`"
-                },
-                "log-id-preferred-length": {
-                    "type": "integer",
-                    "description": "Determines the number of characters displayed for `jj log` for change or commit ids.",
-                    "default": 12
                 },
                 "editor": {
                     "type": "string",

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -110,7 +110,6 @@
                 "unique-prefixes": {
                     "enum": [
                         "none",
-                        "brackets",
                         "styled"
                     ],
                     "description": "How formatter indicates the unique prefix part of a revision or change ID",

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -34,6 +34,7 @@ show = 'show'
 
 # Hook points for users to customize the default templates:
 'format_short_id(id)' = 'id.shortest(12)'
+'format_timestamp(timestamp)' = 'timestamp'
 
 # TODO: Add branches, tags, etc
 # TODO: Indent the description like Git does

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -32,6 +32,9 @@ show = 'show'
 [template-aliases]
 'description_placeholder' = 'label("description", "(no description set)")'
 
+# Hook points for users to customize the default templates:
+'format_short_id(id)' = 'id.shortest(12)'
+
 # TODO: Add branches, tags, etc
 # TODO: Indent the description like Git does
 'show' = '''

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -34,6 +34,7 @@ show = 'show'
 
 # Hook points for users to customize the default templates:
 'format_short_id(id)' = 'id.shortest(12)'
+'format_short_signature(signature)' = 'signature.email()'
 'format_timestamp(timestamp)' = 'timestamp'
 
 # TODO: Add branches, tags, etc

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -896,6 +896,20 @@ fn build_shortest_id_prefix_method<'a, I: 'a>(
     _build_keyword: &impl Fn(&str, pest::Span) -> TemplateParseResult<PropertyAndLabels<'a, I>>,
 ) -> TemplateParseResult<Property<'a, I>> {
     let property = match function.name {
+        "prefix" => {
+            expect_no_arguments(function)?;
+            Property::String(chain_properties(
+                self_property,
+                TemplatePropertyFn(|id: &ShortestIdPrefix| id.prefix.clone()),
+            ))
+        }
+        "rest" => {
+            expect_no_arguments(function)?;
+            Property::String(chain_properties(
+                self_property,
+                TemplatePropertyFn(|id: &ShortestIdPrefix| id.rest.clone()),
+            ))
+        }
         "with_brackets" => {
             // TODO: If we had a map function, this could be expressed as a template
             // like 'id.shortest() % (.prefix() if(.rest(), "[" .rest() "]"))'

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -910,15 +910,6 @@ fn build_shortest_id_prefix_method<'a, I: 'a>(
                 TemplatePropertyFn(|id: &ShortestIdPrefix| id.rest.clone()),
             ))
         }
-        "with_brackets" => {
-            // TODO: If we had a map function, this could be expressed as a template
-            // like 'id.shortest() % (.prefix() if(.rest(), "[" .rest() "]"))'
-            expect_no_arguments(function)?;
-            Property::String(chain_properties(
-                self_property,
-                TemplatePropertyFn(|id: &ShortestIdPrefix| id.with_brackets()),
-            ))
-        }
         _ => {
             return Err(TemplateParseError::no_such_method(
                 "ShortestIdPrefix",

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -609,8 +609,8 @@ impl Template<()> for CommitOrChangeId<'_> {
 }
 
 pub struct ShortestIdPrefix {
-    prefix: String,
-    rest: String,
+    pub prefix: String,
+    pub rest: String,
 }
 
 impl ShortestIdPrefix {

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -613,16 +613,6 @@ pub struct ShortestIdPrefix {
     pub rest: String,
 }
 
-impl ShortestIdPrefix {
-    pub fn with_brackets(&self) -> String {
-        if self.rest.is_empty() {
-            self.prefix.clone()
-        } else {
-            format!("{}[{}]", self.prefix, self.rest)
-        }
-    }
-}
-
 impl Template<()> for ShortestIdPrefix {
     fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
         formatter.with_label("prefix", |fmt| fmt.write_str(&self.prefix))?;

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -81,38 +81,6 @@ fn test_log_default() {
        (empty) (no description set)
     "###);
 
-    // Test default log output format with bracket prefixes
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &["log", "--config-toml", "ui.unique-prefixes='brackets'"],
-    );
-    insta::assert_snapshot!(stdout, @r###"
-    @  k[kmpptxzrspx] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9[de54178d59d]
-    │  (empty) description 1
-    o  q[pvuntsmwlqt] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[291e264ae97]
-    │  add a file
-    o  z[zzzzzzzzzzz] 1970-01-01 00:00:00.000 +00:00 0[00000000000]
-       (empty) (no description set)
-    "###);
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &[
-            "log",
-            "--config-toml",
-            "ui.unique-prefixes='brackets'",
-            "--config-toml",
-            "ui.log-id-preferred-length=2",
-        ],
-    );
-    insta::assert_snapshot!(stdout, @r###"
-    @  k[k] test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9[d]
-    │  (empty) description 1
-    o  q[p] test.user@example.com 2001-02-03 04:05:08.000 +07:00 4[2]
-    │  add a file
-    o  z[z] 1970-01-01 00:00:00.000 +00:00 0[0]
-       (empty) (no description set)
-    "###);
-
     // Test default log output format with styled prefixes and color
     let stdout = test_env.jj_cmd_success(
         &repo_path,

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -288,6 +288,18 @@ fn test_log_prefix_highlight_brackets() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
+    let render = |rev, template| {
+        test_env.jj_cmd_success(
+            &repo_path,
+            &["log", "--no-graph", "-r", rev, "-T", template],
+        )
+    };
+    test_env.add_config(
+        r###"
+        [template-aliases]
+        'format_id(id)' = 'id.shortest(12).prefix() "[" id.shortest(12).rest() "]"'
+        "###,
+    );
 
     fn prefix_format(len: Option<usize>) -> String {
         format!(
@@ -377,6 +389,22 @@ fn test_log_prefix_highlight_brackets() {
     o  Change zzz  00
     "###
     );
+
+    insta::assert_snapshot!(
+        render(":@", r#"format_id(change_id) " " format_id(commit_id) "\n""#),
+        @r###"
+    wq[nwkozpkust] 03[f51310b83e]
+    km[kuslswpqwq] f7[7fb1909080]
+    kp[qxywonksrl] e7[15ad5db646]
+    zn[kkpsqqskkl] 38[622e54e2e5]
+    yo[stqsxwqrlt] 0cf[42f60199c]
+    vr[uxwmqvtpmx] 9e[6015e4e622]
+    yq[osqzytrlsw] 06f[34d9b1475]
+    ro[yxmykxtrkr] 1f[99a5e19891]
+    mz[vwutvlkqwt] 7b[1f7dee65b4]
+    qpv[untsmwlqt] ba1[a30916d29]
+    zzz[zzzzzzzzz] 00[0000000000]
+    "###);
 }
 
 #[test]

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -561,7 +561,7 @@ fn test_log_shortest_length_parameter() {
 }
 
 #[test]
-fn test_log_author_format_in_default_template() {
+fn test_log_author_format() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
@@ -574,88 +574,16 @@ fn test_log_author_format_in_default_template() {
     ~
     "###
     );
+
+    let decl = "template-aliases.'format_short_signature(signature)'";
     insta::assert_snapshot!(
         test_env.jj_cmd_success(
             &repo_path,
             &[
-                "--config-toml=ui.log-author-format=''",
+                "--config-toml",
+                &format!("{decl}='signature.username()'"),
                 "log",
                 "--revisions=@",
-            ],
-        ),
-        @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
-    │  (empty) (no description set)
-    ~
-    "###
-    );
-    insta::assert_snapshot!(
-        test_env.jj_cmd_success(
-            &repo_path,
-            &[
-                "--config-toml=ui.log-author-format='gibberish'",
-                "log",
-                "--revisions=@",
-            ],
-        ),
-        @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
-    │  (empty) (no description set)
-    ~
-    "###
-    );
-    insta::assert_snapshot!(
-        test_env.jj_cmd_success(
-            &repo_path,
-            &[
-                "--config-toml=ui.log-author-format='email'",
-                "log",
-                "--revisions=@",
-            ],
-        ),
-        @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
-    │  (empty) (no description set)
-    ~
-    "###
-    );
-    insta::assert_snapshot!(
-        test_env.jj_cmd_success(
-            &repo_path,
-            &[
-                "--config-toml=ui.log-author-format='none'",
-                "log",
-                "--revisions=@",
-            ],
-        ),
-        @r###"
-    @  qpvuntsmwlqt 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
-    │  (empty) (no description set)
-    ~
-    "###
-    );
-    insta::assert_snapshot!(
-        test_env.jj_cmd_success(
-            &repo_path,
-            &[
-                "--config-toml=ui.log-author-format='name'",
-                "log",
-                "--revisions=@"
-            ],
-        ),
-        @r###"
-    @  qpvuntsmwlqt Test User 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
-    │  (empty) (no description set)
-    ~
-    "###
-    );
-    insta::assert_snapshot!(
-        test_env.jj_cmd_success(
-            &repo_path,
-            &[
-                "--config-toml=ui.log-author-format='username'",
-                "log",
-                "--revisions=@"
             ],
         ),
         @r###"

--- a/tests/test_show_command.rs
+++ b/tests/test_show_command.rs
@@ -41,7 +41,12 @@ fn test_show_relative_timestamps() {
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.add_config(r#"ui.relative-timestamps = true"#);
+    test_env.add_config(
+        r#"
+        [template-aliases]
+        'format_timestamp(timestamp)' = 'timestamp.ago()'
+        "#,
+    );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
     let timestamp_re = Regex::new(r"\([0-9]+ years ago\)").unwrap();


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
