### PR TITLE
revset: add a revset function for finding commits with conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `latest(x[, n])` revset function to select the latest `n` commits.
 
+* Added `conflict()` revset function to select commits with conflicts.
+
 * `jj squash` AKA `jj amend` now accepts a `--message` option to set the
   description of the squashed commit on the command-line.
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -120,6 +120,7 @@ revsets (expressions) as arguments.
   user modifications and `root`.
 * `file(pattern..)`: Commits modifying the paths specified by the `pattern..`.
   Paths are relative to the directory `jj` was invoked from.
+* `conflict()`: Commits with conflicts.
 * `present(x)`: Same as `x`, but evaluated to `none()` if any of the commits
   in `x` doesn't exist (e.g. is an unknown branch name.)
 

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -944,6 +944,10 @@ fn build_predicate_fn<'index>(
                 has_diff_from_parent(&store, index, entry, matcher.as_ref())
             })
         }
+        RevsetFilterPredicate::HasConflict => pure_predicate_fn(move |entry| {
+            let commit = store.get_commit(&entry.commit_id()).unwrap();
+            commit.tree().has_conflict()
+        }),
     }
 }
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -205,6 +205,8 @@ pub enum RevsetFilterPredicate {
     Committer(String),
     /// Commits modifying the paths specified by the pattern.
     File(Option<Vec<RepoPath>>), // TODO: embed matcher expression?
+    /// Commits with conflicts
+    HasConflict,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -927,6 +929,10 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
                 RevsetParseErrorKind::FsPathWithoutWorkspace,
             ))
         }
+    });
+    map.insert("conflict", |name, arguments_pair, _state| {
+        expect_no_arguments(name, arguments_pair)?;
+        Ok(RevsetExpression::filter(RevsetFilterPredicate::HasConflict))
     });
     map.insert("present", |name, arguments_pair, state| {
         let arg = expect_one_argument(name, arguments_pair)?;

--- a/testing/bench-revsets-git.txt
+++ b/testing/bench-revsets-git.txt
@@ -43,6 +43,7 @@ tags()+
 # Filter that doesn't read commit object
 merges()
 ~merges()
-# Files are unbearably slow, so only filter within small set
+# These are unbearably slow, so only filter within small set
 file(Makefile) & v1.0.0..v1.2.0
 empty() & v1.0.0..v1.2.0
+conflict() & v1.0.0..v1.2.0


### PR DESCRIPTION
This adds `conflicts()` revset that selects commits with conflicts. We may want to extend it later to consider only conflicts at certain paths.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
