### PR TITLE
revset, template: clean up whitespace rule, parse "\t" and "\r"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,7 @@ name = "jujutsu"
 version = "0.7.0"
 dependencies = [
  "assert_cmd",
+ "assert_matches",
  "chrono",
  "clap 4.0.32",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ libc = { version = "0.2.139" }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
+assert_matches = "1.5.0"
 criterion = "0.4.0"
 criterion_bencher_compat = "0.4.0"
 insta = { version = "1.28.0", features = ["filters"] }

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -22,7 +22,7 @@ symbol = {
   | literal_string
 }
 literal_string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
-whitespace = _{ " " }
+whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 parents_op = { "-" }
 children_op = { "+" }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2449,6 +2449,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_whitespace() {
+        let ascii_whitespaces: String = ('\x00'..='\x7f')
+            .filter(char::is_ascii_whitespace)
+            .collect();
+        assert_eq!(
+            parse(&format!("{ascii_whitespaces}all()")).unwrap(),
+            parse("all()").unwrap(),
+        );
+    }
+
+    #[test]
     fn test_parse_revset_alias_formal_parameter() {
         let mut aliases_map = RevsetAliasesMap::new();
         // Trailing comma isn't allowed for empty parameter

--- a/src/template.pest
+++ b/src/template.pest
@@ -19,7 +19,7 @@
 
 whitespace = _{ " " | "\t" | "\n" }
 
-escape = @{ "\\" ~ ("n" | "\"" | "\\") }
+escape = @{ "\\" ~ ("t" | "r" | "n" | "\"" | "\\") }
 literal_char = @{ !("\"" | "\\") ~ ANY }
 raw_literal = @{ literal_char+ }
 literal = { "\"" ~ (raw_literal | escape)* ~ "\"" }

--- a/src/template.pest
+++ b/src/template.pest
@@ -17,7 +17,7 @@
 // predecessors % ("predecessor: " ++ commit_id)
 // parents % (commit_id ++ " is a parent of " ++ super.commit_id)
 
-whitespace = _{ " " | "\t" | "\n" }
+whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 escape = @{ "\\" ~ ("t" | "r" | "n" | "\"" | "\\") }
 literal_char = @{ !("\"" | "\\") ~ ANY }

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -258,6 +258,8 @@ fn parse_string_literal(pair: Pair<Rule>) -> String {
             Rule::escape => match part.as_str().as_bytes()[1] as char {
                 '"' => result.push('"'),
                 '\\' => result.push('\\'),
+                't' => result.push('\t'),
+                'r' => result.push('\r'),
                 'n' => result.push('\n'),
                 char => panic!("invalid escape: \\{char:?}"),
             },
@@ -1259,6 +1261,21 @@ mod tests {
         assert!(parse_template(r#" label("","") "#).is_ok());
         assert!(parse_template(r#" label("","",) "#).is_ok());
         assert!(parse_template(r#" label("",,"") "#).is_err());
+    }
+
+    #[test]
+    fn test_string_literal() {
+        // "\<char>" escapes
+        assert_eq!(
+            parse_into_kind(r#" "\t\r\n\"\\" "#),
+            Ok(ExpressionKind::String("\t\r\n\"\\".to_owned())),
+        );
+
+        // Invalid "\<char>" escape
+        assert_eq!(
+            parse_into_kind(r#" "\y" "#),
+            Err(TemplateParseErrorKind::SyntaxError),
+        );
     }
 
     #[test]

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -1246,6 +1246,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_whitespace() {
+        let ascii_whitespaces: String = ('\x00'..='\x7f')
+            .filter(char::is_ascii_whitespace)
+            .collect();
+        assert_eq!(
+            parse_normalized(&format!("{ascii_whitespaces}f()")).unwrap(),
+            parse_normalized("f()").unwrap(),
+        );
+    }
+
+    #[test]
     fn test_function_call_syntax() {
         // Trailing comma isn't allowed for empty argument
         assert!(parse_template(r#" "".first_line() "#).is_ok());


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
