### PR TITLE
templater: add `object.field` syntax, migrate some nullary methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `++` operator, `concat()`, or `separate()` function instead.
   Example: `description ++ "\n"`
 
+* In template language, some of the 0-argument methods have been migrated to
+  field access syntax. For details, see [the documentation](docs/templates.md).
+
 * `jj git push` will consider pushing the parent commit only when the
   current commit has no content and no description, such as right after
   a `jj squash`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -156,7 +156,7 @@ Can be customized by the `format_short_id()` template alias.
 # Just the shortest possible unique prefix
 'format_short_id(id)' = 'id.shortest()'
 # Show unique prefix and the rest surrounded by brackets
-'format_short_id(id)' = 'id.shortest(12).prefix() ++ "[" ++ id.shortest(12).rest() ++ "]"'
+'format_short_id(id)' = 'id.shortest(12).prefix ++ "[" ++ id.shortest(12).rest ++ "]"'
 # Always show 12 characters
 'format_short_id(id)' = 'id.short(12)'
 ```
@@ -187,7 +187,7 @@ will need to modify the `format_time_range()` template alias.
 
 ```toml
 [template-aliases]
-'format_time_range(time_range)' = 'time_range.start() ++ " - " ++ time_range.end()'
+'format_time_range(time_range)' = 'time_range.start ++ " - " ++ time_range.end'
 ```
 
 ### Author format
@@ -197,11 +197,11 @@ Can be customized by the `format_short_signature()` template alias.
 ```toml
 [template-aliases]
 # Full email address (default)
-'format_short_signature(signature)' = 'signature.email()'
+'format_short_signature(signature)' = 'signature.email'
 # Both name and email address
 'format_short_signature(signature)' = 'signature'
 # Username part of the email address
-'format_short_signature(signature)' = 'signature.username()'
+'format_short_signature(signature)' = 'signature.username'
 ```
 
 ## Pager

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,8 +1,8 @@
 # Templates
 
 Jujutsu supports a functional language to customize output of commands.
-The language consists of literals, keywords, operators, functions, and
-methods.
+The language consists of literals, keywords, operators, functions, fields,
+and methods.
 
 A couple of `jj` commands accept a template via `-T`/`--template` option.
 
@@ -73,22 +73,22 @@ The following functions are defined.
 
 ### Boolean type
 
-No methods are defined.
+No fields/methods are defined.
 
 ### CommitId / ChangeId type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.short([len: Integer]) -> String`
 * `.shortest([min_len: Integer]) -> ShortestIdPrefix`: Shortest unique prefix.
 
 ### Integer type
 
-No methods are defined.
+No fields/methods are defined.
 
 ### List type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.join(separator: Template) -> Template`: Concatenate elements with
   the given `separator`.
@@ -97,19 +97,19 @@ The following methods are defined.
 
 ### ListTemplate type
 
-The following methods are defined. See also the `List` type.
+The following fields/methods are defined. See also the `List` type.
 
 * `.join(separator: Template) -> Template`
 
 ### OperationId type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.short([len: Integer]) -> String`
 
 ### ShortestIdPrefix type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.prefix() -> String`
 * `.rest() -> String`
@@ -118,7 +118,7 @@ The following methods are defined.
 
 ### Signature type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.name() -> String`
 * `.email() -> String`
@@ -127,8 +127,8 @@ The following methods are defined.
 
 ### String type
 
-A string can be implicitly converted to `Boolean`. The following methods are
-defined.
+A string can be implicitly converted to `Boolean`. The following fields/methods
+are defined.
 
 * `.contains(needle: Template) -> Boolean`
 * `.first_line() -> String`
@@ -138,11 +138,12 @@ defined.
 
 ### Template type
 
