### PR TITLE
working_copy: get conflict id from the current tree

### DIFF
--- a/lib/src/protos/working_copy.proto
+++ b/lib/src/protos/working_copy.proto
@@ -29,7 +29,7 @@ message FileState {
   uint64 size = 2;
   FileType file_type = 3;
   // Set only if file_type is Conflict
-  bytes conflict_id = 4;
+  bytes conflict_id = 4 [deprecated = true];
 }
 
 message SparsePatterns {

--- a/lib/src/protos/working_copy.rs
+++ b/lib/src/protos/working_copy.rs
@@ -8,6 +8,7 @@ pub struct FileState {
     #[prost(enumeration = "FileType", tag = "3")]
     pub file_type: i32,
     /// Set only if file_type is Conflict
+    #[deprecated]
     #[prost(bytes = "vec", tag = "4")]
     pub conflict_id: ::prost::alloc::vec::Vec<u8>,
 }


### PR DESCRIPTION
This prepares for allowing the base tree to be a conflict at the root-tree level (#1624).

We could remove the `Conflict` variant completely. I tried doing that and it slowed down `jj diff` by ~3% in the Linux repo with a clean working copy with only mtime bumped on all files.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
