### PR TITLE
Fix warnings in tests on non-Unix platforms

### DIFF
--- a/tests/test_diff_command.rs
+++ b/tests/test_diff_command.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
-
 use common::TestEnvironment;
 
 pub mod common;
@@ -135,6 +133,7 @@ fn test_diff_types() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        use std::path::PathBuf;
 
         // Executable
         test_env.jj_cmd_success(&repo_path, &["new", "root", "-m=executable"]);

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -14,7 +14,7 @@
 
 use std::path::Path;
 
-use crate::common::{get_stderr_string, TestEnvironment};
+use crate::common::TestEnvironment;
 
 pub mod common;
 
@@ -66,6 +66,8 @@ fn test_edit() {
 // Windows says "Access is denied" when trying to delete the object file.
 #[cfg(unix)]
 fn test_edit_current_wc_commit_missing() {
+    use crate::common::get_stderr_string;
+
     // Test that we get a reasonable error message when the current working-copy
     // commit is missing
     let test_env = TestEnvironment::default();


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
