### PR TITLE
commit template/templater/formatter: Label obsolete commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The progress display on `jj git clone/fetch` now includes the downloaded size.
 
+* The formatter now supports a "default" color that can override another color
+  defined by a parent style.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The formatter now supports a "default" color that can override another color
   defined by a parent style.
 
+* `jj obslog` and `jj log` now show abandoned commits as hidden.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/docs/config.md
+++ b/docs/config.md
@@ -92,8 +92,11 @@ The following colors are available:
 * magenta
 * cyan
 * white
+* default
 
-They each come in a bright version too, e.g. "bright red".
+All of them but "default" come in a bright version too, e.g. "bright red". The
+"default" color can be used to override a color defined by a parent style
+(explained below).
 
 If you use a string value for a color, as in the example above, it will be used
 for the foreground color. You can also set the background color, or make the

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -31,6 +31,7 @@ The following keywords can be used in `jj log`/`jj obslog` templates.
 * `git_head: String`
 * `divergent: Boolean`: True if the change id corresponds to multiple visible
   commits.
+* `hidden: Boolean`: True if the commit is not visible (a.k.a. abandoned).
 * `conflict: Boolean`: True if the commit contains merge conflicts.
 * `empty: Boolean`: True if the commit modifies no files.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -29,8 +29,8 @@ The following keywords can be used in `jj log`/`jj obslog` templates.
 * `tags: String`
 * `git_refs: String`
 * `git_head: String`
-* `divergent: Boolean`: True if the change id corresponds to multiple visible
-  commits.
+* `divergent: Boolean`: True if the commit's change id corresponds to multiple
+  visible commits.
 * `hidden: Boolean`: True if the commit is not visible (a.k.a. abandoned).
 * `conflict: Boolean`: True if the commit contains merge conflicts.
 * `empty: Boolean`: True if the commit modifies no files.

--- a/src/commit_templater.rs
+++ b/src/commit_templater.rs
@@ -248,6 +248,10 @@ fn build_commit_keyword_opt<'repo>(
             let maybe_entries = repo.resolve_change_id(commit.change_id());
             maybe_entries.map_or(0, |entries| entries.len()) > 1
         })),
+        "hidden" => language.wrap_boolean(wrap_fn(property, |commit| {
+            let maybe_entries = repo.resolve_change_id(commit.change_id());
+            maybe_entries.map_or(true, |entries| !entries.contains(commit.id()))
+        })),
         "conflict" => {
             language.wrap_boolean(wrap_fn(property, |commit| commit.tree().has_conflict()))
         }

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -161,6 +161,7 @@
                         "git_refs",
                         "is_git_head",
                         "divergent",
