### PR TITLE
cmd: prohibit creating branches at the root commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj workspace update-stale` now snapshots the working-copy changes before
   updating to the new working-copy commit.
 
+* It is no longer allowed to create branches at the root commit.
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -136,6 +136,7 @@ fn cmd_branch_create(
 
     let target_commit =
         workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
+    workspace_command.check_rewritable(&target_commit)?;
     let mut tx = workspace_command.start_transaction(&format!(
         "create {} pointing to commit {}",
         make_branch_term(&branch_names),
@@ -168,6 +169,7 @@ fn cmd_branch_set(
 
     let target_commit =
         workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
+    workspace_command.check_rewritable(&target_commit)?;
     if !args.allow_backwards
         && !branch_names.iter().all(|branch_name| {
             is_fast_forward(

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -46,6 +46,18 @@ fn test_branch_multiple_names() {
 }
 
 #[test]
+fn test_branch_forbidden_at_root() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["branch", "create", "fred", "-r=root"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Cannot rewrite the root commit
+    "###);
+}
+
+#[test]
 fn test_branch_empty_name() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
Such branches lead to confusing errors on git expoert or push.

I didn't go through the trouble of changing the "cannot rewrite the root commit" message.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
