### PR TITLE
`branch` cli: additional tests and allow defusing deleted branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remote, just like in a non-colocated repo.
   [#864](https://github.com/martinvonz/jj/issues/864)
 
+* It is now possible to `jj branch forget` deleted branches.
+  [#1537](https://github.com/martinvonz/jj/issues/1537)
+
 ## [0.7.0] - 2023-02-16
 
 ### Breaking changes

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -334,9 +334,13 @@ fn cmd_branch_list(
         write!(formatter.labeled("branch"), "{name}")?;
         print_branch_target(formatter, branch_target.local_target.as_ref())?;
 
+        let mut found_non_git_remote = false;
         for (remote, remote_target) in branch_target.remote_targets.iter() {
             if Some(remote_target) == branch_target.local_target.as_ref() {
                 continue;
+            }
+            if remote != "git" {
+                found_non_git_remote = true;
             }
             write!(formatter, "  ")?;
             write!(formatter.labeled("branch"), "@{remote}")?;
@@ -360,6 +364,13 @@ fn cmd_branch_list(
                 }
             }
             print_branch_target(formatter, Some(remote_target))?;
+        }
+        if found_non_git_remote && branch_target.local_target.is_none() {
+            writeln!(
+                formatter,
+                "  (this branch will be *deleted permanently* on the remote on the\n   next `jj \
+                 git push`. Use `jj branch forget` to prevent this)"
+            )?;
         }
     }
 

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -314,15 +314,9 @@ fn test_branch_forget_deleted_or_nonexistent_branch() {
 
     // ============ End of test setup ============
 
-    // BUG: Can't forget a deleted branch
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["branch", "forget", "feature1"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such branch: feature1
-    "###);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1 (deleted)
-      @origin: 9f01a0e04879 message
-    "###);
+    // We can forget a deleted branch
+    test_env.jj_cmd_success(&repo_path, &["branch", "forget", "feature1"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
 
     // Can't forget a non-existent branch
     let stderr = test_env.jj_cmd_failure(&repo_path, &["branch", "forget", "i_do_not_exist"]);

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -310,6 +310,8 @@ fn test_branch_forget_deleted_or_nonexistent_branch() {
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1 (deleted)
       @origin: 9f01a0e04879 message
+      (this branch will be *deleted permanently* on the remote on the
+       next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
 
     // ============ End of test setup ============

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -890,3 +890,64 @@ fn test_git_fetch_removed_parent_branch() {
     ◉  000000000000
     "###);
 }
+
+#[test]
+fn test_git_fetch_remote_only_branch() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // Create non-empty git repo to add as a remote
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let git_repo = git2::Repository::init(git_repo_path).unwrap();
+    let signature =
+        git2::Signature::new("Some One", "some.one@example.com", &git2::Time::new(0, 0)).unwrap();
+    let mut tree_builder = git_repo.treebuilder(None).unwrap();
+    let file_oid = git_repo.blob(b"content").unwrap();
+    tree_builder
+        .insert("file", file_oid, git2::FileMode::Blob.into())
+        .unwrap();
+    let tree_oid = tree_builder.write().unwrap();
+    let tree = git_repo.find_tree(tree_oid).unwrap();
+    test_env.jj_cmd_success(
+        &repo_path,
+        &["git", "remote", "add", "origin", "../git-repo"],
+    );
+    // Create a commit and a branch in the git repo
+    git_repo
+        .commit(
+            Some("refs/heads/feature1"),
+            &signature,
+            &signature,
+            "message",
+            &tree,
+            &[],
+        )
+        .unwrap();
+
+    // Fetch normally
+    test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    feature1: 9f01a0e04879 message
+    "###);
+
+    git_repo
+        .commit(
+            Some("refs/heads/feature2"),
+            &signature,
+            &signature,
+            "message",
+            &tree,
+            &[],
+        )
+        .unwrap();
+
+    // Fetch using git.auto_local_branch = false
+    test_env.add_config("git.auto-local-branch = false");
+    test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    feature1: 9f01a0e04879 message
+    feature2 (deleted)
+      @origin: 9f01a0e04879 message
+    "###);
+}

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -949,5 +949,7 @@ fn test_git_fetch_remote_only_branch() {
     feature1: 9f01a0e04879 message
     feature2 (deleted)
       @origin: 9f01a0e04879 message
+      (this branch will be *deleted permanently* on the remote on the
+       next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
 }

--- a/tests/test_git_import_export.rs
+++ b/tests/test_git_import_export.rs
@@ -90,67 +90,6 @@ fn test_git_export_conflicting_git_refs() {
 }
 
 #[test]
-fn test_git_fetch_remote_only_branch() {
-    let test_env = TestEnvironment::default();
-    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
-    let repo_path = test_env.env_root().join("repo");
-
-    // Create non-empty git repo to add as a remote
-    let git_repo_path = test_env.env_root().join("git-repo");
-    let git_repo = git2::Repository::init(git_repo_path).unwrap();
-    let signature =
-        git2::Signature::new("Some One", "some.one@example.com", &git2::Time::new(0, 0)).unwrap();
-    let mut tree_builder = git_repo.treebuilder(None).unwrap();
-    let file_oid = git_repo.blob(b"content").unwrap();
-    tree_builder
-        .insert("file", file_oid, git2::FileMode::Blob.into())
-        .unwrap();
-    let tree_oid = tree_builder.write().unwrap();
-    let tree = git_repo.find_tree(tree_oid).unwrap();
-    test_env.jj_cmd_success(
-        &repo_path,
-        &["git", "remote", "add", "origin", "../git-repo"],
-    );
-    // Create a commit and a branch in the git repo
-    git_repo
-        .commit(
-            Some("refs/heads/feature1"),
-            &signature,
-            &signature,
-            "message",
-            &tree,
-            &[],
-        )
-        .unwrap();
-
-    // Fetch normally
-    test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
-    "###);
-
-    git_repo
-        .commit(
-            Some("refs/heads/feature2"),
-            &signature,
-            &signature,
-            "message",
-            &tree,
-            &[],
-        )
-        .unwrap();
-
-    // Fetch using git.auto_local_branch = false
-    test_env.add_config("git.auto-local-branch = false");
-    test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
-    feature2 (deleted)
-      @origin: 9f01a0e04879 message
-    "###);
-}
-
-#[test]
 fn test_git_export_undo() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -184,6 +184,8 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @r###"
     branch1 (deleted)
       @origin: 45a3aa29e907 description 1
+      (this branch will be *deleted permanently* on the remote on the
+       next `jj git push`. Use `jj branch forget` to prevent this)
     branch2: 15dcdaa4f12f foo
       @origin (ahead by 1 commits, behind by 1 commits): 8476341eb395 description 2
     my-branch: 15dcdaa4f12f foo


### PR DESCRIPTION
This PR shares 3 commits with #1714, I will rebase whichever gets in first on top of the other.
Fixes #1537

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
