### PR TITLE
revset: use different errors for ambiguous commit/change IDs

### DIFF
--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -70,6 +70,17 @@ fn test_resolve_symbol_root(use_git: bool) {
 }
 
 #[test]
+fn test_resolve_symbol_empty_string() {
+    let test_repo = TestRepo::init(true);
+    let repo = &test_repo.repo;
+
+    assert_matches!(
+        resolve_symbol(repo.as_ref(), "", None),
+        Err(RevsetResolutionError::EmptyString)
+    );
+}
+
+#[test]
 fn test_resolve_symbol_commit_id() {
     let settings = testutils::user_settings();
     // Test only with git so we can get predictable commit ids
@@ -152,12 +163,6 @@ fn test_resolve_symbol_commit_id() {
         vec![commits[2].id().clone()]
     );
 
-    // Test empty commit id
-    assert_matches!(
-        resolve_symbol(repo.as_ref(), "", None),
-        Err(RevsetResolutionError::AmbiguousIdPrefix(s)) if s.is_empty()
-    );
-
     // Test commit id prefix
     assert_eq!(
         resolve_symbol(repo.as_ref(), "046", None).unwrap(),
@@ -165,11 +170,7 @@ fn test_resolve_symbol_commit_id() {
     );
     assert_matches!(
         resolve_symbol(repo.as_ref(), "04", None),
-        Err(RevsetResolutionError::AmbiguousIdPrefix(s)) if s == "04"
-    );
-    assert_matches!(
-        resolve_symbol(repo.as_ref(), "", None),
-        Err(RevsetResolutionError::AmbiguousIdPrefix(s)) if s.is_empty()
+        Err(RevsetResolutionError::AmbiguousCommitIdPrefix(s)) if s == "04"
     );
     assert_matches!(
         resolve_symbol(repo.as_ref(), "040", None),
@@ -187,7 +188,7 @@ fn test_resolve_symbol_commit_id() {
     let symbol_resolver = DefaultSymbolResolver::new(repo.as_ref(), None);
     assert_matches!(
         optimize(parse("present(04)", &RevsetAliasesMap::new(), None).unwrap()).resolve_user_expression(repo.as_ref(), &symbol_resolver),
-        Err(RevsetResolutionError::AmbiguousIdPrefix(s)) if s == "04"
+        Err(RevsetResolutionError::AmbiguousCommitIdPrefix(s)) if s == "04"
     );
     assert_eq!(
         resolve_commit_ids(repo.as_ref(), "present(046)"),
@@ -308,11 +309,7 @@ fn test_resolve_symbol_change_id(readonly: bool) {
     );
     assert_matches!(
         resolve_symbol(repo, "zvly", None),
-        Err(RevsetResolutionError::AmbiguousIdPrefix(s)) if s == "zvly"
-    );
-    assert_matches!(
-        resolve_symbol(repo, "", None),
-        Err(RevsetResolutionError::AmbiguousIdPrefix(s)) if s.is_empty()
+        Err(RevsetResolutionError::AmbiguousChangeIdPrefix(s)) if s == "zvly"
     );
     assert_matches!(
         resolve_symbol(repo, "zvlyw", None),

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -561,7 +561,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(&repo_path, &["log", "-r", "4", "-T", prefix_format]),
         @r###"
-    Error: Commit or change id prefix "4" is ambiguous
+    Error: Commit ID prefix "4" is ambiguous
     "###
     );
     insta::assert_snapshot!(


### PR DESCRIPTION
I made a typo and got something like this:

```
Error: Commit or change id prefix "wl" is ambiguous
```

Since we can tell commit ids from change ids these days, let's make the error message say which kind of id it is. Changing that also kind of forced me to make a special error for empty strings. Otherwise we would have to arbitrarily say that an empty string is a commit id or change id. A specific error message for empty strings seems helpful, so that's probably for the better anyway.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
