### PR TITLE
git_backend: add lock to prevent racy change id assignments

### DIFF
--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -513,11 +513,8 @@ impl Backend for GitBackend {
         }
         let parent_refs = parents.iter().collect_vec();
         let extras = serialize_extras(&contents);
-        let mut mut_table = self
-            .extra_metadata_store
-            .get_head()
-            .unwrap()
-            .start_mutation();
+        let table = self.read_extra_metadata_table()?;
+        let mut mut_table = table.start_mutation();
         let id = loop {
             let git_id = locked_repo
                 .commit(
@@ -533,7 +530,7 @@ impl Backend for GitBackend {
                     source: Box::new(err),
                 })?;
             let id = CommitId::from_bytes(git_id.as_bytes());
-            match mut_table.get_value(id.as_bytes()) {
+            match table.get_value(id.as_bytes()) {
                 Some(existing_extras) if existing_extras != extras => {
                     // It's possible a commit already exists with the same commit id but different
                     // change id. Adjust the timestamp until this is no longer the case.

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -485,7 +485,7 @@ impl Backend for GitBackend {
         };
 
         let table = self.cached_extra_metadata_table()?;
-        if let Some(extras) = table.get_value(git_commit_id.as_bytes()) {
+        if let Some(extras) = table.get_value(id.as_bytes()) {
             deserialize_extras(&mut commit, extras);
         }
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1984,7 +1984,7 @@ fn test_concurrent_write_commit() {
     }
 
     // Ideally, each commit should have unique commit/change ids.
-    // TODO: assert_eq!(commit_change_ids.len(), num_thread);
+    assert_eq!(commit_change_ids.len(), num_thread);
 
     // All unique commits should be preserved.
     let repo = repo.reload_at_head(settings).unwrap();
@@ -1997,13 +1997,11 @@ fn test_concurrent_write_commit() {
     // The index should be consistent with the store.
     for commit_id in commit_change_ids.keys() {
         assert!(repo.index().has_id(commit_id));
-        /* TODO
         let commit = repo.store().get_commit(commit_id).unwrap();
         assert_eq!(
             repo.resolve_change_id(commit.change_id()),
             Some(vec![commit_id.clone()]),
         );
-        */
     }
 }
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1906,7 +1906,7 @@ fn test_rewrite_imported_commit() {
 
     // Try to create identical commit with different change id.
     let mut tx = repo.start_transaction(&settings, "test");
-    let _authored_commit = tx
+    let authored_commit = tx
         .mut_repo()
         .new_commit(
             &settings,
@@ -1918,20 +1918,17 @@ fn test_rewrite_imported_commit() {
         .set_description(imported_commit.description())
         .write()
         .unwrap();
-    let _repo = tx.commit();
+    let repo = tx.commit();
 
     // Imported commit shouldn't be reused, and the timestamp of the authored
     // commit should be adjusted to create new commit.
-    /* TODO
     assert_ne!(imported_commit.id(), authored_commit.id());
     assert_ne!(
         imported_commit.committer().timestamp,
         authored_commit.committer().timestamp,
     );
-    */
 
     // The index should be consistent with the store.
-    /* TODO
     assert_eq!(
         repo.resolve_change_id(imported_commit.change_id()),
         Some(vec![imported_commit.id().clone()]),
@@ -1940,7 +1937,6 @@ fn test_rewrite_imported_commit() {
         repo.resolve_change_id(authored_commit.change_id()),
         Some(vec![authored_commit.id().clone()]),
     );
-    */
 }
 
 #[test]
@@ -2094,13 +2090,11 @@ fn test_concurrent_read_write_commit() {
     let repo = repo.reload_at_head(settings).unwrap();
     for commit_id in &commit_ids {
         assert!(repo.index().has_id(commit_id));
-        /* TODO
         let commit = repo.store().get_commit(commit_id).unwrap();
         assert_eq!(
             repo.resolve_change_id(commit.change_id()),
             Some(vec![commit_id.clone()]),
         );
-        */
     }
 }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