+                        "hidden",
                         "conflict"
                     ]
                 }

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -128,6 +128,7 @@
             "definitions": {
                 "colors": {
                     "enum": [
+                        "default",
                         "black",
                         "red",
                         "green",

--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -14,6 +14,10 @@
 "rest" = "bright black"
 "divergent rest" = "red"
 "divergent prefix" = {fg = "red", underline=true}
+"hidden prefix" = "default"
+"divergent hidden" = {fg = "default", bold = true}
+"divergent hidden prefix" = {fg = "default", underline = false}
+"divergent hidden rest" = {fg ="bright black", bold = false}
 
 "email" = "yellow"
 "timestamp" = "cyan"
@@ -41,7 +45,7 @@
 "working_copy tags" = "bright magenta"
 "working_copy git_refs" = "bright magenta"
 "working_copy divergent" =  "bright red"
-"working_copy divergent change_id"="bright red"
+"working_copy divergent change_id" = "bright red"
 "working_copy conflict" = "bright red"
 "working_copy empty" = "bright green"
 "diff header" = "yellow"

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -10,9 +10,11 @@ log = '''
 label(if(current_working_copy, "working_copy"),
   concat(
     separate(" ",
-      if(divergent,
-        label("divergent", format_short_change_id(change_id) ++ "??"),
-        format_short_change_id(change_id)),
+      label(
+        separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
+        separate(" ",
+          format_short_change_id(change_id) ++ if(divergent, "??"),
+          if(hidden, "hidden"))),
       format_short_signature(author),
       format_timestamp(committer.timestamp()),
       branches,

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -156,7 +156,7 @@ fn test_log_default() {
 }
 
 #[test]
-fn test_log_default_divergence() {
+fn test_log_obslog_divergence() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
@@ -196,6 +196,28 @@ fn test_log_default_divergence() {
     │ @  [1m[4m[38;5;1mq[24mpvuntsmwlqt[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e633c[39m[0m
     ├─╯  [1mdescription 1[0m
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+       [38;5;2m(empty)[39m (no description set)
+    "###);
+
+    // Obslog and hidden divergent
+    let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
+    │  description 1
+    ◉  qpvuntsmwlqt?? hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 3b68ce2550b4
+    │  (no description set)
+    ◉  qpvuntsmwlqt?? hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+       (empty) (no description set)
+    "###);
+
+    // Colored obslog
+    let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--color=always"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  [1m[4m[38;5;1mq[24mpvuntsmwlqt[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e633c[39m[0m
+    │  [1mdescription 1[0m
+    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsmwlqt[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m3[0m[38;5;8mb68ce2550b4[39m
+    │  (no description set)
+    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsmwlqt[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059e1b0[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 }

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -33,12 +33,25 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     │  my description
-    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     │  my description
-    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     │  my description
-    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
        (empty) my description
+    "###);
+
+    // Color
+    let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "obslog"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  [1m[38;5;13mr[38;5;8mlvkpnrzqnoo[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:10.000 +07:00[39m [38;5;12m66[38;5;8mb42ad36073[39m[0m
+    │  [1mmy description[0m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrzqnoo[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4maf[0m[38;5;8m536e5af67e[39m [38;5;1mconflict[39m
+    │  my description
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrzqnoo[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4m6f[0m[38;5;8mbba7bcb590[39m
+    │  my description
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrzqnoo[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4me[0m[38;5;8mac0d0dae082[39m
+       [38;5;2m(empty)[39m my description
     "###);
 
     // There should be no diff caused by the rebase because it was a pure rebase
@@ -54,16 +67,16 @@ fn test_obslog_with_or_without_diff() {
     │     4     : +bar
     │     5     : +++++++
     │     6     : >>>>>>>
-    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     │  my description
-    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ◉  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
        (empty) my description
     "###);
 
@@ -72,11 +85,11 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
     my description
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     my description
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     my description
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
     (empty) my description
     "###);
 
@@ -97,9 +110,9 @@ fn test_obslog_with_or_without_diff() {
     -+++++++
     ->>>>>>>
     +resolved
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
     my description
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -115,7 +128,7 @@ fn test_obslog_with_or_without_diff() {
     +++ b/file2
     @@ -1,0 +1,1 @@
     +foo
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
     (empty) my description
     "###);
 }
@@ -145,7 +158,7 @@ fn test_obslog_word_wrap() {
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
     @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     │  (empty) first
-    ◉  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
@@ -153,15 +166,15 @@ fn test_obslog_word_wrap() {
     │  2001-02-03 04:05:08.000 +07:00
     │  69542c1984c1
     │  (empty) first
-    ◉  qpvuntsmwlqt test.user@example.com
-       2001-02-03 04:05:07.000 +07:00
-       230dd059e1b0
+    ◉  qpvuntsmwlqt hidden
+       test.user@example.com 2001-02-03
+       04:05:07.000 +07:00 230dd059e1b0
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, false), @r###"
     qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     (empty) first
-    qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
     (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, true), @r###"
@@ -169,9 +182,9 @@ fn test_obslog_word_wrap() {
     2001-02-03 04:05:08.000 +07:00
     69542c1984c1
     (empty) first
-    qpvuntsmwlqt test.user@example.com
-    2001-02-03 04:05:07.000 +07:00
-    230dd059e1b0
+    qpvuntsmwlqt hidden
+    test.user@example.com 2001-02-03
+    04:05:07.000 +07:00 230dd059e1b0
     (empty) (no description set)
     "###);
 }
@@ -198,20 +211,20 @@ fn test_obslog_squash() {
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    ◉ │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
+    ◉ │  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
     │ │  first
     │ │  Added regular file file1:
     │ │          1: foo
-    ◉ │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    ◉ │  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
     │ │  (empty) first
-    ◉ │  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉ │  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
       │  (empty) (no description set)
-      ◉  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
+      ◉  kkmpptxzrspx hidden test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
       │  second
       │  Modified regular file file1:
       │     1    1: foo
       │          2: bar
-      ◉  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
+      ◉  kkmpptxzrspx hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
          (empty) second
     "###);
 }


### PR DESCRIPTION
This PR has two separate features:

- Support for a "normal" color in the formatter that can override the color of a parent's style.
- Obsolete commits are now labeled as such. This can be useful when, e.g., doing `jj log commit_id`.

If needed, I can split this into two PRs (this may require changing the styling of obsolete commits).

Here is an example of test of `jj obslog` (note: the underlines were later removed):

![image](https://user-images.githubusercontent.com/4123047/230741400-9b8af38e-18cf-4857-a6ac-0cb6c10ebb5f.png)

`jj log`:

![image](https://user-images.githubusercontent.com/4123047/230746809-d4a6cd78-6f8e-4658-8081-0231d6da2924.png)

<details><summary>Previous version for comparison</summary>

![image](https://user-images.githubusercontent.com/4123047/230708271-4108cf5f-255d-419e-bd3e-fc97dc8b8660.png)

</details> 

I also considered the wording `(Was change_id)` or `change_id (old)`, but I settled on `change_id (obs)` + color.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
