### PR TITLE
nix: use packaged builds of foreign dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,12 +56,14 @@
             makeWrapper
             pkg-config
           ];
-          buildInputs = with pkgs; [ openssl dbus sqlite ]
+          buildInputs = with pkgs; [ openssl dbus sqlite zstd libgit2 libssh2 ]
             ++ lib.optionals stdenv.isDarwin [
             darwin.apple_sdk.frameworks.Security
             darwin.apple_sdk.frameworks.SystemConfiguration
             libiconv
-          ];
+            ];
+          ZSTD_SYS_USE_PKG_CONFIG = "1";
+          LIBSSH2_SYS_USE_PKG_CONFIG = "1";
           postInstall = ''
             $out/bin/jj util mangen > ./jj.1
             installManPage ./jj.1


### PR DESCRIPTION
Requires https://github.com/martinvonz/jj/pull/1578 for prebuilt libgit2 to be accepted by the current version of libgit2-sys (which will otherwise happily vendor away).