### PR TITLE
Implement "config set" subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj git fetch` now supports a `--branch` argument to fetch some of the
   branches only.
 
+* `jj config set` command allows simple config edits like
+  `jj config set --repo user.email "somebody@example.com"`
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "textwrap 0.16.0",
  "thiserror",
  "timeago",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1021,6 +1022,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1595,6 +1605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1883,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ thiserror = "1.0.38"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["std", "ansi", "env-filter", "fmt"] }
 indexmap = "1.9.2"
+toml_edit = { version = "0.19.1", features = ["serde"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.139" }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -21,6 +21,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::rc::Rc;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use clap::builder::{NonEmptyStringValueParser, TypedValueParser, ValueParserFactory};
@@ -55,10 +56,13 @@ use jujutsu_lib::working_copy::{
 use jujutsu_lib::workspace::{Workspace, WorkspaceInitError, WorkspaceLoadError, WorkspaceLoader};
 use jujutsu_lib::{dag_walk, file_util, git, revset};
 use thiserror::Error;
+use toml_edit;
 use tracing_subscriber::prelude::*;
 
 use crate::commit_templater;
-use crate::config::{AnnotatedValue, CommandNameAndArgs, LayeredConfigs};
+use crate::config::{
+    config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
+};
 use crate::formatter::{Formatter, PlainTextFormatter};
 use crate::merge_tools::{ConflictResolveError, DiffEditError};
 use crate::template_parser::{TemplateAliasesMap, TemplateParseError};
@@ -1612,6 +1616,94 @@ pub fn serialize_config_value(value: &config::Value) -> String {
         config::ValueKind::String(val) => format!("{val:?}"),
         _ => value.to_string(),
     }
+}
+
+pub fn write_config_value_to_file(
+    key: &str,
+    value_str: &str,
+    path: &Path,
+) -> Result<(), CommandError> {
+    // Read config
+    let config_toml = std::fs::read_to_string(path).or_else(|err| {
+        match err.kind() {
+            // If config doesn't exist yet, read as empty and we'll write one.
+            std::io::ErrorKind::NotFound => Ok("".to_string()),
+            _ => Err(user_error(format!(
+                "Failed to read file {path}: {err:?}",
+                path = path.display()
+            ))),
+        }
+    })?;
+    let mut doc = toml_edit::Document::from_str(&config_toml).map_err(|err| {
+        user_error(format!(
+            "Failed to parse file {path}: {err:?}",
+            path = path.display()
+        ))
+    })?;
+
+    // Apply config value
+    // Iterpret value as string unless it's another simple scalar type.
+    // TODO(#531): Infer types based on schema (w/ --type arg to override).
+    let item = match toml_edit::Value::from_str(value_str) {
+        Ok(value @ toml_edit::Value::Boolean(..))
+        | Ok(value @ toml_edit::Value::Integer(..))
+        | Ok(value @ toml_edit::Value::Float(..))
+        | Ok(value @ toml_edit::Value::String(..)) => toml_edit::value(value),
+        _ => toml_edit::value(value_str),
+    };
+    let mut target_table = doc.as_table_mut();
+    let mut key_parts_iter = key.split('.');
+    // Note: split guarantees at least one item.
+    let last_key_part = key_parts_iter.next_back().unwrap();
+    for key_part in key_parts_iter {
+        target_table = target_table
+            .entry(key_part)
+            .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
+            .as_table_mut()
+            .ok_or_else(|| {
+                user_error(format!(
+                    "Failed to set {key}: would overwrite non-table value with parent table"
+                ))
+            })?;
+    }
+    // Error out if overwriting non-scalar value for key (table or array).
+    match target_table.get(last_key_part) {
+        None | Some(toml_edit::Item::None) => {}
+        Some(toml_edit::Item::Value(val)) if !val.is_array() && !val.is_inline_table() => {}
+        _ => {
+            return Err(user_error(format!(
+                "Failed to set {key}: would overwrite entire non-scalar value with scalar"
+            )))
+        }
+    }
+    target_table[last_key_part] = item;
+
+    // Write config back
+    std::fs::write(path, doc.to_string()).map_err(|err| {
+        user_error(format!(
+            "Failed to write file {path}: {err:?}",
+            path = path.display()
+        ))
+    })
+}
+
+pub fn get_config_file_path(
+    config_source: &ConfigSource,
+    workspace_loader: &WorkspaceLoader,
+) -> Result<PathBuf, CommandError> {
+    let edit_path = match config_source {
+        // TODO(#531): Special-case for editors that can't handle viewing directories?
+        ConfigSource::User => {
+            config_path()?.ok_or_else(|| user_error("No repo config path found to edit"))?
+        }
+        ConfigSource::Repo => workspace_loader.repo_path().join("config.toml"),
+        _ => {
+            return Err(user_error(format!(
+                "Can't get path for config source {config_source:?}"
+            )));
+        }
+    };
+    Ok(edit_path)
 }
 
 pub fn run_ui_editor(settings: &UserSettings, edit_path: &PathBuf) -> Result<(), CommandError> {


### PR DESCRIPTION
Uses toml_edit to support simple config edits like:
  `jj config set --repo user.email "somebody@example.com"`

Fixes #531.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
