### PR TITLE
Allow `jj rebase` to take multiple `-s` or `-b` args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj restore` without `--from` works correctly even if `@` is a merge
   commit.
 
-* `jj rebase` now accepts multiple `-s` arguments. Revsets with multiple commits
-  are allowed with `--allow-large-revsets`.
+* `jj rebase` now accepts multiple `-s` and `-b` arguments. Revsets with
+  multiple commits are allowed with `--allow-large-revsets`.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj restore` without `--from` works correctly even if `@` is a merge
   commit.
 
+* `jj rebase` now accepts multiple `-s` arguments. Revsets with multiple commits
+  are allowed with `--allow-large-revsets`.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -69,6 +69,7 @@ pub trait Index {
 
     fn heads(&self, candidates: &mut dyn Iterator<Item = &CommitId>) -> Vec<CommitId>;
 
+    /// Parents before children
     fn topo_order(&self, input: &mut dyn Iterator<Item = &CommitId>) -> Vec<IndexEntry>;
 }
 
@@ -920,6 +921,7 @@ impl<'a> CompositeIndex<'a> {
         candidate_positions
     }
 
+    /// Parents before children
     pub fn topo_order(&self, input: &mut dyn Iterator<Item = &CommitId>) -> Vec<IndexEntry<'a>> {
         let mut entries_by_generation = input
             .into_iter()


### PR DESCRIPTION
This is two-thirds of #1158. (Though, these thirds are likely simpler than the last third)

One application (not the prettiest, but useful until we have `jj sync` at least):

    jj rebase -s oldmain+~:main -d main -L

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (command line args)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
