### PR TITLE
cleanup: fix minor typos in function names

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1986,7 +1986,7 @@ impl VisibilityResolutionContext<'_> {
         // but if it does, the heads set could be extended to include the commits
         // (and `remote_branches()`) specified in the revset expression. Alternatively,
         // some optimization rules could be removed, but that means `author(_) & x`
-        // would have to test `:visble_heads() & x`.
+        // would have to test `:visible_heads() & x`.
         ResolvedExpression::Ancestors {
             heads: self.resolve_visible_heads().into(),
             generation: GENERATION_RANGE_FULL,

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1664,7 +1664,7 @@ pub fn resolve_multiple_nonempty_revsets(
     Ok(acc)
 }
 
-pub fn resolve_mutliple_nonempty_revsets_flag_guarded(
+pub fn resolve_multiple_nonempty_revsets_flag_guarded(
     workspace_command: &WorkspaceCommandHelper,
     revisions: &[RevisionArg],
     allow_plural_revsets: bool,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -52,7 +52,7 @@ use maplit::{hashmap, hashset};
 
 use crate::cli_util::{
     check_stale_working_copy, get_config_file_path, print_checkout_stats,
-    resolve_multiple_nonempty_revsets, resolve_mutliple_nonempty_revsets_flag_guarded,
+    resolve_multiple_nonempty_revsets, resolve_multiple_nonempty_revsets_flag_guarded,
     run_ui_editor, serialize_config_value, short_commit_hash, user_error, user_error_with_hint,
     write_config_value_to_file, Args, CommandError, CommandHelper, DescriptionArg,
     LogContentFormat, RevisionArg, WorkspaceCommandHelper,
@@ -2051,7 +2051,7 @@ fn resolve_destination_revs(
     revisions: &[RevisionArg],
     allow_plural_revsets: bool,
 ) -> Result<IndexSet<Commit>, CommandError> {
-    let commits = resolve_mutliple_nonempty_revsets_flag_guarded(
+    let commits = resolve_multiple_nonempty_revsets_flag_guarded(
         workspace_command,
         revisions,
         allow_plural_revsets,
@@ -2889,7 +2889,7 @@ fn cmd_rebase(ui: &mut Ui, command: &CommandHelper, args: &RebaseArgs) -> Result
     if let Some(rev_str) = &args.revision {
         rebase_revision(ui, command, &mut workspace_command, &new_parents, rev_str)?;
     } else if !args.source.is_empty() {
-        let source_commits = resolve_mutliple_nonempty_revsets_flag_guarded(
+        let source_commits = resolve_multiple_nonempty_revsets_flag_guarded(
             &workspace_command,
             &args.source,
             args.allow_large_revsets,
@@ -2905,7 +2905,7 @@ fn cmd_rebase(ui: &mut Ui, command: &CommandHelper, args: &RebaseArgs) -> Result
         let branch_commits = if args.branch.is_empty() {
             IndexSet::from([workspace_command.resolve_single_rev("@")?])
         } else {
-            resolve_mutliple_nonempty_revsets_flag_guarded(
+            resolve_multiple_nonempty_revsets_flag_guarded(
                 &workspace_command,
                 &args.branch,
                 args.allow_large_revsets,


### PR DESCRIPTION
I was testing out a codespell alternative for a separate project and thought I'd run it on the jj repo...

> error: `mutliple` should be `multiple`
> error: `visble` should be `visible`

Found via typos:
- https://github.com/crate-ci/typos

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
