### PR TITLE
cli: print commands in alphabetical order

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -64,34 +64,29 @@ use crate::ui::Ui;
 
 #[derive(clap::Parser, Clone, Debug)]
 enum Commands {
-    Version(VersionArgs),
-    Init(InitArgs),
+    Abandon(AbandonArgs),
+    Backout(BackoutArgs),
     #[command(subcommand)]
-    Config(ConfigSubcommand),
-    Checkout(CheckoutArgs),
-    Untrack(UntrackArgs),
-    Files(FilesArgs),
+    Branch(branch::BranchSubcommand),
     #[command(alias = "print")]
     Cat(CatArgs),
-    Diff(DiffArgs),
-    Show(ShowArgs),
-    Status(StatusArgs),
-    Log(LogArgs),
-    Obslog(ObslogArgs),
-    Interdiff(InterdiffArgs),
-    Describe(DescribeArgs),
+    Checkout(CheckoutArgs),
     Commit(CommitArgs),
-    Duplicate(DuplicateArgs),
-    Abandon(AbandonArgs),
-    Edit(EditArgs),
-    New(NewArgs),
-    Move(MoveArgs),
-    Squash(SquashArgs),
-    Unsquash(UnsquashArgs),
-    Restore(RestoreArgs),
+    #[command(subcommand)]
+    Config(ConfigSubcommand),
+    #[command(subcommand)]
+    Debug(DebugCommands),
+    Describe(DescribeArgs),
+    Diff(DiffArgs),
     Diffedit(DiffeditArgs),
-    Resolve(ResolveArgs),
-    Split(SplitArgs),
+    Duplicate(DuplicateArgs),
+    Edit(EditArgs),
+    Files(FilesArgs),
+    #[command(subcommand)]
+    Git(git::GitCommands),
+    Init(InitArgs),
+    Interdiff(InterdiffArgs),
+    Log(LogArgs),
     /// Merge work from multiple branches
     ///
     /// Unlike most other VCSs, `jj merge` does not implicitly include the
@@ -102,22 +97,27 @@ enum Commands {
     /// This is the same as `jj new`, except that it requires at least two
     /// arguments.
     Merge(NewArgs),
-    Rebase(RebaseArgs),
-    Backout(BackoutArgs),
-    #[command(subcommand)]
-    Branch(branch::BranchSubcommand),
-    /// Undo an operation (shortcut for `jj op undo`)
-    Undo(operation::OperationUndoArgs),
+    Move(MoveArgs),
+    New(NewArgs),
+    Obslog(ObslogArgs),
     #[command(subcommand)]
     #[command(visible_alias = "op")]
     Operation(operation::OperationCommands),
+    Rebase(RebaseArgs),
+    Resolve(ResolveArgs),
+    Restore(RestoreArgs),
+    Show(ShowArgs),
+    Sparse(SparseArgs),
+    Split(SplitArgs),
+    Squash(SquashArgs),
+    Status(StatusArgs),
+    /// Undo an operation (shortcut for `jj op undo`)
+    Undo(operation::OperationUndoArgs),
+    Unsquash(UnsquashArgs),
+    Untrack(UntrackArgs),
+    Version(VersionArgs),
     #[command(subcommand)]
     Workspace(WorkspaceCommands),
-    Sparse(SparseArgs),
-    #[command(subcommand)]
-    Git(git::GitCommands),
-    #[command(subcommand)]
-    Debug(DebugCommands),
 }
 
 /// Display version information


### PR DESCRIPTION
Until https://github.com/clap-rs/clap/issues/1553 is fixed, I don't think we can do better than alphabetical order (without a lot of work).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
