### PR TITLE
templater: add text wrapping function

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -56,6 +56,8 @@ The following operators are supported.
 
 The following functions are defined.
 
+* `fill(width: Integer, content: Template) -> Template`: Fill lines at
+  the given `width`.
 * `indent(prefix: Template, content: Template) -> Template`: Indent
   non-empty lines by the given `prefix`.
 * `label(label: Template, content: Template) -> Template`: Apply label to

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -59,7 +59,6 @@ use thiserror::Error;
 use toml_edit;
 use tracing_subscriber::prelude::*;
 
-use crate::commit_templater;
 use crate::config::{
     config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
 };
@@ -68,6 +67,7 @@ use crate::merge_tools::{ConflictResolveError, DiffEditError};
 use crate::template_parser::{TemplateAliasesMap, TemplateParseError};
 use crate::templater::Template;
 use crate::ui::{ColorChoice, Ui};
+use crate::{commit_templater, text_util};
 
 #[derive(Clone, Debug)]
 pub enum CommandError {
@@ -1882,7 +1882,7 @@ impl DescriptionArg {
 
 impl From<String> for DescriptionArg {
     fn from(s: String) -> Self {
-        DescriptionArg(complete_newline(s))
+        DescriptionArg(text_util::complete_newline(s))
     }
 }
 
@@ -1896,14 +1896,6 @@ impl AsRef<str> for DescriptionArg {
     fn as_ref(&self) -> &str {
         self.as_str()
     }
-}
-
-pub fn complete_newline(s: impl Into<String>) -> String {
-    let mut s = s.into();
-    if !s.is_empty() && !s.ends_with('\n') {
-        s.push('\n');
-    }
-    s
 }
 
 #[derive(Clone, Debug)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,7 +49,7 @@ use jujutsu_lib::{conflicts, file_util, revset};
 use maplit::{hashmap, hashset};
 
 use crate::cli_util::{
-    self, check_stale_working_copy, get_config_file_path, print_checkout_stats,
+    check_stale_working_copy, get_config_file_path, print_checkout_stats,
     resolve_multiple_nonempty_revsets, resolve_mutliple_nonempty_revsets_flag_guarded,
     run_ui_editor, serialize_config_value, short_commit_hash, user_error, user_error_with_hint,
     write_config_value_to_file, Args, CommandError, CommandHelper, DescriptionArg, RevisionArg,
@@ -59,8 +59,8 @@ use crate::config::{AnnotatedValue, ConfigSource};
 use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
 use crate::formatter::{Formatter, PlainTextFormatter};
 use crate::graphlog::{get_graphlog, Edge};
-use crate::template_parser;
 use crate::ui::Ui;
+use crate::{template_parser, text_util};
 
 #[derive(clap::Parser, Clone, Debug)]
 enum Commands {
@@ -1770,7 +1770,7 @@ fn edit_description(
         .filter(|line| !line.starts_with("JJ: "))
         .join("\n");
     description.truncate(description.trim_end_matches('\n').len());
-    Ok(cli_util::complete_newline(description))
+    Ok(text_util::complete_newline(description))
 }
 
 fn cmd_describe(

--- a/src/commit_templater.rs
+++ b/src/commit_templater.rs
@@ -23,7 +23,6 @@ use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::Repo;
 use jujutsu_lib::rewrite;
 
-use crate::cli_util;
 use crate::formatter::Formatter;
 use crate::template_parser::{
     self, CoreTemplatePropertyKind, FunctionCallNode, IntoTemplateProperty, TemplateAliasesMap,
@@ -33,6 +32,7 @@ use crate::templater::{
     self, IntoTemplate, PlainTextFormattedProperty, Template, TemplateFunction, TemplateProperty,
     TemplatePropertyFn,
 };
+use crate::text_util;
 
 struct CommitTemplateLanguage<'repo, 'b> {
     repo: &'repo dyn Repo,
@@ -158,7 +158,7 @@ fn build_commit_keyword<'repo>(
     let repo = language.repo;
     let property = match name {
         "description" => language.wrap_string(wrap_fn(|commit| {
-            cli_util::complete_newline(commit.description())
+            text_util::complete_newline(commit.description())
         })),
         "change_id" => language.wrap_commit_or_change_id(wrap_fn(move |commit| {
             CommitOrChangeId::new(repo, IdKind::Change(commit.change_id().to_owned()))

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -1071,6 +1071,16 @@ fn build_global_function<'a, L: TemplateLanguage<'a>>(
     function: &FunctionCallNode,
 ) -> TemplateParseResult<Expression<L::Property>> {
     let property = match function.name {
+        "fill" => {
+            let [width_node, content_node] = expect_exact_arguments(function)?;
+            let width = expect_integer_expression(language, width_node)?;
+            let content = build_expression(language, content_node)?.into_template();
+            let template = ReformatTemplate::new(content, move |context, formatter, recorded| {
+                let width = width.extract(context).try_into().unwrap_or(0);
+                text_util::write_wrapped(formatter, recorded, width)
+            });
+            language.wrap_template(template)
+        }
         "indent" => {
             let [prefix_node, content_node] = expect_exact_arguments(function)?;
             let prefix = build_expression(language, prefix_node)?.into_template();

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -30,9 +30,10 @@ pub fn write_indented(
     recorded_content: &FormatRecorder,
     mut write_prefix: impl FnMut(&mut dyn Formatter) -> io::Result<()>,
 ) -> io::Result<()> {
+    let data = recorded_content.data();
     let mut new_line = true;
-    recorded_content.replay_with(formatter, |formatter, data| {
-        for line in data.split_inclusive(|&c| c == b'\n') {
+    recorded_content.replay_with(formatter, |formatter, range| {
+        for line in data[range].split_inclusive(|&c| c == b'\n') {
             if new_line && line != b"\n" {
                 // Prefix inherits the current labels. This is implementation detail
                 // and may be fixed later.

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -12,10 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+
+use crate::formatter::{FormatRecorder, Formatter};
+
 pub fn complete_newline(s: impl Into<String>) -> String {
     let mut s = s.into();
     if !s.is_empty() && !s.ends_with('\n') {
         s.push('\n');
     }
     s
+}
+
+/// Indents each line by the given prefix preserving labels.
+pub fn write_indented(
+    formatter: &mut dyn Formatter,
+    recorded_content: &FormatRecorder,
+    mut write_prefix: impl FnMut(&mut dyn Formatter) -> io::Result<()>,
+) -> io::Result<()> {
+    let mut new_line = true;
+    recorded_content.replay_with(formatter, |formatter, data| {
+        for line in data.split_inclusive(|&c| c == b'\n') {
+            if new_line && line != b"\n" {
+                // Prefix inherits the current labels. This is implementation detail
+                // and may be fixed later.
+                write_prefix(formatter)?;
+            }
+            formatter.write_all(line)?;
+            new_line = line.ends_with(b"\n");
+        }
+        Ok(())
+    })
 }

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -45,3 +45,233 @@ pub fn write_indented(
         Ok(())
     })
 }
+
+/// Word with trailing whitespace.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ByteFragment<'a> {
+    word: &'a [u8],
+    whitespace_len: usize,
+    word_width: usize,
+}
+
+impl<'a> ByteFragment<'a> {
+    fn new(word: &'a [u8], whitespace_len: usize) -> Self {
+        // We don't care about the width of non-UTF-8 bytes, but should not panic.
+        let word_width = textwrap::core::display_width(&String::from_utf8_lossy(word));
+        ByteFragment {
+            word,
+            whitespace_len,
+            word_width,
+        }
+    }
+
+    fn offset_in(&self, text: &[u8]) -> usize {
+        byte_offset_from(text, self.word)
+    }
+}
+
+impl textwrap::core::Fragment for ByteFragment<'_> {
+    fn width(&self) -> f64 {
+        self.word_width as f64
+    }
+
+    fn whitespace_width(&self) -> f64 {
+        self.whitespace_len as f64
+    }
+
+    fn penalty_width(&self) -> f64 {
+        0.0
+    }
+}
+
+fn byte_offset_from(outer: &[u8], inner: &[u8]) -> usize {
+    let outer_start = outer.as_ptr() as usize;
+    let inner_start = inner.as_ptr() as usize;
+    assert!(outer_start <= inner_start);
+    assert!(inner_start + inner.len() <= outer_start + outer.len());
+    inner_start - outer_start
+}
+
+fn split_byte_line_to_words(line: &[u8]) -> Vec<ByteFragment<'_>> {
+    let mut words = Vec::new();
+    let mut tail = line;
+    while let Some(word_end) = tail.iter().position(|&c| c == b' ') {
+        let word = &tail[..word_end];
+        let ws_end = tail[word_end + 1..]
+            .iter()
+            .position(|&c| c != b' ')
+            .map(|p| p + word_end + 1)
+            .unwrap_or(tail.len());
+        words.push(ByteFragment::new(word, ws_end - word_end));
+        tail = &tail[ws_end..];
+    }
+    if !tail.is_empty() {
+        words.push(ByteFragment::new(tail, 0));
+    }
+    words
+}
+
+/// Wraps lines at the given width, returns a vector of lines (excluding "\n".)
+///
+/// Existing newline characters will never be removed. For `str` content, you
+/// can use `textwrap::refill()` to refill a pre-formatted text.
+///
+/// Each line is a sub-slice of the given text, even if the line is empty.
+///
+/// The wrapping logic is more restricted than the default of the `textwrap`.
+/// Notably, this doesn't support hyphenation nor unicode line break. The
+/// display width is calculated based on unicode property in the same manner
+/// as `textwrap::wrap()`.
+pub fn wrap_bytes(text: &[u8], width: usize) -> Vec<&[u8]> {
+    let mut split_lines = Vec::new();
+    for line in text.split(|&c| c == b'\n') {
+        let words = split_byte_line_to_words(line);
+        let split = textwrap::wrap_algorithms::wrap_first_fit(&words, &[width as f64]);
+        split_lines.extend(split.iter().map(|words| match words {
+            [] => &line[..0], // Empty line
+            [a] => a.word,
+            [a, .., b] => {
+                let start = a.offset_in(line);
+                let end = b.offset_in(line) + b.word.len();
+                &line[start..end]
+            }
+        }));
+    }
+    split_lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_byte_line_to_words() {
+        assert_eq!(split_byte_line_to_words(b""), vec![]);
+        assert_eq!(
+            split_byte_line_to_words(b"foo"),
+            vec![ByteFragment {
+                word: b"foo",
+                whitespace_len: 0,
+                word_width: 3
+            }],
+        );
+        assert_eq!(
+            split_byte_line_to_words(b"  foo"),
+            vec![
+                ByteFragment {
+                    word: b"",
+                    whitespace_len: 2,
+                    word_width: 0
+                },
+                ByteFragment {
+                    word: b"foo",
+                    whitespace_len: 0,
+                    word_width: 3
+                },
+            ],
+        );
+        assert_eq!(
+            split_byte_line_to_words(b"foo  "),
+            vec![ByteFragment {
+                word: b"foo",
+                whitespace_len: 2,
+                word_width: 3
+            }],
+        );
+        assert_eq!(
+            split_byte_line_to_words(b"a b  foo bar "),
+            vec![
+                ByteFragment {
+                    word: b"a",
+                    whitespace_len: 1,
+                    word_width: 1
+                },
+                ByteFragment {
+                    word: b"b",
+                    whitespace_len: 2,
+                    word_width: 1
+                },
+                ByteFragment {
+                    word: b"foo",
+                    whitespace_len: 1,
+                    word_width: 3,
+                },
+                ByteFragment {
+                    word: b"bar",
+                    whitespace_len: 1,
+                    word_width: 3,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn test_wrap_bytes() {
+        assert_eq!(wrap_bytes(b"foo", 10), [b"foo".as_ref()]);
+        assert_eq!(wrap_bytes(b"foo bar", 10), [b"foo bar".as_ref()]);
+        assert_eq!(
+            wrap_bytes(b"foo bar baz", 10),
+            [b"foo bar".as_ref(), b"baz".as_ref()],
+        );
+
+        // Empty text is represented as [""]
+        assert_eq!(wrap_bytes(b"", 10), [b"".as_ref()]);
+        assert_eq!(wrap_bytes(b" ", 10), [b"".as_ref()]);
+
+        // Whitespace in the middle should be preserved
+        assert_eq!(
+            wrap_bytes(b"foo  bar   baz", 8),
+            [b"foo  bar".as_ref(), b"baz".as_ref()],
+        );
+        assert_eq!(
+            wrap_bytes(b"foo  bar   x", 7),
+            [b"foo".as_ref(), b"bar   x".as_ref()],
+        );
+        assert_eq!(
+            wrap_bytes(b"foo bar \nx", 7),
+            [b"foo bar".as_ref(), b"x".as_ref()],
+        );
+        assert_eq!(
+            wrap_bytes(b"foo bar\n x", 7),
+            [b"foo bar".as_ref(), b" x".as_ref()],
+        );
+        assert_eq!(
+            wrap_bytes(b"foo bar x", 4),
+            [b"foo".as_ref(), b"bar".as_ref(), b"x".as_ref()],
+        );
+
+        // Ends with "\n"
+        assert_eq!(wrap_bytes(b"foo\n", 10), [b"foo".as_ref(), b"".as_ref()]);
+        assert_eq!(wrap_bytes(b"foo\n", 3), [b"foo".as_ref(), b"".as_ref()]);
+        assert_eq!(wrap_bytes(b"\n", 10), [b"".as_ref(), b"".as_ref()]);
+
+        // Overflow
+        assert_eq!(wrap_bytes(b"foo x", 2), [b"foo".as_ref(), b"x".as_ref()]);
+        assert_eq!(wrap_bytes(b"x y", 0), [b"x".as_ref(), b"y".as_ref()]);
+
+        // Invalid UTF-8 bytes should not cause panic
+        assert_eq!(wrap_bytes(b"foo\x80", 10), [b"foo\x80".as_ref()]);
+    }
+
+    #[test]
+    fn test_wrap_bytes_slice_ptr() {
+        let text = b"\nfoo\n\nbar baz\n";
+        let lines = wrap_bytes(text, 10);
+        assert_eq!(
+            lines,
+            [
+                b"".as_ref(),
+                b"foo".as_ref(),
+                b"".as_ref(),
+                b"bar baz".as_ref(),
+                b"".as_ref()
+            ],
+        );
+        // Each line should be a sub-slice of the source text
+        assert_eq!(lines[0].as_ptr(), text[0..].as_ptr());
+        assert_eq!(lines[1].as_ptr(), text[1..].as_ptr());
+        assert_eq!(lines[2].as_ptr(), text[5..].as_ptr());
+        assert_eq!(lines[3].as_ptr(), text[6..].as_ptr());
+        assert_eq!(lines[4].as_ptr(), text[14..].as_ptr());
+    }
+}

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 The Jujutsu Authors
+// Copyright 2022-2023 The Jujutsu Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(unused_must_use)]
-
-pub mod cleanup_guard;
-pub mod cli_util;
-pub mod commands;
-pub mod commit_templater;
-pub mod config;
-pub mod diff_util;
-pub mod formatter;
-pub mod graphlog;
-pub mod merge_tools;
-pub mod operation_templater;
-mod progress;
-pub mod template_parser;
-pub mod templater;
-pub mod text_util;
-pub mod time_util;
-pub mod ui;
+pub fn complete_newline(s: impl Into<String>) -> String {
+    let mut s = s.into();
+    if !s.is_empty() && !s.ends_with('\n') {
+        s.push('\n');
+    }
+    s
+}


### PR DESCRIPTION
TBD: template function syntax (see also the last commit)
* `fill(width, content)` (weird to add optional parameters)
* `fill(content, width)` (hard to read for lengthy content)
* `template`|`string.fill(width)` (method)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
