### PR TITLE
Make revsets iterate over CommitId instead of IndexEntry

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -733,7 +733,8 @@ impl Index for MutableIndexImpl {
         repo: &'index dyn Repo,
         expression: &RevsetExpression,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetError> {
-        default_revset_engine::evaluate(repo, CompositeIndex(self), expression)
+        let revset_impl = default_revset_engine::evaluate(repo, CompositeIndex(self), expression)?;
+        Ok(Box::new(revset_impl))
     }
 }
 
@@ -1698,6 +1699,10 @@ impl ReadonlyIndexImpl {
         }))
     }
 
+    pub fn as_composite(&self) -> CompositeIndex {
+        CompositeIndex(self)
+    }
+
     fn name(&self) -> &str {
         &self.name
     }
@@ -1806,7 +1811,8 @@ impl Index for ReadonlyIndexImpl {
         repo: &'index dyn Repo,
         expression: &RevsetExpression,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetError> {
-        default_revset_engine::evaluate(repo, CompositeIndex(self), expression)
+        let revset_impl = default_revset_engine::evaluate(repo, CompositeIndex(self), expression)?;
+        Ok(Box::new(revset_impl))
     }
 }
 

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -74,7 +74,7 @@ impl<'index> Revset<'index> for RevsetImpl<'index> {
     }
 
     fn iter_graph(&self) -> Box<dyn Iterator<Item = (CommitId, Vec<RevsetGraphEdge>)> + '_> {
-        Box::new(RevsetGraphIterator::new(self))
+        Box::new(RevsetGraphIterator::new(self.inner.iter()))
     }
 
     fn change_id_index(&self) -> Box<dyn ChangeIdIndex + 'index> {

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -51,7 +51,7 @@ trait InternalRevset<'index>: ToPredicateFn<'index> {
     fn iter(&self) -> Box<dyn Iterator<Item = IndexEntry<'index>> + '_>;
 }
 
-struct RevsetImpl<'index> {
+pub struct RevsetImpl<'index> {
     inner: Box<dyn InternalRevset<'index> + 'index>,
     index: CompositeIndex<'index>,
 }
@@ -65,6 +65,10 @@ impl<'index> RevsetImpl<'index> {
             inner: revset,
             index,
         }
+    }
+
+    pub fn iter_graph_impl(&self) -> RevsetGraphIterator<'_, 'index> {
+        RevsetGraphIterator::new(self.inner.iter())
     }
 }
 
@@ -491,9 +495,9 @@ pub fn evaluate<'index>(
     repo: &'index dyn Repo,
     index: CompositeIndex<'index>,
     expression: &RevsetExpression,
-) -> Result<Box<dyn Revset<'index> + 'index>, RevsetError> {
+) -> Result<RevsetImpl<'index>, RevsetError> {
     let internal_revset = internal_evaluate(repo, expression)?;
-    Ok(Box::new(RevsetImpl::new(internal_revset, index)))
+    Ok(RevsetImpl::new(internal_revset, index))
 }
 
 fn internal_evaluate<'index>(

--- a/lib/src/default_revset_graph_iterator.rs
+++ b/lib/src/default_revset_graph_iterator.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, HashSet};
 use crate::backend::CommitId;
 use crate::default_index_store::{IndexEntry, IndexPosition};
 use crate::nightly_shims::BTreeMapExt;
-use crate::revset::{Revset, RevsetGraphEdge, RevsetGraphEdgeType};
+use crate::revset::{RevsetGraphEdge, RevsetGraphEdgeType};
 
 // Given an iterator over some set of revisions, yields the same revisions with
 // associated edge types.
@@ -101,9 +101,11 @@ pub struct RevsetGraphIterator<'revset, 'index> {
 }
 
 impl<'revset, 'index> RevsetGraphIterator<'revset, 'index> {
-    pub fn new(revset: &'revset dyn Revset<'index>) -> RevsetGraphIterator<'revset, 'index> {
+    pub fn new(
+        input_set_iter: Box<dyn Iterator<Item = IndexEntry<'index>> + 'revset>,
+    ) -> RevsetGraphIterator<'revset, 'index> {
         RevsetGraphIterator {
-            input_set_iter: revset.iter(),
+            input_set_iter,
             look_ahead: Default::default(),
             min_position: IndexPosition::MAX,
             edges: Default::default(),

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -161,7 +161,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
             .evaluate(mut_repo)
             .unwrap()
             .iter()
-            .commit_ids()
             .collect();
 
         let to_visit_expression = old_commits_expression.descendants();

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -66,7 +66,7 @@ fn test_graph_iterator_linearized(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_d]);
-    let commits = RevsetGraphIterator::new(revset.as_ref())
+    let commits = RevsetGraphIterator::new(revset.iter())
         .set_skip_transitive_edges(skip_transitive_edges)
         .collect_vec();
     assert_eq!(commits.len(), 2);
@@ -105,7 +105,7 @@ fn test_graph_iterator_virtual_octopus(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_b, &commit_c, &commit_f]);
-    let commits = RevsetGraphIterator::new(revset.as_ref())
+    let commits = RevsetGraphIterator::new(revset.iter())
         .set_skip_transitive_edges(skip_transitive_edges)
         .collect_vec();
     assert_eq!(commits.len(), 4);
@@ -155,7 +155,7 @@ fn test_graph_iterator_simple_fork(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_c, &commit_e]);
-    let commits = RevsetGraphIterator::new(revset.as_ref())
+    let commits = RevsetGraphIterator::new(revset.iter())
         .set_skip_transitive_edges(skip_transitive_edges)
         .collect_vec();
     assert_eq!(commits.len(), 3);
@@ -195,7 +195,7 @@ fn test_graph_iterator_multiple_missing(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_b, &commit_f]);
-    let commits = RevsetGraphIterator::new(revset.as_ref())
+    let commits = RevsetGraphIterator::new(revset.iter())
         .set_skip_transitive_edges(skip_transitive_edges)
         .collect_vec();
     assert_eq!(commits.len(), 2);
