### PR TITLE
Sync git refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj git fetch`: when re-adding a remote repository that had been previously
   removed, in some situations the remote branches were not recreated.
 
+* `jj git remote rename`: the git remote references were not rewritten with
+  the new name. If a new remote with the old name and containing the same
+  branches was added, the remote branches may not be recreated in some cases.
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed a bug that could get partially resolved conflicts to be interpreted
   incorrectly.
 
+* `jj git fetch`: when re-adding a remote repository that had been previously
+  removed, in some situations the remote branches were not recreated.
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes


### PR DESCRIPTION
Fixes #1308

The problem came from the fact that git refs were not synchronized with the remote branches: removing a remote branch (for example, while removing a remote, let's say branch "main@origin") didn't remove the corresponding git ref (for example "refs/remotes/origin/main"). When re-adding the same remote and re-fetching from it, since the git ref did exist already locally no remote branch was added.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [X] I have added tests to cover my changes
