### PR TITLE
`config.md`: expand on equivalence of headers and dotted keys

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,11 +17,19 @@ e.g. `user.name = "YOUR NAME"` is equivalent to:
 name = "YOUR NAME"
 ```
 
-Headings only need to be set once in the real config file but Jujutsu favors the
-dotted style in these instructions, if only because it's easier to write down in
-an unconfusing way. If you are confident with TOML then use whichever suits you
-in your config. If you mix the styles, put the dotted keys before the first
-heading.
+For a more complicated example,
+
+```toml
+[template-aliases]
+"format_short_id(id)" = "id.shortest(12)"
+```
+
+is equivalent to `template-aliases."format_short_id(id)" = "id.shortest(12)"`.
+
+Jujutsu favors the dotted style in these instructions, if only because it's
+easier to write down in an unconfusing way. If you are confident with TOML
+then use whichever suits you in your config. If you mix dotted keys and headings,
+**put the dotted keys before the first heading**.
 
 The other thing to remember is that the value of a setting (the part to the
 right of the `=` sign) should be surrounded in quotes if it's a string. That's

--- a/docs/config.md
+++ b/docs/config.md
@@ -33,8 +33,10 @@ then use whichever suits you in your config. If you mix dotted keys and headings
 
 The other thing to remember is that the value of a setting (the part to the
 right of the `=` sign) should be surrounded in quotes if it's a string. That's
-probably enough TOML to keep you out of trouble but the syntax guide is very
+probably enough TOML to keep you out of trouble but the [syntax guide] is very
 short if you ever need to check.
+
+[syntax guide]: https://toml.io/en/v1.0.0
 
 ## User settings
 


### PR DESCRIPTION
Now that we use headers to define `[template-aliases]`, I thought we should explain how they are also equivalent to dotted keys.

Alternatively, we could rewrite them all in the dotted style, but it would look awkward.


# Checklist

If applicable:
- [x] I have updated the documentation (README.md, docs/, demos/)
