### PR TITLE
Switch graph node to use `◉` for commit instead of `●`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `ui.log-word-wrap` option to wrap `jj log`/`obslog`/`op log` content
   based on terminal width. [#1043](https://github.com/martinvonz/jj/issues/1043)
 
-* Nodes in the (text-based) graphical log output now use a `●` symbol instead
+* Nodes in the (text-based) graphical log output now use a `◉` symbol instead
   of the letter `o`. The ASCII-based graph styles still use `o`.  
 
 * Commands that accept a diff format (`jj diff`, `jj interdiff`, `jj show`,

--- a/demos/demo_operation_log.sh
+++ b/demos/demo_operation_log.sh
@@ -30,7 +30,7 @@ is:"
 run_command "jj op log --color=always | head"
 
 comment "Let's undo that rebase operation:"
-rebase_op=$(jj --color=never op log | grep '^●  ' | sed '2q;d' | cut -b4-15)
+rebase_op=$(jj --color=never op log | grep '^◉  ' | sed '2q;d' | cut -b4-15)
 run_command "jj undo $rebase_op"
 
 comment "Note that only the rebase was undone, and the

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -117,9 +117,9 @@ in its `jj log` command:
 $ jj log
 @  mpqrykypylvy martinvonz@google.com 2023-02-12 15:00:22.000 -08:00 aef4df99ea11
 │  (empty) (no description set)
-●  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
 │  Say goodbye
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -144,13 +144,13 @@ example:
 $ jj log -r '@ | root | branches()'
 @  mpqrykypylvy martinvonz@google.com 2023-02-12 15:00:22.000 -08:00 aef4df99ea11
 ╷  (empty) (no description set)
-╷ ●  kowxouwzwxmv octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test b3cbd5bbd7e8
+╷ ◉  kowxouwzwxmv octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test b3cbd5bbd7e8
 ╭─╯  Create CONTRIBUTING.md
-│ ●  tpstlustrvsn support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1 b1b3f9723831
+│ ◉  tpstlustrvsn support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1 b1b3f9723831
 ├─╯  sentence case
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 ╷  (empty) Merge pull request #6 from Spaceghost/patch-1
-●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
    (empty) (no description set)
 ```
 
@@ -182,15 +182,15 @@ Working copy now at: 62a3c6d315cd C
 $ jj log
 @  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:07:41.946 -08:00 2370ddf3fa39
 │  C
-●  puqltuttrvzp martinvonz@google.com 2023-02-12 15:07:33.000 -08:00 daa6ffd5a09a
+◉  puqltuttrvzp martinvonz@google.com 2023-02-12 15:07:33.000 -08:00 daa6ffd5a09a
 │  B2
-●  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
 │  B1
-●  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
 │  A
-│ ●  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
 ├─╯  Say goodbye
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -205,15 +205,15 @@ Added 0 files, modified 1 files, removed 0 files
 $ jj log
 @  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b53430cd conflict
 │  C
-●  puqltuttrvzp martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943ee41 conflict
+◉  puqltuttrvzp martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943ee41 conflict
 │  B2
-│ ●  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+│ ◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
 ├─╯  B1
-●  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
 │  A
-│ ●  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
 ├─╯  Say goodbye
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -254,17 +254,17 @@ Working copy now at: e3c279cc2043 (no description set)
 $ jj log
 @  ntxxqymrlvxu martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 e3c279cc2043
 │  (empty) (no description set)
-│ ●  qzvqqupxlkot martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 b9da9d28b26b
+│ ◉  qzvqqupxlkot martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 b9da9d28b26b
 ├─╯  C
-●  puqltuttrvzp martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 2c7a658e2586
+◉  puqltuttrvzp martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 2c7a658e2586
 │  B2
-│ ●  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+│ ◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
 ├─╯  B1
-●  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
 │  A
-│ ●  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
 ├─╯  Say goodbye
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -286,12 +286,12 @@ $ jj op log
 @  d3b77addea49 martinvonz@vonz.svl.corp.google.com 2023-02-12 19:34:09.549 -08:00 - 2023-02-12 19:34:09.552 -08:00
 │  squash commit 63874fe6c4fba405ffc38b0dd926f03b715cf7ef
 │  args: jj squash
-●  6fc1873c1180 martinvonz@vonz.svl.corp.google.com 2023-02-12 19:34:09.548 -08:00 - 2023-02-12 19:34:09.549 -08:00
+◉  6fc1873c1180 martinvonz@vonz.svl.corp.google.com 2023-02-12 19:34:09.548 -08:00 - 2023-02-12 19:34:09.549 -08:00
 │  snapshot working copy
-●  ed91f7bcc1fb martinvonz@vonz.svl.corp.google.com 2023-02-12 19:32:46.007 -08:00 - 2023-02-12 19:32:46.008 -08:00
+◉  ed91f7bcc1fb martinvonz@vonz.svl.corp.google.com 2023-02-12 19:32:46.007 -08:00 - 2023-02-12 19:32:46.008 -08:00
 │  new empty commit
 │  args: jj new puqltuttrvzp
-●  367400773f87 martinvonz@vonz.svl.corp.google.com 2023-02-12 15:08:33.917 -08:00 - 2023-02-12 15:08:33.920 -08:00
+◉  367400773f87 martinvonz@vonz.svl.corp.google.com 2023-02-12 15:08:33.917 -08:00 - 2023-02-12 15:08:33.920 -08:00
 │  rebase commit daa6ffd5a09a8a7d09a65796194e69b7ed0a566d and descendants
 │  args: jj rebase -s puqltuttrvzp -d nuvyytnqlquo
 [many more lines]
@@ -305,17 +305,17 @@ Working copy now at: 63874fe6c4fb (no description set)
 $ jj log
 @  zxoosnnpvvpn martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 63874fe6c4fb
 │  (no description set)
-│ ●  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b53430cd conflict
+│ ◉  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b53430cd conflict
 ├─╯  C
-●  puqltuttrvzp martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943ee41 conflict
+◉  puqltuttrvzp martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943ee41 conflict
 │  B2
-│ ●  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+│ ◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
 ├─╯  B1
-●  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
 │  A
-│ ●  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
 ├─╯  Say goodbye
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -351,11 +351,11 @@ Working copy now at: a67491542e10 ABCD
 $ jj log -r master:@
 @  mrxqplykzpkw martinvonz@google.com 2023-02-12 19:38:21.000 -08:00 b98c607bf87f
 │  ABCD
-●  kwtuwqnmqyqp martinvonz@google.com 2023-02-12 19:38:12.000 -08:00 30aecc0871ea
+◉  kwtuwqnmqyqp martinvonz@google.com 2023-02-12 19:38:12.000 -08:00 30aecc0871ea
 │  ABC
-●  ztqrpvnwqqnq martinvonz@google.com 2023-02-12 19:38:03.000 -08:00 510022615871
+◉  ztqrpvnwqqnq martinvonz@google.com 2023-02-12 19:38:03.000 -08:00 510022615871
 │  abc
-●  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```

--- a/src/graphlog.rs
+++ b/src/graphlog.rs
@@ -138,11 +138,11 @@ pub fn get_graphlog<'a, K: Clone + Eq + Hash + 'a>(
     let builder = GraphRowRenderer::new().output().with_min_row_height(0);
 
     match settings.graph_style().as_str() {
-        "curved" => SaplingGraphLog::create(builder.build_box_drawing(), formatter, "●"),
+        "curved" => SaplingGraphLog::create(builder.build_box_drawing(), formatter, "◉"),
         "square" => SaplingGraphLog::create(
             builder.build_box_drawing().with_square_glyphs(),
             formatter,
-            "●",
+            "◉",
         ),
         "ascii" => SaplingGraphLog::create(builder.build_ascii(), formatter, "o"),
         "ascii-large" => SaplingGraphLog::create(builder.build_ascii_large(), formatter, "o"),

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -45,13 +45,13 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    ● │  d
-    ● │  c
-    │ │ ●  b
+    ◉ │  d
+    ◉ │  c
+    │ │ ◉  b
     │ ├─╯
-    │ ●  a
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d"]);
@@ -64,12 +64,12 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    ● │  c d
-    │ │ ●  b
+    ◉ │  c d
+    │ │ ◉  b
     │ ├─╯
-    │ ●  a
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
@@ -81,13 +81,13 @@ fn test_rebase_branch_with_merge() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @
-    │ ●  d e??
-    │ ●  c
-    │ │ ●  b
+    │ ◉  d e??
+    │ ◉  c
+    │ │ ◉  b
     ├───╯
-    ● │  a e??
+    ◉ │  a e??
     ├─╯
-    ●
+    ◉
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
@@ -102,10 +102,10 @@ fn test_rebase_branch_with_merge() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @
-    │ ●  b
+    │ ◉  b
     ├─╯
-    ●  a e??
-    ●  c d e??
+    ◉  a e??
+    ◉  c d e??
     "###);
 
     // Test abandoning the same commit twice directly
@@ -117,11 +117,11 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    ● │  d
-    ● │  c
-    │ ●  a b
+    ◉ │  d
+    ◉ │  c
+    │ ◉  a b
     ├─╯
-    ●
+    ◉
     "###);
 
     // Test abandoning the same commit twice indirectly
@@ -138,9 +138,9 @@ fn test_rebase_branch_with_merge() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @
-    │ ●  c d e??
+    │ ◉  c d e??
     ├─╯
-    ●  a b e??
+    ◉  a b e??
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["abandon", "root"]);

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -137,7 +137,7 @@ fn test_alias_cannot_override_builtin() {
     // Alias should be ignored
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 }
@@ -177,28 +177,28 @@ fn test_alias_global_args_before_and_after() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Can pass global args before
     let stdout = test_env.jj_cmd_success(&repo_path, &["l", "--at-op", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     // Can pass global args after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "@-", "l"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     // Test passing global args both before and after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "abc123", "l", "--at-op", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["-R", "../nonexistent", "l", "-R", "."]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -214,7 +214,7 @@ fn test_alias_global_args_in_definition() {
     // The global argument in the alias is respected
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  [38;5;4m0000000000000000000000000000000000000000[39m
+    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 }
 

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -34,14 +34,14 @@ fn test_branch_multiple_names() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar foo 230dd059e1b0
-    ●   000000000000
+    ◉   000000000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "delete", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   230dd059e1b0
-    ●   000000000000
+    ◉   000000000000
     "###);
 }
 
@@ -71,13 +71,13 @@ fn test_branch_forget_glob() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1 foo-3 foo-4 230dd059e1b0
-    ●   000000000000
+    ◉   000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "forget", "--glob", "foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-4 230dd059e1b0
-    ●   000000000000
+    ◉   000000000000
     "###);
 
     // Forgetting a branch via both explicit name and glob pattern, or with
@@ -91,7 +91,7 @@ fn test_branch_forget_glob() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 230dd059e1b0
-    ●   000000000000
+    ◉   000000000000
     "###);
 
     // Malformed glob

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -34,19 +34,19 @@ fn test_checkout() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  05ce7118568d3007efc9163b055f9cb4a6becfde
-    ●  5c52832c3483e0ace06d047a806024984f28f1d7 second
-    ●  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
-    ●  0000000000000000000000000000000000000000
+    ◉  5c52832c3483e0ace06d047a806024984f28f1d7 second
+    ◉  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Can provide a description
     test_env.jj_cmd_success(&repo_path, &["checkout", "@--", "-m", "my message"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1191baaf276e3d0b96b1747e885b3a517be80d6f my message
-    │ ●  5c52832c3483e0ace06d047a806024984f28f1d7 second
+    │ ◉  5c52832c3483e0ace06d047a806024984f28f1d7 second
     ├─╯
-    ●  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
-    ●  0000000000000000000000000000000000000000
+    ◉  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/tests/test_commit_command.rs
+++ b/tests/test_commit_command.rs
@@ -28,8 +28,8 @@ fn test_commit_with_description_from_cli() {
     test_env.jj_cmd_success(&workspace_path, &["commit", "-m=first"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  b88fb4e51bdd
-    ●  69542c1984c1 first
-    ●  000000000000
+    ◉  69542c1984c1 first
+    ◉  000000000000
     "###);
 }
 
@@ -47,8 +47,8 @@ fn test_commit_with_editor() {
     test_env.jj_cmd_success(&workspace_path, &["commit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  3df78bc2b9b5
-    ●  30a8c2b3d6eb modified
-    ●  000000000000
+    ◉  30a8c2b3d6eb modified
+    ◉  000000000000
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -32,11 +32,11 @@ fn test_log_parents() {
     insta::assert_snapshot!(stdout, @r###"
     @    c067170d4ca1bc6162b64f7550617ec809647f84
     ├─╮  P: 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ● │  4db490c88528133d579540b6900b8098f0c17701
+    ◉ │  4db490c88528133d579540b6900b8098f0c17701
     ├─╯  P: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  P: 0000000000000000000000000000000000000000
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
        P:
     "###);
 
@@ -87,8 +87,8 @@ fn test_log_author_timestamp() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 04:05:09.000 +07:00
-    ●  2001-02-03 04:05:07.000 +07:00
-    ●  1970-01-01 00:00:00.000 +00:00
+    ◉  2001-02-03 04:05:07.000 +07:00
+    ◉  1970-01-01 00:00:00.000 +00:00
     "###);
 }
 
@@ -126,9 +126,9 @@ fn test_log_default() {
     insta::assert_snapshot!(stdout, @r###"
     @  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
     │  (empty) description 1
-    ●  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
+    ◉  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
     │  add a file
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 
@@ -137,9 +137,9 @@ fn test_log_default() {
     insta::assert_snapshot!(stdout, @r###"
     @  [1m[38;5;13mk[38;5;8mkmpptxzrspx[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178d59d[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ●  [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
     │  add a file
-    ●  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 
@@ -168,7 +168,7 @@ fn test_log_default_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
     │  description 1
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 
@@ -180,22 +180,22 @@ fn test_log_default_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    ●  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d4c67
+    ◉  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d4c67
     │  description 2
     │ @  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
     ├─╯  description 1
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsmwlqt??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [1m[38;5;4m8[0m[38;5;8m979953d4c67[39m
+    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsmwlqt??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [1m[38;5;4m8[0m[38;5;8m979953d4c67[39m
     │  description 2
     │ @  [1m[4m[38;5;1mq[24mpvuntsmwlqt[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e633c[39m[0m
     ├─╯  [1mdescription 1[0m
-    ●  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 }
@@ -213,9 +213,9 @@ fn test_log_git_head() {
     insta::assert_snapshot!(stdout, @r###"
     @  [1m[38;5;13mr[38;5;8mlvkpnrzqnoo[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[38;5;8m0aaf4754c1e[39m[0m
     │  [1minitial[0m
-    ●  [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;5mHEAD@git[39m [1m[38;5;4m23[0m[38;5;8m0dd059e1b0[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;5mHEAD@git[39m [1m[38;5;4m23[0m[38;5;8m0dd059e1b0[39m
     │  [38;5;2m(empty)[39m (no description set)
-    ●  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 }
@@ -241,7 +241,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  Q_pvun test.user@example.com 2001-02-03 04:05:08.000 +07:00 6_9542
     │  (empty) first
-    ●  Z_zzzz 1970-01-01 00:00:00.000 +00:00 0_0000
+    ◉  Z_zzzz 1970-01-01 00:00:00.000 +00:00 0_0000
        (empty) (no description set)
     "###);
 
@@ -260,7 +260,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  QPVUNTSMWLQT test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     │  (empty) first
-    ●  ZZZZZZZZZZZZ 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  ZZZZZZZZZZZZ 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 }

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -34,10 +34,10 @@ fn test_concurrent_operation_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    ●  message 2
+    ◉  message 2
     │ @  message 1
     ├─╯
-    ●
+    ◉
     "###);
 }
 
@@ -54,12 +54,12 @@ fn test_concurrent_operations_auto_rebase() {
     @  cde29280d4a9 test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  describe commit 123ed18e4c4c0d77428df41112bc02ffc83fb935
     │  args: jj describe -m initial
-    ●  7c212e0863fd test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  7c212e0863fd test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  snapshot working copy
     │  args: jj describe -m initial
-    ●  a99a3fd5c51e test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  a99a3fd5c51e test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  add workspace 'default'
-    ●  56b94dfc38e7 test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  56b94dfc38e7 test-username@host.example.com 22 years ago, lasted less than a microsecond
        initialize repo
     "###);
     let op_id_hex = stdout[3..15].to_string();
@@ -74,9 +74,9 @@ fn test_concurrent_operations_auto_rebase() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    ●  3f06323826b4a293a9ee6d24cc0e07ad2961b5d5 new child
+    ◉  3f06323826b4a293a9ee6d24cc0e07ad2961b5d5 new child
     @  d91437157468ec86bbbc9e6a14a60d3e8d1790ac rewritten
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -105,10 +105,10 @@ fn test_concurrent_operations_wc_modified() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     Concurrent modification detected, resolving automatically.
     @  4eb0610031b7cd148ff9f729a673a3f815033170 new child1
-    │ ●  4b20e61d23ee7d7c4d5e61e11e97c26e716f9c30 new child2
+    │ ◉  4b20e61d23ee7d7c4d5e61e11e97c26e716f9c30 new child2
     ├─╯
-    ●  52c893bf3cd201e215b23e084e8a871244ca14d5 initial
-    ●  0000000000000000000000000000000000000000
+    ◉  52c893bf3cd201e215b23e084e8a871244ca14d5 initial
+    ◉  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -125,15 +125,15 @@ fn test_concurrent_operations_wc_modified() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription"]);
     insta::assert_snapshot!(stdout, @r###"
     @  snapshot working copy
-    ●    resolve concurrent operations
+    ◉    resolve concurrent operations
     ├─╮
-    ● │  new empty commit
-    │ ●  new empty commit
+    ◉ │  new empty commit
+    │ ◉  new empty commit
     ├─╯
-    ●  describe commit cf911c223d3e24e001fc8264d6dbf0610804fc40
-    ●  snapshot working copy
-    ●  add workspace 'default'
-    ●  initialize repo
+    ◉  describe commit cf911c223d3e24e001fc8264d6dbf0610804fc40
+    ◉  snapshot working copy
+    ◉  add workspace 'default'
+    ◉  initialize repo
     "###);
 }
 

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -43,10 +43,10 @@ fn test_duplicate() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    17a00fc21654   c
     ├─╮
-    ● │  d370aee184ba   b
-    │ ●  2443ea76b0b1   a
+    ◉ │  d370aee184ba   b
+    │ ◉  2443ea76b0b1   a
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "root"]);
@@ -59,14 +59,14 @@ fn test_duplicate() {
     Duplicated 2443ea76b0b1 as 2f6dc5a1ffc2 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  2f6dc5a1ffc2   a
+    ◉  2f6dc5a1ffc2   a
     │ @    17a00fc21654   c
     │ ├─╮
-    │ ● │  d370aee184ba   b
+    │ ◉ │  d370aee184ba   b
     ├─╯ │
-    │   ●  2443ea76b0b1   a
+    │   ◉  2443ea76b0b1   a
     ├───╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
@@ -75,14 +75,14 @@ fn test_duplicate() {
     Duplicated 17a00fc21654 as 1dd099ea963c c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    1dd099ea963c   c
+    ◉    1dd099ea963c   c
     ├─╮
     │ │ @  17a00fc21654   c
     ╭─┬─╯
-    ● │  d370aee184ba   b
-    │ ●  2443ea76b0b1   a
+    ◉ │  d370aee184ba   b
+    │ ◉  2443ea76b0b1   a
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -101,12 +101,12 @@ fn test_duplicate_many() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
     ├─╮
-    ● │  ebd06dba20ec   d
-    ● │  c0cb3a0b73e7   c
-    │ ●  1394f625cbbd   b
+    ◉ │  ebd06dba20ec   d
+    ◉ │  c0cb3a0b73e7   c
+    │ ◉  1394f625cbbd   b
     ├─╯
-    ●  2443ea76b0b1   a
-    ●  000000000000
+    ◉  2443ea76b0b1   a
+    ◉  000000000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b:"]);
@@ -115,18 +115,18 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as 8348ddcec733 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    8348ddcec733   e
+    ◉    8348ddcec733   e
     ├─╮
-    ● │  3b74d9691015   b
+    ◉ │  3b74d9691015   b
     │ │ @  921dde6e55c0   e
     │ ╭─┤
-    │ ● │  ebd06dba20ec   d
-    │ ● │  c0cb3a0b73e7   c
+    │ ◉ │  ebd06dba20ec   d
+    │ ◉ │  c0cb3a0b73e7   c
     ├─╯ │
-    │   ●  1394f625cbbd   b
+    │   ◉  1394f625cbbd   b
     ├───╯
-    ●  2443ea76b0b1   a
-    ●  000000000000
+    ◉  2443ea76b0b1   a
+    ◉  000000000000
     "###);
 
     // Try specifying the same commit twice directly
@@ -136,16 +136,16 @@ fn test_duplicate_many() {
     Duplicated 1394f625cbbd as 0276d3d7c24d b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  0276d3d7c24d   b
+    ◉  0276d3d7c24d   b
     │ @    921dde6e55c0   e
     │ ├─╮
-    │ ● │  ebd06dba20ec   d
-    │ ● │  c0cb3a0b73e7   c
+    │ ◉ │  ebd06dba20ec   d
+    │ ◉ │  c0cb3a0b73e7   c
     ├─╯ │
-    │   ●  1394f625cbbd   b
+    │   ◉  1394f625cbbd   b
     ├───╯
-    ●  2443ea76b0b1   a
-    ●  000000000000
+    ◉  2443ea76b0b1   a
+    ◉  000000000000
     "###);
 
     // Try specifying the same commit twice indirectly
@@ -157,20 +157,20 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as 0f7430f2727a e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    0f7430f2727a   e
+    ◉    0f7430f2727a   e
     ├─╮
-    ● │  2181781b4f81   d
-    │ ●  fa167d18a83a   b
+    ◉ │  2181781b4f81   d
+    │ ◉  fa167d18a83a   b
     │ │ @    921dde6e55c0   e
     │ │ ├─╮
-    │ │ ● │  ebd06dba20ec   d
+    │ │ ◉ │  ebd06dba20ec   d
     ├───╯ │
-    ● │   │  c0cb3a0b73e7   c
+    ◉ │   │  c0cb3a0b73e7   c
     ├─╯   │
-    │     ●  1394f625cbbd   b
+    │     ◉  1394f625cbbd   b
     ├─────╯
-    ●  2443ea76b0b1   a
-    ●  000000000000
+    ◉  2443ea76b0b1   a
+    ◉  000000000000
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
@@ -178,12 +178,12 @@ fn test_duplicate_many() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
     ├─╮
-    ● │  ebd06dba20ec   d
-    ● │  c0cb3a0b73e7   c
-    │ ●  1394f625cbbd   b
+    ◉ │  ebd06dba20ec   d
+    ◉ │  c0cb3a0b73e7   c
+    │ ◉  1394f625cbbd   b
     ├─╯
-    ●  2443ea76b0b1   a
-    ●  000000000000
+    ◉  2443ea76b0b1   a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "d:", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -192,20 +192,20 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as 9bd4389f5d47 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    9bd4389f5d47   e
+    ◉    9bd4389f5d47   e
     ├─╮
-    ● │  d94e4c55a68b   d
-    │ │ ●  c6f7f8c4512e   a
+    ◉ │  d94e4c55a68b   d
+    │ │ ◉  c6f7f8c4512e   a
     │ │ │ @  921dde6e55c0   e
     │ ╭───┤
-    │ │ │ ●  ebd06dba20ec   d
+    │ │ │ ◉  ebd06dba20ec   d
     ├─────╯
-    ● │ │  c0cb3a0b73e7   c
-    │ ● │  1394f625cbbd   b
+    ◉ │ │  c0cb3a0b73e7   c
+    │ ◉ │  1394f625cbbd   b
     ├─╯ │
-    ●   │  2443ea76b0b1   a
+    ◉   │  2443ea76b0b1   a
     ├───╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // Check for BUG -- makes too many 'a'-s, etc.
@@ -219,22 +219,22 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as ee8fe64ed254 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    ee8fe64ed254   e
+    ◉    ee8fe64ed254   e
     ├─╮
-    ● │  2f2442db08eb   d
-    ● │  df53fa589286   c
-    │ ●  e13ac0adabdf   b
+    ◉ │  2f2442db08eb   d
+    ◉ │  df53fa589286   c
+    │ ◉  e13ac0adabdf   b
     ├─╯
-    ●  0fe67a05989e   a
+    ◉  0fe67a05989e   a
     │ @    921dde6e55c0   e
     │ ├─╮
-    │ ● │  ebd06dba20ec   d
-    │ ● │  c0cb3a0b73e7   c
-    │ │ ●  1394f625cbbd   b
+    │ ◉ │  ebd06dba20ec   d
+    │ ◉ │  c0cb3a0b73e7   c
+    │ │ ◉  1394f625cbbd   b
     │ ├─╯
-    │ ●  2443ea76b0b1   a
+    │ ◉  2443ea76b0b1   a
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -248,7 +248,7 @@ fn test_undo_after_duplicate() {
     create_commit(&test_env, &repo_path, "a", &[]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
@@ -256,16 +256,16 @@ fn test_undo_after_duplicate() {
     Duplicated 2443ea76b0b1 as f5cefcbb65a4 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  f5cefcbb65a4   a
+    ◉  f5cefcbb65a4   a
     │ @  2443ea76b0b1   a
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -281,8 +281,8 @@ fn test_rebase_duplicates() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
     @  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
-    ●  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
-    ●  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
@@ -294,13 +294,13 @@ fn test_rebase_duplicates() {
     Duplicated 1394f625cbbd as 870cf438ccbb b
     "###);
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
-    ●  870cf438ccbb   b @ 2001-02-03 04:05:14.000 +07:00
-    │ ●  fdaaf3950f07   b @ 2001-02-03 04:05:13.000 +07:00
+    ◉  870cf438ccbb   b @ 2001-02-03 04:05:14.000 +07:00
+    │ ◉  fdaaf3950f07   b @ 2001-02-03 04:05:13.000 +07:00
     ├─╯
     │ @  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
     ├─╯
-    ●  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
-    ●  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
@@ -311,13 +311,13 @@ fn test_rebase_duplicates() {
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
-    ●  b43fe7354758   b @ 2001-02-03 04:05:14.000 +07:00
-    │ ●  08beb14c3ead   b @ 2001-02-03 04:05:15.000 +07:00
+    ◉  b43fe7354758   b @ 2001-02-03 04:05:14.000 +07:00
+    │ ◉  08beb14c3ead   b @ 2001-02-03 04:05:15.000 +07:00
     ├─╯
     │ @  29bd36b60e60   b @ 2001-02-03 04:05:16.000 +07:00
     ├─╯
-    ●  2f6dc5a1ffc2   a @ 2001-02-03 04:05:16.000 +07:00
-    ●  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ◉  2f6dc5a1ffc2   a @ 2001-02-03 04:05:16.000 +07:00
+    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 }
 

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -46,9 +46,9 @@ fn test_edit() {
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  b2f7e9c549aa second
+    ◉  b2f7e9c549aa second
     @  f41390a5efbf first
-    ●  000000000000
+    ◉  000000000000
     "###);
     insta::assert_snapshot!(read_file(&repo_path.join("file1")), @"0");
 
@@ -56,9 +56,9 @@ fn test_edit() {
     std::fs::write(repo_path.join("file2"), "0").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     Rebased 1 descendant commits onto updated working copy
-    ●  51d937a3eeb4 second
+    ◉  51d937a3eeb4 second
     @  409306de8f44 first
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -75,9 +75,9 @@ fn test_edit_current_wc_commit_missing() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "second"]);
     test_env.jj_cmd_success(&repo_path, &["edit", "@-"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  5c52832c3483 second
+    ◉  5c52832c3483 second
     @  69542c1984c1 first
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // Make the Git backend fail to read the current working copy commit

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -60,8 +60,8 @@ fn test_git_colocated() {
     test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  3e9369cd54227eb88455e1834dbc08aad6a16ac4
-    ●  e61b6729ff4292870702f2f72b2a60165679ef37 master
-    ●  0000000000000000000000000000000000000000
+    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
@@ -73,8 +73,8 @@ fn test_git_colocated() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  b26951a9c6f5c270e4d039880208952fd5faae5e
-    ●  e61b6729ff4292870702f2f72b2a60165679ef37 master
-    ●  0000000000000000000000000000000000000000
+    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
@@ -85,9 +85,9 @@ fn test_git_colocated() {
     test_env.jj_cmd_success(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  9dbb23ff2ff5e66c43880f1042369d704f7a321e
-    ●  b26951a9c6f5c270e4d039880208952fd5faae5e
-    ●  e61b6729ff4292870702f2f72b2a60165679ef37 master
-    ●  0000000000000000000000000000000000000000
+    ◉  b26951a9c6f5c270e4d039880208952fd5faae5e
+    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
@@ -110,7 +110,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     test_env.jj_cmd_success(&workspace_root, &["branch", "create", "foo"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  438471f3fbf1004298d8fb01eeb13663a051a643 foo
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // The branch gets updated when we modify the working copy, and it should get
@@ -118,7 +118,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca foo
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(git_repo
         .find_reference("refs/heads/foo")
@@ -159,8 +159,8 @@ fn test_git_colocated_rebase_on_import() {
     git_repo.set_head("refs/heads/master").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  7f96185cfbe36341d0f9a86ebfaeab67a5922c7e
-    ●  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master
-    ●  0000000000000000000000000000000000000000
+    ◉  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -174,10 +174,10 @@ fn test_git_colocated_branches() {
     test_env.jj_cmd_success(&workspace_root, &["new", "@-", "-m", "bar"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  3560559274ab431feea00b7b7e0b9250ecce951f
-    │ ●  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda
+    │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda
     ├─╯
-    ●  230dd059e1b059aefc0da06a2e5a7dbf22362f22 master
-    ●  0000000000000000000000000000000000000000
+    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 master
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Create a branch in jj. It should be exported to Git even though it points to
@@ -204,10 +204,10 @@ fn test_git_colocated_branches() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     Working copy now at: eb08b363bb5e (no description set)
     @  eb08b363bb5ef8ee549314260488980d7bbe8f63
-    │ ●  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master
+    │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master
     ├─╯
-    ●  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -249,9 +249,9 @@ fn test_git_colocated_fetch_deleted_branch() {
     test_env.jj_cmd_success(&clone_path, &["init", "--git-repo=."]);
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
     @  bc7d08e8de9b7bc248b9358a05e96f1671bbd4d9
-    ●  e1f4268fabd2c84e880c5eb5bd87e076180fc8e3 B
-    ●  a86754f975f953fa25da4265764adc0c62e9ce6b A master
-    ●  0000000000000000000000000000000000000000
+    ◉  e1f4268fabd2c84e880c5eb5bd87e076180fc8e3 B
+    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A master
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     test_env.jj_cmd_success(&origin_path, &["branch", "delete", "B"]);
@@ -260,9 +260,9 @@ fn test_git_colocated_fetch_deleted_branch() {
     // TODO: e1f4 should have been abandoned (#864)
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
     @  bc7d08e8de9b7bc248b9358a05e96f1671bbd4d9
-    ●  e1f4268fabd2c84e880c5eb5bd87e076180fc8e3
-    ●  a86754f975f953fa25da4265764adc0c62e9ce6b A master
-    ●  0000000000000000000000000000000000000000
+    ◉  e1f4268fabd2c84e880c5eb5bd87e076180fc8e3
+    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A master
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -276,25 +276,25 @@ fn test_git_colocated_squash_undo() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo 8f71e3b6a3be
-    ●  qpvuntsmwlqt a86754f975f9 A master
-    ●  zzzzzzzzzzzz 000000000000
+    ◉  qpvuntsmwlqt a86754f975f9 A master
+    ◉  zzzzzzzzzzzz 000000000000
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr f0c12b0396d9
-    ●  qpvuntsmwlqt 2f376ea1478c A master
-    ●  zzzzzzzzzzzz 000000000000
+    ◉  qpvuntsmwlqt 2f376ea1478c A master
+    ◉  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    ●  qpvuntsmwlqt 2f376ea1478c A master !divergence!
+    ◉  qpvuntsmwlqt 2f376ea1478c A master !divergence!
     │ @  rlvkpnrzqnoo 8f71e3b6a3be
-    │ ●  qpvuntsmwlqt a86754f975f9 A !divergence!
+    │ ◉  qpvuntsmwlqt a86754f975f9 A !divergence!
     ├─╯
-    ●  zzzzzzzzzzzz 000000000000
+    ◉  zzzzzzzzzzzz 000000000000
     "###);
 }
 
@@ -373,8 +373,8 @@ fn test_git_colocated_unreachable_commits() {
     test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  66ae47cee4f8c28ee8d7e4f5d9401b03c07e22f2
-    ●  2ee37513d2b5e549f7478c671a780053614bff19 master
-    ●  0000000000000000000000000000000000000000
+    ◉  2ee37513d2b5e549f7478c671a780053614bff19 master
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -308,18 +308,18 @@ fn test_git_fetch_all() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
 
     // Nothing in our repo before the fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ●  000000000000
+    ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @"");
@@ -331,15 +331,15 @@ fn test_git_fetch_all() {
     trunk1: ff36dc55760e descr_for_trunk1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // ==== Change both repos ====
@@ -347,14 +347,14 @@ fn test_git_fetch_all() {
     let source_log = create_trunk2_and_rebase_branches(&test_env, &source_git_repo_path);
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
-    ●  babc49226c14 descr_for_b b
-    │ ●  91e46b4b2653 descr_for_a2 a2
+    ◉  babc49226c14 descr_for_b b
+    │ ◉  91e46b4b2653 descr_for_a2 a2
     ├─╯
-    │ ●  0424f6dfc1ff descr_for_a1 a1
+    │ ◉  0424f6dfc1ff descr_for_a1 a1
     ├─╯
     @  8f1f14fbbf42 descr_for_trunk2 trunk2
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
     // Change a branch in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_success(
@@ -364,15 +364,15 @@ fn test_git_fetch_all() {
 
     // Our repo before and after fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  061eddbb43ab new_descr_for_b_to_create_conflict b*
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  061eddbb43ab new_descr_for_b_to_create_conflict b*
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: 359a9a02457d descr_for_a1
@@ -396,18 +396,18 @@ fn test_git_fetch_all() {
     trunk2: 8f1f14fbbf42 descr_for_trunk2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  babc49226c14 descr_for_b b?? b@origin
-    │ ●  91e46b4b2653 descr_for_a2 a2
+    ◉  babc49226c14 descr_for_b b?? b@origin
+    │ ◉  91e46b4b2653 descr_for_a2 a2
     ├─╯
-    │ ●  0424f6dfc1ff descr_for_a1 a1
+    │ ◉  0424f6dfc1ff descr_for_a1 a1
     ├─╯
-    ●  8f1f14fbbf42 descr_for_trunk2 trunk2
-    │ ●  061eddbb43ab new_descr_for_b_to_create_conflict b??
+    ◉  8f1f14fbbf42 descr_for_trunk2 trunk2
+    │ ◉  061eddbb43ab new_descr_for_b_to_create_conflict b??
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -431,12 +431,12 @@ fn test_git_fetch_some_of_many_branches() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
 
     // Test an error message
@@ -449,17 +449,17 @@ fn test_git_fetch_some_of_many_branches() {
     // Nothing in our repo before the fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ●  000000000000
+    ◉  000000000000
     "###);
     // Fetch one branch...
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  c7d4bdcbc215 descr_for_b b
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
@@ -469,15 +469,15 @@ fn test_git_fetch_some_of_many_branches() {
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a*"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  decaa3966c83 descr_for_a2 a2
-    │ ●  359a9a02457d descr_for_a1 a1
+    ◉  decaa3966c83 descr_for_a2 a2
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    │ ●  c7d4bdcbc215 descr_for_b b
+    │ ◉  c7d4bdcbc215 descr_for_b b
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
     // Fetching the same branch again
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a1"]);
@@ -485,15 +485,15 @@ fn test_git_fetch_some_of_many_branches() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  decaa3966c83 descr_for_a2 a2
-    │ ●  359a9a02457d descr_for_a1 a1
+    ◉  decaa3966c83 descr_for_a2 a2
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    │ ●  c7d4bdcbc215 descr_for_b b
+    │ ◉  c7d4bdcbc215 descr_for_b b
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // ==== Change both repos ====
@@ -501,14 +501,14 @@ fn test_git_fetch_some_of_many_branches() {
     let source_log = create_trunk2_and_rebase_branches(&test_env, &source_git_repo_path);
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
-    ●  13ac032802f1 descr_for_b b
-    │ ●  010977d69c5b descr_for_a2 a2
+    ◉  13ac032802f1 descr_for_b b
+    │ ◉  010977d69c5b descr_for_a2 a2
     ├─╯
-    │ ●  6f4e1c4dfe29 descr_for_a1 a1
+    │ ◉  6f4e1c4dfe29 descr_for_a1 a1
     ├─╯
     @  09430ba04a82 descr_for_trunk2 trunk2
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
     // Change a branch in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_success(
@@ -518,15 +518,15 @@ fn test_git_fetch_some_of_many_branches() {
 
     // Our repo before and after fetch of two branches
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  2be688d8c664 new_descr_for_b_to_create_conflict b*
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  2be688d8c664 new_descr_for_b_to_create_conflict b*
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(
         &target_jj_repo_path,
@@ -534,18 +534,18 @@ fn test_git_fetch_some_of_many_branches() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  13ac032802f1 descr_for_b b?? b@origin
-    │ ●  6f4e1c4dfe29 descr_for_a1 a1
+    ◉  13ac032802f1 descr_for_b b?? b@origin
+    │ ◉  6f4e1c4dfe29 descr_for_a1 a1
     ├─╯
-    ●  09430ba04a82 descr_for_trunk2
-    │ ●  2be688d8c664 new_descr_for_b_to_create_conflict b??
+    ◉  09430ba04a82 descr_for_trunk2
+    │ ◉  2be688d8c664 new_descr_for_b_to_create_conflict b??
     ├─╯
-    │ ●  decaa3966c83 descr_for_a2 a2
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // We left a2 where it was before, let's see how `jj branch list` sees this.
@@ -566,18 +566,18 @@ fn test_git_fetch_some_of_many_branches() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  010977d69c5b descr_for_a2 a2
-    │ ●  13ac032802f1 descr_for_b b?? b@origin
+    ◉  010977d69c5b descr_for_a2 a2
+    │ ◉  13ac032802f1 descr_for_b b?? b@origin
     ├─╯
-    │ ●  6f4e1c4dfe29 descr_for_a1 a1
+    │ ◉  6f4e1c4dfe29 descr_for_a1 a1
     ├─╯
-    ●  09430ba04a82 descr_for_trunk2
-    │ ●  2be688d8c664 new_descr_for_b_to_create_conflict b??
+    ◉  09430ba04a82 descr_for_trunk2
+    │ ◉  2be688d8c664 new_descr_for_b_to_create_conflict b??
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: 6f4e1c4dfe29 descr_for_a1
@@ -610,12 +610,12 @@ fn test_git_fetch_undo() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
 
     // Fetch 2 branches
@@ -625,29 +625,29 @@ fn test_git_fetch_undo() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  359a9a02457d descr_for_a1 a1
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["undo"]), @"");
     // The undo works as expected
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ●  000000000000
+    ◉  000000000000
     "###);
     // Now try to fetch just one branch
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  c7d4bdcbc215 descr_for_b b
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -749,27 +749,27 @@ fn test_git_fetch_removed_branch() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
 
     // Fetch all branches
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // Remove a2 branch in origin
@@ -781,28 +781,28 @@ fn test_git_fetch_removed_branch() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // Fetch branches a2 from origin, and check that it has been removed locally
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  359a9a02457d descr_for_a1 a1
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 
@@ -826,27 +826,27 @@ fn test_git_fetch_removed_parent_branch() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
-    ●  000000000000
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  000000000000
     "###);
 
     // Fetch all branches
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ●  359a9a02457d descr_for_a1 a1
+    │ ◉  359a9a02457d descr_for_a1 a1
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1 master trunk1
+    ◉  ff36dc55760e descr_for_trunk1 master trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 
     // Remove all branches in origin.
@@ -863,12 +863,12 @@ fn test_git_fetch_removed_parent_branch() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ●  c7d4bdcbc215 descr_for_b b
-    │ ●  decaa3966c83 descr_for_a2 a2
+    ◉  c7d4bdcbc215 descr_for_b b
+    │ ◉  decaa3966c83 descr_for_a2 a2
     ├─╯
-    ●  ff36dc55760e descr_for_trunk1
+    ◉  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -74,7 +74,7 @@ fn test_ignore_working_copy() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  438471f3fbf1004298d8fb01eeb13663a051a643
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Modify the file. With --ignore-working-copy, we still get the same commit
@@ -90,7 +90,7 @@ fn test_ignore_working_copy() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -214,7 +214,7 @@ fn test_color_config() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ●  [38;5;4m0000000000000000000000000000000000000000[39m
+    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that color is used if it's requested in the config file
@@ -222,21 +222,21 @@ fn test_color_config() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ●  [38;5;4m0000000000000000000000000000000000000000[39m
+    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that --color=never overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=never", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Test that --color=auto overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=auto", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Test that --config-toml 'ui.color="never"' overrides the config.
@@ -252,7 +252,7 @@ fn test_color_config() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // --color overrides --config-toml 'ui.color=...'.
@@ -270,7 +270,7 @@ fn test_color_config() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Test that NO_COLOR does NOT override the request for color in the config file
@@ -278,7 +278,7 @@ fn test_color_config() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ●  [38;5;4m0000000000000000000000000000000000000000[39m
+    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that per-repo config overrides the user config.
@@ -290,7 +290,7 @@ fn test_color_config() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -107,7 +107,7 @@ fn test_init_git_external() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  mwrttmoslwzp git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
+    ◉  mwrttmoslwzp git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
     │  My commit message
     ~
     "###);
@@ -151,7 +151,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  mwrttmoslwzp git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
+    ◉  mwrttmoslwzp git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
     │  My commit message
     ~
     "###);

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -44,8 +44,8 @@ fn test_log_with_or_without_diff() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
-    ●  add a file
-    ●
+    ◉  add a file
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p"]);
@@ -54,10 +54,10 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ●  add a file
+    ◉  add a file
     │  Added regular file file1:
     │          1: foo
-    ●
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--no-graph"]);
@@ -74,11 +74,11 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ●  add a file
+    ◉  add a file
     │  A file1
     │  Added regular file file1:
     │          1: foo
-    ●
+    ◉
     "###);
 
     // `-s` for summary, `--git` for git diff (which implies `-p`)
@@ -93,7 +93,7 @@ fn test_log_with_or_without_diff() {
     │  @@ -1,1 +1,2 @@
     │   foo
     │  +bar
-    ●  add a file
+    ◉  add a file
     │  A file1
     │  diff --git a/file1 b/file1
     │  new file mode 100644
@@ -102,7 +102,7 @@ fn test_log_with_or_without_diff() {
     │  +++ b/file1
     │  @@ -1,0 +1,1 @@
     │  +foo
-    ●
+    ◉
     "###);
 
     // `-p` enables default "summary" output, so `-s` is noop
@@ -120,9 +120,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
     │  M file1
-    ●  add a file
+    ◉  add a file
     │  A file1
-    ●
+    ◉
     "###);
 
     // `-p` enables default "color-words" diff output, so `--color-words` is noop
@@ -135,10 +135,10 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ●  add a file
+    ◉  add a file
     │  Added regular file file1:
     │          1: foo
-    ●
+    ◉
     "###);
 
     // `--git` enables git diff, so `-p` is noop
@@ -191,9 +191,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
     │  M file1
-    ●  add a file
+    ◉  add a file
     │  A file1
-    ●
+    ◉
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -385,7 +385,7 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
         @r###"
-    ●  Change qpvuntsmwlqt initial ba1a30916d29 original
+    ◉  Change qpvuntsmwlqt initial ba1a30916d29 original
     │
     ~
     "###
@@ -404,16 +404,16 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(stdout,
         @r###"
     @  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4m03[0m[38;5;8mf51310b83e[39m
-    ●  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7fb1909080[39m
-    ●  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4me7[0m[38;5;8m15ad5db646[39m
-    ●  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m38[0m[38;5;8m622e54e2e5[39m
-    ●  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m0cf[0m[38;5;8m42f60199c[39m
-    ●  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6015e4e622[39m
-    ●  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m06f[0m[38;5;8m34d9b1475[39m
-    ●  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4m1f[0m[38;5;8m99a5e19891[39m
-    ●  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1f7dee65b4[39m
-    ●  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4mba1[0m[38;5;8ma30916d29[39m [38;5;5moriginal[39m
-    ●  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
+    ◉  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7fb1909080[39m
+    ◉  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4me7[0m[38;5;8m15ad5db646[39m
+    ◉  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m38[0m[38;5;8m622e54e2e5[39m
+    ◉  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m0cf[0m[38;5;8m42f60199c[39m
+    ◉  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6015e4e622[39m
+    ◉  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m06f[0m[38;5;8m34d9b1475[39m
+    ◉  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4m1f[0m[38;5;8m99a5e19891[39m
+    ◉  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1f7dee65b4[39m
+    ◉  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4mba1[0m[38;5;8ma30916d29[39m [38;5;5moriginal[39m
+    ◉  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
     "###
     );
     let stdout = test_env.jj_cmd_success(
@@ -430,16 +430,16 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(stdout,
         @r###"
     @  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4m03[0m[38;5;8mf[39m
-    ●  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7[39m
-    ●  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4me7[0m[38;5;8m1[39m
-    ●  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m38[0m[38;5;8m6[39m
-    ●  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m0cf[0m
-    ●  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6[39m
-    ●  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m06f[0m
-    ●  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4m1f[0m[38;5;8m9[39m
-    ●  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1[39m
-    ●  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
-    ●  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
+    ◉  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7[39m
+    ◉  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4me7[0m[38;5;8m1[39m
+    ◉  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m38[0m[38;5;8m6[39m
+    ◉  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m0cf[0m
+    ◉  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6[39m
+    ◉  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m06f[0m
+    ◉  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4m1f[0m[38;5;8m9[39m
+    ◉  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1[39m
+    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
+    ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
     "###
     );
     let stdout = test_env.jj_cmd_success(
@@ -456,16 +456,16 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(stdout,
         @r###"
     @  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4m03[0m
-    ●  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mf7[0m
-    ●  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4me7[0m
-    ●  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m38[0m
-    ●  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4m0cf[0m
-    ●  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m9e[0m
-    ●  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m06f[0m
-    ●  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4m1f[0m
-    ●  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m7b[0m
-    ●  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
-    ●  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
+    ◉  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mf7[0m
+    ◉  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4me7[0m
+    ◉  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m38[0m
+    ◉  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4m0cf[0m
+    ◉  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m9e[0m
+    ◉  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m06f[0m
+    ◉  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4m1f[0m
+    ◉  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m7b[0m
+    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
+    ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
     "###
     );
 }
@@ -499,7 +499,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
         @r###"
     @  Change q[pvuntsmwlqt] initial b[a1a30916d29] original
-    ●  Change z[zzzzzzzzzzz] 0[00000000000]
+    ◉  Change z[zzzzzzzzzzz] 0[00000000000]
     "###
     );
 
@@ -515,9 +515,9 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-T", prefix_format]),
         @r###"
     @  Change w[qnwkozpkust] 44[4c3c5066d3]
-    │ ●  Change q[pvuntsmwlqt] initial ba[1a30916d29] original
+    │ ◉  Change q[pvuntsmwlqt] initial ba[1a30916d29] original
     ├─╯
-    ●  Change z[zzzzzzzzzzz] 00[0000000000]
+    ◉  Change z[zzzzzzzzzzz] 00[0000000000]
     "###
     );
     insta::assert_snapshot!(
@@ -529,7 +529,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "d0", "-T", prefix_format]),
         @r###"
-    ●  Change p[szsrknsmxqw] extra d0[947f34cec4]
+    ◉  Change p[szsrknsmxqw] extra d0[947f34cec4]
     │
     ~
     "###
@@ -545,12 +545,12 @@ fn test_log_shortest_length_parameter() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(0)"]), @r###"
     @  2
-    ●  0
+    ◉  0
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(100)"]), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -601,7 +601,7 @@ fn test_log_divergence() {
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
     @  description 1
-    ●
+    ◉
     "###);
 
     // Create divergence
@@ -612,10 +612,10 @@ fn test_log_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    ●  description 2 !divergence!
+    ◉  description 2 !divergence!
     │ @  description 1 !divergence!
     ├─╯
-    ●
+    ◉
     "###);
 }
 
@@ -630,8 +630,8 @@ fn test_log_reversed() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●
-    ●  first
+    ◉
+    ◉  first
     @  second
     "###);
 
@@ -660,7 +660,7 @@ fn test_log_filtered_by_path() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     @  second
-    ●  first
+    ◉  first
     │
     ~
     "###);
@@ -676,7 +676,7 @@ fn test_log_filtered_by_path() {
     insta::assert_snapshot!(stdout, @r###"
     @  second
     │  M file1
-    ●  first
+    ◉  first
     │  A file1
     ~
     "###);
@@ -853,18 +853,18 @@ fn test_graph_template_color() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  single line
-    ●  first line
+    ◉  first line
     │  second line
     │  third line
-    ●
+    ◉
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  [1m[38;5;2msingle line[0m
-    ●  [38;5;1mfirst line[39m
+    ◉  [38;5;1mfirst line[39m
     │  [38;5;1msecond line[39m
     │  [38;5;1mthird line[39m
-    ●
+    ◉
     "###);
 }
 
@@ -892,15 +892,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─╮
-    ● │  side branch
+    ◉ │  side branch
     │ │  with
     │ │  long
     │ │  description
-    ● │  main branch 2
+    ◉ │  main branch 2
     ├─╯
-    ●  main branch 1
-    ●  initial
-    ●
+    ◉  main branch 1
+    ◉  initial
+    ◉
     "###);
 
     // ASCII style
@@ -945,15 +945,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─╮
-    ● │  side branch
+    ◉ │  side branch
     │ │  with
     │ │  long
     │ │  description
-    ● │  main branch 2
+    ◉ │  main branch 2
     ├─╯
-    ●  main branch 1
-    ●  initial
-    ●
+    ◉  main branch 1
+    ◉  initial
+    ◉
     "###);
 
     // Square style
@@ -962,15 +962,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─┐
-    ● │  side branch
+    ◉ │  side branch
     │ │  with
     │ │  long
     │ │  description
-    ● │  main branch 2
+    ◉ │  main branch 2
     ├─┘
-    ●  main branch 1
-    ●  initial
-    ●
+    ◉  main branch 1
+    ◉  initial
+    ◉
     "###);
 }
 
@@ -1036,18 +1036,18 @@ fn test_log_word_wrap() {
     ├─╮  3 4 5
     │ │  6 7 8
     │ │  9
-    ● │  0 1 2
+    ◉ │  0 1 2
     │ │  3 4 5
     │ │  6 7 8
     │ │  9
-    ● │  0 1 2
+    ◉ │  0 1 2
     ├─╯  3 4 5
     │    6 7 8
     │    9
-    ●  0 1 2 3
+    ◉  0 1 2 3
     │  4 5 6 7
     │  8 9
-    ●  0 1 2 3
+    ◉  0 1 2 3
        4 5 6 7
        8 9
     "###);

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -58,13 +58,13 @@ fn test_move() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  0d7353584003 f
-    ●  e9515f21068c e
-    ●  bdd835cae844 d
-    │ ●  caa4d0b23201 c
-    │ ●  55171e33db26 b
+    ◉  e9515f21068c e
+    ◉  bdd835cae844 d
+    │ ◉  caa4d0b23201 c
+    │ ◉  55171e33db26 b
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
 
     // Errors out without arguments
@@ -91,12 +91,12 @@ fn test_move() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1c03e3d3c63f f
-    ●  e9515f21068c e
-    ●  bdd835cae844 d
-    │ ●  55171e33db26 b c
+    ◉  e9515f21068c e
+    ◉  bdd835cae844 d
+    │ ◉  55171e33db26 b c
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -119,12 +119,12 @@ fn test_move() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c8d83075e8c2 f
-    ●  2c50bfc59c68 e
-    │ ●  caa4d0b23201 c
-    │ ●  55171e33db26 b
+    ◉  2c50bfc59c68 e
+    │ ◉  caa4d0b23201 c
+    │ ◉  55171e33db26 b
     ├─╯
-    ●  3db0a2f5b535 a d
-    ●  000000000000
+    ◉  3db0a2f5b535 a d
+    ◉  000000000000
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
@@ -144,12 +144,12 @@ fn test_move() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2b723b1d6033 f
-    ●  4293930d6333 d e
-    │ ●  caa4d0b23201 c
-    │ ●  55171e33db26 b
+    ◉  4293930d6333 d e
+    │ ◉  caa4d0b23201 c
+    │ ◉  55171e33db26 b
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2", "-r", "d"]);
@@ -188,11 +188,11 @@ fn test_move_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bdd835cae844 d
-    │ ●  5028db694b6b c
-    │ ●  55171e33db26 b
+    │ ◉  5028db694b6b c
+    │ ◉  55171e33db26 b
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
 
     let edit_script = test_env.set_up_fake_diff_editor();
@@ -205,10 +205,10 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  71b69e433fbc d
-    │ ●  55171e33db26 b c
+    │ ◉  55171e33db26 b c
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -235,11 +235,11 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  63f1a6e96edb d
-    │ ●  d027c6e3e6bc c
-    │ ●  55171e33db26 b
+    │ ◉  d027c6e3e6bc c
+    │ ◉  55171e33db26 b
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -268,11 +268,11 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  17c2e6632cc5 d
-    │ ●  6a3ae047a03e c
-    │ ●  55171e33db26 b
+    │ ◉  6a3ae047a03e c
+    │ ◉  55171e33db26 b
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -300,12 +300,12 @@ fn test_move_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  21253406d416 c
-    ●  e1cf08aae711 b
+    ◉  21253406d416 c
+    ◉  e1cf08aae711 b
     │ @  bdd835cae844 d
     ├─╯
-    ●  3db0a2f5b535 a
-    ●  000000000000
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);

--- a/tests/test_new_command.rs
+++ b/tests/test_new_command.rs
@@ -29,18 +29,18 @@ fn test_new() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    ●  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
-    ●  0000000000000000000000000000000000000000
+    ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Start a new change off of a specific commit (the root commit in this case).
     test_env.jj_cmd_success(&repo_path, &["new", "-m", "off of root", "root"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ●  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    │ ●  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    │ ◉  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
+    │ ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
     ├─╯
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -61,10 +61,10 @@ fn test_new_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    0c4e5b9b68ae0cbe7ce3c61042619513d09005bf
     ├─╮
-    ● │  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    │ ●  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    ◉ │  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
+    │ ◉  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
     ├─╯
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @"a");
@@ -77,10 +77,10 @@ fn test_new_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    200ed1a14c8acf09783dafefe5bebf2ff58f12fd
     ├─╮
-    ● │  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    │ ●  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    ◉ │  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
+    │ ◉  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
     ├─╯
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // `jj merge` with less than two arguments is an error
@@ -115,14 +115,14 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    ● │  E
-    │ ●  D
+    ◉ │  E
+    │ ◉  D
     ├─╯
-    │ ●  C
-    │ ●  B
-    │ ●  A
+    │ ◉  C
+    │ ◉  B
+    │ ◉  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 
     let stdout =
@@ -132,18 +132,18 @@ fn test_new_insert_after() {
     Working copy now at: ca7c6481a8dd G
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ●  C
-    │ ●  F
+    ◉  C
+    │ ◉  F
     ╭─┤
     @ │    G
     ├───╮
-    │ ● │  E
-    ● │ │  D
+    │ ◉ │  E
+    ◉ │ │  D
     ├─╯ │
-    │   ●  B
-    │   ●  A
+    │   ◉  B
+    │   ◉  A
     ├───╯
-    ●  root
+    ◉  root
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "H", "D"]);
@@ -152,19 +152,19 @@ fn test_new_insert_after() {
     Working copy now at: fcf8281b4135 H
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ●  C
-    │ ●  F
+    ◉  C
+    │ ◉  F
     ╭─┤
-    ● │    G
+    ◉ │    G
     ├───╮
     @ │ │  H
-    │ ● │  E
-    ● │ │  D
+    │ ◉ │  E
+    ◉ │ │  D
     ├─╯ │
-    │   ●  B
-    │   ●  A
+    │   ◉  B
+    │   ◉  A
     ├───╯
-    ●  root
+    ◉  root
     "###);
 }
 
@@ -177,14 +177,14 @@ fn test_new_insert_after_children() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    ● │  E
-    │ ●  D
+    ◉ │  E
+    │ ◉  D
     ├─╯
-    │ ●  C
-    │ ●  B
-    │ ●  A
+    │ ◉  C
+    │ ◉  B
+    │ ◉  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 
     // Check that inserting G after A and C doesn't try to rebase B (which is
@@ -198,17 +198,17 @@ fn test_new_insert_after_children() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
     ├─╮
-    │ │ ●    F
+    │ │ ◉    F
     │ │ ├─╮
-    │ │ ● │  E
-    │ │ │ ●  D
+    │ │ ◉ │  E
+    │ │ │ ◉  D
     │ │ ├─╯
-    ● │ │  C
-    ● │ │  B
+    ◉ │ │  C
+    ◉ │ │  B
     ├─╯ │
-    ●   │  A
+    ◉   │  A
     ├───╯
-    ●  root
+    ◉  root
     "###);
 }
 
@@ -221,14 +221,14 @@ fn test_new_insert_before() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    ● │  E
-    │ ●  D
+    ◉ │  E
+    │ ◉  D
     ├─╯
-    │ ●  C
-    │ ●  B
-    │ ●  A
+    │ ◉  C
+    │ ◉  B
+    │ ◉  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 
     let stdout =
@@ -238,18 +238,18 @@ fn test_new_insert_before() {
     Working copy now at: ff6bbbc7b8df G
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ●  F
-    │ ●  C
+    ◉  F
+    │ ◉  C
     ├─╯
     @      G
     ├─┬─╮
-    ● │ │  E
-    │ ● │  D
+    ◉ │ │  E
+    │ ◉ │  D
     ├─╯ │
-    │   ●  B
-    │   ●  A
+    │   ◉  B
+    │   ◉  A
     ├───╯
-    ●  root
+    ◉  root
     "###);
 }
 
@@ -262,14 +262,14 @@ fn test_new_insert_before_root_successors() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    ● │  E
-    │ ●  D
+    ◉ │  E
+    │ ◉  D
     ├─╯
-    │ ●  C
-    │ ●  B
-    │ ●  A
+    │ ◉  C
+    │ ◉  B
+    │ ◉  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 
     let stdout =
@@ -279,17 +279,17 @@ fn test_new_insert_before_root_successors() {
     Working copy now at: 3654197754f8 G
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ●    F
+    ◉    F
     ├─╮
-    │ │ ●  C
-    │ │ ●  B
-    ● │ │  D
-    │ │ ●  A
+    │ │ ◉  C
+    │ │ ◉  B
+    ◉ │ │  D
+    │ │ ◉  A
     ├───╯
     @ │  G
-    │ ●  E
+    │ ◉  E
     ├─╯
-    ●  root
+    ◉  root
     "###);
 }
 
@@ -304,14 +304,14 @@ fn test_new_insert_before_no_loop() {
     insta::assert_snapshot!(stdout, @r###"
     @    7705d353bf5d F
     ├─╮
-    ● │  41a89ffcbba2 E
-    │ ●  c9257eff5bf9 D
+    ◉ │  41a89ffcbba2 E
+    │ ◉  c9257eff5bf9 D
     ├─╯
-    │ ●  ec18c57d72d8 C
-    │ ●  6041917ceeb5 B
-    │ ●  65b1ef43c737 A
+    │ ◉  ec18c57d72d8 C
+    │ ◉  6041917ceeb5 B
+    │ ◉  65b1ef43c737 A
     ├─╯
-    ●  000000000000 root
+    ◉  000000000000 root
     "###);
 
     let stderr =
@@ -330,14 +330,14 @@ fn test_new_insert_before_no_root_merge() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    ● │  E
-    │ ●  D
+    ◉ │  E
+    │ ◉  D
     ├─╯
-    │ ●  C
-    │ ●  B
-    │ ●  A
+    │ ◉  C
+    │ ◉  B
+    │ ◉  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 
     let stdout =
@@ -347,17 +347,17 @@ fn test_new_insert_before_no_root_merge() {
     Working copy now at: bf9fc49331de G
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ●    F
+    ◉    F
     ├─╮
-    │ │ ●  C
-    ● │ │  D
-    │ │ ●  B
+    │ │ ◉  C
+    ◉ │ │  D
+    │ │ ◉  B
     ├───╯
     @ │  G
-    │ ●  E
-    ● │  A
+    │ ◉  E
+    ◉ │  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 }
 
@@ -370,14 +370,14 @@ fn test_new_insert_before_root() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    ● │  E
-    │ ●  D
+    ◉ │  E
+    │ ◉  D
     ├─╯
-    │ ●  C
-    │ ●  B
-    │ ●  A
+    │ ◉  C
+    │ ◉  B
+    │ ◉  A
     ├─╯
-    ●  root
+    ◉  root
     "###);
 
     let stderr =

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -33,11 +33,11 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     │  my description
-    ●  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     │  my description
-    ●  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     │  my description
-    ●  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
        (empty) my description
     "###);
 
@@ -54,16 +54,16 @@ fn test_obslog_with_or_without_diff() {
     │     4     : +bar
     │     5     : +++++++
     │     6     : >>>>>>>
-    ●  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     │  my description
-    ●  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ●  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
        (empty) my description
     "###);
 
@@ -145,7 +145,7 @@ fn test_obslog_word_wrap() {
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
     @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     │  (empty) first
-    ●  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
@@ -153,7 +153,7 @@ fn test_obslog_word_wrap() {
     │  2001-02-03 04:05:08.000 +07:00
     │  69542c1984c1
     │  (empty) first
-    ●  qpvuntsmwlqt test.user@example.com
+    ◉  qpvuntsmwlqt test.user@example.com
        2001-02-03 04:05:07.000 +07:00
        230dd059e1b0
        (empty) (no description set)
@@ -193,25 +193,25 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●    qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5ba72
+    ◉    qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5ba72
     ├─╮  squashed
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    ● │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
+    ◉ │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
     │ │  first
     │ │  Added regular file file1:
     │ │          1: foo
-    ● │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    ◉ │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     │ │  (empty) first
-    ● │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉ │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
       │  (empty) (no description set)
-      ●  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
+      ◉  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
       │  second
       │  Modified regular file file1:
       │     1    1: foo
       │          2: bar
-      ●  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
+      ◉  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
          (empty) second
     "###);
 }

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -40,9 +40,9 @@ fn test_op_log() {
     @  45108169c0f8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
-    ●  a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ◉  a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ●  56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ◉  56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
        initialize repo
     "###);
     // Test op log with relative dates
@@ -52,9 +52,9 @@ fn test_op_log() {
     @  45108169c0f8 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
-    ●  a99a3fd5c51e test-username@host.example.com NN years ago, lasted less than a microsecond
+    ◉  a99a3fd5c51e test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
-    ●  56b94dfc38e7 test-username@host.example.com NN years ago, lasted less than a microsecond
+    ◉  56b94dfc38e7 test-username@host.example.com NN years ago, lasted less than a microsecond
        initialize repo
     "###);
     let add_workspace_id = "a99a3fd5c51e";
@@ -62,24 +62,24 @@ fn test_op_log() {
 
     // Can load the repo at a specific operation ID
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, initialize_repo_id), @r###"
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, add_workspace_id), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     // "@" resolves to the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@"), @r###"
     @  bc8f18aa6f396a93572811632313cbb5625d475d
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     // "@-" resolves to the parent of the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@-"), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@--"), @r###"
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "@---"]), @r###"
@@ -88,7 +88,7 @@ fn test_op_log() {
     // "ID-" also resolves to the parent.
     insta::assert_snapshot!(
         get_log_output(&test_env, &repo_path, &format!("{add_workspace_id}-")), @r###"
-    ●  0000000000000000000000000000000000000000
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // We get a reasonable message if an invalid operation ID is specified
@@ -137,13 +137,13 @@ fn test_op_log_template() {
 
     insta::assert_snapshot!(render(r#"id ++ "\n""#), @r###"
     @  a99a3fd5c51e8f7ccb9ae2f9fb749612a23f0a7cf25d8c644f36c35c077449ce3c66f49d098a5a704ca5e47089a7f019563a5b8cbc7d451619e0f90c82241ceb
-    ●  56b94dfc38e7d54340377f566e96ab97dc6163ea7841daf49fb2e1d1ceb27e26274db1245835a1a421fb9d06e6e0fe1e4f4aa1b0258c6e86df676ad9111d0dab
+    ◉  56b94dfc38e7d54340377f566e96ab97dc6163ea7841daf49fb2e1d1ceb27e26274db1245835a1a421fb9d06e6e0fe1e4f4aa1b0258c6e86df676ad9111d0dab
     "###);
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
                                 time.start(), time.end(), time.duration()) ++ "\n""#), @r###"
     @  a99a3 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
-    ●  56b94 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+    ◉  56b94 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     "###);
 }
 
@@ -170,7 +170,7 @@ fn test_op_log_word_wrap() {
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @r###"
     @  a99a3fd5c51e test-username@host.example.com 22 years ago, lasted less than a microsecond
     │  add workspace 'default'
-    ●  56b94dfc38e7 test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  56b94dfc38e7 test-username@host.example.com 22 years ago, lasted less than a microsecond
        initialize repo
     "###);
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @r###"
@@ -179,7 +179,7 @@ fn test_op_log_word_wrap() {
     │  years ago, lasted less than a
     │  microsecond
     │  add workspace 'default'
-    ●  56b94dfc38e7
+    ◉  56b94dfc38e7
        test-username@host.example.com 22
        years ago, lasted less than a
        microsecond

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -99,13 +99,13 @@ fn test_rebase_branch() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ●  d
-    │ │ ●  c
+    │ ◉  d
+    │ │ ◉  c
     │ ├─╯
-    │ ●  b
+    │ ◉  b
     ├─╯
-    ●  a
-    ●
+    ◉  a
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b", "c", "-d", "e"]);
@@ -113,13 +113,13 @@ fn test_rebase_branch() {
     Rebased 3 commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  d
-    │ ●  c
+    ◉  d
+    │ ◉  c
     ├─╯
-    ●  b
+    ◉  b
     @  e
-    ●  a
-    ●
+    ◉  a
+    ◉
     "###);
 
     // Test rebasing multiple branches at once
@@ -131,14 +131,14 @@ fn test_rebase_branch() {
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  d
+    ◉  d
     │ @  e
     ├─╯
-    │ ●  c
+    │ ◉  c
     ├─╯
-    ●  b
-    ●  a
-    ●
+    ◉  b
+    ◉  a
+    ◉
     "###);
 
     // Same test but with more than one revision per argument and same revision
@@ -162,14 +162,14 @@ fn test_rebase_branch() {
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  d
+    ◉  d
     │ @  e
     ├─╯
-    │ ●  c
+    │ ◉  c
     ├─╯
-    ●  b
-    ●  a
-    ●
+    ◉  b
+    ◉  a
+    ◉
     "###);
 }
 
@@ -188,13 +188,13 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    ● │  d
-    ● │  c
-    │ │ ●  b
+    ◉ │  d
+    ◉ │  c
+    │ │ ◉  b
     │ ├─╯
-    │ ●  a
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
@@ -205,11 +205,11 @@ fn test_rebase_branch_with_merge() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    ●  d
-    ●  c
-    ●  b
-    ●  a
-    ●
+    ◉  d
+    ◉  c
+    ◉  b
+    ◉  a
+    ◉
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
@@ -221,11 +221,11 @@ fn test_rebase_branch_with_merge() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    ●  d
-    ●  c
-    ●  b
-    ●  a
-    ●
+    ◉  d
+    ◉  c
+    ◉  b
+    ◉  a
+    ◉
     "###);
 }
 
@@ -242,12 +242,12 @@ fn test_rebase_single_revision() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ●    c
+    ◉    c
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     // Descendants of the rebased commit "b" should be rebased onto parents. First
@@ -264,11 +264,11 @@ fn test_rebase_single_revision() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ●  c
-    │ ●  b
+    ◉  c
+    │ ◉  b
     ├─╯
-    ●  a
-    ●
+    ◉  a
+    ◉
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo"]);
 
@@ -283,12 +283,12 @@ fn test_rebase_single_revision() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    d
     ├─╮
-    │ │ ●  c
-    ● │ │  b
+    │ │ ◉  c
+    ◉ │ │  b
     ├───╯
-    │ ●  a
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 }
 
@@ -306,11 +306,11 @@ fn test_rebase_single_revision_merge_parent() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    d
     ├─╮
-    ● │  c
-    ● │  b
-    │ ●  a
+    ◉ │  c
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     // Descendants of the rebased commit should be rebased onto parents, and if
@@ -324,12 +324,12 @@ fn test_rebase_single_revision_merge_parent() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    d
     ├─╮
-    │ │ ●  c
+    │ │ ◉  c
     │ ├─╯
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 }
 
@@ -345,22 +345,22 @@ fn test_rebase_multiple_destinations() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    │ ●  b
+    │ ◉  b
     ├─╯
-    │ ●  a
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "c"]);
     insta::assert_snapshot!(stdout, @r###""###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    a
+    ◉    a
     ├─╮
     @ │  c
-    │ ●  b
+    │ ◉  b
     ├─╯
-    ●
+    ◉
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b|c"]);
@@ -377,12 +377,12 @@ fn test_rebase_multiple_destinations() {
     );
     insta::assert_snapshot!(stdout, @r###""###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    a
+    ◉    a
     ├─╮
     @ │  c
-    │ ●  b
+    │ ◉  b
     ├─╯
-    ●
+    ◉
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
@@ -407,11 +407,11 @@ fn test_rebase_multiple_destinations() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  a
+    ◉  a
     │ @  c
-    ● │  b
+    ◉ │  b
     ├─╯
-    ●
+    ◉
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -428,12 +428,12 @@ fn test_rebase_multiple_destinations() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●    a
+    ◉    a
     ├─╮
     @ │  c
-    │ ●  b
+    │ ◉  b
     ├─╯
-    ●
+    ◉
     "###);
 
     let stderr =
@@ -456,12 +456,12 @@ fn test_rebase_with_descendants() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ●    c
+    ◉    c
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
@@ -471,10 +471,10 @@ fn test_rebase_with_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ●  c
-    ●  b
-    ●  a
-    ●
+    ◉  c
+    ◉  b
+    ◉  a
+    ◉
     "###);
 
     // Rebase several subtrees at once.
@@ -487,24 +487,24 @@ fn test_rebase_with_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    │ ●  c
+    │ ◉  c
     ├─╯
-    │ ●  b
-    ● │  a
+    │ ◉  b
+    ◉ │  a
     ├─╯
-    ●
+    ◉
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     // Reminder of the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ●    c
+    ◉    c
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●
+    ◉
     "###);
 
     // `d` was a descendant of `b`, and both are moved to be direct descendants of
@@ -516,12 +516,12 @@ fn test_rebase_with_descendants() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  c
+    ◉  c
     │ @  d
-    ● │  b
+    ◉ │  b
     ├─╯
-    ●  a
-    ●
+    ◉  a
+    ◉
     "###);
 
     // Same test as above, but with duplicate commits and multiple commits per
@@ -545,12 +545,12 @@ fn test_rebase_with_descendants() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ●  c
-    ●  b
+    ◉  c
+    ◉  b
     │ @  d
     ├─╯
-    ●  a
-    ●
+    ◉  a
+    ◉
     "###);
 }
 

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -56,11 +56,11 @@ fn test_resolution() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -301,11 +301,11 @@ fn test_normal_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -342,11 +342,11 @@ fn test_baseless_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -411,11 +411,11 @@ fn test_edit_delete_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -454,11 +454,11 @@ fn test_file_vs_dir() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -501,13 +501,13 @@ fn test_description_with_dir_and_deletion() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @      conflict
     ├─┬─╮
-    ● │ │  del
-    │ ● │  dir
+    ◉ │ │  del
+    │ ◉ │  dir
     ├─╯ │
-    │   ●  edit
+    │   ◉  edit
     ├───╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -581,11 +581,11 @@ fn test_multiple_conflicts() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap()

--- a/tests/test_restore_command.rs
+++ b/tests/test_restore_command.rs
@@ -118,11 +118,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    ● │  b
-    │ ●  a
+    ◉ │  b
+    │ ◉  a
     ├─╯
-    ●  base
-    ●
+    ◉  base
+    ◉
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -256,13 +256,13 @@ fn test_alias() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
 
@@ -358,7 +358,7 @@ fn test_bad_alias_decl() {
         .assert()
         .success();
     insta::assert_snapshot!(get_stdout_string(&assert), @r###"
-    ●  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_stderr_string(&assert), @r###"

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -30,7 +30,7 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  qpvuntsmwlqt false
-    ●  zzzzzzzzzzzz true
+    ◉  zzzzzzzzzzzz true
     "###);
 
     let edit_script = test_env.set_up_fake_editor();
@@ -67,8 +67,8 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  kkmpptxzrspx false
-    ●  qpvuntsmwlqt false
-    ●  zzzzzzzzzzzz true
+    ◉  qpvuntsmwlqt false
+    ◉  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
@@ -93,9 +93,9 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  kkmpptxzrspx false
-    ●  yqosqzytrlsw true
-    ●  qpvuntsmwlqt false
-    ●  zzzzzzzzzzzz true
+    ◉  yqosqzytrlsw true
+    ◉  qpvuntsmwlqt false
+    ◉  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@--"]);
@@ -124,9 +124,9 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  kkmpptxzrspx false
-    ●  kpqxywonksrl false
-    ●  qpvuntsmwlqt true
-    ●  zzzzzzzzzzzz true
+    ◉  kpqxywonksrl false
+    ◉  qpvuntsmwlqt true
+    ◉  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -35,9 +35,9 @@ fn test_squash() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  90fe0a96fc90 c
-    ●  fa5efbdf533c b
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  fa5efbdf533c b
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
 
     // Squashes the working copy into the parent by default
@@ -47,9 +47,9 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b9280a9898cb
-    ●  6ca29c9d2e7c b c
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  6ca29c9d2e7c b c
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -65,8 +65,8 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e87cf8ebc7e1 c
-    ●  893c93ae2a87 a b
-    ●  000000000000
+    ◉  893c93ae2a87 a b
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -89,12 +89,12 @@ fn test_squash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    c7a11b36d333 e
     ├─╮
-    ● │  5658521e0f8b d
-    │ ●  90fe0a96fc90 c
+    ◉ │  5658521e0f8b d
+    │ ◉  90fe0a96fc90 c
     ├─╯
-    ●  fa5efbdf533c b
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  fa5efbdf533c b
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -110,14 +110,14 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  959145c11426
-    ●    80960125bb96 e
+    ◉    80960125bb96 e
     ├─╮
-    ● │  5658521e0f8b d
-    │ ●  90fe0a96fc90 c
+    ◉ │  5658521e0f8b d
+    │ ◉  90fe0a96fc90 c
     ├─╯
-    ●  fa5efbdf533c b
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  fa5efbdf533c b
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "e"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -145,9 +145,9 @@ fn test_squash_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d989314f3df0 c
-    ●  2a2d19a3283f b
-    ●  47a1e795d146 a
-    ●  000000000000
+    ◉  2a2d19a3283f b
+    ◉  47a1e795d146 a
+    ◉  000000000000
     "###);
 
     // If we don't make any changes in the diff-editor, the whole change is moved
@@ -160,8 +160,8 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f03d5ce4a973 c
-    ●  c9f931cd78af a b
-    ●  000000000000
+    ◉  c9f931cd78af a b
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -178,9 +178,9 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e7a40106bee6 c
-    ●  05d951646873 b
-    ●  0c5ddc685260 a
-    ●  000000000000
+    ◉  05d951646873 b
+    ◉  0c5ddc685260 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -210,9 +210,9 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a911fa1d0627 c
-    ●  fb73ad17899f b
-    ●  70621f4c7a42 a
-    ●  000000000000
+    ◉  fb73ad17899f b
+    ◉  70621f4c7a42 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_templater.rs
+++ b/tests/test_templater.rs
@@ -66,13 +66,13 @@ fn test_templater_branches() {
     let template = r#"commit_id.short() ++ " " ++ branches"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ●  b1bb3766d584 branch3??
+    ◉  b1bb3766d584 branch3??
     │ @  a5b4d15489cc branch2* new-branch
-    │ │ ●  21c33875443e branch1*
+    │ │ ◉  21c33875443e branch1*
     ├───╯
-    │ ●  8476341eb395 branch2@origin
+    │ ◉  8476341eb395 branch2@origin
     ├─╯
-    ●  000000000000
+    ◉  000000000000
     "###);
 }
 

--- a/tests/test_undo.rs
+++ b/tests/test_undo.rs
@@ -32,8 +32,8 @@ fn test_undo_rewrite_with_child() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  child
-    ●  modified
-    ●
+    ◉  modified
+    ◉
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo", &op_id_hex]);
 
@@ -42,7 +42,7 @@ fn test_undo_rewrite_with_child() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  child
-    ●  initial
-    ●
+    ◉  initial
+    ◉
     "###);
 }

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -35,9 +35,9 @@ fn test_unsquash() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  90fe0a96fc90 c
-    ●  fa5efbdf533c b
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  fa5efbdf533c b
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
 
     // Unsquashes into the working copy from its parent by default
@@ -47,8 +47,8 @@ fn test_unsquash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1b10d78f6136 c
-    ●  90aeefd03044 a b
-    ●  000000000000
+    ◉  90aeefd03044 a b
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -64,8 +64,8 @@ fn test_unsquash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  45b8b3ddc25a c
-    ●  9146bcc8d996 b
-    ●  000000000000 a
+    ◉  9146bcc8d996 b
+    ◉  000000000000 a
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -88,12 +88,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    1f8f152ff48e e
     ├─╮
-    ● │  5658521e0f8b d
-    │ ●  90fe0a96fc90 c
+    ◉ │  5658521e0f8b d
+    │ ◉  90fe0a96fc90 c
     ├─╯
-    ●  fa5efbdf533c b
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  fa5efbdf533c b
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -110,12 +110,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    3217340cb761
     ├─╮
-    ● │  5658521e0f8b d e??
-    │ ●  90fe0a96fc90 c e??
+    ◉ │  5658521e0f8b d e??
+    │ ◉  90fe0a96fc90 c e??
     ├─╯
-    ●  fa5efbdf533c b
-    ●  90aeefd03044 a
-    ●  000000000000
+    ◉  fa5efbdf533c b
+    ◉  90aeefd03044 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -143,9 +143,9 @@ fn test_unsquash_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d989314f3df0 c
-    ●  2a2d19a3283f b
-    ●  47a1e795d146 a
-    ●  000000000000
+    ◉  2a2d19a3283f b
+    ◉  47a1e795d146 a
+    ◉  000000000000
     "###);
 
     // If we don't make any changes in the diff-editor, the whole change is moved
@@ -158,9 +158,9 @@ fn test_unsquash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  37c961d0d1e2 c
-    ●  000af22057b9 b
-    ●  ee67504598b6 a
-    ●  000000000000
+    ◉  000af22057b9 b
+    ◉  ee67504598b6 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -176,9 +176,9 @@ fn test_unsquash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a8e8fded1021 c
-    ●  46cc06672a99 b
-    ●  47a1e795d146 a
-    ●  000000000000
+    ◉  46cc06672a99 b
+    ◉  47a1e795d146 a
+    ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -47,18 +47,18 @@ fn test_workspaces_add_second_workspace() {
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ●  397eac932ad3c349b2659fd2eb035a4dd3da4193 second@
+    ◉  397eac932ad3c349b2659fd2eb035a4dd3da4193 second@
     │ @  e0e6d5672858dc9a57ec5b772b7c4f3270ed0223 default@
     ├─╯
-    ●  7d308bc9d934c53c6cc52935192e2d6ac5d78cfd
-    ●  0000000000000000000000000000000000000000
+    ◉  7d308bc9d934c53c6cc52935192e2d6ac5d78cfd
+    ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  397eac932ad3c349b2659fd2eb035a4dd3da4193 second@
-    │ ●  e0e6d5672858dc9a57ec5b772b7c4f3270ed0223 default@
+    │ ◉  e0e6d5672858dc9a57ec5b772b7c4f3270ed0223 default@
     ├─╯
-    ●  7d308bc9d934c53c6cc52935192e2d6ac5d78cfd
-    ●  0000000000000000000000000000000000000000
+    ◉  7d308bc9d934c53c6cc52935192e2d6ac5d78cfd
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Both workspaces show up when we list them
@@ -84,11 +84,11 @@ fn test_workspaces_conflicting_edits() {
     test_env.jj_cmd_success(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ●  265af0cdbcc7bb33e3734ad72565c943ce3fb0d4 secondary@
+    ◉  265af0cdbcc7bb33e3734ad72565c943ce3fb0d4 secondary@
     │ @  351099fa72cfbb1b34e410e89821efc623295974 default@
     ├─╯
-    ●  cf911c223d3e24e001fc8264d6dbf0610804fc40
-    ●  0000000000000000000000000000000000000000
+    ◉  cf911c223d3e24e001fc8264d6dbf0610804fc40
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Make changes in both working copies
@@ -105,10 +105,10 @@ fn test_workspaces_conflicting_edits() {
     // The secondary workspace's working-copy commit was updated
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
-    │ ●  a1896a17282f19089a5cec44358d6609910e0513 secondary@
+    │ ◉  a1896a17282f19089a5cec44358d6609910e0513 secondary@
     ├─╯
-    ●  c0d4a99ef98ada7da8dc73a778bbb747c4178385
-    ●  0000000000000000000000000000000000000000
+    ◉  c0d4a99ef98ada7da8dc73a778bbb747c4178385
+    ◉  0000000000000000000000000000000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -133,25 +133,25 @@ fn test_workspaces_conflicting_edits() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ●  8d90dc175c874af0dff032d611029dc722d4e108 (divergent)
-    │ ●  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
+    ◉  8d90dc175c874af0dff032d611029dc722d4e108 (divergent)
+    │ ◉  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
     ├─╯
     │ @  a1896a17282f19089a5cec44358d6609910e0513 secondary@ (divergent)
     ├─╯
-    ●  c0d4a99ef98ada7da8dc73a778bbb747c4178385
-    ●  0000000000000000000000000000000000000000
+    ◉  c0d4a99ef98ada7da8dc73a778bbb747c4178385
+    ◉  0000000000000000000000000000000000000000
     "###);
     // The stale working copy should have been resolved by the previous command
     let stdout = get_log_output(&test_env, &secondary_path);
     assert!(!stdout.starts_with("The working copy is stale"));
     insta::assert_snapshot!(stdout, @r###"
-    ●  8d90dc175c874af0dff032d611029dc722d4e108 (divergent)
-    │ ●  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
+    ◉  8d90dc175c874af0dff032d611029dc722d4e108 (divergent)
+    │ ◉  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
     ├─╯
     │ @  a1896a17282f19089a5cec44358d6609910e0513 secondary@ (divergent)
     ├─╯
-    ●  c0d4a99ef98ada7da8dc73a778bbb747c4178385
-    ●  0000000000000000000000000000000000000000
+    ◉  c0d4a99ef98ada7da8dc73a778bbb747c4178385
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -169,11 +169,11 @@ fn test_workspaces_updated_by_other() {
     test_env.jj_cmd_success(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ●  265af0cdbcc7bb33e3734ad72565c943ce3fb0d4 secondary@
+    ◉  265af0cdbcc7bb33e3734ad72565c943ce3fb0d4 secondary@
     │ @  351099fa72cfbb1b34e410e89821efc623295974 default@
     ├─╯
-    ●  cf911c223d3e24e001fc8264d6dbf0610804fc40
-    ●  0000000000000000000000000000000000000000
+    ◉  cf911c223d3e24e001fc8264d6dbf0610804fc40
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Rewrite the check-out commit in one workspace.
@@ -187,10 +187,10 @@ fn test_workspaces_updated_by_other() {
     // The secondary workspace's working-copy commit was updated.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
-    │ ●  a1896a17282f19089a5cec44358d6609910e0513 secondary@
+    │ ◉  a1896a17282f19089a5cec44358d6609910e0513 secondary@
     ├─╯
-    ●  c0d4a99ef98ada7da8dc73a778bbb747c4178385
-    ●  0000000000000000000000000000000000000000
+    ◉  c0d4a99ef98ada7da8dc73a778bbb747c4178385
+    ◉  0000000000000000000000000000000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -206,11 +206,11 @@ fn test_workspaces_updated_by_other() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ●  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
+    ◉  fe8f41ed01d693b2d4365cd89e42ad9c531a939b default@
     │ @  a1896a17282f19089a5cec44358d6609910e0513 secondary@
     ├─╯
-    ●  c0d4a99ef98ada7da8dc73a778bbb747c4178385
-    ●  0000000000000000000000000000000000000000
+    ◉  c0d4a99ef98ada7da8dc73a778bbb747c4178385
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -237,7 +237,7 @@ fn test_workspaces_update_stale_noop() {
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "-Tdescription"]);
     insta::assert_snapshot!(stdout, @r###"
     @  add workspace 'default'
-    ●  initialize repo
+    ◉  initialize repo
     "###);
 }
 
@@ -267,11 +267,11 @@ fn test_workspaces_update_stale_snapshot() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  4976dfa88529814c4dd8c06253fbd82d076b79f8 secondary@
-    │ ●  8357b22214ba8adb6d2d378fa5b85274f1c7967c default@
-    │ ●  1a769966ed69fa7abadbd2d899e2be1025cb04fb
+    │ ◉  8357b22214ba8adb6d2d378fa5b85274f1c7967c default@
+    │ ◉  1a769966ed69fa7abadbd2d899e2be1025cb04fb
     ├─╯
-    ●  b4a6c25e777817db67fdcbd50f1dd3b74b46b5f1
-    ●  0000000000000000000000000000000000000000
+    ◉  b4a6c25e777817db67fdcbd50f1dd3b74b46b5f1
+    ◉  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -307,11 +307,11 @@ fn test_workspaces_forget() {
     // there's only one workspace. We should show it when the command is not run
     // from that workspace.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ●  feda1c4e5ffe63fb16818ccdd8c21483537e31f2
-    │ ●  e949be04e93e830fcce23fefac985c1deee52eea
+    ◉  feda1c4e5ffe63fb16818ccdd8c21483537e31f2
+    │ ◉  e949be04e93e830fcce23fefac985c1deee52eea
     ├─╯
-    ●  123ed18e4c4c0d77428df41112bc02ffc83fb935
-    ●  0000000000000000000000000000000000000000
+    ◉  123ed18e4c4c0d77428df41112bc02ffc83fb935
+    ◉  0000000000000000000000000000000000000000
     "###);
 
     // Revision "@" cannot be used


### PR DESCRIPTION
This follows up on 5c703aeb0397b560a383bdd57a87235834074b64.

The only reason for this change is that, subjectively, the result looks better to me. I'm not sure why, but I couldn't get used to the old symbol in spite of its seeming reasonableness. It felt really bold and heavy.

If people agree, we can wait until we need to update the screenshots for some other reason before merging this. Sorry I didn't figure this out while the discussion about the referenced commit was going on.

I'm not 100% certain how many fonts support each symbol. Please try it out and let me know if it doesn't work for you.

Compare after:

![image](https://user-images.githubusercontent.com/4123047/229251383-563b889d-7233-42e2-a3c5-bf9368a4d1fd.png)

and before:

![image](https://user-images.githubusercontent.com/4123047/229251695-7fd0ff2c-2832-4262-ade5-5120288cccdf.png)


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
