### PR TITLE
templates: extract default template to an alias

### DIFF
--- a/src/config/colors.toml
+++ b/src/config/colors.toml
@@ -20,6 +20,7 @@
 "divergent hidden rest" = {fg ="bright black", bold = false}
 
 "email" = "yellow"
+"username" = "yellow"
 "timestamp" = "cyan"
 "working_copies" = "magenta"
 "branch" = "magenta"

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -6,8 +6,37 @@ separate(" ",
 )
 '''
 
-log = '''
-label(if(current_working_copy, "working_copy"),
+log = 'builtin_log_compact'
+
+op_log = 'builtin_op_log_compact'
+
+# Defined as alias to allow 'log -T show'
+show = 'show'
+
+[template-aliases]
+'builtin_log_oneline' = '''label(if(current_working_copy, "working_copy"),
+  concat(
+    separate(" ",
+      label(
+        separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
+        separate(" ",
+          format_short_change_id(change_id) ++ if(divergent, "??"),
+          if(hidden, "hidden"))),
+      author.username(),
+      format_timestamp(committer.timestamp()),
+      branches,
+      tags,
+      working_copies,
+      git_head,
+      format_short_commit_id(commit_id),
+      if(conflict, label("conflict", "conflict")),
+      if(empty, label("empty", "(empty)")),
+      if(description, description.first_line(), description_placeholder),
+    ) ++ "\n",
+  ),
+)
+'''
+'builtin_log_compact' = '''label(if(current_working_copy, "working_copy"),
   concat(
     separate(" ",
       label(
@@ -31,8 +60,9 @@ label(if(current_working_copy, "working_copy"),
   ),
 )
 '''
+builtin_log_comfortable = 'builtin_log_compact ++ "\n"'
 
-op_log = '''
+builtin_op_log_compact = '''
 label(if(current_operation, "current_operation"),
   concat(
     separate(" ",
@@ -41,15 +71,12 @@ label(if(current_operation, "current_operation"),
       format_time_range(time),
     ) ++ "\n",
     description.first_line() ++ "\n",
-    tags,
+    if(tags, tags ++ "\n"),
   ),
 )
 '''
+builtin_op_log_comfortable = 'builtin_op_log_compact ++ "\n"'
 
-# Defined as alias to allow 'log -T show'
-show = 'show'
-
-[template-aliases]
 'description_placeholder' = 'label("description", "(no description set)")'
 
 # Hook points for users to customize the default templates:

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -156,6 +156,35 @@ fn test_log_default() {
 }
 
 #[test]
+fn test_log_builtin_templates() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    let render = |template| test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
+
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
+    @  qpvuntsmwlqt test.user 2001-02-03 04:05:07.000 +07:00 230dd059e1b0 (empty) (no description set)
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000 (empty) (no description set)
+    "###);
+
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
+    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    │  (empty) (no description set)
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+       (empty) (no description set)
+    "###);
+
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
+    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    │  (empty) (no description set)
+    │
+    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+       (empty) (no description set)
+
+    "###);
+}
+
+#[test]
 fn test_log_obslog_divergence() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/tests/test_operations.rs
+++ b/tests/test_operations.rs
@@ -153,6 +153,38 @@ fn test_op_log_template() {
 }
 
 #[test]
+fn test_op_log_builtin_templates() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    let render = |template| test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
+    test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description 0"]);
+
+    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r###"
+    @  45108169c0f8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    │  args: jj describe -m 'description 0'
+    ◉  a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │  add workspace 'default'
+    ◉  56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+       initialize repo
+    "###);
+
+    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r###"
+    @  45108169c0f8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    │  args: jj describe -m 'description 0'
+    │
+    ◉  a99a3fd5c51e test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │  add workspace 'default'
+    │
+    ◉  56b94dfc38e7 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+       initialize repo
+
+    "###);
+}
+
+#[test]
 fn test_op_log_word_wrap() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
This way you can do `jj log -T 'default_log_template + "\n"'` to add a blank line between commits.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
