### PR TITLE
release: build Linux (musl) release using vendored OpenSSL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,6 @@ jobs:
         toolchain: stable
         target: ${{ matrix.target }}
     - name: Build release binary
-      run: cargo build --target ${{ matrix.target }} --verbose --release
-    - name: (re-)Build release binary with vendored OpenSSL
-      if: matrix.os != 'ubuntu-20.04' && matrix.os != 'macos-11'
       run: cargo build --target ${{ matrix.target }} --verbose --release --features vendored-openssl
     - name: Build archive
       shell: bash


### PR DESCRIPTION
The 0.7.0 release build failed because it didn't find OpenSSL. I don't know much about musl, but I think we added it in order to get a single binary without dependencies, so I think vendoring is what we want.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
