### PR TITLE
Add .gitmodules parser

### DIFF
--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -25,7 +25,7 @@ use jujutsu_lib::backend::{
 use jujutsu_lib::commit::Commit;
 use jujutsu_lib::commit_builder::CommitBuilder;
 use jujutsu_lib::git;
-use jujutsu_lib::git::{GitFetchError, GitPushError, GitRefUpdate};
+use jujutsu_lib::git::{GitFetchError, GitPushError, GitRefUpdate, SubmoduleConfig};
 use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::op_store::{BranchTarget, RefTarget};
 use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
@@ -2168,4 +2168,57 @@ fn create_rooted_commit<'repo>(
         )
         .set_author(signature.clone())
         .set_committer(signature)
+}
+
+#[test]
+fn test_parse_gitmodules() {
+    let result = git::parse_gitmodules(
+        &mut r#"
+[submodule "wellformed"]
+url = https://github.com/martinvonz/jj
+path = mod
+update = checkout # Extraneous config
+
+[submodule "uppercase"]
+URL = https://github.com/martinvonz/jj
+PATH = mod2
+
+[submodule "repeated_keys"]
+url = https://github.com/martinvonz/jj
+path = mod3
+url = https://github.com/chooglen/jj
+path = mod4
+
+# The following entries aren't expected in a well-formed .gitmodules
+[submodule "missing_url"]
+path = mod
+
+[submodule]
+ignoreThisSection = foo
+
+[randomConfig]
+ignoreThisSection = foo
+"#
+        .as_bytes(),
+    )
+    .unwrap();
+    let expected = btreemap! {
+        "wellformed".to_string() => SubmoduleConfig {
+            name: "wellformed".to_string(),
+            url: "https://github.com/martinvonz/jj".to_string(),
+            path: "mod".to_string(),
+        },
+        "uppercase".to_string() => SubmoduleConfig {
+            name: "uppercase".to_string(),
+            url: "https://github.com/martinvonz/jj".to_string(),
+            path: "mod2".to_string(),
+        },
+        "repeated_keys".to_string() => SubmoduleConfig {
+            name: "repeated_keys".to_string(),
+            url: "https://github.com/martinvonz/jj".to_string(),
+            path: "mod3".to_string(),
+        },
+    };
+
+    assert_eq!(result, expected);
 }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -31,7 +31,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use jujutsu_lib::backend::{BackendError, ChangeId, CommitId, ObjectId, TreeId};
 use jujutsu_lib::commit::Commit;
-use jujutsu_lib::git::{GitExportError, GitImportError};
+use jujutsu_lib::git::{GitConfigParseError, GitExportError, GitImportError};
 use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::gitignore::GitIgnoreFile;
 use jujutsu_lib::hex_util::to_reverse_hex;
@@ -319,6 +319,12 @@ impl From<glob::PatternError> for CommandError {
 impl From<clap::Error> for CommandError {
     fn from(err: clap::Error) -> Self {
         CommandError::ClapCliError(Arc::new(err))
+    }
+}
+
+impl From<GitConfigParseError> for CommandError {
+    fn from(err: GitConfigParseError) -> Self {
+        CommandError::InternalError(format!("Failed to parse Git config: {err} "))
     }
 }
 

--- a/tests/test_git_submodule.rs
+++ b/tests/test_git_submodule.rs
@@ -1,0 +1,65 @@
+// Copyright 2020 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_gitsubmodule_print_gitmodules() {
+    let test_env = TestEnvironment::default();
+    let workspace_root = test_env.env_root().join("repo");
+    git2::Repository::init(&workspace_root).unwrap();
+    test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
+
+    std::fs::write(
+        workspace_root.join(".gitmodules"),
+        "
+[submodule \"old\"]
+	path = old
+	url = https://github.com/old/old.git
+",
+    )
+    .unwrap();
+
+    test_env.jj_cmd_success(&workspace_root, &["new"]);
+
+    std::fs::write(
+        workspace_root.join(".gitmodules"),
+        "
+[submodule \"new\"]
+	path = new
+	url = https://github.com/new/new.git
+",
+    )
+    .unwrap();
+
+    let stdout = test_env.jj_cmd_success(
+        &workspace_root,
+        &["git", "submodule", "print-gitmodules", "-r", "@-"],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+	name:old
+	url:https://github.com/old/old.git
+	path:old
+    "###);
+
+    let stdout =
+        test_env.jj_cmd_success(&workspace_root, &["git", "submodule", "print-gitmodules"]);
+    insta::assert_snapshot!(stdout, @r###"
+	name:new
+	url:https://github.com/new/new.git
+	path:new
+    "###);
+}


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

We'll need to read `.gitmodules` for most basic submodules operations. Add a simple `.gitmodules` parser, and verify it works by using a new debugging command `jj git submodule print-gitmodules` that reads `.gitmodules` from the working copy (revisions and operations not supported yet).