### PR TITLE
template: allow tab as whitespace as well

### DIFF
--- a/src/template.pest
+++ b/src/template.pest
@@ -17,7 +17,7 @@
 // predecessors % ("predecessor: " ++ commit_id)
 // parents % (commit_id ++ " is a parent of " ++ super.commit_id)
 
-whitespace = _{ " " | "\n" }
+whitespace = _{ " " | "\t" | "\n" }
 
 escape = @{ "\\" ~ ("n" | "\"" | "\\") }
 literal_char = @{ !("\"" | "\\") ~ ANY }


### PR DESCRIPTION
My jjconfig is otherwise all indented with tabs and it helps for my
template-aliases to be indented the same way too.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
