### PR TITLE
docs: use `git switch/restore` in command-equivalence table

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -178,7 +178,7 @@ parent.
     <tr>
       <td>Discard working copy changes in some files</td>
       <td><code>jj restore &lt;paths&gt;...</code></td>
-      <td><code>git checkout -- &lt;paths&gt;...</code></td>
+      <td><code>git restore &lt;paths&gt;...</code> or <code>git checkout HEAD -- &lt;paths&gt;...</code></td>
     </tr>
     <tr>
       <td>Edit description (commit message) of the current change</td>
@@ -199,8 +199,9 @@ parent.
     <tr>
       <td>Start working on a new change based on the &lt;main&gt; branch</td>
       <td><code>jj co main</code></td>
-      <td><code>git checkout -b topic main</code> (may need to stash or commit
-          first)</td>
+      <td><code>git switch -c topic main</code> or
+        <code>git checkout -b topic main</code> (may need to stash or commit
+        first)</td>
     </tr>
     <tr>
       <td>Move branch A onto branch B</td>


### PR DESCRIPTION
IIUC, the consensus in the Git project is that the overloaded nature of `git checkout` for many use cases was a mistake, and `git switch/restore` are meant to replace it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
