### PR TITLE
cmd: when a single remote is defined, default to it for git fetch/push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   based on terminal width. [#1043](https://github.com/martinvonz/jj/issues/1043)
 
 * Nodes in the (text-based) graphical log output now use a `◉` symbol instead
-  of the letter `o`. The ASCII-based graph styles still use `o`.  
+  of the letter `o`. The ASCII-based graph styles still use `o`.
 
 * Commands that accept a diff format (`jj diff`, `jj interdiff`, `jj show`,
   `jj log`, and `jj obslog`) now accept `--types` to show only the type of file
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defined by a parent style.
 
 * `jj obslog` and `jj log` now show abandoned commits as hidden.
+
+* `jj git fetch` and `jj git push` will now use the single defined remote even if it is not named "origin".
 
 ### Fixed bugs
 
@@ -211,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [the documentation](docs/config.md).
 
 * `jj print` was renamed to `jj cat`. `jj print` remains as an alias.
-  
+
 * In content that goes to the terminal, the ANSI escape byte (0x1b) is replaced
   by a "␛" character. That prevents them from interfering with the ANSI escapes
   jj itself writes.

--- a/src/config/misc.toml
+++ b/src/config/misc.toml
@@ -1,10 +1,6 @@
 [aliases]
 # Placeholder: added by user
 
-[git]
-push = "origin"
-fetch = "origin"
-
 [revset-aliases]
 # Placeholder: added by user
 

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -88,6 +88,23 @@ fn test_git_fetch_single_remote() {
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "rem1");
 
+    test_env
+        .jj_cmd(&repo_path, &["git", "fetch"])
+        .assert()
+        .success()
+        .stderr("Fetching from the only existing remote: rem1\n");
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    rem1: 6a21102783e8 message
+    "###);
+}
+
+#[test]
+fn test_git_fetch_single_remote_from_arg() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    add_git_remote(&test_env, &repo_path, "rem1");
+
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: 6a21102783e8 message


### PR DESCRIPTION
A simple quick implementation of what I've suggested on discord

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes

I've actually didn't find tests for `jj git push --remote`, so I didn't adjust them, hm
