### PR TITLE
Fixup to ed0b23d: make build.rs not insert color

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,7 @@ fn get_git_hash() -> Option<String> {
     if let Ok(output) = Command::new("jj")
         .args([
             "--ignore-working-copy",
+            "--color=never",
             "log",
             "--no-graph",
             "-r=@-",


### PR DESCRIPTION
After #1493, the hash becomes colored if jj is used to get it at build time and the user configured `color="always"` in jj's config.


# Checklist

If applicable:
- [ ] I have added tests to cover my changes (not sure how to do that...)
