### PR TITLE
revset: do not scan ancestors more than once to evaluate nested children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "rand_chacha",
  "regex",
  "serde_json",
+ "smallvec",
  "tempfile",
  "test-case",
  "testutils",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -40,6 +40,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 regex = "1.7.3"
 serde_json = "1.0.96"
+smallvec = { version = "1.10.0", features = ["const_generics", "const_new", "union"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 tracing = "0.1.38"

--- a/testing/bench-revsets-git.txt
+++ b/testing/bench-revsets-git.txt
@@ -13,7 +13,6 @@ v2.40.0
 v2.39.0..v2.40.0
 :v2.40.0 ~ :v2.39.0
 v2.39.0:v2.40.0
-v2.40.0+
 # Tags and branches
 tags()
 branches()
@@ -42,16 +41,26 @@ heads(:v2.40.0)
 v1.0.0-
 v1.0.0---
 :v1.0.0---
+# Children and descendants of old commit
+v1.0.0+
+v1.0.0+++
+v1.0.0+++:
 # Parents and ancestors of recent commit
 v2.40.0-
 v2.40.0---
 :v2.40.0---
+# Children and descendants of recent commit
+v2.40.0+
+v2.40.0+++
+v2.40.0+++:
 # Parents and ancestors of small subset
 tags()-
 tags()---
 :tags()---
-# Children of small subset
+# Children and descendants of small subset
 tags()+
+tags()+++
+tags()+++:
 # Filter that doesn't read commit object
 merges()
 ~merges()


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
