### PR TITLE
revset: add substitution rule for `roots+++` (but no fast evaluation yet)

### DIFF
--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -618,12 +618,16 @@ impl<'index> EvaluationContext<'index> {
                 heads,
                 generation_from_roots,
             } => {
-                let root_set = self.evaluate(roots)?;
+                let mut root_set = self.evaluate(roots)?;
                 let head_set = self.evaluate(heads)?;
-                if generation_from_roots == &(1..2) {
-                    Ok(Box::new(self.walk_children(&*root_set, &*head_set)))
+                // TODO: implement generic evaluation path for generation filter
+                for _ in 0..generation_from_roots.start {
+                    root_set = Box::new(self.walk_children(&*root_set, &*head_set));
+                }
+                if generation_from_roots.end == generation_from_roots.start + 1 {
+                    Ok(root_set)
                 } else {
-                    assert_eq!(generation_from_roots, &GENERATION_RANGE_FULL); // TODO
+                    assert_eq!(generation_from_roots.end, u64::MAX); // TODO
                     let (dag_range_set, _) = self.collect_dag_range(&*root_set, &*head_set);
                     Ok(Box::new(dag_range_set))
                 }

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -618,9 +618,14 @@ impl<'index> EvaluationContext<'index> {
                     Ok(Box::new(RevWalkRevset { walk }))
                 }
             }
-            ResolvedExpression::DagRange { roots, heads } => {
+            ResolvedExpression::DagRange {
+                roots,
+                heads,
+                generation_from_roots,
+            } => {
                 let root_set = self.evaluate(roots)?;
                 let head_set = self.evaluate(heads)?;
+                assert_eq!(generation_from_roots, &GENERATION_RANGE_FULL); // TODO
                 let (dag_range_set, _) = self.collect_dag_range(&*root_set, &*head_set);
                 Ok(Box::new(dag_range_set))
             }

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -586,11 +586,6 @@ impl<'index> EvaluationContext<'index> {
             ResolvedExpression::Commits(commit_ids) => {
                 Ok(Box::new(self.revset_for_commit_ids(commit_ids)))
             }
-            ResolvedExpression::Children { roots, heads } => {
-                let root_set = self.evaluate(roots)?;
-                let head_set = self.evaluate(heads)?;
-                Ok(Box::new(self.walk_children(&*root_set, &*head_set)))
-            }
             ResolvedExpression::Ancestors { heads, generation } => {
                 let head_set = self.evaluate(heads)?;
                 let walk = self.walk_ancestors(&*head_set);
@@ -625,9 +620,13 @@ impl<'index> EvaluationContext<'index> {
             } => {
                 let root_set = self.evaluate(roots)?;
                 let head_set = self.evaluate(heads)?;
-                assert_eq!(generation_from_roots, &GENERATION_RANGE_FULL); // TODO
-                let (dag_range_set, _) = self.collect_dag_range(&*root_set, &*head_set);
-                Ok(Box::new(dag_range_set))
+                if generation_from_roots == &(1..2) {
+                    Ok(Box::new(self.walk_children(&*root_set, &*head_set)))
+                } else {
+                    assert_eq!(generation_from_roots, &GENERATION_RANGE_FULL); // TODO
+                    let (dag_range_set, _) = self.collect_dag_range(&*root_set, &*head_set);
+                    Ok(Box::new(dag_range_set))
+                }
             }
             ResolvedExpression::Heads(candidates) => {
                 let candidate_set = self.evaluate(candidates)?;

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -593,7 +593,7 @@ impl<'index> EvaluationContext<'index> {
                     self.walk_ancestors_until_roots(&*root_set, &*head_set);
                 let roots: HashSet<_> = root_positions.into_iter().collect();
                 let candidates = Box::new(RevWalkRevset { walk });
-                let predicate = pure_predicate_fn(move |entry| {
+                let predicate = PurePredicateFn(move |entry: &IndexEntry| {
                     entry
                         .parent_positions()
                         .iter()


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
