### PR TITLE
git push: do not consider @- if @ is not discardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `++` operator, `concat()`, or `separate()` function instead.
   Example: `description ++ "\n"`
 
+* `jj git push` will consider pushing the parent commit only when the
+  current commit has no content and no description, such as right after
+  a `jj squash`.
+
 ### New features
 
 * `jj git push --deleted` will remove all locally deleted branches from the remote.

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -128,4 +128,15 @@ impl Commit {
     pub fn committer(&self) -> &Signature {
         &self.data.committer
     }
+
+    /// A commit is discardable if it has one parent, no change from its
+    /// parent, and an empty description.
+    pub fn is_discardable(&self) -> bool {
+        if self.description().is_empty() {
+            if let [parent_commit] = &*self.parents() {
+                return self.tree_id() == parent_commit.tree_id();
+            }
+        }
+        false
+    }
 }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -743,11 +743,7 @@ impl MutableRepo {
                 .store()
                 .get_commit(&wc_commit_id)
                 .map_err(EditCommitError::WorkingCopyCommitNotFound)?;
-            if wc_commit.parent_ids().len() == 1
-                && wc_commit.parents()[0].tree_id() == wc_commit.tree_id()
-                && wc_commit.description().is_empty()
-                && self.view().heads().contains(wc_commit.id())
-            {
+            if wc_commit.is_discardable() && self.view().heads().contains(wc_commit.id()) {
                 // Abandon the working-copy commit we're leaving if it's empty and a head commit
                 self.record_abandoned_commit(wc_commit_id);
             }

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -703,13 +703,15 @@ fn cmd_git_push(
                     &RefTarget::Normal(wc_commit.clone()),
                 );
                 if branches.is_empty() {
-                    // Try @- instead if it has exactly one parent, such as after `jj squash`
+                    // Try @- instead if @ is discardable
                     let commit = workspace_command.repo().store().get_commit(wc_commit)?;
-                    if let [parent] = commit.parent_ids() {
-                        branches = find_branches_targeting(
-                            workspace_command.repo().view(),
-                            &RefTarget::Normal(parent.clone()),
-                        );
+                    if commit.is_discardable() {
+                        if let [parent_commit_id] = commit.parent_ids() {
+                            branches = find_branches_targeting(
+                                workspace_command.repo().view(),
+                                &RefTarget::Normal(parent_commit_id.clone()),
+                            );
+                        }
                     }
                 }
                 if branches.is_empty() {


### PR DESCRIPTION
As discussed on discord: `jj git push` should not push `@-` unless `@` is empty.

*Edit:* a previous version used the `if_chain` crate but this is really not necessary here.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [X] I have added tests to cover my changes
