### PR TITLE
revset: fix slow ancestors query `:x--` in mergey history

### DIFF
--- a/testing/bench-revsets-git.txt
+++ b/testing/bench-revsets-git.txt
@@ -38,8 +38,19 @@ heads(author(peff))
 # Roots and heads of range
 roots(:v2.40.0)
 heads(:v2.40.0)
-# Parents and children of small subset
+# Parents and ancestors of old commit
+v1.0.0-
+v1.0.0---
+:v1.0.0---
+# Parents and ancestors of recent commit
+v2.40.0-
+v2.40.0---
+:v2.40.0---
+# Parents and ancestors of small subset
 tags()-
+tags()---
+:tags()---
+# Children of small subset
 tags()+
 # Filter that doesn't read commit object
 merges()


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