-Any types can be implicitly converted to `Template`. No methods are defined.
+Any types can be implicitly converted to `Template`. No fields/methods are
+defined.
 
 ### Timestamp type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.ago() -> String`: Format as relative timestamp.
 * `.format(format: String) -> String`: Format with [the specified strftime-like
@@ -150,7 +151,7 @@ The following methods are defined.
 
 ### TimestampRange type
 
-The following methods are defined.
+The following fields/methods are defined.
 
 * `.start() -> Timestamp`
 * `.end() -> Timestamp`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -111,8 +111,8 @@ The following fields/methods are defined.
 
 The following fields/methods are defined.
 
-* `.prefix() -> String`
-* `.rest() -> String`
+* `.prefix: String`
+* `.rest: String`
 * `.upper() -> ShortestIdPrefix`
 * `.lower() -> ShortestIdPrefix`
 
@@ -120,10 +120,10 @@ The following fields/methods are defined.
 
 The following fields/methods are defined.
 
-* `.name() -> String`
-* `.email() -> String`
-* `.username() -> String`
-* `.timestamp() -> Timestamp`
+* `.name: String`
+* `.email: String`
+* `.username: String`
+* `.timestamp: Timestamp`
 
 ### String type
 
@@ -153,8 +153,8 @@ The following fields/methods are defined.
 
 The following fields/methods are defined.
 
-* `.start() -> Timestamp`
-* `.end() -> Timestamp`
+* `.start: Timestamp`
+* `.end: Timestamp`
 * `.duration() -> String`
 
 ## Configuration

--- a/src/commit_templater.rs
+++ b/src/commit_templater.rs
@@ -453,11 +453,18 @@ impl ShortestIdPrefix {
 }
 
 fn build_shortest_id_prefix_field<'repo>(
-    _language: &CommitTemplateLanguage<'repo, '_>,
-    _self_property: impl TemplateProperty<Commit, Output = ShortestIdPrefix> + 'repo,
+    language: &CommitTemplateLanguage<'repo, '_>,
+    self_property: impl TemplateProperty<Commit, Output = ShortestIdPrefix> + 'repo,
     field: &FieldNode,
 ) -> TemplateParseResult<CommitTemplatePropertyKind<'repo>> {
-    Err(TemplateParseError::no_such_field("ShortestIdPrefix", field))
+    let property = match field.name {
+        "prefix" => language.wrap_string(TemplateFunction::new(self_property, |id| id.prefix)),
+        "rest" => language.wrap_string(TemplateFunction::new(self_property, |id| id.rest)),
+        _ => {
+            return Err(TemplateParseError::no_such_field("ShortestIdPrefix", field));
+        }
+    };
+    Ok(property)
 }
 
 fn build_shortest_id_prefix_method<'repo>(
