### PR TITLE
Fix `jj init --git-repo` fails and leaves broken .jj folder

### DIFF
--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -54,7 +54,7 @@ fn run_custom_command(
             let wc_path = command_helper.cwd();
             // Initialize a workspace with the custom backend
             Workspace::init_with_backend(command_helper.settings(), wc_path, |store_path| {
-                Box::new(JitBackend::init(store_path))
+                Ok(Box::new(JitBackend::init(store_path)))
             })?;
             Ok(())
         }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -850,7 +850,12 @@ impl GitRepoData {
         let repo = ReadonlyRepo::init(
             &settings,
             &jj_repo_dir,
-            |store_path| Box::new(GitBackend::init_external(store_path, &git_repo_dir)),
+            |store_path| {
+                Ok(Box::new(GitBackend::init_external(
+                    store_path,
+                    &git_repo_dir,
+                )?))
+            },
             ReadonlyRepo::default_op_store_factory(),
             ReadonlyRepo::default_op_heads_store_factory(),
             ReadonlyRepo::default_index_store_factory(),
@@ -1417,7 +1422,12 @@ fn test_init() {
     let repo = ReadonlyRepo::init(
         &settings,
         &jj_repo_dir,
-        |store_path| Box::new(GitBackend::init_external(store_path, &git_repo_dir)),
+        |store_path| {
+            Ok(Box::new(GitBackend::init_external(
+                store_path,
+                &git_repo_dir,
+            )?))
+        },
         ReadonlyRepo::default_op_store_factory(),
         ReadonlyRepo::default_op_heads_store_factory(),
         ReadonlyRepo::default_index_store_factory(),
@@ -1677,7 +1687,12 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
     let jj_repo = ReadonlyRepo::init(
         settings,
         &jj_repo_dir,
-        |store_path| Box::new(GitBackend::init_external(store_path, &clone_repo_dir)),
+        |store_path| {
+            Ok(Box::new(GitBackend::init_external(
+                store_path,
+                &clone_repo_dir,
+            )?))
+        },
         ReadonlyRepo::default_op_store_factory(),
         ReadonlyRepo::default_op_heads_store_factory(),
         ReadonlyRepo::default_index_store_factory(),

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Once};
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{FileId, TreeId, TreeValue};
+use jujutsu_lib::backend::{Backend, BackendError, FileId, TreeId, TreeValue};
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::git_backend::GitBackend;
@@ -95,7 +95,9 @@ impl TestRepo {
             ReadonlyRepo::init(
                 &settings,
                 &repo_dir,
-                |store_path| Box::new(GitBackend::init_external(store_path, &git_path)),
+                |store_path| -> Result<Box<dyn Backend>, BackendError> {
+                    Ok(Box::new(GitBackend::init_external(store_path, &git_path)?))
+                },
                 ReadonlyRepo::default_op_store_factory(),
                 ReadonlyRepo::default_op_heads_store_factory(),
                 ReadonlyRepo::default_index_store_factory(),
@@ -106,7 +108,9 @@ impl TestRepo {
             ReadonlyRepo::init(
                 &settings,
                 &repo_dir,
-                |store_path| Box::new(LocalBackend::init(store_path)),
+                |store_path| -> Result<Box<dyn Backend>, BackendError> {
+                    Ok(Box::new(LocalBackend::init(store_path)))
+                },
                 ReadonlyRepo::default_op_store_factory(),
                 ReadonlyRepo::default_op_heads_store_factory(),
                 ReadonlyRepo::default_index_store_factory(),

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -176,6 +176,9 @@ impl From<WorkspaceInitError> for CommandError {
             WorkspaceInitError::Path(err) => {
                 CommandError::InternalError(format!("Failed to access the repository: {err}"))
             }
+            WorkspaceInitError::Backend(err) => {
+                user_error(format!("Failed to access the repository: {err}"))
+            }
         }
     }
 }


### PR DESCRIPTION
Before this commit, running `jj init --git-repo=./` in a folder that does not have a .git would cause jj to panick and leave an unfinished corrupted jj repo.

This commit fixes https://github.com/martinvonz/jj/issues/1305

This commit fixes that by changing the call chain to return an error instead of calling .unwrap() and panicking. This commit also adds logic to delete the unfinished jj repository when the git backend initialization failed.

Before this commit, running the above command would result in the following
```
Running `jj/target/debug/jj init --git-repo=./`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { code: -3, klass: 2, message: "failed to resolve path '/Users/kevincliao/github/jj/test-repo/.jj/repo/store/../../../.git': No such file or directory" }', lib/src/git_backend.rs:83:75
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After this commit, the result is the following and the jj repo is deleted:
```
Running `jj/target/debug/jj init --git-repo=./`
Error: Failed to access the repository: Error: Failed to open git repository: failed to resolve path '/Users/kevincliao/github/jj/test-repo/.jj/repo/store/../../../.git': No such file or directory; class=Os (2); code=NotFound (-3)
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
