### PR TITLE
cargo: bump zstd-sys from v2.0.1+zstd.1.5.2 to v2.0.8+zstd.1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,10 +2450,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]


### PR DESCRIPTION
Motivated by including https://github.com/gyscos/zstd-rs/commit/22e359a53f4b577a45ae28bed6a1717c1b0fb6a9, which makes it easier to package jj with a prebuilt libzstd. Not sure why dependabot didn't get this.