### PR TITLE
git push: add --deleted option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* `jj git push --deleted` will remove all locally deleted branches from the remote.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -369,3 +369,20 @@ fn test_git_push_missing_committer() {
     Error: Won't push commit f73024ee65ec since it has no description and it has no author and/or committer set
     "###);
 }
+
+#[test]
+fn test_git_push_deleted() {
+    let (test_env, workspace_root) = set_up();
+
+    test_env.jj_cmd_success(&workspace_root, &["branch", "delete", "branch1"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--deleted"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Branch changes to push to origin:
+      Delete branch branch1 from 45a3aa29e907
+    "###);
+    let stdout =
+        test_env.jj_cmd_success(&workspace_root, &["git", "push", "--deleted", "--dry-run"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+}


### PR DESCRIPTION
Right now, `--deleted` is exclusive of other options, as `--all` is. Should `--deleted` be allowed along with `--all` or `-b` and add to the list of branches in the second situation?

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [X] I have added tests to cover my changes
