### PR TITLE
tests: use absolute timestamps in the operation log

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,7 +41,7 @@ impl Default for TestEnvironment {
         let config_dir = env_root.join("config");
         std::fs::create_dir(&config_dir).unwrap();
         let env_vars = HashMap::new();
-        Self {
+        let env = Self {
             _temp_dir: tmp_dir,
             env_root,
             home_dir,
@@ -49,7 +49,16 @@ impl Default for TestEnvironment {
             env_vars,
             config_file_number: RefCell::new(0),
             command_number: RefCell::new(0),
-        }
+        };
+        // Use absolute timestamps in the operation log to make tests independent of the
+        // current time.
+        env.add_config(
+            r#"
+[template-aliases]
+'format_time_range(time_range)' = 'time_range.start() ++ " - " ++ time_range.end()'
+        "#,
+        );
+        env
     }
 }
 

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -51,15 +51,15 @@ fn test_concurrent_operations_auto_rebase() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  cde29280d4a9 test-username@host.example.com 22 years ago, lasted less than a microsecond
+    @  cde29280d4a9 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 123ed18e4c4c0d77428df41112bc02ffc83fb935
     │  args: jj describe -m initial
-    ◉  7c212e0863fd test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  7c212e0863fd test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj describe -m initial
-    ◉  a99a3fd5c51e test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  56b94dfc38e7 test-username@host.example.com 22 years ago, lasted less than a microsecond
+    ◉  56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
        initialize repo
     "###);
     let op_id_hex = stdout[3..15].to_string();

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -328,7 +328,7 @@ fn test_invalid_config() {
     test_env.add_config("[section]key = value-missing-quotes");
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Config error: expected newline, found an identifier at line 1 column 10 in config/config0001.toml
+    Config error: expected newline, found an identifier at line 1 column 10 in config/config0002.toml
     For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
 }


### PR DESCRIPTION
The current use of `timestamp.ago()` in the default template makes the tests depend on the current time, which they shouldn't.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
