### PR TITLE
backend: replace `git_repo()` by `as_any()`

### DIFF
--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::io::Read;
 use std::path::Path;
 
-use git2::Repository;
 use jujutsu::cli_util::{CliRunner, CommandError, CommandHelper};
 use jujutsu::ui::Ui;
 use jujutsu_lib::backend::{
@@ -89,6 +89,10 @@ impl JitBackend {
 }
 
 impl Backend for JitBackend {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn name(&self) -> &str {
         "jit"
     }
@@ -99,10 +103,6 @@ impl Backend for JitBackend {
 
     fn change_id_length(&self) -> usize {
         self.inner.change_id_length()
-    }
-
-    fn git_repo(&self) -> Option<Repository> {
-        self.inner.git_repo()
     }
 
     fn read_file(&self, path: &RepoPath, id: &FileId) -> BackendResult<Box<dyn Read>> {

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Error, Formatter};
 use std::io::Read;
@@ -369,6 +370,8 @@ pub fn make_root_commit(root_change_id: ChangeId, empty_tree_id: TreeId) -> Comm
 }
 
 pub trait Backend: Send + Sync + Debug {
+    fn as_any(&self) -> &dyn Any;
+
     /// A unique name that identifies this backend. Written to
     /// `.jj/repo/store/backend` when the repo is created.
     fn name(&self) -> &str;
@@ -378,8 +381,6 @@ pub trait Backend: Send + Sync + Debug {
 
     /// The length of change IDs in bytes.
     fn change_id_length(&self) -> usize;
-
-    fn git_repo(&self) -> Option<git2::Repository>;
 
     fn read_file(&self, path: &RepoPath, id: &FileId) -> BackendResult<Box<dyn Read>>;
 

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::fs;
 use std::fs::File;
@@ -125,6 +126,10 @@ impl LocalBackend {
 }
 
 impl Backend for LocalBackend {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn name(&self) -> &str {
         "local"
     }
@@ -135,10 +140,6 @@ impl Backend for LocalBackend {
 
     fn change_id_length(&self) -> usize {
         CHANGE_ID_LENGTH
-    }
-
-    fn git_repo(&self) -> Option<git2::Repository> {
-        None
     }
 
     fn read_file(&self, _path: &RepoPath, id: &FileId) -> BackendResult<Box<dyn Read>> {

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::io::Read;
 use std::sync::{Arc, RwLock};
@@ -43,16 +44,16 @@ impl Store {
         })
     }
 
+    pub fn backend_impl(&self) -> &dyn Any {
+        self.backend.as_any()
+    }
+
     pub fn commit_id_length(&self) -> usize {
         self.backend.commit_id_length()
     }
 
     pub fn change_id_length(&self) -> usize {
         self.backend.change_id_length()
-    }
-
-    pub fn git_repo(&self) -> Option<git2::Repository> {
-        self.backend.git_repo()
     }
 
     pub fn empty_tree_id(&self) -> &TreeId {

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -14,6 +14,7 @@
 
 use std::path::{Path, PathBuf};
 
+use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::op_store::WorkspaceId;
 use jujutsu_lib::repo::Repo;
 use jujutsu_lib::settings::UserSettings;
@@ -33,7 +34,11 @@ fn test_init_local() {
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let (workspace, repo) = Workspace::init_local(&settings, &uncanonical).unwrap();
-    assert!(repo.store().git_repo().is_none());
+    assert!(repo
+        .store()
+        .backend_impl()
+        .downcast_ref::<GitBackend>()
+        .is_none());
     assert_eq!(repo.repo_path(), &canonical.join(".jj").join("repo"));
     assert_eq!(workspace.workspace_root(), &canonical);
 
@@ -48,7 +53,11 @@ fn test_init_internal_git() {
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let (workspace, repo) = Workspace::init_internal_git(&settings, &uncanonical).unwrap();
-    assert!(repo.store().git_repo().is_some());
+    assert!(repo
+        .store()
+        .backend_impl()
+        .downcast_ref::<GitBackend>()
+        .is_some());
     assert_eq!(repo.repo_path(), &canonical.join(".jj").join("repo"));
     assert_eq!(workspace.workspace_root(), &canonical);
 
@@ -67,7 +76,12 @@ fn test_init_external_git() {
     std::fs::create_dir(uncanonical.join("jj")).unwrap();
     let (workspace, repo) =
         Workspace::init_external_git(&settings, &uncanonical.join("jj"), &git_repo_path).unwrap();
-    assert!(repo.store().git_repo().is_some());
+
+    assert!(repo
+        .store()
+        .backend_impl()
+        .downcast_ref::<GitBackend>()
+        .is_some());
     assert_eq!(
         repo.repo_path(),
         &canonical.join("jj").join(".jj").join("repo")

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use jujutsu_lib::backend::{ChangeId, CommitId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::git;
+use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::index::{HexPrefix, PrefixResolution};
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::repo::Repo;
@@ -203,7 +204,12 @@ fn test_resolve_symbol_change_id(readonly: bool) {
     let test_repo = TestRepo::init(true);
     let repo = &test_repo.repo;
 
-    let git_repo = repo.store().git_repo().unwrap();
+    let git_repo = repo
+        .store()
+        .backend_impl()
+        .downcast_ref::<GitBackend>()
+        .unwrap()
+        .git_repo_clone();
     // Add some commits that will end up having change ids with common prefixes
     let empty_tree_id = git_repo.treebuilder(None).unwrap().write().unwrap();
     let git_author = git2::Signature::new(

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -10,6 +10,7 @@ use clap::{ArgGroup, Subcommand};
 use itertools::Itertools;
 use jujutsu_lib::backend::ObjectId;
 use jujutsu_lib::git::{self, GitFetchError, GitPushError, GitRefUpdate};
+use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::op_store::{BranchTarget, RefTarget};
 use jujutsu_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
 use jujutsu_lib::repo::Repo;
@@ -149,9 +150,9 @@ pub struct GitImportArgs {}
 pub struct GitExportArgs {}
 
 fn get_git_repo(store: &Store) -> Result<git2::Repository, CommandError> {
-    match store.git_repo() {
+    match store.backend_impl().downcast_ref::<GitBackend>() {
         None => Err(user_error("The repo is not backed by a git repo")),
-        Some(git_repo) => Ok(git_repo),
+        Some(git_backend) => Ok(git_backend.git_repo_clone()),
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,6 +34,7 @@ use jujutsu_lib::backend::{CommitId, ObjectId, TreeValue};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::dag_walk::topo_order_reverse;
 use jujutsu_lib::default_index_store::{DefaultIndexStore, ReadonlyIndexWrapper};
+use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::matchers::EverythingMatcher;
 use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
 use jujutsu_lib::repo::{ReadonlyRepo, Repo};
@@ -1057,7 +1058,12 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
         }
         let (workspace, repo) =
             Workspace::init_external_git(command.settings(), &wc_path, &git_store_path)?;
-        let git_repo = repo.store().git_repo().unwrap();
+        let git_repo = repo
+            .store()
+            .backend_impl()
+            .downcast_ref::<GitBackend>()
+            .unwrap()
+            .git_repo_clone();
         let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;
         workspace_command.snapshot(ui)?;
         if workspace_command.working_copy_shared_with_git() {


### PR DESCRIPTION
This has several advantages:

 * Makes it possible to downcast to non-Git custom backends (might be useful at Google, but we haven't needed it yet)

 * Lets us access more specific functionality on the `GitBackend`, making it possible to access the `git2::Repository` without creating a copy of it.

 * Removes the dependency on Git from the backend

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
