### PR TITLE
cli: include total downloaded size in progress output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj squash` AKA `jj amend` now accepts a `--message` option to set the
   description of the squashed commit on the command-line.
 
+* The progress display on `jj git clone/fetch` now includes the downloaded size.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -57,9 +57,13 @@ impl Progress {
         write!(self.buffer, "\r{}", Clear(ClearType::CurrentLine)).unwrap();
         let control_chars = self.buffer.len();
         write!(self.buffer, "{: >3.0}% ", 100.0 * progress.overall).unwrap();
+        if let Some(total) = progress.bytes_downloaded {
+            let (scaled, prefix) = binary_prefix(total as f32);
+            write!(self.buffer, "{scaled: >5.1} {prefix}B ").unwrap();
+        }
         if let Some(estimate) = rate {
             let (scaled, prefix) = binary_prefix(estimate);
-            write!(self.buffer, " at {scaled: >5.1} {prefix}B/s ").unwrap();
+            write!(self.buffer, "at {scaled: >5.1} {prefix}B/s ").unwrap();
         }
 
         let bar_width = ui


### PR DESCRIPTION
With this change, the output looks like this:

```
  3% 165.9 Mi at  13.4 MiB/s [█▋                                                   ]
```

Closes #1483.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
