### PR TITLE
cli: rename `jj support` to `jj util`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead.
 
 * `jj debug completion`, `jj debug mangen` and `jj debug config-schema` have
-  been moved from `jj debug` to `jj support`.
+  been moved from `jj debug` to `jj util`.
 
 * `jj describe` now supports `--reset-author` for resetting a commit's author
   to the configured user. `jj describe` also gained a `--no-edit` option to

--- a/README.md
+++ b/README.md
@@ -252,29 +252,29 @@ email = "martinvonz@google.com"
 ## Command-line completion
 
 To set up command-line completion, source the output of
-`jj support completion --bash/--zsh/--fish`. Exactly how to source it depends on
-your shell.
+`jj util completion --bash/--zsh/--fish` (called `jj debug completion` in
+jj <= 0.7.0). Exactly how to source it depends on your shell.
 
 ### Bash
 ```shell script
-source <(jj support completion)  # --bash is the default
+source <(jj util completion)  # --bash is the default
 ```
 
 ### Zsh
 ```shell script
 autoload -U compinit
 compinit
-source <(jj support completion --zsh)
+source <(jj util completion --zsh)
 ```
 
 ### Fish
 ```shell script
-jj support completion --fish | source
+jj util completion --fish | source
 ```
 
 ### Xonsh
 ```shell script
-source-bash $(jj support completion)
+source-bash $(jj util completion)
 ```
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -63,13 +63,13 @@
             libiconv
           ];
           postInstall = ''
-            $out/bin/jj support mangen > ./jj.1
+            $out/bin/jj util mangen > ./jj.1
             installManPage ./jj.1
 
             installShellCompletion --cmd jj \
-              --bash <($out/bin/jj support completion --bash) \
-              --fish <($out/bin/jj support completion --fish) \
-              --zsh <($out/bin/jj support completion --zsh)
+              --bash <($out/bin/jj util completion --bash) \
+              --fish <($out/bin/jj util completion --fish) \
+              --zsh <($out/bin/jj util completion --zsh)
           '';
         };
         default = self.packages.${system}.jujutsu;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -115,7 +115,7 @@ enum Commands {
     Squash(SquashArgs),
     Status(StatusArgs),
     #[command(subcommand)]
-    Support(SupportCommands),
+    Util(UtilCommands),
     /// Undo an operation (shortcut for `jj op undo`)
     Undo(operation::OperationUndoArgs),
     Unsquash(UnsquashArgs),
@@ -888,27 +888,27 @@ struct SparseArgs {
 
 /// Infrequently used commands such as for generating shell completions
 #[derive(Subcommand, Clone, Debug)]
-enum SupportCommands {
-    Completion(SupportCompletionArgs),
-    Mangen(SupportMangenArgs),
-    ConfigSchema(SupportConfigSchemaArgs),
+enum UtilCommands {
+    Completion(UtilCompletionArgs),
+    Mangen(UtilMangenArgs),
+    ConfigSchema(UtilConfigSchemaArgs),
 }
 
 /// Print a command-line-completion script
 #[derive(clap::Args, Clone, Debug)]
-struct SupportCompletionArgs {
+struct UtilCompletionArgs {
     /// Print a completion script for Bash
     ///
     /// Apply it by running this:
     ///
-    /// source <(jj support completion)
+    /// source <(jj util completion)
     #[arg(long, verbatim_doc_comment)]
     bash: bool,
     /// Print a completion script for Fish
     ///
     /// Apply it by running this:
     ///
-    /// jj support completion --fish | source
+    /// jj util completion --fish | source
     #[arg(long, verbatim_doc_comment)]
     fish: bool,
     /// Print a completion script for Zsh
@@ -917,7 +917,7 @@ struct SupportCompletionArgs {
     ///
     /// autoload -U compinit
     /// compinit
-    /// source <(jj support completion --zsh | sed '$d')  # remove the last line
+    /// source <(jj util completion --zsh | sed '$d')  # remove the last line
     /// compdef _jj jj
     #[arg(long, verbatim_doc_comment)]
     zsh: bool,
@@ -925,11 +925,11 @@ struct SupportCompletionArgs {
 
 /// Print a ROFF (manpage)
 #[derive(clap::Args, Clone, Debug)]
-struct SupportMangenArgs {}
+struct UtilMangenArgs {}
 
 /// Print the JSON schema for the jj TOML config format.
 #[derive(clap::Args, Clone, Debug)]
-struct SupportConfigSchemaArgs {}
+struct UtilConfigSchemaArgs {}
 
 /// Low-level commands not intended for users
 #[derive(Subcommand, Clone, Debug)]
@@ -3067,13 +3067,13 @@ fn make_branch_term(branch_names: &[impl AsRef<str>]) -> String {
     }
 }
 
-fn cmd_support(
+fn cmd_util(
     ui: &mut Ui,
     command: &CommandHelper,
-    subcommand: &SupportCommands,
+    subcommand: &UtilCommands,
 ) -> Result<(), CommandError> {
     match subcommand {
-        SupportCommands::Completion(completion_matches) => {
+        UtilCommands::Completion(completion_matches) => {
             let mut app = command.app().clone();
             let mut buf = vec![];
             let shell = if completion_matches.zsh {
@@ -3086,13 +3086,13 @@ fn cmd_support(
             clap_complete::generate(shell, &mut app, "jj", &mut buf);
             ui.stdout_formatter().write_all(&buf)?;
         }
-        SupportCommands::Mangen(_mangen_matches) => {
+        UtilCommands::Mangen(_mangen_matches) => {
             let mut buf = vec![];
             let man = clap_mangen::Man::new(command.app().clone());
             man.render(&mut buf)?;
             ui.stdout_formatter().write_all(&buf)?;
         }
-        SupportCommands::ConfigSchema(_config_schema_matches) => {
+        UtilCommands::ConfigSchema(_config_schema_matches) => {
             // TODO(#879): Consider generating entire schema dynamically vs. static file.
             let buf = include_bytes!("../config-schema.json");
             ui.stdout_formatter().write_all(buf)?;
@@ -3521,7 +3521,7 @@ pub fn run_command(
         Commands::Workspace(sub_args) => cmd_workspace(ui, command_helper, sub_args),
         Commands::Sparse(sub_args) => cmd_sparse(ui, command_helper, sub_args),
         Commands::Git(sub_args) => git::cmd_git(ui, command_helper, sub_args),
-        Commands::Support(sub_args) => cmd_support(ui, command_helper, sub_args),
+        Commands::Util(sub_args) => cmd_util(ui, command_helper, sub_args),
         #[cfg(feature = "bench")]
         Commands::Bench(sub_args) => bench::cmd_bench(ui, command_helper, sub_args),
         Commands::Debug(sub_args) => cmd_debug(ui, command_helper, sub_args),

--- a/tests/test_util_command.rs
+++ b/tests/test_util_command.rs
@@ -19,9 +19,9 @@ use crate::common::TestEnvironment;
 pub mod common;
 
 #[test]
-fn test_support_config_schema() {
+fn test_util_config_schema() {
     let test_env = TestEnvironment::default();
-    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["support", "config-schema"]);
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["util", "config-schema"]);
     // Validate partial snapshot, redacting any lines nested 2+ indent levels.
     insta::with_settings!({filters => vec![(r"(?m)(^        .*$\r?\n)+", "        [...]\n")]}, {
         assert_snapshot!(stdout, @r###"


### PR DESCRIPTION
I wasn't quite happy with `jj support` but I couldn't think of anything better when I moved the commands from `jj debug` in e2b4d7058daa. Thanks to @ilyagr for suggesting `jj util`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
