### PR TITLE
index: move `Index::as_any()` to `MutableIndex`, clean up references passed to revset engine

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -721,8 +721,7 @@ impl Index for MutableIndexImpl {
         expression: &ResolvedExpression,
         store: &Arc<Store>,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
-        let revset_impl = default_revset_engine::evaluate(expression, store, CompositeIndex(self))?;
-        Ok(Box::new(revset_impl))
+        CompositeIndex(self).evaluate_revset(expression, store)
     }
 }
 
@@ -1039,6 +1038,15 @@ impl<'a> CompositeIndex<'a> {
         }
         candidate_positions
     }
+
+    fn evaluate_revset(
+        &self,
+        expression: &ResolvedExpression,
+        store: &Arc<Store>,
+    ) -> Result<Box<dyn Revset<'a> + 'a>, RevsetEvaluationError> {
+        let revset_impl = default_revset_engine::evaluate(expression, store, *self)?;
+        Ok(Box::new(revset_impl))
+    }
 }
 
 impl Index for CompositeIndex<'_> {
@@ -1116,8 +1124,7 @@ impl Index for CompositeIndex<'_> {
         expression: &ResolvedExpression,
         store: &Arc<Store>,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
-        let revset_impl = default_revset_engine::evaluate(expression, store, *self)?;
-        Ok(Box::new(revset_impl))
+        CompositeIndex::evaluate_revset(self, expression, store)
     }
 }
 
@@ -2016,8 +2023,7 @@ impl Index for ReadonlyIndexImpl {
         expression: &ResolvedExpression,
         store: &Arc<Store>,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
-        let revset_impl = default_revset_engine::evaluate(expression, store, CompositeIndex(self))?;
-        Ok(Box::new(revset_impl))
+        CompositeIndex(self).evaluate_revset(expression, store)
     }
 }
 

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -688,10 +688,6 @@ impl MutableIndexImpl {
 }
 
 impl Index for MutableIndexImpl {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize {
         CompositeIndex(self).shortest_unique_commit_id_prefix_len(commit_id)
     }
@@ -732,6 +728,10 @@ impl Index for MutableIndexImpl {
 }
 
 impl MutableIndex for MutableIndexImpl {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         Box::new(*self)
     }
@@ -1976,10 +1976,6 @@ impl ReadonlyIndexImpl {
 }
 
 impl Index for ReadonlyIndexImpl {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize {
         CompositeIndex(self).shortest_unique_commit_id_prefix_len(commit_id)
     }

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -721,8 +721,7 @@ impl Index for MutableIndexImpl {
         expression: &ResolvedExpression,
         store: &Arc<Store>,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
-        let revset_impl =
-            default_revset_engine::evaluate(expression, store, self, CompositeIndex(self))?;
+        let revset_impl = default_revset_engine::evaluate(expression, store, CompositeIndex(self))?;
         Ok(Box::new(revset_impl))
     }
 }
@@ -1117,7 +1116,7 @@ impl Index for CompositeIndex<'_> {
         expression: &ResolvedExpression,
         store: &Arc<Store>,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
-        let revset_impl = default_revset_engine::evaluate(expression, store, self, *self)?;
+        let revset_impl = default_revset_engine::evaluate(expression, store, *self)?;
         Ok(Box::new(revset_impl))
     }
 }
