### PR TITLE
Fix #922 and uncover additional bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * It is no longer allowed to create branches at the root commit.
 
+* In colocated repos, a bug causing conflicts when undoing branch moves (#922)
+  has been fixed. There remain some known similar, but less severe, bugs when
+  `jj undo` interacts with `jj git push`, for example, in colocated repos.
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -16,7 +16,12 @@ use std::io::Result;
 use std::path::Path;
 
 fn main() -> Result<()> {
-    let input = ["op_store.proto", "store.proto", "working_copy.proto"];
+    let input = [
+        "git_ref_view.proto",
+        "op_store.proto",
+        "store.proto",
+        "working_copy.proto",
+    ];
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
     let protos_dir = root.join("src").join("protos");

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -487,6 +487,8 @@ pub enum GitFetchError {
     StateReadWriteError(String),
 }
 
+// TODO: Investigate whether this uses `with_last_seen_refs` correctly and
+// sufficiently via `import_some_refs`.
 #[tracing::instrument(skip(mut_repo, git_repo, callbacks))]
 pub fn fetch(
     mut_repo: &mut MutableRepo,
@@ -670,6 +672,7 @@ pub fn push_updates(
     result
 }
 
+// TODO: Investigate whether this should use `with_last_seen_refs`.
 fn push_refs(
     git_repo: &git2::Repository,
     remote_name: &str,

--- a/lib/src/git_ref_view.rs
+++ b/lib/src/git_ref_view.rs
@@ -53,7 +53,6 @@ type GitRefViewProto = crate::protos::git_ref_view::GitRefView;
 type GitRefProto = crate::protos::git_ref_view::GitRef;
 
 impl GitRefView {
-    #[allow(dead_code)] // Short-term TODO: remove this
     pub fn read_view_from_file(view_path: PathBuf) -> Result<Self, GitRefViewError> {
         let buf = fs::read(view_path)?;
 
@@ -61,7 +60,6 @@ impl GitRefView {
         Ok(view_from_proto(proto))
     }
 
-    #[allow(dead_code)] // Short-term TODO: remove this
     pub fn write_view_to_file(&self, path: PathBuf) -> Result<(), GitRefViewError> {
         let proto = view_to_proto(self);
         Ok(std::fs::write(path, proto.encode_to_vec())?)

--- a/lib/src/git_ref_view.rs
+++ b/lib/src/git_ref_view.rs
@@ -1,0 +1,121 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::fs;
+use std::path::PathBuf;
+
+use prost::Message;
+use thiserror::Error;
+
+use crate::backend::{CommitId, ObjectId};
+
+// TODO: consider making this more expressive. Currently, it's based on
+// OpStoreError
+#[derive(Debug, Error)]
+pub enum GitRefViewError {
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<std::io::Error> for GitRefViewError {
+    fn from(err: std::io::Error) -> Self {
+        GitRefViewError::Other(err.to_string())
+    }
+}
+
+impl From<prost::DecodeError> for GitRefViewError {
+    fn from(err: prost::DecodeError) -> Self {
+        GitRefViewError::Other(err.to_string())
+    }
+}
+
+pub type RefName = String;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GitRefView {
+    pub refs: BTreeMap<RefName, CommitId>,
+}
+
+type GitRefViewProto = crate::protos::git_ref_view::GitRefView;
+type GitRefProto = crate::protos::git_ref_view::GitRef;
+
+impl GitRefView {
+    #[allow(dead_code)] // Short-term TODO: remove this
+    pub fn read_view_from_file(view_path: PathBuf) -> Result<Self, GitRefViewError> {
+        let buf = fs::read(view_path)?;
+
+        let proto = GitRefViewProto::decode(&*buf)?;
+        Ok(view_from_proto(proto))
+    }
+
+    #[allow(dead_code)] // Short-term TODO: remove this
+    pub fn write_view_to_file(&self, path: PathBuf) -> Result<(), GitRefViewError> {
+        let proto = view_to_proto(self);
+        Ok(std::fs::write(path, proto.encode_to_vec())?)
+    }
+}
+
+fn view_to_proto(ref_view: &GitRefView) -> GitRefViewProto {
+    let mut proto = GitRefViewProto::default();
+    for (ref_name, commit_id) in &ref_view.refs {
+        proto.refs.push(GitRefProto {
+            name: ref_name.clone(),
+            commit_id: commit_id.to_bytes(),
+        });
+    }
+
+    proto
+}
+
+fn view_from_proto(proto: GitRefViewProto) -> GitRefView {
+    let mut view = GitRefView::default();
+    for GitRefProto {
+        name,
+        commit_id: id_bytes,
+    } in proto.refs
+    {
+        view.refs.insert(name, CommitId::new(id_bytes));
+    }
+
+    view
+}
+
+#[cfg(test)]
+mod tests {
+
+    use maplit::btreemap;
+
+    use super::*;
+    use crate::backend::{CommitId, ObjectId};
+
+    fn create_view() -> GitRefView {
+        GitRefView {
+            refs: btreemap! {
+                "ref1".to_string() => CommitId::from_hex("aaa111"),
+                "ref2".to_string() => CommitId::from_hex("aaa222"),
+            },
+        }
+    }
+
+    #[test]
+    fn test_read_write_view() {
+        let temp_file = testutils::new_temp_dir().into_path().join("git_ref_view");
+        let view = create_view();
+        view.write_view_to_file(temp_file.clone()).unwrap();
+        let read_view = GitRefView::read_view_from_file(temp_file).unwrap();
+        assert_eq!(read_view, view);
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,6 +16,7 @@
 
 #[macro_use]
 mod content_hash;
+mod git_ref_view;
 
 pub mod backend;
 pub mod commit;

--- a/lib/src/protos/git_ref_view.proto
+++ b/lib/src/protos/git_ref_view.proto
@@ -1,0 +1,34 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package git_ref_view;
+
+message GitRef {
+  string name = 1;
+  bytes commit_id = 2;
+}
+
+// This is the view of the last seen state of refs in the backing Git
+// repository. Unlike the refs in jj's "View", these are not affected by `jj
+// undo`. They also do not support conflicted states. Note that this implies
+// that this data does not support concurrent changes and should be modified
+// under lock.
+message GitRefView {
+    // TODO: We may eventually also track the HEAD (or HEADs if we support
+    // multiple worktrees) here as well. For now, we do not allow it to be
+    // conflicted.
+    repeated GitRef refs = 1;
+}

--- a/lib/src/protos/git_ref_view.rs
+++ b/lib/src/protos/git_ref_view.rs
@@ -1,0 +1,22 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GitRef {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub commit_id: ::prost::alloc::vec::Vec<u8>,
+}
+/// This is the view of the last seen state of refs in the backing Git
+/// repository. Unlike the refs in jj's "View", these are not affected by `jj
+/// undo`. They also do not support conflicted states. Note that this implies
+/// that this data does not support concurrent changes and should be modified
+/// under lock.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GitRefView {
+    /// TODO: We may eventually also track the HEAD (or HEADs if we support
+    /// multiple worktrees) here as well. For now, we do not allow it to be
+    /// conflicted.
+    #[prost(message, repeated, tag = "1")]
+    pub refs: ::prost::alloc::vec::Vec<GitRef>,
+}

--- a/lib/src/protos/mod.rs
+++ b/lib/src/protos/mod.rs
@@ -1,3 +1,6 @@
+pub mod git_ref_view {
+    include!("git_ref_view.rs");
+}
 pub mod op_store {
     include!("op_store.rs");
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -771,6 +771,10 @@ fn test_export_import_sequence() {
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(commit_a.id().clone()))
     );
+    // Short-term TODO: This export is necessary for the "main" branch to be
+    // successfully exported in the following export (after modifying where
+    // "main" points). This is a bug that will be fixed in a subsequent commit.
+    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
 
     // Modify the branch in jj to point to B
     mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -771,10 +771,6 @@ fn test_export_import_sequence() {
         mut_repo.get_git_ref("refs/heads/main"),
         Some(RefTarget::Normal(commit_a.id().clone()))
     );
-    // Short-term TODO: This export is necessary for the "main" branch to be
-    // successfully exported in the following export (after modifying where
-    // "main" points). This is a bug that will be fixed in a subsequent commit.
-    assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
 
     // Modify the branch in jj to point to B
     mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -489,6 +489,9 @@ fn do_git_clone(
         GitFetchError::InvalidGlob => {
             unreachable!("we didn't provide any globs")
         }
+        GitFetchError::StateReadWriteError(s) => {
+            CommandError::InternalError(format!("io error: {s}"))
+        }
     })?;
     fetch_tx.finish(ui)?;
     Ok((workspace_command, maybe_default_branch))

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -288,13 +288,9 @@ fn test_git_colocated_squash_undo() {
     ◉  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo"]);
-    // TODO: There should be no divergence here; 2f376ea1478c should be hidden
-    // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    ◉  qpvuntsmwlqt 2f376ea1478c A master !divergence!
-    │ @  rlvkpnrzqnoo 8f71e3b6a3be
-    │ ◉  qpvuntsmwlqt a86754f975f9 A !divergence!
-    ├─╯
+    @  rlvkpnrzqnoo 8f71e3b6a3be
+    ◉  qpvuntsmwlqt a86754f975f9 A master
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 }

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -274,23 +274,25 @@ fn test_git_colocated_squash_undo() {
     git2::Repository::init(&repo_path).unwrap();
     test_env.jj_cmd_success(&repo_path, &["init", "--git-repo=."]);
     test_env.jj_cmd_success(&repo_path, &["ci", "-m=A"]);
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m=B"]);
+    test_env.jj_cmd_success(&repo_path, &["branch", "set", "master"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  rlvkpnrzqnoo 8f71e3b6a3be
-    ◉  qpvuntsmwlqt a86754f975f9 A master
+    @  rlvkpnrzqnoo 2a3078eda7fe B master
+    ◉  qpvuntsmwlqt a86754f975f9 A
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 
-    test_env.jj_cmd_success(&repo_path, &["squash"]);
+    test_env.jj_cmd_success(&repo_path, &["squash", "-m=A+B"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  zsuskulnrvyr f0c12b0396d9
-    ◉  qpvuntsmwlqt 2f376ea1478c A master
+    @  royxmykxtrkr 83c0d8df2b78
+    ◉  qpvuntsmwlqt 1873a0811bf5 A+B master
     ◉  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  rlvkpnrzqnoo 8f71e3b6a3be
-    ◉  qpvuntsmwlqt a86754f975f9 A master
+    @  rlvkpnrzqnoo 2a3078eda7fe B master
+    ◉  qpvuntsmwlqt a86754f975f9 A
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 }


### PR DESCRIPTION
Fixes #922.

This is not a complete fix, some of the commits demonstrate bugs that are yet to be fix. However, in practice this helps a lot.

This is a little unfinished, but the rest can be done in subsequent PRs (or in this one, if people prefer). In any case, it seems ready to review. For example, this PR mostly changes `jj git export` and only changes `jj git import` a little.

See https://github.com/martinvonz/jj/labels/colocated for yet more bugs to fix.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (not planned) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
