### PR TITLE
templater: merge parse error variants (prepare for `.map(|x| ...)` expression)

### DIFF
--- a/src/template_builder.rs
+++ b/src/template_builder.rs
@@ -17,7 +17,7 @@ use jujutsu_lib::backend::{Signature, Timestamp};
 
 use crate::template_parser::{
     self, ExpressionKind, ExpressionNode, FunctionCallNode, MethodCallNode, TemplateParseError,
-    TemplateParseErrorKind, TemplateParseResult,
+    TemplateParseResult,
 };
 use crate::templater::{
     ConcatTemplate, ConditionalTemplate, FormattablePropertyListTemplate, IntoTemplate,
@@ -388,8 +388,7 @@ fn build_timestamp_method<'a, L: TemplateLanguage<'a>>(
             let format =
                 template_parser::expect_string_literal_with(format_node, |format, span| {
                     time_util::FormattingItems::parse(format).ok_or_else(|| {
-                        let kind = TemplateParseErrorKind::InvalidTimeFormat;
-                        TemplateParseError::with_span(kind, span)
+                        TemplateParseError::unexpected_expression("Invalid time format", span)
                     })
                 })?
                 .into_owned();
@@ -570,7 +569,7 @@ pub fn expect_boolean_expression<'a, L: TemplateLanguage<'a>>(
 ) -> TemplateParseResult<Box<dyn TemplateProperty<L::Context, Output = bool> + 'a>> {
     build_expression(language, node)?
         .try_into_boolean()
-        .ok_or_else(|| TemplateParseError::invalid_argument_type("Boolean", node.span))
+        .ok_or_else(|| TemplateParseError::expected_type("Boolean", node.span))
 }
 
 pub fn expect_integer_expression<'a, L: TemplateLanguage<'a>>(
@@ -579,5 +578,5 @@ pub fn expect_integer_expression<'a, L: TemplateLanguage<'a>>(
 ) -> TemplateParseResult<Box<dyn TemplateProperty<L::Context, Output = i64> + 'a>> {
     build_expression(language, node)?
         .try_into_integer()
-        .ok_or_else(|| TemplateParseError::invalid_argument_type("Integer", node.span))
+        .ok_or_else(|| TemplateParseError::expected_type("Integer", node.span))
 }

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -232,7 +232,7 @@ fn test_templater_parse_error() {
     1 | if(label("foo", "bar"), "baz")
       |    ^-----------------^
       |
-      = Expected argument of type "Boolean"
+      = Expected expression of type "Boolean"
     "###);
 }
 
@@ -368,7 +368,7 @@ fn test_templater_timestamp_method() {
     1 | author.timestamp().format(0)
       |                           ^
       |
-      = Expected argument of type "String literal"
+      = Expected string literal
     "###);
 
     // Dynamic string isn't supported yet
@@ -378,7 +378,7 @@ fn test_templater_timestamp_method() {
     1 | author.timestamp().format("%Y" ++ "%m")
       |                           ^----------^
       |
-      = Expected argument of type "String literal"
+      = Expected string literal
     "###);
 
     // Literal alias expansion
@@ -657,7 +657,7 @@ fn test_templater_alias() {
     1 | identity(identity(commit_id.short("")))
       |                                   ^^
       |
-      = Expected argument of type "Integer"
+      = Expected expression of type "Integer"
     "###);
 
     insta::assert_snapshot!(render_err("commit_id ++ recurse"), @r###"
@@ -716,7 +716,7 @@ fn test_templater_alias() {
     1 | coalesce(label("x", "not boolean"), "")
       |          ^-----------------------^
       |
-      = Expected argument of type "Boolean"
+      = Expected expression of type "Boolean"
     "###);
 }
 

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -180,7 +180,7 @@ fn test_templater_parse_error() {
     1 | description.contains()
       |                      ^
       |
-      = Expected 1 arguments
+      = Function "contains": Expected 1 arguments
     "###);
 
     insta::assert_snapshot!(render_err(r#"description.first_line("foo")"#), @r###"
@@ -189,7 +189,7 @@ fn test_templater_parse_error() {
     1 | description.first_line("foo")
       |                        ^---^
       |
-      = Expected 0 arguments
+      = Function "first_line": Expected 0 arguments
     "###);
 
     insta::assert_snapshot!(render_err(r#"label()"#), @r###"
@@ -198,7 +198,7 @@ fn test_templater_parse_error() {
     1 | label()
       |       ^
       |
-      = Expected 2 arguments
+      = Function "label": Expected 2 arguments
     "###);
     insta::assert_snapshot!(render_err(r#"label("foo", "bar", "baz")"#), @r###"
     Error: Failed to parse template:  --> 1:7
@@ -206,7 +206,7 @@ fn test_templater_parse_error() {
     1 | label("foo", "bar", "baz")
       |       ^-----------------^
       |
-      = Expected 2 arguments
+      = Function "label": Expected 2 arguments
     "###);
 
     insta::assert_snapshot!(render_err(r#"if()"#), @r###"
@@ -215,7 +215,7 @@ fn test_templater_parse_error() {
     1 | if()
       |    ^
       |
-      = Expected 2 to 3 arguments
+      = Function "if": Expected 2 to 3 arguments
     "###);
     insta::assert_snapshot!(render_err(r#"if("foo", "bar", "baz", "quux")"#), @r###"
     Error: Failed to parse template:  --> 1:4
@@ -223,7 +223,7 @@ fn test_templater_parse_error() {
     1 | if("foo", "bar", "baz", "quux")
       |    ^-------------------------^
       |
-      = Expected 2 to 3 arguments
+      = Function "if": Expected 2 to 3 arguments
     "###);
 
     insta::assert_snapshot!(render_err(r#"if(label("foo", "bar"), "baz")"#), @r###"
@@ -693,7 +693,7 @@ fn test_templater_alias() {
     1 | identity()
       |          ^
       |
-      = Expected 1 arguments
+      = Function "identity": Expected 1 arguments
     "###);
     insta::assert_snapshot!(render_err("identity(commit_id, commit_id)"), @r###"
     Error: Failed to parse template:  --> 1:10
@@ -701,7 +701,7 @@ fn test_templater_alias() {
     1 | identity(commit_id, commit_id)
       |          ^------------------^
       |
-      = Expected 1 arguments
+      = Function "identity": Expected 1 arguments
     "###);
 
     insta::assert_snapshot!(render_err(r#"coalesce(label("x", "not boolean"), "")"#), @r###"


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
