### PR TITLE
style: simplify topo_order()

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -923,15 +923,9 @@ impl<'a> CompositeIndex<'a> {
 
     /// Parents before children
     pub fn topo_order(&self, input: &mut dyn Iterator<Item = &CommitId>) -> Vec<IndexEntry<'a>> {
-        let mut entries_by_generation = input
-            .into_iter()
-            .map(|id| IndexEntryByPosition(self.entry_by_id(id).unwrap()))
-            .collect_vec();
-        entries_by_generation.sort();
+        let mut entries_by_generation = input.map(|id| self.entry_by_id(id).unwrap()).collect_vec();
+        entries_by_generation.sort_unstable_by_key(|e| e.pos);
         entries_by_generation
-            .into_iter()
-            .map(|key| key.0)
-            .collect_vec()
     }
 }
 


### PR DESCRIPTION
- Calling `.into_iter()` on an iterator is a no-op.
- There is no need to wrap index entries into another type to unwrap them right after sorting.

`.sort_unstable_by_key()` could probably be used instead of `.sort_by_key()` here but I'm not familiar enough with this part of the code to confidently change that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
