### PR TITLE
merge: make `trivial_merge()` return a reference

### DIFF
--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -227,7 +227,7 @@ pub fn merge(removes: &[&[u8]], adds: &[&[u8]]) -> MergeResult {
             }
             DiffHunk::Different(parts) => {
                 if let Some(resolved) = trivial_merge(&parts[..num_diffs], &parts[num_diffs..]) {
-                    resolved_hunk.extend(resolved);
+                    resolved_hunk.extend(*resolved);
                 } else {
                     if !resolved_hunk.is_empty() {
                         merge_hunks.push(MergeHunk::Resolved(resolved_hunk));

--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -545,7 +545,7 @@ pub fn merge_trees(
     assert_eq!(side2_tree.dir(), dir);
 
     if let Some(resolved) = trivial_merge(&[&base_tree.id], &[&side1_tree.id, &side2_tree.id]) {
-        return Ok(resolved.clone());
+        return Ok((*resolved).clone());
     }
 
     // Start with a tree identical to side 1 and modify based on changes from base
@@ -738,7 +738,7 @@ fn try_resolve_file_conflict(
         &added_contents.iter().map(Vec::as_slice).collect_vec(),
     );
     match merge_result {
-        MergeResult::Resolved(merged_content) => Ok(Some((merged_content, executable))),
+        MergeResult::Resolved(merged_content) => Ok(Some((merged_content, *executable))),
         MergeResult::Conflict(_) => Ok(None),
     }
 }


### PR DESCRIPTION
I don't know why I made it return an owned value. It seems like an unnecessary restriction that the value implements `Clone`, so let's return a reference instead.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
