### PR TITLE
index: remove entry_by_id() from trait

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -493,6 +493,10 @@ impl MutableIndexImpl {
         }
     }
 
+    pub fn as_composite(&self) -> CompositeIndex {
+        CompositeIndex(self)
+    }
+
     pub(crate) fn add_commit_data(
         &mut self,
         commit_id: CommitId,
@@ -509,7 +513,7 @@ impl MutableIndexImpl {
             parent_positions: vec![],
         };
         for parent_id in parent_ids {
-            let parent_entry = self
+            let parent_entry = CompositeIndex(self)
                 .entry_by_id(parent_id)
                 .expect("parent commit is not indexed");
             entry.generation_number = max(
@@ -697,10 +701,6 @@ impl Index for MutableIndexImpl {
 
     fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId> {
         CompositeIndex(self).resolve_prefix(prefix)
-    }
-
-    fn entry_by_id(&self, commit_id: &CommitId) -> Option<IndexEntry> {
-        CompositeIndex(self).entry_by_id(commit_id)
     }
 
     fn has_id(&self, commit_id: &CommitId) -> bool {
@@ -953,7 +953,7 @@ impl<'a> CompositeIndex<'a> {
             })
     }
 
-    pub(crate) fn entry_by_id(&self, commit_id: &CommitId) -> Option<IndexEntry<'a>> {
+    pub fn entry_by_id(&self, commit_id: &CommitId) -> Option<IndexEntry<'a>> {
         self.commit_id_to_pos(commit_id)
             .map(|pos| self.entry_by_pos(pos))
     }
@@ -1779,10 +1779,6 @@ impl Index for ReadonlyIndexImpl {
 
     fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId> {
         CompositeIndex(self).resolve_prefix(prefix)
-    }
-
-    fn entry_by_id(&self, commit_id: &CommitId) -> Option<IndexEntry> {
-        CompositeIndex(self).entry_by_id(commit_id)
     }
 
     fn has_id(&self, commit_id: &CommitId) -> bool {

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -944,7 +944,6 @@ mod tests {
     use super::*;
     use crate::backend::{ChangeId, CommitId, ObjectId};
     use crate::default_index_store::MutableIndexImpl;
-    use crate::index::Index;
 
     #[test]
     fn test_id_index_resolve_prefix() {
@@ -1073,7 +1072,7 @@ mod tests {
         index.add_commit_data(id_3.clone(), new_change_id(), &[id_2.clone()]);
         index.add_commit_data(id_4.clone(), new_change_id(), &[id_3.clone()]);
 
-        let get_entry = |id: &CommitId| index.entry_by_id(id).unwrap();
+        let get_entry = |id: &CommitId| index.as_composite().entry_by_id(id).unwrap();
         let make_entries = |ids: &[&CommitId]| ids.iter().map(|id| get_entry(id)).collect_vec();
         let make_set = |ids: &[&CommitId]| -> Box<dyn InternalRevset> {
             let index_entries = make_entries(ids);

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 use crate::backend::{CommitId, ObjectId};
 use crate::commit::Commit;
-use crate::default_index_store::{IndexEntry, RevWalk};
+use crate::default_index_store::RevWalk;
 use crate::op_store::OperationId;
 use crate::operation::Operation;
 use crate::revset::{ResolvedExpression, Revset, RevsetEvaluationError};
@@ -52,8 +52,6 @@ pub trait Index: Send + Sync {
     fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize;
 
     fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId>;
-
-    fn entry_by_id(&self, commit_id: &CommitId) -> Option<IndexEntry>;
 
     fn has_id(&self, commit_id: &CommitId) -> bool;
 

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -36,7 +36,11 @@ fn child_commit<'repo>(
 
 // Helper just to reduce line wrapping
 fn generation_number(index: &ReadonlyIndexImpl, commit_id: &CommitId) -> u32 {
-    index.entry_by_id(commit_id).unwrap().generation_number()
+    index
+        .as_composite()
+        .entry_by_id(commit_id)
+        .unwrap()
+        .generation_number()
 }
 
 #[test_case(false ; "local backend")]


### PR DESCRIPTION
It no longer needs to be on the `Index` trait, thereby removing the last direct use of `IndexEntry` in the trait (it's still used indirectly in `walk_revs()`).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
