### PR TITLE
Allow listing and resolving `@git` branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj debug completion`, `jj debug mangen` and `jj debug config-schema` have
   been moved from `jj debug` to `jj util`.
 
+* `jj` will no longer parse `br` as a git_ref `refs/heads/br` when a branch `br`
+  does not exist but the git_ref does (this is rare). Use `br@git` instead.
+
 ### New features
 
 * `jj git push --deleted` will remove all locally deleted branches from the remote.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now shorter within the default log revset. You can override the default by
   setting the `revsets.short-prefixes` config to a different revset.
 
+* The last seen state of branches in the underlying git repo is now presented by
+  `jj branch list` as a remote called `git` (e.g. `main@git`). Such branches
+  exist in colocated repos or if you use `jj git export`.
+
 ### Fixed bugs
 
 * Modify/delete conflicts now include context lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setting the `revsets.short-prefixes` config to a different revset.
 
 * The last seen state of branches in the underlying git repo is now presented by
-  `jj branch list` as a remote called `git` (e.g. `main@git`). Such branches
-  exist in colocated repos or if you use `jj git export`.
+  `jj branch list` as a remote called `git` (e.g. `main@git`). They can also be
+  referenced in revsets. Such branches exist in colocated repos or if you use
+  `jj git export`.
 
 ### Fixed bugs
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -70,6 +70,10 @@ pub fn git_tracking_branches(view: &View) -> impl Iterator<Item = (&str, &RefTar
     })
 }
 
+pub fn get_git_tracking_branch<'a>(view: &'a View, branch: &str) -> Option<&'a RefTarget> {
+    view.git_refs().get(&local_branch_name_to_ref_name(branch))
+}
+
 fn prevent_gc(git_repo: &git2::Repository, id: &CommitId) -> Result<(), git2::Error> {
     // If multiple processes do git::import_refs() in parallel, this can fail to
     // acquire a lock file even with force=true.

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -27,7 +27,7 @@ use crate::op_store::RefTarget;
 use crate::repo::{MutableRepo, Repo};
 use crate::revset;
 use crate::settings::GitSettings;
-use crate::view::RefName;
+use crate::view::{RefName, View};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum GitImportError {
@@ -58,6 +58,16 @@ fn ref_name_to_local_branch_name(ref_name: &str) -> Option<&str> {
 
 fn local_branch_name_to_ref_name(branch: &str) -> String {
     format!("refs/heads/{branch}")
+}
+
+// TODO: Eventually, git-tracking branches should no longer be stored in
+// git_refs but with the other remote-tracking branches in BranchTarget. Note
+// that there are important but subtle differences in behavior for, e.g. `jj
+// branch forget`.
+pub fn git_tracking_branches(view: &View) -> impl Iterator<Item = (&str, &RefTarget)> {
+    view.git_refs().iter().filter_map(|(ref_name, target)| {
+        ref_name_to_local_branch_name(ref_name).map(|branch_name| (branch_name, target))
+    })
 }
 
 fn prevent_gc(git_repo: &git2::Repository, id: &CommitId) -> Result<(), git2::Error> {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1617,7 +1617,9 @@ pub fn walk_revs<'index>(
 
 fn resolve_git_ref(repo: &dyn Repo, symbol: &str) -> Option<Vec<CommitId>> {
     let view = repo.view();
-    for git_ref_prefix in &["", "refs/", "refs/heads/", "refs/tags/", "refs/remotes/"] {
+    // TODO: We should remove `refs/remotes` from this list once we have a better
+    // way to address local git repo's remote-tracking branches.
+    for git_ref_prefix in &["", "refs/", "refs/tags/", "refs/remotes/"] {
         if let Some(ref_target) = view.git_refs().get(&(git_ref_prefix.to_string() + symbol)) {
             return Some(ref_target.adds());
         }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -452,7 +452,8 @@ fn test_resolve_symbol_git_refs() {
     // Nonexistent ref
     assert_matches!(
         resolve_symbol(mut_repo, "nonexistent", None),
-        Err(RevsetResolutionError::NoSuchRevision{name, candidates}) if name == "nonexistent" && candidates.is_empty()
+        Err(RevsetResolutionError::NoSuchRevision{name, candidates})
+            if name == "nonexistent" && candidates.is_empty()
     );
 
     // Full ref
@@ -470,27 +471,25 @@ fn test_resolve_symbol_git_refs() {
         "refs/heads/branch".to_string(),
         RefTarget::Normal(commit5.id().clone()),
     );
+    // branch alone is not recognized
+    assert_matches!(
+        resolve_symbol(mut_repo, "branch", None),
+        Err(RevsetResolutionError::NoSuchRevision{name, candidates})
+            if name == "branch" && candidates.is_empty()
+    );
     mut_repo.set_git_ref(
         "refs/tags/branch".to_string(),
         RefTarget::Normal(commit4.id().clone()),
     );
+    // The *tag* branch is recognized
+    assert_eq!(
+        resolve_symbol(mut_repo, "branch", None).unwrap(),
+        vec![commit4.id().clone()]
+    );
+    // heads/branch does get resolved to the git ref refs/heads/branch
     assert_eq!(
         resolve_symbol(mut_repo, "heads/branch", None).unwrap(),
         vec![commit5.id().clone()]
-    );
-
-    // Unqualified branch name
-    mut_repo.set_git_ref(
-        "refs/heads/branch".to_string(),
-        RefTarget::Normal(commit3.id().clone()),
-    );
-    mut_repo.set_git_ref(
-        "refs/tags/branch".to_string(),
-        RefTarget::Normal(commit4.id().clone()),
-    );
-    assert_eq!(
-        resolve_symbol(mut_repo, "branch", None).unwrap(),
-        vec![commit3.id().clone()]
     );
 
     // Unqualified tag name

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -113,6 +113,8 @@ fn test_branch_forget_glob() {
     "###);
 }
 
+// TODO: Test `jj branch list` with a remote named `git`
+
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
     let template = r#"branches ++ " " ++ commit_id.short()"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -140,11 +140,11 @@ fn test_branch_forget_export() {
     foo (deleted)
       @git: 65b6b74e0897 (no description set)
     "###);
-
-    // Aside: the way we currently resolve git refs means that `foo`
-    // resolves to `foo@git` when actual `foo` doesn't exist.
-    // Short-term TODO: This behavior will be changed in a subsequent commit.
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r=foo", "--no-graph"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r=foo", "--no-graph"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Revision "foo" doesn't exist
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r=foo@git", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
     rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 65b6b74e0897
     (empty) (no description set)

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -217,6 +217,35 @@ fn test_git_colocated_branches() {
 }
 
 #[test]
+fn test_git_colocated_branch_forget() {
+    let test_env = TestEnvironment::default();
+    let workspace_root = test_env.env_root().join("repo");
+    let _git_repo = git2::Repository::init(&workspace_root).unwrap();
+    test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
+    test_env.jj_cmd_success(&workspace_root, &["new"]);
+    test_env.jj_cmd_success(&workspace_root, &["branch", "set", "foo"]);
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    @  65b6b74e08973b88d38404430f119c8c79465250 foo
+    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 master HEAD@git
+    ◉  0000000000000000000000000000000000000000
+    "###);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    insta::assert_snapshot!(stdout, @r###"
+    foo: 65b6b74e0897 (no description set)
+    master: 230dd059e1b0 (no description set)
+    "###);
+
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "forget", "foo"]);
+    insta::assert_snapshot!(stdout, @"");
+    // A forgotten branch is deleted in the git repo. For a detailed demo explaining
+    // this, see `test_branch_forget_export` in `test_branch_command.rs`.
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    insta::assert_snapshot!(stdout, @r###"
+    master: 230dd059e1b0 (no description set)
+    "###);
+}
+
+#[test]
 fn test_git_colocated_conflicting_git_refs() {
     let test_env = TestEnvironment::default();
     let workspace_root = test_env.env_root().join("repo");

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -272,6 +272,7 @@ fn test_git_fetch_conflicting_branches_colocated() {
     rem1 (conflicted):
       + f652c32197cf (no description set)
       + 6a21102783e8 message
+      @git (behind by 1 commits): f652c32197cf (no description set)
       @rem1 (behind by 1 commits): 6a21102783e8 message
     "###);
 }

--- a/tests/test_git_import_export.rs
+++ b/tests/test_git_import_export.rs
@@ -197,6 +197,7 @@ fn test_git_import_move_export_undo() {
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "a"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: 096dc80da670 (no description set)
+      @git (behind by 1 commits): 230dd059e1b0 (no description set)
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
 


### PR DESCRIPTION
Also demos `jj branch forget` behavior with git-tracking branches.

This addresses a portion of #1666 and also includes a commit describing
some nuanced behavior of `jj branch forget` in a test.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [?] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
