### PR TITLE
revset: make empty()/file(".") not load root tree for liner history

### DIFF
--- a/testing/bench-revsets-git.txt
+++ b/testing/bench-revsets-git.txt
@@ -45,3 +45,4 @@ merges()
 ~merges()
 # Files are unbearably slow, so only filter within small set
 file(Makefile) & v1.0.0..v1.2.0
+empty() & v1.0.0..v1.2.0


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
