### PR TITLE
Rename `ui.relative-timestamps` to `ui.oplog-relative-timestamps`, make it default to `true`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Use the `format_timestamp()` template alias instead. For details, see
   [the documentation](docs/config.md).
 
+* `jj op log` now shows relative timestamps by default. To disable, set `ui.relative-timestamps` to `false`.
+
 * The global `--no-commit-working-copy` is now called `--ignore-working-copy`.
 
 * The `diff.format` config option is now called `ui.diff.format`. The old name
@@ -84,8 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This can be prevented by the new `--quiet` option.
 
 * Per-repository configuration is now read from `.jj/repo/config.toml`.
-
-* The `ui.relative-timestamps` option now affects `jj op log`.
 
 * Background colors, bold text, and underlining are now supported. You can set
   e.g. `color.error = { bg = "red", bold = true, underline = true }` in your

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `label(if(current_working_copy, "working_copy"), ...)` to label the
   working-copy entry.
 
-* `jj log` and `jj show` no longer respect `ui.relative-timestamps = true`.
-  Use the `format_timestamp()` template alias instead. For details, see
-  [the documentation](docs/config.md).
+* The `ui.relative-timestamps` option has been removed. Use the
+  `format_timestamp()` template alias instead. For details on showing relative
+  timestamps in `jj log` and `jj show`, see [the documentation](docs/config.md).
 
-* `jj op log` now shows relative timestamps by default. To disable, set `ui.relative-timestamps` to `false`.
+* `jj op log` now shows relative timestamps by default. To disable, set
+  `ui.oplog-relative-timestamps` to `false`.
 
 * The global `--no-commit-working-copy` is now called `--ignore-working-copy`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -140,6 +140,14 @@ Can be customized by the `format_timestamp()` template alias.
 'format_timestamp(timestamp)' = 'timestamp.ago()'
 ```
 
+`jj op log` defaults to relative timestamps. To use absolute timestamps, you
+will need to modify an option.
+
+```toml
+[ui]
+oplog-relative-timestamps=false
+```
+
 ### Author format
 
 Can be customized by the `format_short_signature()` template alias.

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,9 +7,6 @@ user.email = "YOUR_EMAIL@example.com"
 ui.color = "auto" # the default
 # ui.color = never # no color
 
-ui.relative-timestamps = false # the default
-# ui.relative-timestamps = true # renders timestamps relatively, e.g. "x hours ago"
-
 ui.editor = "pico" # the default
 # ui.editor = "vim"
 
@@ -19,6 +16,9 @@ ui.diff-editor = "meld" # default, requires meld to be installed
 ui.merge-editor = "meld" # default
 # ui.merge-editor = "vimdiff"
 # ui.merge-editor = "kdiff3"
+
+# Relative timestamp rendered as "x days/hours/seconds ago"
+template-aliases.'format_timestamp(timestamp)' = 'timestamp.ago()'
 
 # The three merge tools above are pre-configured. For detailed information
 # about how to change the default configuration or how to configure another tool,

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -161,7 +161,7 @@ impl UserSettings {
     pub fn relative_timestamps(&self) -> bool {
         self.config
             .get_bool("ui.relative-timestamps")
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     pub fn config(&self) -> &config::Config {

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -158,9 +158,9 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
-    pub fn relative_timestamps(&self) -> bool {
+    pub fn oplog_relative_timestamps(&self) -> bool {
         self.config
-            .get_bool("ui.relative-timestamps")
+            .get_bool("ui.oplog-relative-timestamps")
             .unwrap_or(true)
     }
 

--- a/src/commands/operation.rs
+++ b/src/commands/operation.rs
@@ -105,7 +105,7 @@ fn cmd_op_log(
         }
     }
     let template = OpTemplate {
-        relative_timestamps: command.settings().relative_timestamps(),
+        relative_timestamps: command.settings().oplog_relative_timestamps(),
     };
 
     let mut graph = get_graphlog(command.settings(), formatter.raw());

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -53,8 +53,8 @@
                 },
                 "relative-timestamps": {
                     "type": "boolean",
-                    "description": "Whether to change timestamps to be rendered as a relative description instead of a full timestamp",
-                    "default": false
+                    "description": "Whether to change timestamps in the op log to be rendered as a relative description instead of a full timestamp",
+                    "default": true
                 },
                 "default-revset": {
                     "type": "string",

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -51,7 +51,7 @@
                     "description": "Whether to allow initializing a repo with the native backend",
                     "default": false
                 },
-                "relative-timestamps": {
+                "oplog-relative-timestamps": {
                     "type": "boolean",
                     "description": "Whether to change timestamps in the op log to be rendered as a relative description instead of a full timestamp",
                     "default": true

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -51,14 +51,14 @@ fn test_concurrent_operations_auto_rebase() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  eac5ad986688 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  eac5ad986688 test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  describe commit 123ed18e4c4c0d77428df41112bc02ffc83fb935
     │  args: jj describe -m initial
-    o  09a674690d20 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    o  09a674690d20 test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  snapshot working copy
-    o  a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    o  a99a3fd5c51e test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  add workspace 'default'
-    o  56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    o  56b94dfc38e7 test-username@host.example.com 22 years ago, lasted less than a microsecond
        initialize repo
     "###);
     let op_id_hex = stdout[3..15].to_string();

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -27,7 +27,10 @@ fn test_op_log() {
     let repo_path = test_env.env_root().join("repo");
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description 0"]);
 
-    let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["op", "log", "--config-toml", "ui.relative-timestamps=false"],
+    );
     insta::assert_snapshot!(&stdout, @r###"
     @  45108169c0f8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
@@ -38,10 +41,7 @@ fn test_op_log() {
        initialize repo
     "###);
     // Test op log with relative dates
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &["op", "log", "--config-toml", "ui.relative-timestamps=true"],
-    );
+    let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     let regex = Regex::new(r"\d\d years").unwrap();
     insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r###"
     @  45108169c0f8 test-username@host.example.com NN years ago, lasted less than a microsecond

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -29,7 +29,12 @@ fn test_op_log() {
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
-        &["op", "log", "--config-toml", "ui.relative-timestamps=false"],
+        &[
+            "op",
+            "log",
+            "--config-toml",
+            "ui.oplog-relative-timestamps=false",
+        ],
     );
     insta::assert_snapshot!(&stdout, @r###"
     @  45108169c0f8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00


### PR DESCRIPTION
This seems like a better default for `jj op log`, which is now the only thing this option affects.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
