### PR TITLE
revset: remove use of expression builder API from engine, optimize children/dag-range/roots query

### DIFF
--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -688,11 +688,9 @@ impl<'index, 'heads> EvaluationContext<'index, 'heads> {
                     .revset_for_commit_ids(&self.composite_index.heads(&mut candidate_ids.iter())))
             }
             RevsetExpression::Roots(candidates) => {
-                let connected_set = self.evaluate(&candidates.connected())?;
-                let filled: HashSet<_> =
-                    connected_set.iter().map(|entry| entry.position()).collect();
-                let mut index_entries = vec![];
                 let candidate_set = self.evaluate(candidates)?;
+                let (_, filled) = self.collect_dag_range(&*candidate_set, &*candidate_set);
+                let mut index_entries = vec![];
                 for candidate in candidate_set.iter() {
                     if !candidate
                         .parent_positions()

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -688,8 +688,10 @@ impl<'index, 'heads> EvaluationContext<'index, 'heads> {
                     .revset_for_commit_ids(&self.composite_index.heads(&mut candidate_ids.iter())))
             }
             RevsetExpression::Roots(candidates) => {
-                let candidate_set = self.evaluate(candidates)?;
-                let (_, filled) = self.collect_dag_range(&*candidate_set, &*candidate_set);
+                let candidate_set = EagerRevset {
+                    index_entries: self.evaluate(candidates)?.iter().collect(),
+                };
+                let (_, filled) = self.collect_dag_range(&candidate_set, &candidate_set);
                 let mut index_entries = vec![];
                 for candidate in candidate_set.iter() {
                     if !candidate

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -976,6 +976,30 @@ fn test_evaluate_expression_dag_range(use_git: bool) {
         vec![]
     );
 
+    // Empty root
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("none():{}", commit5.id().hex())),
+        vec![],
+    );
+
+    // Multiple root, commit1 shouldn't be hidden by commit2
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!(
+                "({}|{}):{}",
+                commit1.id().hex(),
+                commit2.id().hex(),
+                commit3.id().hex()
+            )
+        ),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone()
+        ]
+    );
+
     // Including a merge
     assert_eq!(
         resolve_commit_ids(

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -803,6 +803,9 @@ fn test_evaluate_expression_children(use_git: bool) {
         ),
         vec![commit5.id().clone()]
     );
+
+    // Empty root
+    assert_eq!(resolve_commit_ids(mut_repo, "none()+"), vec![]);
 }
 
 #[test_case(false ; "local backend")]

--- a/testing/bench-revsets-git.txt
+++ b/testing/bench-revsets-git.txt
@@ -13,6 +13,7 @@ v2.40.0
 v2.39.0..v2.40.0
 :v2.40.0 ~ :v2.39.0
 v2.39.0:v2.40.0
+v2.40.0+
 # Tags and branches
 tags()
 branches()


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
