### PR TITLE
Fix relative paths on Windows

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -377,6 +377,10 @@ impl CommandHelper {
         maybe_workspace_loader: Result<WorkspaceLoader, CommandError>,
         store_factories: StoreFactories,
     ) -> Self {
+        // `cwd` is canonicalized for consistency with `Workspace::workspace_root()` and
+        // to easily compute relative paths between them.
+        let cwd = cwd.canonicalize().unwrap_or(cwd);
+
         Self {
             app,
             cwd,


### PR DESCRIPTION
`workspace_root` is [canonicalized](https://github.com/martinvonz/jj/blob/41a2855b4fd84d8811d295dcaa0ea0aa0d5be171/lib/src/workspace.rs#L119), but `cwd` [isn't](https://github.com/martinvonz/jj/blob/41a2855b4fd84d8811d295dcaa0ea0aa0d5be171/src/cli_util.rs#L581). When [working with relative paths](https://github.com/martinvonz/jj/blob/41a2855b4fd84d8811d295dcaa0ea0aa0d5be171/src/cli_util.rs#L749-L760), this leads to issues in Windows: canonicalized paths start with `\\?\`, whereas non-canonicalized paths do not. Therefore, paths were formatted canonicalized, and commands did not accept non-canonicalized paths:

```
$ jj st
Parent commit: bdb62c926e75 canonicalize cwd in cli_util.rs
Working copy : 059c104379cd (no description set)
Working copy changes:
A \\?\C:\github.com\71\jj\.vscode\launch.json

$ jj diff .vscode\launch.json
Error: Path ".vscode\launch.json" is not in the repo

$ jj diff \\?\C:\github.com\71\jj\.vscode\launch.json
Added regular file \\?\C:\github.com\71\jj\.vscode\launch.json:
...
```

With this change:
```
$ jj st
Parent commit: bdb62c926e75 canonicalize cwd in cli_util.rs
Working copy : 059c104379cd (no description set)
Working copy changes:
A .vscode\launch.json

$ jj diff .vscode\launch.json
Added regular file .vscode\launch.json:
...
```

Note that `jj diff .vscode/launch.json` (with the forward-slash path separator) also works.

I'm not particularly familiar with the code base, so perhaps:
1. There might be better locations where `cwd` could be canonicalized (in case we have similar issues with other parts of the code base later on)?
2. There could be a test for this that runs specifically on Windows?

Also note that I did not use `jj` for this PR, since it's still mostly unusable to me (notably most `jj git` commands fail due to various SSH-related issues).

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
