### PR TITLE
`jj op undo/restore` no longer restore git-tracking branches by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#697](https://github.com/martinvonz/jj/issues/697),
   [#1608](https://github.com/martinvonz/jj/issues/1608)
 
+* In colocated repos, a bug causing conflicts when undoing branch moves (#922)
+  has been fixed. Some surprising behaviors related to undoing `jj git push` or
+  `jj git fetch` remain.
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/src/commands/operation.rs
+++ b/src/commands/operation.rs
@@ -166,19 +166,22 @@ fn view_with_desired_portions_restored(
         current_view.git_refs.clone()
     };
 
+    if what.contains(&UndoWhatToRestore::RemoteTracking) == what.contains(&UndoWhatToRestore::Repo)
+    {
+        // new_view already contains the correct branches; we can short-curcuit
+        return new_view;
+    }
+
     let all_branch_names: BTreeSet<_> = itertools::chain(
         view_being_restored.branches.keys(),
         current_view.branches.keys(),
     )
     .collect();
-
     let branch_source_view = if what.contains(&UndoWhatToRestore::RemoteTracking) {
         view_being_restored
     } else {
         current_view
     };
-    // Short-term TODO: we will optimize this to avoid recreating branches if they
-    // are already correct in `new_view`
     let mut new_branches = BTreeMap::default();
     for branch_name in all_branch_names {
         let local_target = new_view

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -275,6 +275,18 @@ impl TestEnvironment {
             })
             .to_string()
     }
+
+    /// Used before mutating operations to create more predictable commit ids
+    /// and change ids in tests
+    ///
+    /// `test_env.advance_test_rng_seed_to_multiple_of(200_000)` can be inserted
+    /// wherever convenient throughout your test. If desired, you can have
+    /// "subheadings" with steps of (e.g.) 10_000, 500, 25.
+    pub fn advance_test_rng_seed_to_multiple_of(&self, step: i64) {
+        assert!(step > 0, "step must be >0, got {step}");
+        let mut command_number = self.command_number.borrow_mut();
+        *command_number = step * (*command_number / step) + step;
+    }
 }
 
 pub fn get_stdout_string(assert: &assert_cmd::assert::Assert) -> String {

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -371,10 +371,8 @@ fn test_git_colocated_squash_undo() {
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    ◉  qpvuntsmwlqt 2f376ea1478c A master !divergence!
-    │ @  rlvkpnrzqnoo 8f71e3b6a3be
-    │ ◉  qpvuntsmwlqt a86754f975f9 A HEAD@git !divergence!
-    ├─╯
+    @  rlvkpnrzqnoo 8f71e3b6a3be
+    ◉  qpvuntsmwlqt a86754f975f9 A master HEAD@git
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 }


### PR DESCRIPTION
This is attempt number ~3-4 to fix #922 and is heavily based on #1541 (two more attempts happened as two versions of #1487). There is a long discussion in that PR, the plan for this PR specifically is discussed towards the end.

The first 2 commits are somewhat unrelated and could be moved to a separate PR. They add tests pertaining to the question of whether we should import/export remote-tracking branches by default in normal repos (see discussion in #1739). It is unfortunate that changes to import/export & git-tracking branches affect push and fetch. However, I thought it might be interesting which of these tests are and are not changed by this PR.

See also #1741 for what tests change if we have this behavior in non-colocated repos as well (making this equivalent to #1541).

This may still be a bit unpolished, and I may have gone a bit overboard with the tests. Oh well.

I also discovered some minor unexpected behaviors and some mysteries about the test behavior still remain, mostly having to do with `fetch/push` behavior. We've been discussing what to do about these in #1739, I think it's a separate issue. I think they are acceptable (mostly changing from one weird behavior to another); I'll look at them again and suggestions are welcome. 

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (maybe in followup PR) I have updated the documentation (README.md, docs/, demos/)
- (not planned) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
