### PR TITLE
trim snapshot progress output

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -196,10 +196,15 @@ pub fn snapshot_progress(ui: &mut Ui) -> Option<impl Fn(&RepoPath) + '_> {
                     .output_guard(format!("\r{}", Clear(ClearType::CurrentLine))),
             );
         }
+
+        let line_width = state.ui.term_width().map(usize::from).unwrap_or(80);
+        let path_width = line_width.saturating_sub(13); // Account for "Snapshotting "
+
         _ = write!(
             state.ui,
-            "\r{}Snapshotting {}",
+            "\r{}Snapshotting {:.*}",
             Clear(ClearType::CurrentLine),
+            path_width,
             path.to_fs_path(Path::new("")).display()
         );
         _ = state.ui.flush();


### PR DESCRIPTION
Following [this discussion](https://discord.com/channels/968932220549103686/969829516539228222/1105304374584025251) on Discord, this trims the output of the snapshot progress messages so that they can be cleared correctly.