### PR TITLE
cli: move default ui.pager config to misc.toml

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -2168,6 +2168,10 @@ pub fn handle_command_result(
         }
         Err(CommandError::ConfigError(message)) => {
             writeln!(ui.error(), "Config error: {message}")?;
+            writeln!(
+                ui.hint(),
+                "For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md."
+            )?;
             Ok(ExitCode::from(1))
         }
         Err(CommandError::CliError(message)) => {

--- a/src/config/misc.toml
+++ b/src/config/misc.toml
@@ -9,4 +9,5 @@ fetch = "origin"
 # Placeholder: added by user
 
 [ui]
+pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,10 +18,9 @@ use std::str::FromStr;
 use std::{env, fmt, io, mem};
 
 use crossterm::tty::IsTty;
-use maplit::hashmap;
 
 use crate::cli_util::CommandError;
-use crate::config::{CommandNameAndArgs, NonEmptyCommandArgsVec};
+use crate::config::CommandNameAndArgs;
 use crate::formatter::{Formatter, FormatterFactory, LabeledWriter};
 
 pub struct Ui {
@@ -95,19 +94,7 @@ pub enum PaginationChoice {
 fn pager_setting(config: &config::Config) -> Result<CommandNameAndArgs, CommandError> {
     config
         .get::<CommandNameAndArgs>("ui.pager")
-        .or_else(|err| match err {
-            config::ConfigError::NotFound(_) => Ok(CommandNameAndArgs::Structured {
-                command: NonEmptyCommandArgsVec::try_from(vec![
-                    "less".to_string(),
-                    "-FRX".to_string(),
-                ])
-                .unwrap(),
-                env: hashmap! { "LESSCHARSET".to_string() => "utf-8".to_string() },
-            }),
-            err => Err(CommandError::ConfigError(format!(
-                "Invalid `ui.pager`: {err:?}"
-            ))),
-        })
+        .map_err(|err| CommandError::ConfigError(format!("Invalid `ui.pager`: {err:?}")))
 }
 
 impl Ui {

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -326,6 +326,7 @@ fn test_invalid_config() {
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Config error: expected newline, found an identifier at line 1 column 10 in config/config0001.toml
+    For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
 }
 


### PR DESCRIPTION
I actually wanted to make `(unset LESS; PAGER=less jj help)` work like it does with git (it seems to set `LESS` to something including `R` if it's not already set) but it got a bit messy. Maybe I'll get back to it later.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
