### PR TITLE
`squash`/`amend`: Add `-m` argument to set description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `latest(x[, n])` revset function to select the latest `n` commits.
 
+* `jj squash` AKA `jj amend` now accepts a `--message` option to set the
+  description of the squashed commit on the command-line.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -556,6 +556,9 @@ struct MoveArgs {
 struct SquashArgs {
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,
+    /// The description to use for squashed revision (don't open editor)
+    #[arg(long, short)]
+    message: Option<DescriptionArg>,
     /// Interactively choose which parts to squash
     #[arg(long, short)]
     interactive: bool,
@@ -2302,13 +2305,17 @@ from the source will be moved into the parent.
     // Abandon the child if the parent now has all the content from the child
     // (always the case in the non-interactive case).
     let abandon_child = &new_parent_tree_id == commit.tree_id();
-    let description = combine_messages(
-        tx.base_repo(),
-        &commit,
-        parent,
-        command.settings(),
-        abandon_child,
-    )?;
+    let description = if let Some(m) = &args.message {
+        m.into()
+    } else {
+        combine_messages(
+            tx.base_repo(),
+            &commit,
+            parent,
+            command.settings(),
+            abandon_child,
+        )?
+    };
     let mut_repo = tx.mut_repo();
     let new_parent = mut_repo
         .rewrite_commit(command.settings(), parent)

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -273,6 +273,13 @@ fn test_squash_description() {
     destination
     "###);
 
+    // An explicit description on the command-line overrides this
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["squash", "-m", "custom"]);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    custom
+    "###);
+
     // If both descriptions were non-empty, we get asked for a combined description
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "source"]);
@@ -293,6 +300,14 @@ fn test_squash_description() {
     source
 
     JJ: Lines starting with "JJ: " (like this one) will be removed.
+    "###);
+
+    // An explicit description on the command-line overrides prevents launching an
+    // editor
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["squash", "-m", "custom"]);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    custom
     "###);
 
     // If the source's *content* doesn't become empty, then the source remains and


### PR DESCRIPTION
This prevents an editor opening, and is useful in scripts/tests.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- N/A I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
