### PR TITLE
 Fix bug where a forgotten branch couldn't be fetched (v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * It is now possible to `jj branch forget` deleted branches.
   [#1537](https://github.com/martinvonz/jj/issues/1537)
 
+* `jj git fetch` can now restore branches forgotten by `jj branch forget`.
+  [#1714](https://github.com/martinvonz/jj/pull/1714)
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes


### PR DESCRIPTION
The fix is slightly messy, but I don't know a better way without reworking
the logic of `jj git fetch` and `jj git push` in-depth.

This bug was originally reported by @arxanas in a [Discord discussion].

[Discord discussion]: https://discord.com/channels/968932220549103686/969829516539228222/1114997445949136936

Summary:

> How do I proceed here to check out the remote branch that I know exists?
> 
> ```
> $ jj git fetch --branch 'arxanas/fsmonitor' --remote origin
> Nothing changed.
> $ jj checkout arxanas/fsmonitor                            
> Error: Revision "arxanas/fsmonitor" doesn't exist
> $ jj checkout arxanas/fsmonitor@origin
> Error: Revision "arxanas/fsmonitor@origin" doesn't exist
> $ git show origin/arxanas/fsmonitor                        
> commit https://github.com/ilyagr/jj/commit/bac43af9fbaade36a2374f4b2a7457ca4caa05ee (origin/arxanas/fsmonitor, refs/jj/keep/bac43af9fbaade36a2374f4b2a7457ca4caa05ee)
> Author: Waleed Khan <me@waleedkhan.name>
> Date:   Fri Jun 10 18:58:21 2022 -0700
> 
>     fsmonitor: add `.watchmanconfig` to repo
>     
>     This identifies the directory as Watchman-enabled. Additional config settings can go in this file.
> 
> diff --git a/.watchmanconfig b/.watchmanconfig
> new file mode 100644
> index 00000000..0967ef42
> --- /dev/null
> +++ b/.watchmanconfig
> @@ -0,0 +1 @@
> +{}
> ```

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
