### PR TITLE
Rename `ConflictPart` to `ConflictTerm`

### DIFF
--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -152,7 +152,7 @@ content_hash! {
 
 content_hash! {
     #[derive(Debug, PartialEq, Eq, Clone)]
-    pub struct ConflictPart {
+    pub struct ConflictTerm {
         // TODO: Store e.g. CommitId here too? Labels (theirs/ours/base)? Would those still be
         //       useful e.g. after rebasing this conflict?
         pub value: TreeValue,
@@ -166,8 +166,8 @@ content_hash! {
         // In a simple 3-way merge of B and C with merge base A, the conflict will be { add: [B, C],
         // remove: [A] }. Also note that a conflict of the form { add: [A], remove: [] } is the
         // same as non-conflict A.
-        pub removes: Vec<ConflictPart>,
-        pub adds: Vec<ConflictPart>,
+        pub removes: Vec<ConflictTerm>,
+        pub adds: Vec<ConflictTerm>,
     }
 }
 

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -24,7 +24,7 @@ use tempfile::{NamedTempFile, PersistError};
 
 use crate::backend::{
     make_root_commit, Backend, BackendError, BackendResult, ChangeId, Commit, CommitId, Conflict,
-    ConflictId, ConflictPart, FileId, MillisSinceEpoch, ObjectId, Signature, SymlinkId, Timestamp,
+    ConflictId, ConflictTerm, FileId, MillisSinceEpoch, ObjectId, Signature, SymlinkId, Timestamp,
     Tree, TreeId, TreeValue,
 };
 use crate::content_hash::blake2b_hash;
@@ -401,34 +401,34 @@ fn signature_from_proto(proto: crate::protos::store::commit::Signature) -> Signa
 
 fn conflict_to_proto(conflict: &Conflict) -> crate::protos::store::Conflict {
     let mut proto = crate::protos::store::Conflict::default();
-    for part in &conflict.adds {
-        proto.adds.push(conflict_part_to_proto(part));
+    for term in &conflict.adds {
+        proto.adds.push(conflict_term_to_proto(term));
     }
-    for part in &conflict.removes {
-        proto.removes.push(conflict_part_to_proto(part));
+    for term in &conflict.removes {
+        proto.removes.push(conflict_term_to_proto(term));
     }
     proto
 }
 
 fn conflict_from_proto(proto: crate::protos::store::Conflict) -> Conflict {
     let mut conflict = Conflict::default();
-    for part in proto.removes {
-        conflict.removes.push(conflict_part_from_proto(part))
+    for term in proto.removes {
+        conflict.removes.push(conflict_term_from_proto(term))
     }
-    for part in proto.adds {
-        conflict.adds.push(conflict_part_from_proto(part))
+    for term in proto.adds {
+        conflict.adds.push(conflict_term_from_proto(term))
     }
     conflict
 }
 
-fn conflict_part_from_proto(proto: crate::protos::store::conflict::Part) -> ConflictPart {
-    ConflictPart {
+fn conflict_term_from_proto(proto: crate::protos::store::conflict::Term) -> ConflictTerm {
+    ConflictTerm {
         value: tree_value_from_proto(proto.content.unwrap()),
     }
 }
 
-fn conflict_part_to_proto(part: &ConflictPart) -> crate::protos::store::conflict::Part {
-    crate::protos::store::conflict::Part {
+fn conflict_term_to_proto(part: &ConflictTerm) -> crate::protos::store::conflict::Term {
+    crate::protos::store::conflict::Term {
         content: Some(tree_value_to_proto(&part.value)),
     }
 }

--- a/lib/src/protos/store.proto
+++ b/lib/src/protos/store.proto
@@ -63,10 +63,10 @@ message Commit {
 }
 
 message Conflict {
-  message Part {
+  message Term {
     TreeValue content = 1;
   }
 
-  repeated Part removes = 1;
-  repeated Part adds = 2;
+  repeated Term removes = 1;
+  repeated Term adds = 2;
 }

--- a/lib/src/protos/store.rs
+++ b/lib/src/protos/store.rs
@@ -93,15 +93,15 @@ pub mod commit {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Conflict {
     #[prost(message, repeated, tag = "1")]
-    pub removes: ::prost::alloc::vec::Vec<conflict::Part>,
+    pub removes: ::prost::alloc::vec::Vec<conflict::Term>,
     #[prost(message, repeated, tag = "2")]
-    pub adds: ::prost::alloc::vec::Vec<conflict::Part>,
+    pub adds: ::prost::alloc::vec::Vec<conflict::Term>,
 }
 /// Nested message and enum types in `Conflict`.
 pub mod conflict {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct Part {
+    pub struct Term {
         #[prost(message, optional, tag = "1")]
         pub content: ::core::option::Option<super::TreeValue>,
     }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::backend::{Conflict, ConflictPart, FileId, TreeValue};
+use jujutsu_lib::backend::{Conflict, ConflictTerm, FileId, TreeValue};
 use jujutsu_lib::conflicts::{materialize_conflict, parse_conflict, update_conflict_from_content};
 use jujutsu_lib::files::{ConflictHunk, MergeHunk};
 use jujutsu_lib::repo::Repo;
@@ -20,8 +20,8 @@ use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::store::Store;
 use testutils::TestRepo;
 
-fn file_conflict_part(file_id: &FileId) -> ConflictPart {
-    ConflictPart {
+fn file_conflict_term(file_id: &FileId) -> ConflictTerm {
+    ConflictTerm {
         value: TreeValue::File {
             id: file_id.clone(),
             executable: false,
@@ -69,8 +69,8 @@ line 5
     );
 
     let mut conflict = Conflict {
-        removes: vec![file_conflict_part(&base_id)],
-        adds: vec![file_conflict_part(&left_id), file_conflict_part(&right_id)],
+        removes: vec![file_conflict_term(&base_id)],
+        adds: vec![file_conflict_term(&left_id), file_conflict_term(&right_id)],
     };
     insta::assert_snapshot!(
         &materialize_conflict_string(store, &path, &conflict),
@@ -150,10 +150,10 @@ line 5
 
     // left modifies a line, right deletes the same line.
     let conflict = Conflict {
-        removes: vec![file_conflict_part(&base_id)],
+        removes: vec![file_conflict_term(&base_id)],
         adds: vec![
-            file_conflict_part(&modified_id),
-            file_conflict_part(&deleted_id),
+            file_conflict_term(&modified_id),
+            file_conflict_term(&deleted_id),
         ],
     };
     insta::assert_snapshot!(&materialize_conflict_string(store, &path, &conflict), @r###"
@@ -172,10 +172,10 @@ line 5
 
     // right modifies a line, left deletes the same line.
     let conflict = Conflict {
-        removes: vec![file_conflict_part(&base_id)],
+        removes: vec![file_conflict_term(&base_id)],
         adds: vec![
-            file_conflict_part(&deleted_id),
-            file_conflict_part(&modified_id),
+            file_conflict_term(&deleted_id),
+            file_conflict_term(&modified_id),
         ],
     };
     insta::assert_snapshot!(&materialize_conflict_string(store, &path, &conflict), @r###"
@@ -194,8 +194,8 @@ line 5
 
     // modify/delete conflict at the file level
     let conflict = Conflict {
-        removes: vec![file_conflict_part(&base_id)],
-        adds: vec![file_conflict_part(&modified_id)],
+        removes: vec![file_conflict_term(&base_id)],
+        adds: vec![file_conflict_term(&modified_id)],
     };
     insta::assert_snapshot!(&materialize_conflict_string(store, &path, &conflict), @r###"
     <<<<<<<
@@ -381,10 +381,10 @@ fn test_update_conflict_from_content() {
     let left_file_id = testutils::write_file(store, &path, "left 1\nline 2\nleft 3\n");
     let right_file_id = testutils::write_file(store, &path, "right 1\nline 2\nright 3\n");
     let conflict = Conflict {
-        removes: vec![file_conflict_part(&base_file_id)],
+        removes: vec![file_conflict_term(&base_file_id)],
         adds: vec![
-            file_conflict_part(&left_file_id),
-            file_conflict_part(&right_file_id),
+            file_conflict_term(&left_file_id),
+            file_conflict_term(&right_file_id),
         ],
     };
     let conflict_id = store.write_conflict(&path, &conflict).unwrap();
@@ -424,10 +424,10 @@ fn test_update_conflict_from_content() {
     assert_eq!(
         new_conflict,
         Conflict {
-            removes: vec![file_conflict_part(&new_base_file_id)],
+            removes: vec![file_conflict_term(&new_base_file_id)],
             adds: vec![
-                file_conflict_part(&new_left_file_id),
-                file_conflict_part(&new_right_file_id)
+                file_conflict_term(&new_left_file_id),
+                file_conflict_term(&new_right_file_id)
             ]
         }
     )

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -14,7 +14,7 @@
 
 use assert_matches::assert_matches;
 use itertools::Itertools;
-use jujutsu_lib::backend::{ConflictPart, TreeValue};
+use jujutsu_lib::backend::{ConflictTerm, TreeValue};
 use jujutsu_lib::repo::Repo;
 use jujutsu_lib::repo_path::{RepoPath, RepoPathComponent};
 use jujutsu_lib::rewrite::rebase_commit;
@@ -126,10 +126,10 @@ fn test_same_type(use_git: bool) {
             assert_eq!(
                 conflict.adds,
                 vec![
-                    ConflictPart {
+                    ConflictTerm {
                         value: side1_tree.value(&component).cloned().unwrap()
                     },
-                    ConflictPart {
+                    ConflictTerm {
                         value: side2_tree.value(&component).cloned().unwrap()
                     }
                 ]
@@ -146,13 +146,13 @@ fn test_same_type(use_git: bool) {
                 .unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: side2_tree.value(&component).cloned().unwrap()
                 }]
             );
@@ -167,13 +167,13 @@ fn test_same_type(use_git: bool) {
                 .unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: side1_tree.value(&component).cloned().unwrap()
                 }]
             );
@@ -188,17 +188,17 @@ fn test_same_type(use_git: bool) {
                 .unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
                 vec![
-                    ConflictPart {
+                    ConflictTerm {
                         value: side1_tree.value(&component).cloned().unwrap()
                     },
-                    ConflictPart {
+                    ConflictTerm {
                         value: side2_tree.value(&component).cloned().unwrap()
                     }
                 ]
@@ -406,17 +406,17 @@ fn test_types(use_git: bool) {
                 .unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
                 vec![
-                    ConflictPart {
+                    ConflictTerm {
                         value: side1_tree.value(&component).cloned().unwrap()
                     },
-                    ConflictPart {
+                    ConflictTerm {
                         value: side2_tree.value(&component).cloned().unwrap()
                     },
                 ]
@@ -432,17 +432,17 @@ fn test_types(use_git: bool) {
                 .unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
                 vec![
-                    ConflictPart {
+                    ConflictTerm {
                         value: side1_tree.value(&component).cloned().unwrap()
                     },
-                    ConflictPart {
+                    ConflictTerm {
                         value: side2_tree.value(&component).cloned().unwrap()
                     },
                 ]
@@ -507,17 +507,17 @@ fn test_simplify_conflict(use_git: bool) {
                 .unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
                 vec![
-                    ConflictPart {
+                    ConflictTerm {
                         value: branch_tree.value(&component).cloned().unwrap()
                     },
-                    ConflictPart {
+                    ConflictTerm {
                         value: upstream2_tree.value(&component).cloned().unwrap()
                     },
                 ]
@@ -531,17 +531,17 @@ fn test_simplify_conflict(use_git: bool) {
             let conflict = store.read_conflict(&path, id).unwrap();
             assert_eq!(
                 conflict.removes,
-                vec![ConflictPart {
+                vec![ConflictTerm {
                     value: base_tree.value(&component).cloned().unwrap()
                 }]
             );
             assert_eq!(
                 conflict.adds,
                 vec![
-                    ConflictPart {
+                    ConflictTerm {
                         value: upstream2_tree.value(&component).cloned().unwrap()
                     },
-                    ConflictPart {
+                    ConflictTerm {
                         value: branch_tree.value(&component).cloned().unwrap()
                     },
                 ]

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -21,7 +21,7 @@ use std::os::unix::net::UnixListener;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{Conflict, ConflictPart, TreeValue};
+use jujutsu_lib::backend::{Conflict, ConflictTerm, TreeValue};
 use jujutsu_lib::gitignore::GitIgnoreFile;
 #[cfg(unix)]
 use jujutsu_lib::op_store::OperationId;
@@ -121,20 +121,20 @@ fn test_checkout_file_transitions(use_git: bool) {
                 let left_file_id = testutils::write_file(store, path, "left file contents");
                 let right_file_id = testutils::write_file(store, path, "right file contents");
                 let conflict = Conflict {
-                    removes: vec![ConflictPart {
+                    removes: vec![ConflictTerm {
                         value: TreeValue::File {
                             id: base_file_id,
                             executable: false,
                         },
                     }],
                     adds: vec![
-                        ConflictPart {
+                        ConflictTerm {
                             value: TreeValue::File {
                                 id: left_file_id,
                                 executable: false,
                             },
                         },
-                        ConflictPart {
+                        ConflictTerm {
                             value: TreeValue::File {
                                 id: right_file_id,
                                 executable: false,


### PR DESCRIPTION
It took a while before I realized that conflicts could be modeled as simple algebraic expressions with positive and negative terms (they were modeled as recursive 3-way conflicts initially). We've been thinking of them that way for a while now, so let's make the `ConflictPart` name match that model.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
