### PR TITLE
conflicts: change model to have single list of positive and negative …

### DIFF
--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -156,18 +156,44 @@ content_hash! {
         // TODO: Store e.g. CommitId here too? Labels (theirs/ours/base)? Would those still be
         //       useful e.g. after rebasing this conflict?
         pub value: TreeValue,
+        pub negative: bool,
+    }
+}
+
+impl ConflictTerm {
+    pub fn positive(value: TreeValue) -> Self {
+        Self {
+            value,
+            negative: false,
+        }
+    }
+
+    pub fn negative(value: TreeValue) -> Self {
+        Self {
+            value,
+            negative: true,
+        }
     }
 }
 
 content_hash! {
     #[derive(Default, Debug, PartialEq, Eq, Clone)]
     pub struct Conflict {
-        // A conflict is represented by a list of positive and negative states that need to be applied.
-        // In a simple 3-way merge of B and C with merge base A, the conflict will be { add: [B, C],
-        // remove: [A] }. Also note that a conflict of the form { add: [A], remove: [] } is the
-        // same as non-conflict A.
-        pub removes: Vec<ConflictTerm>,
-        pub adds: Vec<ConflictTerm>,
+        // A conflict is represented by a list of positive and negative states that need to be
+        // applied. In a simple 3-way merge of B and C with merge base A, the conflict will be
+        // `B+(C-A)`. Also note that a conflict of the form `A` (i.e. `+A`) is the same as
+        // non-conflict A.
+        pub terms: Vec<ConflictTerm>,
+    }
+}
+
+impl Conflict {
+    pub fn num_negative(&self) -> usize {
+        self.terms.iter().filter(|term| term.negative).count()
+    }
+
+    pub fn num_positive(&self) -> usize {
+        self.terms.iter().filter(|term| !term.negative).count()
     }
 }
 

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -124,17 +124,12 @@ fn test_same_type(use_git: bool) {
                 .read_conflict(&RepoPath::from_internal_string("_ab"), id)
                 .unwrap();
             assert_eq!(
-                conflict.adds,
+                conflict.terms,
                 vec![
-                    ConflictTerm {
-                        value: side1_tree.value(&component).cloned().unwrap()
-                    },
-                    ConflictTerm {
-                        value: side2_tree.value(&component).cloned().unwrap()
-                    }
+                    ConflictTerm::positive(side1_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side2_tree.value(&component).cloned().unwrap())
                 ]
             );
-            assert!(conflict.removes.is_empty());
         }
         _ => panic!("unexpected value"),
     };
@@ -145,16 +140,11 @@ fn test_same_type(use_git: bool) {
                 .read_conflict(&RepoPath::from_internal_string("a_b"), id)
                 .unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
-                vec![ConflictTerm {
-                    value: side2_tree.value(&component).cloned().unwrap()
-                }]
+                conflict.terms,
+                vec![
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side2_tree.value(&component).cloned().unwrap())
+                ]
             );
         }
         _ => panic!("unexpected value"),
@@ -166,16 +156,11 @@ fn test_same_type(use_git: bool) {
                 .read_conflict(&RepoPath::from_internal_string("ab_"), id)
                 .unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
-                vec![ConflictTerm {
-                    value: side1_tree.value(&component).cloned().unwrap()
-                }]
+                conflict.terms,
+                vec![
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side1_tree.value(&component).cloned().unwrap())
+                ]
             );
         }
         _ => panic!("unexpected value"),
@@ -187,20 +172,11 @@ fn test_same_type(use_git: bool) {
                 .read_conflict(&RepoPath::from_internal_string("abc"), id)
                 .unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
+                conflict.terms,
                 vec![
-                    ConflictTerm {
-                        value: side1_tree.value(&component).cloned().unwrap()
-                    },
-                    ConflictTerm {
-                        value: side2_tree.value(&component).cloned().unwrap()
-                    }
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side1_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side2_tree.value(&component).cloned().unwrap())
                 ]
             );
         }
@@ -405,20 +381,11 @@ fn test_types(use_git: bool) {
                 )
                 .unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
+                conflict.terms,
                 vec![
-                    ConflictTerm {
-                        value: side1_tree.value(&component).cloned().unwrap()
-                    },
-                    ConflictTerm {
-                        value: side2_tree.value(&component).cloned().unwrap()
-                    },
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side1_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side2_tree.value(&component).cloned().unwrap())
                 ]
             );
         }
