### PR TITLE
add `--edit` option to `jj sparse set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on arbitrary revisions. Bits other than the executable bit are not planned to
   be supported.
 
+* `jj sparse set` now accepts an `--edit` flag which brings up the `$EDITOR` to
+  edit sparse patterns.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
