### PR TITLE
Fix #864 (fetching deleted/moved branches in colocated repos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the previously checked-out anonymous branch.
   [#1042](https://github.com/martinvonz/jj/issues/1042).
 
+* `jj git fetch` in a colocated repo now abandons branches deleted on the
+  remote, just like in a non-colocated repo.
+  [#864](https://github.com/martinvonz/jj/issues/864)
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -98,7 +98,7 @@ commands and readonly Git commands. It's also useful when tools (e.g. build
 tools) expect a Git repo to be present.
 
 There are some bugs and surprising behavior related to `jj undo` in this mode,
-such as #864 and #922.
+such as #922.
 
 ## Creating a repo by cloning a Git repo
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -480,11 +480,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
             jj_id(&commit_main),
             // Neither commit_remote_only nor commit_remote_and_local should be
             // listed as a head. commit_remote_only was never affected by #864,
-            // but commit_remote_and_local is.
-            // BUG: commit_remote_and_local is still listed as a head (#864)
-            // even though the feature-remote branch was deleted as we'll see
-            // below.
-            jj_id(&commit_remote_and_local),
+            // but commit_remote_and_local was.
     };
     assert_eq!(*view.heads(), expected_heads);
 }
@@ -601,8 +597,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
             jj_id(&new_commit_remote_only),
             // Neither commit_remote_only nor commit_remote_and_local should be
             // listed as a head. commit_remote_only was never affected by #864,
-            // but commit_remote_and_local is.
-            jj_id(&commit_remote_and_local),
+            // but commit_remote_and_local was.
     };
     assert_eq!(*view.heads(), expected_heads);
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -399,6 +399,97 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
 }
 
 #[test]
+fn test_import_refs_reimport_with_deleted_remote_ref() {
+    let settings = testutils::user_settings();
+    let git_settings = GitSettings::default();
+    let test_workspace = TestRepo::init(true);
+    let repo = &test_workspace.repo;
+    let git_repo = get_git_repo(repo);
+
+    let commit_base = empty_git_commit(&git_repo, "refs/heads/main", &[]);
+    let commit_main = empty_git_commit(&git_repo, "refs/heads/main", &[&commit_base]);
+    let commit_remote_only = empty_git_commit(
+        &git_repo,
+        "refs/remotes/origin/feature-remote-only",
+        &[&commit_base],
+    );
+    let commit_remote_and_local = empty_git_commit(
+        &git_repo,
+        "refs/remotes/origin/feature-remote-and-local",
+        &[&commit_base],
+    );
+    git_ref(
+        &git_repo,
+        "refs/heads/feature-remote-and-local",
+        commit_remote_and_local.id(),
+    );
+
+    let mut tx = repo.start_transaction(&settings, "test");
+    git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
+    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    let repo = tx.commit();
+
+    let expected_heads = hashset! {
+            jj_id(&commit_main),
+            jj_id(&commit_remote_only),
+            jj_id(&commit_remote_and_local),
+    };
+    let view = repo.view();
+    assert_eq!(*view.heads(), expected_heads);
+    assert_eq!(view.branches().len(), 3);
+    assert_eq!(
+        view.branches().get("feature-remote-only"),
+        Some(&BranchTarget {
+            // Even though the git repo does not have a local branch for `feature-remote-only`, jj
+            // creates one. This follows the model explained in docs/branches.md.
+            local_target: Some(RefTarget::Normal(jj_id(&commit_remote_only))),
+            remote_targets: btreemap! {
+                "origin".to_string() => RefTarget::Normal(jj_id(&commit_remote_only))
+            },
+        }),
+    );
+    assert_eq!(
+        view.branches().get("feature-remote-and-local"),
+        Some(&BranchTarget {
+            local_target: Some(RefTarget::Normal(jj_id(&commit_remote_and_local))),
+            remote_targets: btreemap! {
+                "origin".to_string() => RefTarget::Normal(jj_id(&commit_remote_and_local))
+            },
+        }),
+    );
+    view.branches().get("main").unwrap(); // branch #3 of 3
+
+    // Simulate fetching from a remote where feature-remote-only and
+    // feature-remote-and-local branches were deleted. This leads to the
+    // following import deleting the corresponding local branches.
+    delete_git_ref(&git_repo, "refs/remotes/origin/feature-remote-only");
+    delete_git_ref(&git_repo, "refs/remotes/origin/feature-remote-and-local");
+
+    let mut tx = repo.start_transaction(&settings, "test");
+    git::import_refs(tx.mut_repo(), &git_repo, &git_settings).unwrap();
+    tx.mut_repo().rebase_descendants(&settings).unwrap();
+    let repo = tx.commit();
+
+    let view = repo.view();
+    // The local branches were indeed deleted
+    assert_eq!(view.branches().len(), 1);
+    view.branches().get("main").unwrap(); // branch #1 of 1
+    assert_eq!(view.branches().get("feature-remote-local"), None);
+    assert_eq!(view.branches().get("feature-remote-and-local"), None);
+    let expected_heads = hashset! {
+            jj_id(&commit_main),
+            // Neither commit_remote_only nor commit_remote_and_local should be
+            // listed as a head. commit_remote_only was never affected by #864,
+            // but commit_remote_and_local is.
+            // BUG: commit_remote_and_local is still listed as a head (#864)
+            // even though the feature-remote branch was deleted as we'll see
+            // below.
+            jj_id(&commit_remote_and_local),
+    };
+    assert_eq!(*view.heads(), expected_heads);
+}
+
+#[test]
 fn test_import_refs_reimport_git_head_with_fixed_ref() {
     // Simulate external `git checkout` in colocated repo, from named branch.
     let settings = testutils::user_settings();

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -265,14 +265,11 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     test_env.jj_cmd_success(&origin_path, &["describe", "C_to_move", "-m", "moved C"]);
     let stdout = test_env.jj_cmd_success(&clone_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
-    // TODO: 929e and 8d4e should have been abandoned (#864)
+    // 929e and 8d4e are abandoned, as the corresponding branches were deleted or
+    // moved on the remote (#864)
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
     ◉  04fd29df05638156b20044b3b6136b42abcb09ab C_to_move
     │ @  0335878796213c3a701f1c9c34dcae242bee4131
-    ├─╯
-    │ ◉  8d4e006fd63547965fbc3a26556a9aa531076d32
-    ├─╯
-    │ ◉  929e298ae9edf969b405a304c75c10457c47d52c
     ├─╯
     ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A master HEAD@git
     ◉  0000000000000000000000000000000000000000


### PR DESCRIPTION
Fixes #864 ("In a git colocated repo, commits are not rebased off of a deleted/moved branch")

**Update:** Some technical details from the commit description:

> This bug concerns the way `import_refs` that gets called by `fetch` computes
> the heads that should be visible after the import.
> 
> Previously, the list of such heads was computed *before* local branches were
> updated based on changes to the remote branches. So, commits that should have
> been abandoned based on this update of the local branches weren't properly
> abandoned.
> 
> Now, `import_refs` tracks the heads that need to be visible because of some ref
> in a mapping keyed by the ref. If the ref moves or is deleted, the
> corresponding heads are updated.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
