### PR TITLE
tree: avoid creating a `RepoPath` instance for an assertion

### DIFF
--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -133,7 +133,7 @@ impl Tree {
     }
 
     pub fn path_value(&self, path: &RepoPath) -> Option<TreeValue> {
-        assert_eq!(self.dir(), &RepoPath::root());
+        assert!(self.dir().is_root());
         match path.split() {
             Some((dir, basename)) => self
                 .sub_tree_recursive(dir.components())


### PR DESCRIPTION
I just happened to notice this, not seen in profiling.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