@@ -2017,8 +2016,7 @@ impl Index for ReadonlyIndexImpl {
         expression: &ResolvedExpression,
         store: &Arc<Store>,
     ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
-        let revset_impl =
-            default_revset_engine::evaluate(expression, store, self, CompositeIndex(self))?;
+        let revset_impl = default_revset_engine::evaluate(expression, store, CompositeIndex(self))?;
         Ok(Box::new(revset_impl))
     }
 }

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -826,7 +826,7 @@ trait IndexSegment: Send + Sync {
     fn segment_entry_by_pos(&self, pos: IndexPosition, local_pos: u32) -> IndexEntry;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct CompositeIndex<'a>(&'a dyn IndexSegment);
 
 impl<'a> CompositeIndex<'a> {
@@ -1052,7 +1052,7 @@ impl<'a> CompositeIndex<'a> {
     }
 
     pub fn walk_revs(&self, wanted: &[CommitId], unwanted: &[CommitId]) -> RevWalk<'a> {
-        let mut rev_walk = RevWalk::new(self.clone());
+        let mut rev_walk = RevWalk::new(*self);
         for pos in wanted.iter().map(|id| self.commit_id_to_pos(id).unwrap()) {
             rev_walk.add_wanted(pos);
         }
@@ -1426,7 +1426,7 @@ impl<'a> RevWalk<'a> {
         root_positions: &[IndexPosition],
         generation_range: Range<u32>,
     ) -> RevWalkDescendantsGenerationRange<'a> {
-        let index = self.0.queue.index.clone();
+        let index = self.0.queue.index;
         let entries = self.take_until_roots(root_positions);
         let descendants_index = RevWalkDescendantsIndex::build(index, entries);
         let mut queue = RevWalkQueue::new(descendants_index);

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -409,7 +409,7 @@ pub enum IndexLoadError {
 // TODO: replace the table by a trie so we don't have to repeat the full commit
 //       ids
 // TODO: add a fanout table like git's commit graph has?
-pub struct ReadonlyIndexImpl {
+pub(crate) struct ReadonlyIndexImpl {
     parent_file: Option<Arc<ReadonlyIndexImpl>>,
     num_parent_commits: u32,
     name: String,
@@ -484,7 +484,7 @@ impl MutableIndexImpl {
         }
     }
 
-    pub fn incremental(parent_file: Arc<ReadonlyIndexImpl>) -> Self {
+    pub(crate) fn incremental(parent_file: Arc<ReadonlyIndexImpl>) -> Self {
         let num_parent_commits = parent_file.num_parent_commits + parent_file.num_local_commits;
         let commit_id_length = parent_file.commit_id_length;
         let change_id_length = parent_file.change_id_length;

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -113,7 +113,7 @@ impl<'index> Revset<'index> for RevsetImpl<'index> {
         }
         let pos_by_change = IdIndex::from_vec(pos_by_change);
         Box::new(ChangeIdIndexImpl {
-            index: self.index.clone(),
+            index: self.index,
             pos_by_change,
         })
     }
@@ -492,7 +492,7 @@ pub fn evaluate<'index>(
     let context = EvaluationContext {
         store: store.clone(),
         index,
-        composite_index: composite_index.clone(),
+        composite_index,
     };
     let internal_revset = context.evaluate(expression)?;
     Ok(RevsetImpl::new(internal_revset, composite_index))

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -46,8 +46,6 @@ pub trait IndexStore: Send + Sync + Debug {
 }
 
 pub trait Index: Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-
     fn shortest_unique_commit_id_prefix_len(&self, commit_id: &CommitId) -> usize;
 
     fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<CommitId>;
@@ -79,6 +77,8 @@ pub trait ReadonlyIndex: Send + Sync {
 }
 
 pub trait MutableIndex: Any {
+    fn as_any(&self) -> &dyn Any;
+
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 
     fn as_index(&self) -> &dyn Index;

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -662,6 +662,10 @@ impl MutableRepo {
         self.view.get_mut()
     }
 
+    pub fn mutable_index(&self) -> &dyn MutableIndex {
+        self.index.as_ref()
+    }
+
     pub fn has_changes(&self) -> bool {
         !(self.abandoned_commits.is_empty()
             && self.rewritten_commits.is_empty()

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -16,7 +16,6 @@ use itertools::Itertools;
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::default_index_store::ReadonlyIndexWrapper;
 use jujutsu_lib::default_revset_engine::{evaluate, RevsetImpl};
-use jujutsu_lib::index::ReadonlyIndex as _;
 use jujutsu_lib::repo::{ReadonlyRepo, Repo as _};
 use jujutsu_lib::revset::{ResolvedExpression, RevsetGraphEdge};
 use test_case::test_case;
@@ -30,16 +29,11 @@ fn revset_for_commits<'index>(
         .readonly_index()
         .as_any()
         .downcast_ref::<ReadonlyIndexWrapper>()
-        .unwrap();
+        .unwrap()
+        .as_composite();
     let expression =
         ResolvedExpression::Commits(commits.iter().map(|commit| commit.id().clone()).collect());
-    evaluate(
-        &expression,
-        repo.store(),
-        index.as_index(),
-        index.as_composite(),
-    )
-    .unwrap()
+    evaluate(&expression, repo.store(), index).unwrap()
 }
 
 fn direct(commit: &Commit) -> RevsetGraphEdge {

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -457,7 +457,7 @@ fn as_readonly_composite(repo: &Arc<ReadonlyRepo>) -> CompositeIndex<'_> {
 }
 
 fn as_mutable_impl(repo: &MutableRepo) -> &MutableIndexImpl {
-    repo.index()
+    repo.mutable_index()
         .as_any()
         .downcast_ref::<MutableIndexImpl>()
         .unwrap()

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use jujutsu_lib::backend::CommitId;
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::commit_builder::CommitBuilder;
-use jujutsu_lib::default_index_store::{CompositeIndex, MutableIndexImpl, ReadonlyIndexImpl};
+use jujutsu_lib::default_index_store::{CompositeIndex, MutableIndexImpl, ReadonlyIndexWrapper};
 use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
 use jujutsu_lib::settings::UserSettings;
 use test_case::test_case;
@@ -445,16 +445,15 @@ fn create_n_commits(
     tx.commit()
 }
 
-fn as_readonly_impl(repo: &Arc<ReadonlyRepo>) -> &ReadonlyIndexImpl {
+fn as_readonly_wrapper(repo: &Arc<ReadonlyRepo>) -> &ReadonlyIndexWrapper {
     repo.readonly_index()
-        .as_index()
         .as_any()
-        .downcast_ref::<ReadonlyIndexImpl>()
+        .downcast_ref::<ReadonlyIndexWrapper>()
         .unwrap()
 }
 
 fn as_readonly_composite(repo: &Arc<ReadonlyRepo>) -> CompositeIndex<'_> {
-    as_readonly_impl(repo).as_composite()
+    as_readonly_wrapper(repo).as_composite()
 }
 
 fn as_mutable_impl(repo: &MutableRepo) -> &MutableIndexImpl {

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -18,6 +18,7 @@ use jujutsu_lib::backend::CommitId;
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::default_index_store::{CompositeIndex, MutableIndexImpl, ReadonlyIndexWrapper};
+use jujutsu_lib::index::Index as _;
 use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
 use jujutsu_lib::settings::UserSettings;
 use test_case::test_case;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3183,7 +3183,7 @@ fn cmd_debug(
             let index_impl: Option<&ReadonlyIndexWrapper> =
                 repo.readonly_index().as_any().downcast_ref();
             if let Some(index_impl) = index_impl {
-                let stats = index_impl.stats();
+                let stats = index_impl.as_composite().stats();
                 writeln!(ui, "Number of commits: {}", stats.num_commits)?;
                 writeln!(ui, "Number of merges: {}", stats.num_merges)?;
                 writeln!(ui, "Max generation number: {}", stats.max_generation_number)?;
@@ -3218,7 +3218,7 @@ fn cmd_debug(
                 writeln!(
                     ui,
                     "Finished indexing {:?} commits.",
-                    index_impl.stats().num_commits
+                    index_impl.as_composite().stats().num_commits
                 )?;
             } else {
                 return Err(user_error(format!(


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
