### PR TITLE
nix: dont install fake binaries and fix dirty jj version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,12 @@ fn main() -> std::io::Result<()> {
 }
 
 fn get_git_hash() -> Option<String> {
+    if let Some(nix_hash) = std::env::var("NIX_JJ_GIT_HASH")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        return Some(nix_hash);
+    }
     if let Ok(output) = Command::new("jj")
         .args([
             "--ignore-working-copy",

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,8 @@
           version = "unstable-${self.shortRev or "dirty"}";
           buildNoDefaultFeatures = true;
           buildFeatures = [];
+          cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
+          useNextest = true;
           src = filterSrc ./. [
             ".*\\.nix$"
             "^.jj/"
@@ -64,6 +66,7 @@
             ];
           ZSTD_SYS_USE_PKG_CONFIG = "1";
           LIBSSH2_SYS_USE_PKG_CONFIG = "1";
+          NIX_JJ_GIT_HASH = self.rev or "";
           postInstall = ''
             $out/bin/jj util mangen > ./jj.1
             installManPage ./jj.1
@@ -105,6 +108,9 @@
           # Foreign dependencies
           openssl zstd libgit2 libssh2
           pkg-config
+
+          # Make sure rust-analyzer is present
+          rust-analyzer
 
           # Additional tools recommended by contributing.md
           cargo-deny


### PR DESCRIPTION
A few minor issues fixed for nix:
- I've found out that after installing jj with `nix profile install` I have `fake-editor` and `fake-diff-editor` installed :) fixed it by making cargo only build the jj executable
- `jj -V` didn't include the commit hash when built/installed with Nix - I did a little env var hack as I'm not entirely sure why it didn't work - just adding git to build env didn't do it so I assume nix build removed the .git folder?.
- Installing through nix does run the tests and I've added `useNextest = true` bit to noticeably speed that up
- Added `rust-analyzer` to the dev shell as the nix way is to not have any dev tools installed globally and have them only be present in the flake - wanted to do that for a while and here's the opportunity.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
