### PR TITLE
cli: make `jj sparse --list` a subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The `ui.default-revset` config was renamed to `revsets.log`.
 
+* The `jj sparse` command was split up into `jj sparse list` and
+  `jj sparse set`.
+
 ### New features
 
 * `jj git push --deleted` will remove all locally deleted branches from the remote.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -877,10 +877,18 @@ enum SparseArgs {
 }
 
 /// List the patterns that are currently present in the working copy
+///
+/// By default, a newly cloned or initialized repo will have have a pattern
+/// matching all files from the repo root. That pattern is rendered as `.` (a
+/// single period).
 #[derive(clap::Args, Clone, Debug)]
 struct SparseListArgs {}
 
 /// Update the patterns that are present in the working copy
+///
+/// For example, if all you need is the `README.md` and the `lib/`
+/// directory, use `jj sparse set --clear --add README.md --add lib`.
+/// If you no longer need the `lib` directory, use `jj sparse set --remove lib`.
 #[derive(clap::Args, Clone, Debug)]
 struct SparseSetArgs {
     /// Patterns to add to the working copy

--- a/tests/test_sparse_command.rs
+++ b/tests/test_sparse_command.rs
@@ -28,18 +28,18 @@ fn test_sparse_manage_patterns() {
     std::fs::write(repo_path.join("file3"), "contents").unwrap();
 
     // By default, all files are tracked
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--list"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     .
     "###);
 
     // Can stop tracking all files
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--remove", "."]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "set", "--remove", "."]);
     insta::assert_snapshot!(stdout, @r###"
     Added 0 files, modified 0 files, removed 3 files
     "###);
     // The list is now empty
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--list"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @"");
     // They're removed from the working copy
     assert!(!repo_path.join("file1").exists());
@@ -54,12 +54,14 @@ fn test_sparse_manage_patterns() {
     "###);
 
     // Can `--add` a few files
-    let stdout =
-        test_env.jj_cmd_success(&repo_path, &["sparse", "--add", "file2", "--add", "file3"]);
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["sparse", "set", "--add", "file2", "--add", "file3"],
+    );
     insta::assert_snapshot!(stdout, @r###"
     Added 2 files, modified 0 files, removed 0 files
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--list"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     file2
     file3
@@ -72,13 +74,13 @@ fn test_sparse_manage_patterns() {
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
-            "sparse", "--add", "file1", "--remove", "file2", "--remove", "file3",
+            "sparse", "set", "--add", "file1", "--remove", "file2", "--remove", "file3",
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
     Added 1 files, modified 0 files, removed 2 files
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--list"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     file1
     "###);
@@ -87,11 +89,12 @@ fn test_sparse_manage_patterns() {
     assert!(!repo_path.join("file3").exists());
 
     // Can use `--clear` and `--add`
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--clear", "--add", "file2"]);
+    let stdout =
+        test_env.jj_cmd_success(&repo_path, &["sparse", "set", "--clear", "--add", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     Added 1 files, modified 0 files, removed 1 files
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--list"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     file2
     "###);
@@ -100,11 +103,11 @@ fn test_sparse_manage_patterns() {
     assert!(!repo_path.join("file3").exists());
 
     // Can reset back to all files
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--reset"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "set", "--reset"]);
     insta::assert_snapshot!(stdout, @r###"
     Added 2 files, modified 0 files, removed 0 files
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "--list"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     .
     "###);

--- a/tests/test_untrack_command.rs
+++ b/tests/test_untrack_command.rs
@@ -116,7 +116,7 @@ fn test_untrack_sparse() {
     file1
     file2
     "###);
-    test_env.jj_cmd_success(&repo_path, &["sparse", "--clear", "--add", "file1"]);
+    test_env.jj_cmd_success(&repo_path, &["sparse", "set", "--clear", "--add", "file1"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["untrack", "file2"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["files"]);


### PR DESCRIPTION
`jj sparse` is a bit different from other commands in that its `jj sparse --list` is practically a separate command. Let's make it an actual subcommand for consistency, and so we can more cleanly add additional flags for `jj sparse list` in the future. I moved all the other arguments to `jj sparse set`. I'm not sure if `jj sparse set --reset` would have been better as `jj sparse reset`, but it is technically just updating the sparse patterns just like the other arguments (`--clear`, `--add` , `--remove`).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
