### PR TITLE
Import refs with filter

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -389,7 +389,9 @@ pub fn fetch(
     fetch_options.proxy_options(proxy_options);
     let callbacks = callbacks.into_git();
     fetch_options.remote_callbacks(callbacks);
-    let refspecs = if let Some(globs) = branch_name_globs {
+    let refspecs = {
+        // If no globs have been given, import all branches
+        let globs = branch_name_globs.unwrap_or(&["*"]);
         if globs.iter().any(|g| g.contains(|c| ":^".contains(c))) {
             return Err(GitFetchError::InvalidGlob);
         }
@@ -399,8 +401,6 @@ pub fn fetch(
             .iter()
             .map(|glob| format!("+refs/heads/{glob}:refs/remotes/{remote_name}/{glob}"))
             .collect_vec()
-    } else {
-        vec![]
     };
     tracing::debug!("remote.download");
     remote.download(&refspecs, Some(&mut fetch_options))?;

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -342,7 +342,7 @@ pub fn fetch(
     mut_repo: &mut MutableRepo,
     git_repo: &git2::Repository,
     remote_name: &str,
-    globs: &[String],
+    globs: &[&str],
     callbacks: RemoteCallbacks<'_>,
     git_settings: &GitSettings,
 ) -> Result<Option<String>, GitFetchError> {

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -957,7 +957,7 @@ fn test_fetch_empty_repo() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -981,7 +981,7 @@ fn test_fetch_initial_commit() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1023,7 +1023,7 @@ fn test_fetch_success() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1044,7 +1044,7 @@ fn test_fetch_success() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1086,7 +1086,7 @@ fn test_fetch_prune_deleted_ref() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1105,7 +1105,7 @@ fn test_fetch_prune_deleted_ref() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1126,7 +1126,7 @@ fn test_fetch_no_default_branch() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1149,7 +1149,7 @@ fn test_fetch_no_default_branch() {
         tx.mut_repo(),
         &test_data.git_repo,
         "origin",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     )
@@ -1169,7 +1169,7 @@ fn test_fetch_no_such_remote() {
         tx.mut_repo(),
         &test_data.git_repo,
         "invalid-remote",
-        &[],
+        None,
         git::RemoteCallbacks::default(),
         &git_settings,
     );

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -302,7 +302,7 @@ fn cmd_git_fetch(
                 tx.mut_repo(),
                 &git_repo,
                 &remote,
-                &branches,
+                (!branches.is_empty()).then(|| &*branches),
                 cb,
                 &command.settings().git_settings(),
             )
@@ -430,7 +430,7 @@ fn do_git_clone(
             fetch_tx.mut_repo(),
             &git_repo,
             remote_name,
-            &[],
+            None,
             cb,
             &command.settings().git_settings(),
         )

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -295,13 +295,14 @@ fn cmd_git_fetch(
         "fetch from git remote(s) {}",
         remotes.iter().join(",")
     ));
+    let branches = args.branch.iter().map(|b| b.as_str()).collect_vec();
     for remote in remotes {
         with_remote_callbacks(ui, |cb| {
             git::fetch(
                 tx.mut_repo(),
                 &git_repo,
                 &remote,
-                &args.branch,
+                &branches,
                 cb,
                 &command.settings().git_settings(),
             )

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -85,7 +85,7 @@ pub struct GitRemoteListArgs {}
 /// Fetch from a Git remote
 #[derive(clap::Args, Clone, Debug)]
 pub struct GitFetchArgs {
-    /// Fetch only some of the branches (caution: known bugs)
+    /// Fetch only some of the branches
     ///
     /// Any `*` in the argument is expanded as a glob. So, one `--branch` can
     /// match several branches.

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -598,10 +598,6 @@ fn test_git_fetch_some_of_many_branches() {
     "###);
 }
 
-// TODO: Fix the bug this test demonstrates. (https://github.com/martinvonz/jj/issues/1300)
-// The issue likely stems from the fact that `jj undo` does not undo the fetch
-// inside the git repo backing the `target` repo. It is unclear whether it
-// should.
 #[test]
 fn test_git_fetch_undo() {
     let test_env = TestEnvironment::default();
@@ -654,11 +650,8 @@ fn test_git_fetch_undo() {
     // Now try to fetch just one branch
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    // BUG: Both branches got fetched.
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     o  c7d4bdcbc215 descr_for_b b
-    │ o  359a9a02457d descr_for_a1 a1
-    ├─╯
     o  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
@@ -741,5 +734,149 @@ fn test_git_fetch_rename_fetch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote", "upstream"]);
     insta::assert_snapshot!(stdout, @r###"
     Nothing changed.
+    "###);
+}
+
+#[test]
+fn test_git_fetch_removed_branch() {
+    let test_env = TestEnvironment::default();
+    let source_git_repo_path = test_env.env_root().join("source");
+    let _git_repo = git2::Repository::init(source_git_repo_path.clone()).unwrap();
+
+    // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
+    let stdout =
+        test_env.jj_cmd_success(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Fetching into new repo in "$TEST_ENV/target"
+    Nothing changed.
+    "###);
+    let target_jj_repo_path = test_env.env_root().join("target");
+
+    let source_log =
+        create_colocated_repo_and_branches_from_trunk1(&test_env, &source_git_repo_path);
+    insta::assert_snapshot!(source_log, @r###"
+       ===== Source git repo contents =====
+    @  c7d4bdcbc215 descr_for_b b
+    │ o  decaa3966c83 descr_for_a2 a2
+    ├─╯
+    │ o  359a9a02457d descr_for_a1 a1
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1 master trunk1
+    o  000000000000
+    "###);
+
+    // Fetch all branches
+    let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    o  c7d4bdcbc215 descr_for_b b
+    │ o  decaa3966c83 descr_for_a2 a2
+    ├─╯
+    │ o  359a9a02457d descr_for_a1 a1
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1 master trunk1
+    │ @  230dd059e1b0
+    ├─╯
+    o  000000000000
+    "###);
+
+    // Remove a2 branch in origin
+    test_env.jj_cmd_success(&source_git_repo_path, &["branch", "forget", "a2"]);
+
+    // Fetch branch a1 from origin and check that a2 is still there
+    let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    o  c7d4bdcbc215 descr_for_b b
+    │ o  decaa3966c83 descr_for_a2 a2
+    ├─╯
+    │ o  359a9a02457d descr_for_a1 a1
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1 master trunk1
+    │ @  230dd059e1b0
+    ├─╯
+    o  000000000000
+    "###);
+
+    // Fetch branches a2 from origin, and check that it has been removed locally
+    let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a2"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    o  c7d4bdcbc215 descr_for_b b
+    │ o  359a9a02457d descr_for_a1 a1
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1 master trunk1
+    │ @  230dd059e1b0
+    ├─╯
+    o  000000000000
+    "###);
+}
+
+#[test]
+fn test_git_fetch_removed_parent_branch() {
+    let test_env = TestEnvironment::default();
+    let source_git_repo_path = test_env.env_root().join("source");
+    let _git_repo = git2::Repository::init(source_git_repo_path.clone()).unwrap();
+
+    // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
+    let stdout =
+        test_env.jj_cmd_success(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Fetching into new repo in "$TEST_ENV/target"
+    Nothing changed.
+    "###);
+    let target_jj_repo_path = test_env.env_root().join("target");
+
+    let source_log =
+        create_colocated_repo_and_branches_from_trunk1(&test_env, &source_git_repo_path);
+    insta::assert_snapshot!(source_log, @r###"
+       ===== Source git repo contents =====
+    @  c7d4bdcbc215 descr_for_b b
+    │ o  decaa3966c83 descr_for_a2 a2
+    ├─╯
+    │ o  359a9a02457d descr_for_a1 a1
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1 master trunk1
+    o  000000000000
+    "###);
+
+    // Fetch all branches
+    let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    o  c7d4bdcbc215 descr_for_b b
+    │ o  decaa3966c83 descr_for_a2 a2
+    ├─╯
+    │ o  359a9a02457d descr_for_a1 a1
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1 master trunk1
+    │ @  230dd059e1b0
+    ├─╯
+    o  000000000000
+    "###);
+
+    // Remove all branches in origin.
+    test_env.jj_cmd_success(&source_git_repo_path, &["branch", "forget", "--glob", "*"]);
+
+    // Fetch branches master, trunk1 and a1 from origin and check that only those
+    // branches have been removed and that others were not rebased because of
+    // abandoned commits.
+    let stdout = test_env.jj_cmd_success(
+        &target_jj_repo_path,
+        &[
+            "git", "fetch", "--branch", "master", "--branch", "trunk1", "--branch", "a1",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    o  c7d4bdcbc215 descr_for_b b
+    │ o  decaa3966c83 descr_for_a2 a2
+    ├─╯
+    o  ff36dc55760e descr_for_trunk1
+    │ @  230dd059e1b0
+    ├─╯
+    o  000000000000
     "###);
 }


### PR DESCRIPTION
This patch series implements what is necessary to selectively import git references into jj. The first part was implemented by @ilyagr one week ago (avoid fetching uninteresting heads from a remote repo), and this is the second part, which also fixes some bugs:

- `jujutsu_lib::git::import_some_refs()` does the same thing as `git/import_refs()` but ignores all references not matched by a filter. Ignored references will never cause a branch to be added, moved, or deleted in the jj repo. We could merge the functions, but that will be a backwards incompatible change.
- `jujutsu_lib::git::fetch()` uses `import_some_refs()` when filtering is required. A trace has been let in if at some points the regex built from the globs must be analyzed/optimized.

The `CHANGELOG.md` file was not updated, as `jj git fetch --branch` is the sole user-facing change and it has been documented by @ilyagr aready.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [X] I have added tests to cover my changes

Fixes #1300