### PR TITLE
cli: use a unique file extension for description tempfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj` with no subcommand now defaults to `jj log` instead of showing help. This
   command can be overridden by setting `ui.default-command`.
 
+* Description tempfiles created via `jj describe` now have the file extension
+  `.jjdescription` to help external tooling detect a unique filetype.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1769,8 +1769,8 @@ fn edit_description(
 ) -> Result<String, CommandError> {
     let description_file_path = (|| -> Result<_, io::Error> {
         let mut file = tempfile::Builder::new()
-            .prefix("description-")
-            .suffix(".txt")
+            .prefix("editor-")
+            .suffix(".jjdescription")
             .tempfile_in(repo.repo_path())?;
         file.write_all(description.as_bytes())?;
         file.write_all(b"\nJJ: Lines starting with \"JJ: \" (like this one) will be removed.\n")?;


### PR DESCRIPTION
Establishing a unique file extension for the temporary files created via `jj describe` helps to ensure that text editors can recognize the filetype and alter settings accordingly. This will open the door for an improved user experience, and allow for setting things like the appropriate text-width/rulers, syntax highlighting of the diff summary (see Git's [commit tree-sitter grammer](https://github.com/the-mikedavis/tree-sitter-git-commit)), easy toggling of the `JJ:` comment lines, etc.

I examined the behavior of filetype detection across a number of common text editors, and the most universally-support mechanism was to have a unique extension that does not include any periods. Meaning that namespacing via something like `.jj.txt` instead, won't always be detected due to inconsistent matching prioritization across editors. It also makes sense to assume that we may want other Jujutsu-specific filetypes in the future.

The filename prefix has also been switched to be `editor-` for clarity, as well as to ease matching a glob-pattern if we ever need to garbage collect leftover tempfiles. This structure is similar to what Mercurial and Sapling do as well.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes