### PR TITLE
tree: return early when trying to resolve modify/delete conflict

### DIFF
--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -653,6 +653,12 @@ fn try_resolve_file_conflict(
     filename: &RepoPath,
     conflict: &Conflict,
 ) -> Result<Option<(Vec<u8>, bool)>, TreeMergeError> {
+    // If the file was missing from any side (typically a modify/delete conflict),
+    // we can't automatically merge it.
+    if conflict.adds.len() != conflict.removes.len() + 1 {
+        return Ok(None);
+    }
+
     // If there are any non-file parts in the conflict, we can't merge it. We check
     // early so we don't waste time reading file contents if we can't merge them
     // anyway. At the same time we determine whether the resulting file should


### PR DESCRIPTION
Modify/delete conflicts cannot be automatically resolved, so there's no point in wasting resources calculating the diff(s).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
