### PR TITLE
feat(diff): add `ui.diff-instructions` option to suppress `JJ-INSTRUCTIONS` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured by `template-aliases.<name> = <expression>`. Be aware that
   the template syntax isn't documented yet and is likely to change.
 
+* The `ui.diff-instructions` config setting can be set to `false` to inhibit the
+  creation of the `JJ-INSTRUCTIONS` file as part of diff editing.
+
 ### Fixed bugs
 
 * When sharing the working copy with a Git repo, we used to forget to export

--- a/docs/config.md
+++ b/docs/config.md
@@ -327,6 +327,13 @@ merge-tools.kdiff3.edit-args = [
     "--merge", "--cs", "CreateBakFiles=0", "$left", "$right"]
 ```
 
+### `JJ-INSTRUCTIONS`
+
+When editing a diff, jj will include a synthetic file called `JJ-INSTRUCTIONS`
+in the diff with instructions on how to edit the diff. Any changes you make to
+this file will be ignored. To suppress the creation of this file, set
+`ui.diff-instructions = false`.
+
 ### Using Vim as a diff editor
 
 Using `ui.diff-editor = "vimdiff"` is possible but not recommended. For a better

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -162,6 +162,10 @@ impl UserSettings {
             .unwrap_or(false)
     }
 
+    pub fn diff_instructions(&self) -> bool {
+        self.config.get_bool("ui.diff-instructions").unwrap_or(true)
+    }
+
     pub fn config(&self) -> &config::Config {
         &self.config
     }

--- a/src/merge_tools.rs
+++ b/src/merge_tools.rs
@@ -345,7 +345,8 @@ pub fn edit_diff(
     let instructions_path = right_wc_dir.join("JJ-INSTRUCTIONS");
     // In the unlikely event that the file already exists, then the user will simply
     // not get any instructions.
-    let add_instructions = !instructions.is_empty() && !instructions_path.exists();
+    let add_instructions =
+        settings.diff_instructions() && !instructions.is_empty() && !instructions_path.exists();
     if add_instructions {
         // TODO: This can be replaced with std::fs::write. Is this used in other places
         // as well?


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

Behold, instructionless diff editing:

![Screenshot 2023-06-06 at 19 35 33](https://github.com/martinvonz/jj/assets/454057/8d6d063b-e80a-4dc2-90c0-15ec22ce9497)

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
