### PR TITLE
SECURITY.md: show the email plainly

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 To report a security issue, please
-email [Jujutsu VCS Security](jj-security@googlegroups.com)
+email Jujutsu VCS Security at <jj-security@googlegroups.com>
 with a description of the issue, the steps you took to create the issue,
 affected versions, and, if known, mitigations for the issue. Our vulnerability
 management team will respond within 3 working days of your email. If the issue


### PR DESCRIPTION
Previously, the link wasn't working from Github's rendered markdown.

Another alternative is to add `malto:` to the link, which would make it work. However, I thought that since the email is the most important piece of information in the entire file, we should just write it out.
