### PR TITLE
cli: default to log when no subcommand is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj git fetch` and `jj git push` will now use the single defined remote even if it is not named "origin".
 
+* `jj` with no subcommand now defaults to `jj log` instead of showing help. This
+  command can be overridden by setting `ui.default-command`.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/docs/config.md
+++ b/docs/config.md
@@ -124,6 +124,16 @@ Which elements can be colored is not yet documented, but see
 the [default color configuration](https://github.com/martinvonz/jj/blob/main/src/config/colors.toml)
 for some examples of what's possible.
 
+### Default command
+
+When `jj` is run with no explicit subcommand, the value of the
+`ui.default-command` setting will used instead. Possible values are any valid
+subcommand name, subcommand alias, or user-defined alias (defaults to `"log"`).
+
+```toml
+ui.default-command = "log"
+```
+
 ### Diff format
 
 ```toml

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3474,9 +3474,7 @@ fn cmd_sparse(ui: &mut Ui, command: &CommandHelper, args: &SparseArgs) -> Result
 
 pub fn default_app() -> Command {
     let app: Command = Commands::augment_subcommands(Args::command());
-    app.arg_required_else_help(true)
-        .subcommand_required(true)
-        .version(env!("JJ_VERSION"))
+    app.version(env!("JJ_VERSION"))
 }
 
 pub fn run_command(

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -51,6 +51,11 @@
                     "description": "Whether to allow initializing a repo with the native backend",
                     "default": false
                 },
+                "default-command": {
+                    "type": "string",
+                    "description": "Default command to run when no explicit command is given",
+                    "default": "log"
+                },
                 "default-revset": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -69,7 +69,7 @@ fn test_alias_bad_name() {
     insta::assert_snapshot!(stderr, @r###"
     error: unrecognized subcommand 'foo.'
 
-    Usage: jj [OPTIONS] <COMMAND>
+    Usage: jj [OPTIONS] [COMMAND]
 
     For more information, try '--help'.
     "###);
@@ -86,7 +86,7 @@ fn test_alias_calls_unknown_command() {
     insta::assert_snapshot!(stderr, @r###"
     error: unrecognized subcommand 'nonexistent'
 
-    Usage: jj [OPTIONS] <COMMAND>
+    Usage: jj [OPTIONS] [COMMAND]
 
     For more information, try '--help'.
     "###);
@@ -123,7 +123,7 @@ fn test_alias_calls_help() {
 
     To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/docs/tutorial.md.
 
-    Usage: jj [OPTIONS] <COMMAND>
+    Usage: jj [OPTIONS] [COMMAND]
     "###);
 }
 


### PR DESCRIPTION
This is a convenience optimization to improve the default user experience, since `jj log` is a frequently run command. Accessing the help information explicitly still follows normal CLI conventions, and instructions are displayed appropriately if the user happens to make a mistake. Discoverability should not be adversely harmed.

Note that this behavior mirrors [what Sapling does](https://sapling-scm.com/docs/overview/smartlog), where `sl` will display the smartlog by default.

If people are onboard with this change, where else would you recommend that the behavior be documented?

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
