### PR TITLE
docs: don't say "both inclusive" about `x:y` and `x..y` revset endpoint

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -60,11 +60,10 @@ only symbols.
 * `x+`: Children of `x`.
 * `:x`: Ancestors of `x`, including the commits in `x` itself.
 * `x:`: Descendants of `x`, including the commits in `x` itself.
-* `x:y`: Descendants of `x` that are also ancestors of `y`, both inclusive.
-  Equivalent to `x: & :y`. This is what `git log` calls `--ancestry-path x..y`.
-* `x..y`: Ancestors of `y` that are not also ancestors of `x`, both inclusive.
-  Equivalent to `:y ~ :x`. This is what `git log` calls `x..y` (i.e. the same as
-  we call it).
+* `x:y`: Descendants of `x` that are also ancestors of `y`. Equivalent to
+  `x: & :y`. This is what `git log` calls `--ancestry-path x..y`.
+* `x..y`: Ancestors of `y` that are not also ancestors of `x`. Equivalent to
+  `:y ~ :x`. This is what `git log` calls `x..y` (i.e. the same as we call it).
 * `..x`: Ancestors of `x`, including the commits in `x` itself. Equivalent to
    `:x` and provided for consistency.
 * `x..`: Revisions that are not ancestors of `x`.


### PR DESCRIPTION
We currently say that `x..y` is "Ancestors of `y` that are not also ancestors of `x`, both inclusive.". However, it's easy to think that "both inclusive" means that both `x` and `y` are included in the set, which is not the case. What we mean is more like "{Ancestors of `y`, including `y` itself} that are not also {ancestors of `x`, including `x` itself}.". Given that we already define ancestors and descendants as being inclusive on the lines above, and we also give the equivalent expressions using the `x:` and `:y` operators, it's probably best to just skip the "both inclusive" parts.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
