### PR TITLE
cli: New `--changes-in` argument to `jj restore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj git clone` now supports the `--colocate` flag to create the git repo
   in the same directory as the jj repo.
 
+* `jj restore` gained a new option `--changes-in` to restore files
+  from a merge revision's parents. This undoes the changes that `jj diff -r`
+  would show.
+
+
 ### Fixed bugs
 
 ## [0.8.0] - 2023-07-09

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -417,7 +417,7 @@ fn test_help() {
     Usage: jj diffedit [OPTIONS]
 
     Options:
-      -r, --revision <REVISION>  The revision to touch up. Defaults to @ if --to/--from are not specified
+      -r, --revision <REVISION>  The revision to touch up. Defaults to @ if neither --to nor --from are specified
           --from <FROM>          Show changes from this revision. Defaults to @ if --to is specified
           --to <TO>              Edit changes in this revision. Defaults to @ if --from is specified
       -h, --help                 Print help (see more with '--help')

--- a/tests/test_restore_command.rs
+++ b/tests/test_restore_command.rs
@@ -43,12 +43,35 @@ fn test_restore() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
 
-    // Can restore from other revision
+    // Can restore another revision from its parents
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
+    insta::assert_snapshot!(stdout, @r###"
+    A file2
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "-c=@-"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Created e989e4b86680 (no description set)
+    Rebased 1 descendant commits
+    Working copy now at: b47256590e11 (no description set)
+    Parent commit      : e989e4b86680 (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
+    insta::assert_snapshot!(stdout, @"");
+
+    // Cannot restore the root revision
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "-c=root"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Cannot rewrite the root commit
+    "###);
+
+    // Can restore this revision from another revision
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 9cb58509136b (no description set)
-    Working copy now at: 9cb58509136b (no description set)
+    Created 1dd6eb63d587 (no description set)
+    Working copy now at: 1dd6eb63d587 (no description set)
     Parent commit      : 1a986a275de6 (no description set)
     Added 1 files, modified 0 files, removed 2 files
     "###);
@@ -61,10 +84,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 5ed06151e039 (no description set)
+    Created ec9d5b59c3cf (no description set)
     Rebased 1 descendant commits
-    Working copy now at: ca6c95b68bd2 (no description set)
-    Parent commit      : 5ed06151e039 (no description set)
+    Working copy now at: d6f3c6815772 (no description set)
+    Parent commit      : ec9d5b59c3cf (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -79,10 +102,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created c83e17dc46fd (no description set)
+    Created 5f6eb3d5c5bf (no description set)
     Rebased 1 descendant commits
-    Working copy now at: df9fb6892f99 (no description set)
-    Parent commit      : c83e17dc46fd (no description set)
+    Working copy now at: 525afd5d4a26 (no description set)
+    Parent commit      : 5f6eb3d5c5bf (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -97,8 +120,8 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 28647642d4a5 (no description set)
-    Working copy now at: 28647642d4a5 (no description set)
+    Created 569ce73d04fb (no description set)
+    Working copy now at: 569ce73d04fb (no description set)
     Parent commit      : 1a986a275de6 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);

--- a/tests/test_restore_command.rs
+++ b/tests/test_restore_command.rs
@@ -32,11 +32,19 @@ fn test_restore() {
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     std::fs::write(repo_path.join("file3"), "c\n").unwrap();
 
+    // There is no `-r` argument
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "-r=@-"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
+    the *current* revision, use `--from`. If you'd like to modify a *different* revision,
+    use `--to` or `--changes-in`.
+    "###);
+
     // Restores from parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created b05f8b84f2fc (no description set)
-    Working copy now at: b05f8b84f2fc (no description set)
+    Created ed1678e3725a (no description set)
+    Working copy now at: ed1678e3725a (no description set)
     Parent commit      : 1a986a275de6 (no description set)
     Added 1 files, modified 1 files, removed 1 files
     "###);
@@ -51,10 +59,10 @@ fn test_restore() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created e989e4b86680 (no description set)
+    Created e25100af9fff (no description set)
     Rebased 1 descendant commits
-    Working copy now at: b47256590e11 (no description set)
-    Parent commit      : e989e4b86680 (no description set)
+    Working copy now at: fd42591eb9a3 (no description set)
+    Parent commit      : e25100af9fff (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
@@ -70,8 +78,8 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 1dd6eb63d587 (no description set)
-    Working copy now at: 1dd6eb63d587 (no description set)
+    Created 237116e2437f (no description set)
+    Working copy now at: 237116e2437f (no description set)
     Parent commit      : 1a986a275de6 (no description set)
     Added 1 files, modified 0 files, removed 2 files
     "###);
@@ -84,10 +92,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created ec9d5b59c3cf (no description set)
+    Created 887f8f96c5a6 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: d6f3c6815772 (no description set)
-    Parent commit      : ec9d5b59c3cf (no description set)
+    Working copy now at: d2725e6e14de (no description set)
+    Parent commit      : 887f8f96c5a6 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -102,10 +110,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 5f6eb3d5c5bf (no description set)
+    Created 50c1fe092f55 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: 525afd5d4a26 (no description set)
-    Parent commit      : 5f6eb3d5c5bf (no description set)
+    Working copy now at: c63aab8ec732 (no description set)
+    Parent commit      : 50c1fe092f55 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -120,8 +128,8 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 569ce73d04fb (no description set)
-    Working copy now at: 569ce73d04fb (no description set)
+    Created 48f89f52d23e (no description set)
+    Working copy now at: 48f89f52d23e (no description set)
     Parent commit      : 1a986a275de6 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);


### PR DESCRIPTION
This argument can restore a merge commit to the merge of its parents. This allows one to apply the default behavior of `jj restore` to another commit. In other words, `jj restore` without arguments is equivalent to `jj restore -c @`. 

### Original description (before switching `-r` => `--rp`)

The title was "cmd: Add `-r` argument to `jj restore

The interface is now similar to `jj diffedit`, `jj diff`, etc.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