@@ -467,14 +474,6 @@ fn build_shortest_id_prefix_method<'repo>(
     function: &FunctionCallNode,
 ) -> TemplateParseResult<CommitTemplatePropertyKind<'repo>> {
     let property = match function.name {
-        "prefix" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_string(TemplateFunction::new(self_property, |id| id.prefix))
-        }
-        "rest" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_string(TemplateFunction::new(self_property, |id| id.rest))
-        }
         "upper" => {
             template_parser::expect_no_arguments(function)?;
             language

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -14,7 +14,7 @@ label(if(current_working_copy, "working_copy"),
         label("divergent", format_short_change_id(change_id) ++ "??"),
         format_short_change_id(change_id)),
       format_short_signature(author),
-      format_timestamp(committer.timestamp()),
+      format_timestamp(committer.timestamp),
       branches,
       tags,
       working_copies,
@@ -54,9 +54,9 @@ show = 'show'
 'format_short_id(id)' = 'id.shortest(12)'
 'format_short_change_id(id)' = 'format_short_id(id)'
 'format_short_commit_id(id)' = 'format_short_id(id)'
-'format_short_signature(signature)' = 'signature.email()'
+'format_short_signature(signature)' = 'signature.email'
 'format_time_range(time_range)' = '''
-  time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
+  time_range.start.ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp'
 
 # TODO: Add branches, tags, etc
@@ -64,8 +64,8 @@ show = 'show'
 concat(
   "Commit ID: " ++ commit_id ++ "\n",
   "Change ID: " ++ change_id ++ "\n",
-  "Author: " ++ author ++ " (" ++ format_timestamp(author.timestamp()) ++ ")\n",
-  "Committer: " ++ committer ++ " (" ++ format_timestamp(committer.timestamp()) ++ ")\n",
+  "Author: " ++ author ++ " (" ++ format_timestamp(author.timestamp) ++ ")\n",
+  "Committer: " ++ committer ++ " (" ++ format_timestamp(committer.timestamp) ++ ")\n",
   "\n",
   indent("    ", if(description, description, description_placeholder ++ "\n")),
   "\n",

--- a/src/template.pest
+++ b/src/template.pest
@@ -55,7 +55,7 @@ primary = _{
 }
 
 term = {
-  primary ~ ("." ~ function)*
+  primary ~ ("." ~ (function | identifier))*
 }
 
 concat = _{

--- a/src/template_builder.rs
+++ b/src/template_builder.rs
@@ -681,6 +681,7 @@ pub fn build_expression<'a, L: TemplateLanguage<'a>>(
         ExpressionKind::FunctionCall(function) => {
             build_global_function(language, build_ctx, function)
         }
+        ExpressionKind::FieldAccess(_) => todo!(),
         ExpressionKind::MethodCall(method) => build_method_call(language, build_ctx, method),
         ExpressionKind::Lambda(_) => Err(TemplateParseError::unexpected_expression(
             "Lambda cannot be defined here",

--- a/src/template_builder.rs
+++ b/src/template_builder.rs
@@ -443,48 +443,36 @@ fn build_integer_method<'a, L: TemplateLanguage<'a>>(
 }
 
 fn build_signature_field<'a, L: TemplateLanguage<'a>>(
-    _language: &L,
-    _self_property: impl TemplateProperty<L::Context, Output = Signature> + 'a,
+    language: &L,
+    self_property: impl TemplateProperty<L::Context, Output = Signature> + 'a,
     field: &FieldNode,
 ) -> TemplateParseResult<L::Property> {
-    Err(TemplateParseError::no_such_field("Signature", field))
+    let property = match field.name {
+        "name" => language.wrap_string(TemplateFunction::new(self_property, |signature| {
+            signature.name
+        })),
+        "email" => language.wrap_string(TemplateFunction::new(self_property, |signature| {
+            signature.email
+        })),
+        "username" => language.wrap_string(TemplateFunction::new(self_property, |signature| {
+            let (username, _) = text_util::split_email(&signature.email);
+            username.to_owned()
+        })),
+        "timestamp" => language.wrap_timestamp(TemplateFunction::new(self_property, |signature| {
+            signature.timestamp
+        })),
+        _ => return Err(TemplateParseError::no_such_field("Signature", field)),
+    };
+    Ok(property)
 }
 
 fn build_signature_method<'a, L: TemplateLanguage<'a>>(
-    language: &L,
+    _language: &L,
     _build_ctx: &BuildContext<L::Property>,
-    self_property: impl TemplateProperty<L::Context, Output = Signature> + 'a,
+    _self_property: impl TemplateProperty<L::Context, Output = Signature> + 'a,
     function: &FunctionCallNode,
 ) -> TemplateParseResult<L::Property> {
-    let property = match function.name {
-        "name" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_string(TemplateFunction::new(self_property, |signature| {
-                signature.name
-            }))
-        }
-        "email" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_string(TemplateFunction::new(self_property, |signature| {
-                signature.email
-            }))
-        }
-        "username" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_string(TemplateFunction::new(self_property, |signature| {
-                let (username, _) = text_util::split_email(&signature.email);
-                username.to_owned()
-            }))
-        }
-        "timestamp" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_timestamp(TemplateFunction::new(self_property, |signature| {
-                signature.timestamp
-            }))
-        }
-        _ => return Err(TemplateParseError::no_such_method("Signature", function)),
-    };
-    Ok(property)
+    Err(TemplateParseError::no_such_method("Signature", function))
 }
 
 fn build_timestamp_field<'a, L: TemplateLanguage<'a>>(
@@ -528,11 +516,20 @@ fn build_timestamp_method<'a, L: TemplateLanguage<'a>>(
 }
 
 fn build_timestamp_range_field<'a, L: TemplateLanguage<'a>>(
-    _language: &L,
-    _self_property: impl TemplateProperty<L::Context, Output = TimestampRange> + 'a,
+    language: &L,
+    self_property: impl TemplateProperty<L::Context, Output = TimestampRange> + 'a,
     field: &FieldNode,
 ) -> TemplateParseResult<L::Property> {
-    Err(TemplateParseError::no_such_field("TimestampRange", field))
+    let property = match field.name {
+        "start" => language.wrap_timestamp(TemplateFunction::new(self_property, |time_range| {
+            time_range.start
+        })),
+        "end" => language.wrap_timestamp(TemplateFunction::new(self_property, |time_range| {
+            time_range.end
+        })),
+        _ => return Err(TemplateParseError::no_such_field("TimestampRange", field)),
+    };
+    Ok(property)
 }
 
 fn build_timestamp_range_method<'a, L: TemplateLanguage<'a>>(
@@ -542,18 +539,6 @@ fn build_timestamp_range_method<'a, L: TemplateLanguage<'a>>(
     function: &FunctionCallNode,
 ) -> TemplateParseResult<L::Property> {
     let property = match function.name {
-        "start" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_timestamp(TemplateFunction::new(self_property, |time_range| {
-                time_range.start
-            }))
-        }
-        "end" => {
-            template_parser::expect_no_arguments(function)?;
-            language.wrap_timestamp(TemplateFunction::new(self_property, |time_range| {
-                time_range.end
-            }))
-        }
         "duration" => {
             template_parser::expect_no_arguments(function)?;
             language.wrap_string(TemplateFunction::new(self_property, |time_range| {

--- a/src/template_parser.rs
+++ b/src/template_parser.rs
@@ -45,6 +45,8 @@ pub enum TemplateParseErrorKind {
     NoSuchKeyword(String),
     #[error(r#"Function "{0}" doesn't exist"#)]
     NoSuchFunction(String),
+    #[error(r#"Field "{name}" doesn't exist for type "{type_name}""#)]
+    NoSuchField { type_name: String, name: String },
     #[error(r#"Method "{name}" doesn't exist for type "{type_name}""#)]
     NoSuchMethod { type_name: String, name: String },
     #[error(r#"Function "{name}": {message}"#)]
@@ -100,6 +102,16 @@ impl TemplateParseError {
         TemplateParseError::with_span(
             TemplateParseErrorKind::NoSuchFunction(function.name.to_owned()),
             function.name_span,
+        )
+    }
+
+    pub fn no_such_field(type_name: impl Into<String>, field: &FieldNode) -> Self {
+        TemplateParseError::with_span(
+            TemplateParseErrorKind::NoSuchField {
+                type_name: type_name.into(),
+                name: field.name.to_owned(),
+            },
+            field.name_span,
         )
     }
 

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -61,7 +61,7 @@ fn test_log_author_timestamp() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
 
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 04:05:09.000 +07:00
     ●  2001-02-03 04:05:07.000 +07:00
@@ -78,7 +78,7 @@ fn test_log_author_timestamp_ago() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_success(&repo_path, &["new", "-m", "second"]);
 
-    let template = r#"author.timestamp().ago() ++ "\n""#;
+    let template = r#"author.timestamp.ago() ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T", template]);
     let line_re = Regex::new(r"[0-9]+ years ago").unwrap();
     assert!(
@@ -212,7 +212,7 @@ fn test_log_customize_short_id() {
         &[
             "log",
             "--config-toml",
-            &format!(r#"{decl}='id.shortest(5).prefix().upper() ++ "_" ++ id.shortest(5).rest()'"#),
+            &format!(r#"{decl}='id.shortest(5).prefix.upper() ++ "_" ++ id.shortest(5).rest'"#),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_describe_command.rs
+++ b/tests/test_describe_command.rs
@@ -150,7 +150,7 @@ fn test_describe_author() {
 
     test_env.add_config(
         r#"[template-aliases]
-'format_signature(signature)' = 'signature.name() ++ " " ++ signature.email() ++ " " ++ signature.timestamp()'"#,
+'format_signature(signature)' = 'signature.name ++ " " ++ signature.email ++ " " ++ signature.timestamp'"#,
     );
     let get_signatures = || {
         test_env.jj_cmd_success(

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -328,7 +328,7 @@ fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
 
 fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> String {
     let template = r###"
-    commit_id.short() ++ "   " ++ description.first_line() ++ " @ " ++ committer.timestamp()
+    commit_id.short() ++ "   " ++ description.first_line() ++ " @ " ++ committer.timestamp
     "###;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -281,7 +281,7 @@ fn test_log_shortest_accessors() {
     test_env.add_config(
         r###"
         [template-aliases]
-        'format_id(id)' = 'id.shortest(12).prefix() ++ "[" ++ id.shortest(12).rest() ++ "]"'
+        'format_id(id)' = 'id.shortest(12).prefix ++ "[" ++ id.shortest(12).rest ++ "]"'
         "###,
     );
 
@@ -478,7 +478,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     test_env.add_config(
         r###"
         [template-aliases]
-        'format_id(id)' = 'id.shortest(12).prefix() ++ "[" ++ id.shortest(12).rest() ++ "]"'
+        'format_id(id)' = 'id.shortest(12).prefix ++ "[" ++ id.shortest(12).rest ++ "]"'
         "###,
     );
 
@@ -575,7 +575,7 @@ fn test_log_author_format() {
             &repo_path,
             &[
                 "--config-toml",
-                &format!("{decl}='signature.username()'"),
+                &format!("{decl}='signature.username'"),
                 "log",
                 "--revisions=@",
             ],

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -141,7 +141,7 @@ fn test_op_log_template() {
     "###);
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
-                                time.start(), time.end(), time.duration()) ++ "\n""#), @r###"
+                                time.start, time.end, time.duration()) ++ "\n""#), @r###"
     @  a99a3 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     ●  56b94 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     "###);

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -376,9 +376,9 @@ fn test_templater_signature() {
     test_env.jj_cmd_success(&repo_path, &["new"]);
 
     insta::assert_snapshot!(render(r#"author"#), @"Test User <test.user@example.com>");
-    insta::assert_snapshot!(render(r#"author.name()"#), @"Test User");
-    insta::assert_snapshot!(render(r#"author.email()"#), @"test.user@example.com");
-    insta::assert_snapshot!(render(r#"author.username()"#), @"test.user");
+    insta::assert_snapshot!(render(r#"author.name"#), @"Test User");
+    insta::assert_snapshot!(render(r#"author.email"#), @"test.user@example.com");
+    insta::assert_snapshot!(render(r#"author.username"#), @"test.user");
 
     test_env.jj_cmd_success(
         &repo_path,
@@ -386,9 +386,9 @@ fn test_templater_signature() {
     );
 
     insta::assert_snapshot!(render(r#"author"#), @"Another Test User <test.user@example.com>");
-    insta::assert_snapshot!(render(r#"author.name()"#), @"Another Test User");
-    insta::assert_snapshot!(render(r#"author.email()"#), @"test.user@example.com");
-    insta::assert_snapshot!(render(r#"author.username()"#), @"test.user");
+    insta::assert_snapshot!(render(r#"author.name"#), @"Another Test User");
+    insta::assert_snapshot!(render(r#"author.email"#), @"test.user@example.com");
+    insta::assert_snapshot!(render(r#"author.username"#), @"test.user");
 
     test_env.jj_cmd_success(
         &repo_path,
@@ -399,15 +399,15 @@ fn test_templater_signature() {
     );
 
     insta::assert_snapshot!(render(r#"author"#), @"Test User <test.user@invalid@example.com>");
-    insta::assert_snapshot!(render(r#"author.name()"#), @"Test User");
-    insta::assert_snapshot!(render(r#"author.email()"#), @"test.user@invalid@example.com");
-    insta::assert_snapshot!(render(r#"author.username()"#), @"test.user");
+    insta::assert_snapshot!(render(r#"author.name"#), @"Test User");
+    insta::assert_snapshot!(render(r#"author.email"#), @"test.user@invalid@example.com");
+    insta::assert_snapshot!(render(r#"author.username"#), @"test.user");
 
     test_env.jj_cmd_success(&repo_path, &["--config-toml=user.email='test.user'", "new"]);
 
     insta::assert_snapshot!(render(r#"author"#), @"Test User <test.user>");
-    insta::assert_snapshot!(render(r#"author.email()"#), @"test.user");
-    insta::assert_snapshot!(render(r#"author.username()"#), @"test.user");
+    insta::assert_snapshot!(render(r#"author.email"#), @"test.user");
+    insta::assert_snapshot!(render(r#"author.username"#), @"test.user");
 
     test_env.jj_cmd_success(
         &repo_path,
@@ -418,14 +418,14 @@ fn test_templater_signature() {
     );
 
     insta::assert_snapshot!(render(r#"author"#), @"Test User <test.user+tag@example.com>");
-    insta::assert_snapshot!(render(r#"author.email()"#), @"test.user+tag@example.com");
-    insta::assert_snapshot!(render(r#"author.username()"#), @"test.user+tag");
+    insta::assert_snapshot!(render(r#"author.email"#), @"test.user+tag@example.com");
+    insta::assert_snapshot!(render(r#"author.username"#), @"test.user+tag");
 
     test_env.jj_cmd_success(&repo_path, &["--config-toml=user.email='x@y'", "new"]);
 
     insta::assert_snapshot!(render(r#"author"#), @"Test User <x@y>");
-    insta::assert_snapshot!(render(r#"author.email()"#), @"x@y");
-    insta::assert_snapshot!(render(r#"author.username()"#), @"x");
+    insta::assert_snapshot!(render(r#"author.email"#), @"x@y");
+    insta::assert_snapshot!(render(r#"author.username"#), @"x");
 }
 
 #[test]
@@ -445,45 +445,45 @@ fn test_templater_timestamp_method() {
     );
 
     insta::assert_snapshot!(
-        render(r#"author.timestamp().format("%Y%m%d %H:%M:%S")"#), @"19700101 00:00:00");
+        render(r#"author.timestamp.format("%Y%m%d %H:%M:%S")"#), @"19700101 00:00:00");
 
     // Invalid format string
-    insta::assert_snapshot!(render_err(r#"author.timestamp().format("%_")"#), @r###"
-    Error: Failed to parse template:  --> 1:27
+    insta::assert_snapshot!(render_err(r#"author.timestamp.format("%_")"#), @r###"
+    Error: Failed to parse template:  --> 1:25
       |
-    1 | author.timestamp().format("%_")
-      |                           ^--^
+    1 | author.timestamp.format("%_")
+      |                         ^--^
       |
       = Invalid time format
     "###);
 
     // Invalid type
-    insta::assert_snapshot!(render_err(r#"author.timestamp().format(0)"#), @r###"
-    Error: Failed to parse template:  --> 1:27
+    insta::assert_snapshot!(render_err(r#"author.timestamp.format(0)"#), @r###"
+    Error: Failed to parse template:  --> 1:25
       |
-    1 | author.timestamp().format(0)
-      |                           ^
+    1 | author.timestamp.format(0)
+      |                         ^
       |
       = Expected string literal
     "###);
 
     // Dynamic string isn't supported yet
-    insta::assert_snapshot!(render_err(r#"author.timestamp().format("%Y" ++ "%m")"#), @r###"
-    Error: Failed to parse template:  --> 1:27
+    insta::assert_snapshot!(render_err(r#"author.timestamp.format("%Y" ++ "%m")"#), @r###"
+    Error: Failed to parse template:  --> 1:25
       |
-    1 | author.timestamp().format("%Y" ++ "%m")
-      |                           ^----------^
+    1 | author.timestamp.format("%Y" ++ "%m")
+      |                         ^----------^
       |
       = Expected string literal
     "###);
 
     // Literal alias expansion
-    insta::assert_snapshot!(render(r#"author.timestamp().format(time_format)"#), @"1970-01-01");
-    insta::assert_snapshot!(render_err(r#"author.timestamp().format(bad_time_format)"#), @r###"
-    Error: Failed to parse template:  --> 1:27
+    insta::assert_snapshot!(render(r#"author.timestamp.format(time_format)"#), @"1970-01-01");
+    insta::assert_snapshot!(render_err(r#"author.timestamp.format(bad_time_format)"#), @r###"
+    Error: Failed to parse template:  --> 1:25
       |
-    1 | author.timestamp().format(bad_time_format)
-      |                           ^-------------^
+    1 | author.timestamp.format(bad_time_format)
+      |                         ^-------------^
       |
       = Alias "bad_time_format" cannot be expanded
      --> 1:1

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -139,6 +139,14 @@ fn test_templater_parse_error() {
       = Function "foo" doesn't exist
     "###);
 
+    insta::assert_snapshot!(render_err(r#"description.first_line().foo"#), @r###"
+    Error: Failed to parse template:  --> 1:26
+      |
+    1 | description.first_line().foo
+      |                          ^-^
+      |
+      = Field "foo" doesn't exist for type "String"
+    "###);
     insta::assert_snapshot!(render_err(r#"description.first_line().foo()"#), @r###"
     Error: Failed to parse template:  --> 1:26
       |


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
