### PR TITLE
cli: move `$JJ_VERSION` out of CLI library

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -2294,6 +2294,12 @@ impl CliRunner {
         }
     }
 
+    /// Set the version to be displayed by `jj version`.
+    pub fn version(mut self, version: &'static str) -> Self {
+        self.app = self.app.version(version);
+        self
+    }
+
     /// Replaces `StoreFactories` to be used.
     pub fn set_store_factories(mut self, store_factories: StoreFactories) -> Self {
         self.store_factories = Some(store_factories);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3473,8 +3473,7 @@ fn cmd_sparse(ui: &mut Ui, command: &CommandHelper, args: &SparseArgs) -> Result
 }
 
 pub fn default_app() -> Command {
-    let app: Command = Commands::augment_subcommands(Args::command());
-    app.version(env!("JJ_VERSION"))
+    Commands::augment_subcommands(Args::command())
 }
 
 pub fn run_command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,5 +15,5 @@
 use jujutsu::cli_util::CliRunner;
 
 fn main() -> std::process::ExitCode {
-    CliRunner::init().run()
+    CliRunner::init().version(env!("JJ_VERSION")).run()
 }


### PR DESCRIPTION
It should be up to the binary to decide which version it is. One should be able to build the library without specifying a version.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