@@ -238,7 +238,7 @@ fn test_graph_iterator_edge_to_ancestor(skip_transitive_edges: bool) {
     let repo = tx.commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_c, &commit_d, &commit_f]);
-    let commits = RevsetGraphIterator::new(revset.as_ref())
+    let commits = RevsetGraphIterator::new(revset.iter())
         .set_skip_transitive_edges(skip_transitive_edges)
         .collect_vec();
     assert_eq!(commits.len(), 3);
@@ -296,7 +296,7 @@ fn test_graph_iterator_edge_escapes_from_(skip_transitive_edges: bool) {
         repo.as_ref(),
         &[&commit_a, &commit_d, &commit_g, &commit_h, &commit_j],
     );
-    let commits = RevsetGraphIterator::new(revset.as_ref())
+    let commits = RevsetGraphIterator::new(revset.iter())
         .set_skip_transitive_edges(skip_transitive_edges)
         .collect_vec();
     assert_eq!(commits.len(), 5);

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -26,7 +26,7 @@ use jujutsu_lib::repo_path::RepoPath;
 use jujutsu_lib::revset::{
     optimize, parse, resolve_symbol, resolve_symbols, ReverseRevsetGraphIterator, Revset,
     RevsetAliasesMap, RevsetError, RevsetExpression, RevsetFilterPredicate, RevsetGraphEdge,
-    RevsetIteratorExt, RevsetWorkspaceContext,
+    RevsetWorkspaceContext,
 };
 use jujutsu_lib::settings::GitSettings;
 use jujutsu_lib::workspace::Workspace;
@@ -502,12 +502,7 @@ fn test_resolve_symbol_git_refs() {
 fn resolve_commit_ids(repo: &dyn Repo, revset_str: &str) -> Vec<CommitId> {
     let expression = optimize(parse(revset_str, &RevsetAliasesMap::new(), None).unwrap());
     let expression = resolve_symbols(repo, expression, None).unwrap();
-    expression
-        .evaluate(repo)
-        .unwrap()
-        .iter()
-        .commit_ids()
-        .collect()
+    expression.evaluate(repo).unwrap().iter().collect()
 }
 
 fn resolve_commit_ids_in_workspace(
@@ -524,12 +519,7 @@ fn resolve_commit_ids_in_workspace(
     let expression =
         optimize(parse(revset_str, &RevsetAliasesMap::new(), Some(&workspace_ctx)).unwrap());
     let expression = resolve_symbols(repo, expression, Some(&workspace_ctx)).unwrap();
-    expression
-        .evaluate(repo)
-        .unwrap()
-        .iter()
-        .commit_ids()
-        .collect()
+    expression.evaluate(repo).unwrap().iter().collect()
 }
 
 #[test_case(false ; "local backend")]
@@ -1993,8 +1983,7 @@ fn test_evaluate_expression_file(use_git: bool) {
         let expression =
             RevsetExpression::filter(RevsetFilterPredicate::File(Some(vec![file_path.clone()])));
         let revset = expression.evaluate(mut_repo).unwrap();
-        let commit_ids = revset.iter().commit_ids().collect();
-        commit_ids
+        revset.iter().collect()
     };
 
     assert_eq!(resolve(&added_clean_clean), vec![commit1.id().clone()]);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,7 +30,7 @@ use itertools::Itertools;
 use jujutsu_lib::backend::{CommitId, ObjectId, TreeValue};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::dag_walk::topo_order_reverse;
-use jujutsu_lib::default_index_store::{DefaultIndexStore, IndexEntry, ReadonlyIndexWrapper};
+use jujutsu_lib::default_index_store::{DefaultIndexStore, ReadonlyIndexWrapper};
 use jujutsu_lib::matchers::EverythingMatcher;
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::repo::{ReadonlyRepo, Repo};
@@ -1563,7 +1563,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
                 )?;
             }
         } else {
-            let iter: Box<dyn Iterator<Item = IndexEntry>> = if args.reversed {
+            let iter: Box<dyn Iterator<Item = CommitId>> = if args.reversed {
                 Box::new(revset.iter().reversed())
             } else {
                 Box::new(revset.iter())
@@ -2054,7 +2054,6 @@ fn cmd_new(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(), C
             .dag_range_to(&new_parents)
             .evaluate(tx.repo())?
             .iter()
-            .commit_ids()
             .next()
         {
             return Err(user_error(format!(


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
