### PR TITLE
git: make noop import_refs() fast

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -130,11 +130,13 @@ pub fn import_some_refs(
         // to `old_git_heads` because HEAD move doesn't automatically mean the old
         // HEAD branch has been rewritten.
         let head_commit_id = CommitId::from_bytes(head_git_commit.id().as_bytes());
-        let head_commit = store.get_commit(&head_commit_id).unwrap();
         new_git_heads.insert("HEAD".to_string(), vec![head_commit_id.clone()]);
-        prevent_gc(git_repo, &head_commit_id)?;
-        mut_repo.add_head(&head_commit);
-        mut_repo.set_git_head(RefTarget::Normal(head_commit_id));
+        if !matches!(mut_repo.git_head(), Some(RefTarget::Normal(id)) if id == head_commit_id) {
+            let head_commit = store.get_commit(&head_commit_id).unwrap();
+            prevent_gc(git_repo, &head_commit_id)?;
+            mut_repo.add_head(&head_commit);
+            mut_repo.set_git_head(RefTarget::Normal(head_commit_id));
+        }
     } else {
         mut_repo.clear_git_head();
     }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -216,6 +216,9 @@ pub fn import_some_refs(
         .filter_map(|(old_git_target, _)| old_git_target.as_ref().map(|target| target.adds()))
         .flatten()
         .collect_vec();
+    if hidable_git_heads.is_empty() {
+        return Ok(());
+    }
     // We must remove non-existing commits from pinned_git_heads, as they could have
     // come from branches which were never fetched.
     let mut pinned_git_heads_set = HashSet::new();

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -111,11 +111,6 @@ pub fn import_some_refs(
     let store = mut_repo.store().clone();
     let mut jj_view_git_refs = mut_repo.view().git_refs().clone();
     let mut pinned_git_heads = HashMap::new();
-    for (ref_name, old_target) in &jj_view_git_refs {
-        if !git_ref_filter(ref_name) {
-            pinned_git_heads.insert(ref_name.to_string(), old_target.adds().clone());
-        }
-    }
 
     // TODO: Should this be a separate function? We may not always want to import
     // the Git HEAD (and add it to our set of heads).
@@ -183,6 +178,8 @@ pub fn import_some_refs(
         if git_ref_filter(&full_name) {
             mut_repo.remove_git_ref(&full_name);
             changed_git_refs.insert(full_name, (Some(target), None));
+        } else {
+            pinned_git_heads.insert(full_name, target.adds());
         }
     }
     for (full_name, (old_git_target, new_git_target)) in &changed_git_refs {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -947,6 +947,10 @@ impl MutableRepo {
         self.view_mut().remove_git_ref(name);
     }
 
+    pub fn git_head(&self) -> Option<RefTarget> {
+        self.view.with_ref(|v| v.git_head().cloned())
+    }
+
     pub fn set_git_head(&mut self, target: RefTarget) {
         self.view_mut().set_git_head(target);
     }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