@@ -431,20 +398,11 @@ fn test_types(use_git: bool) {
                 .read_conflict(&RepoPath::from_internal_string("tree_normal_symlink"), id)
                 .unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
+                conflict.terms,
                 vec![
-                    ConflictTerm {
-                        value: side1_tree.value(&component).cloned().unwrap()
-                    },
-                    ConflictTerm {
-                        value: side2_tree.value(&component).cloned().unwrap()
-                    },
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side1_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(side2_tree.value(&component).cloned().unwrap())
                 ]
             );
         }
@@ -506,20 +464,11 @@ fn test_simplify_conflict(use_git: bool) {
                 .read_conflict(&RepoPath::from_components(vec![component.clone()]), id)
                 .unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
+                conflict.terms,
                 vec![
-                    ConflictTerm {
-                        value: branch_tree.value(&component).cloned().unwrap()
-                    },
-                    ConflictTerm {
-                        value: upstream2_tree.value(&component).cloned().unwrap()
-                    },
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(branch_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(upstream2_tree.value(&component).cloned().unwrap())
                 ]
             );
         }
@@ -530,20 +479,11 @@ fn test_simplify_conflict(use_git: bool) {
         TreeValue::Conflict(id) => {
             let conflict = store.read_conflict(&path, id).unwrap();
             assert_eq!(
-                conflict.removes,
-                vec![ConflictTerm {
-                    value: base_tree.value(&component).cloned().unwrap()
-                }]
-            );
-            assert_eq!(
-                conflict.adds,
+                conflict.terms,
                 vec![
-                    ConflictTerm {
-                        value: upstream2_tree.value(&component).cloned().unwrap()
-                    },
-                    ConflictTerm {
-                        value: branch_tree.value(&component).cloned().unwrap()
-                    },
+                    ConflictTerm::negative(base_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(upstream2_tree.value(&component).cloned().unwrap()),
+                    ConflictTerm::positive(branch_tree.value(&component).cloned().unwrap())
                 ]
             );
         }

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -121,25 +121,19 @@ fn test_checkout_file_transitions(use_git: bool) {
                 let left_file_id = testutils::write_file(store, path, "left file contents");
                 let right_file_id = testutils::write_file(store, path, "right file contents");
                 let conflict = Conflict {
-                    removes: vec![ConflictTerm {
-                        value: TreeValue::File {
+                    terms: vec![
+                        ConflictTerm::negative(TreeValue::File {
                             id: base_file_id,
                             executable: false,
-                        },
-                    }],
-                    adds: vec![
-                        ConflictTerm {
-                            value: TreeValue::File {
-                                id: left_file_id,
-                                executable: false,
-                            },
-                        },
-                        ConflictTerm {
-                            value: TreeValue::File {
-                                id: right_file_id,
-                                executable: false,
-                            },
-                        },
+                        }),
+                        ConflictTerm::positive(TreeValue::File {
+                            id: left_file_id,
+                            executable: false,
+                        }),
+                        ConflictTerm::positive(TreeValue::File {
+                            id: right_file_id,
+                            executable: false,
+                        }),
                     ],
                 };
                 let conflict_id = store.write_conflict(path, &conflict).unwrap();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2484,8 +2484,8 @@ fn print_conflicted_paths(
         std::iter::zip(conflicts.iter(), formatted_paths)
     {
         let conflict = tree.store().read_conflict(repo_path, conflict_id)?;
-        let n_adds = conflict.adds.len();
-        let sides = n_adds.max(conflict.removes.len() + 1);
+        let n_adds = conflict.num_positive();
+        let sides = n_adds.max(conflict.num_negative() + 1);
         let deletions = sides - n_adds;
 
         let mut seen_objects = BTreeMap::new(); // Sort for consistency and easier testing
@@ -2502,9 +2502,9 @@ fn print_conflicted_paths(
         // TODO: We might decide it's OK for `jj resolve` to ignore special files in the
         // `removes` of a conflict (see e.g. https://github.com/martinvonz/jj/pull/978). In
         // that case, `conflict.removes` should be removed below.
-        for object in itertools::chain(conflict.adds.iter(), conflict.removes.iter()) {
+        for term in conflict.terms.iter() {
             seen_objects.insert(
-                match object.value {
+                match term.value {
                     TreeValue::File {
                         executable: false, ..
                     } => continue,


### PR DESCRIPTION
…terms

It seems better to preserve the order than to drop it for no real reason. Maybe the order can be useful at least for keeping the order in conflict markers consistent between files.

I haven't changed the commit backends; they still store the data in the old format.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
