### PR TITLE
git_backend: on read_commit(), bulk-update extra metadata table of ancestors

### DIFF
--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -463,7 +463,7 @@ impl Backend for GitBackend {
         // leading 16 bytes to address that. We also reverse the bits to make it less
         // likely that users depend on any relationship between the two ids.
         let change_id = ChangeId::new(
-            id.as_bytes()[4..HASH_LENGTH]
+            commit.id().as_bytes()[4..HASH_LENGTH]
                 .iter()
                 .rev()
                 .map(|b| b.reverse_bits())


### PR DESCRIPTION
Follows up #1615 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
