### PR TITLE
docs: explicitly list the platform-specific config paths

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -400,11 +400,14 @@ deleted if you push the branch with `jj git push --branch` or `jj git push
 
 # Alternative ways to specify configuration settings
 
-Instead of `~/.jjconfig.toml`, the config settings can be located at
-`$XDG_CONFIG_HOME/jj/config.toml` as per the [XDG specification]. It is an error
-for both of these files to exist.
+Instead of `~/.jjconfig.toml`, the config settings can be located under
+a platform-specific directory. It is an error for both of these files to exist.
 
-[XDG specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+| Platform | Value                                              | Example                                                   |
+| :------- | :------------------------------------------------- | :-------------------------------------------------------- |
+| Linux    | `$XDG_CONFIG_HOME/jj/config.toml`                  | `/home/alice/.config/jj/config.toml`                      |
+| macOS    | `$HOME/Library/Application Support/jj/config.toml` | `/Users/Alice/Library/Application Support/jj/config.toml` |
+| Windows  | `{FOLDERID_RoamingAppData}\jj\config.toml`         | `C:\Users\Alice\AppData\Roaming\jj\config.toml`           |
 
 The location of the `jj` config file can also be overridden with the
 `JJ_CONFIG` environment variable. If it is not empty, it should contain the path


### PR DESCRIPTION
I know that for support reasons, you've preferred documenting the use of `~/.jjconfig.toml` on all platforms (https://github.com/martinvonz/jj/commit/96849da332c809041040371b55eb5b4aaf097330), but as a new user on macOS, I was confused why the alternative `~/.config/jj/config.toml` wasn't working for me and had to dive into the source code.

The value table is borrowed from the upstream dirs library documenation:
- https://docs.rs/dirs/5.0.0/dirs/fn.config_dir.html

Related to https://github.com/martinvonz/jj/commit/0f5e360d96aef041806a89d8e21ab07a0a89545f and https://github.com/martinvonz/jj/issues/233

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
