### PR TITLE
git: on external HEAD move, do not abandon old branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * It is no longer allowed to create branches at the root commit.
 
+* `git checkout` (without using `jj`) in colocated repo no longer abandons
+  the previously checked-out anonymous branch.
+  [#1042](https://github.com/martinvonz/jj/issues/1042).
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -91,9 +91,6 @@ pub fn import_some_refs(
             new_git_heads.extend(old_target.adds());
         }
     }
-    if let Some(old_git_head) = mut_repo.view().git_head() {
-        old_git_heads.extend(old_git_head.adds());
-    }
 
     // TODO: Should this be a separate function? We may not always want to import
     // the Git HEAD (and add it to our set of heads).
@@ -101,6 +98,9 @@ pub fn import_some_refs(
         .head()
         .and_then(|head_ref| head_ref.peel_to_commit())
     {
+        // Add the current HEAD to `new_git_heads` to pin the branch. It's not added
+        // to `old_git_heads` because HEAD move doesn't automatically mean the old
+        // HEAD branch has been rewritten.
         let head_commit_id = CommitId::from_bytes(head_git_commit.id().as_bytes());
         let head_commit = store.get_commit(&head_commit_id).unwrap();
         new_git_heads.insert(head_commit_id.clone());

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -297,10 +297,13 @@ fn test_git_colocated_external_checkout() {
         )
         .unwrap();
 
-    // The old HEAD branch gets abandoned because jj thinks it has been rewritten.
+    // The old working-copy commit gets abandoned, but the whole branch should not
+    // be abandoned. (#1042)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  0521ce3b8c4e29aab79f3c750e2845dcbc4c3874
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master
+    │ ◉  66f4d1806ae41bd604f69155dece64062a0056cf
+    ◉ │  a86754f975f953fa25da4265764adc0c62e9ce6b master
+    ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
 }


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
