### PR TITLE
sign: add basic signing support to backend

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,4 +19,4 @@ jobs:
           check_filenames: true
           check_hidden: true
           skip: target,.jj
-          ignore_words_list: crate,nd,nD
+          ignore_words_list: crate,nd,nD,fpr

--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -20,12 +20,13 @@ use std::sync::Arc;
 use jujutsu::cli_util::{CliRunner, CommandError, CommandHelper};
 use jujutsu::ui::Ui;
 use jujutsu_lib::backend::{
-    Backend, BackendResult, ChangeId, Commit, CommitId, Conflict, ConflictId, FileId, Signer,
-    SymlinkId, Tree, TreeId,
+    Backend, BackendResult, ChangeId, Commit, CommitId, Conflict, ConflictId, FileId,
+    SigningNotSupported, SymlinkId, Tree, TreeId,
 };
 use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::repo::StoreFactories;
 use jujutsu_lib::repo_path::RepoPath;
+use jujutsu_lib::signing::Signer;
 use jujutsu_lib::workspace::Workspace;
 
 #[derive(clap::Parser, Clone, Debug)]
@@ -158,7 +159,7 @@ impl Backend for JitBackend {
         self.inner.write_commit(contents)
     }
 
-    fn install_signer(&self, signer: Arc<Signer>) -> BackendResult<()> {
+    fn install_signer(&self, signer: Arc<Signer>) -> Result<(), SigningNotSupported> {
         self.inner.install_signer(signer)
     }
 }

--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -15,12 +15,13 @@
 use std::any::Any;
 use std::io::Read;
 use std::path::Path;
+use std::sync::Arc;
 
 use jujutsu::cli_util::{CliRunner, CommandError, CommandHelper};
 use jujutsu::ui::Ui;
 use jujutsu_lib::backend::{
-    Backend, BackendResult, ChangeId, Commit, CommitId, Conflict, ConflictId, FileId, SymlinkId,
-    Tree, TreeId,
+    Backend, BackendResult, ChangeId, Commit, CommitId, Conflict, ConflictId, FileId, Signer,
+    SymlinkId, Tree, TreeId,
 };
 use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::repo::StoreFactories;
@@ -155,5 +156,9 @@ impl Backend for JitBackend {
 
     fn write_commit(&self, contents: Commit) -> BackendResult<(CommitId, Commit)> {
         self.inner.write_commit(contents)
+    }
+
+    fn install_signer(&self, signer: Arc<Signer>) -> BackendResult<()> {
+        self.inner.install_signer(signer)
     }
 }

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -46,6 +46,7 @@ impl CommitBuilder<'_> {
             description: String::new(),
             author: signature.clone(),
             committer: signature,
+            sig: None,
         };
         CommitBuilder {
             mut_repo,

--- a/lib/src/gpg_signer.rs
+++ b/lib/src/gpg_signer.rs
@@ -1,0 +1,296 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::io::Write;
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::RwLock;
+
+use thiserror::Error;
+
+use crate::backend::{SigCheck, SigningBackend};
+
+#[derive(Debug)]
+pub struct GpgSigner {
+    key: RwLock<Key>,
+    program: OsString,
+}
+
+#[derive(Debug)]
+pub struct GpgSettings {
+    program: OsString,
+    key: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum GpgError {
+    #[error("GPG failed with exit status {exit_status}:\n{stderr}")]
+    Command {
+        exit_status: ExitStatus,
+        stderr: String,
+    },
+    #[error("Failed to parse GPG output: {0}")]
+    ParseFail(&'static str),
+    #[error("Failed to run GPG: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+// since it's hex-encoded we could've condensed this down to a u64
+// but then such condensation would also have to happen every time we read GPG
+// output
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+struct KeyId([u8; 16]);
+
+impl TryFrom<&[u8]> for KeyId {
+    type Error = GpgError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        value
+            .try_into()
+            .map(Self)
+            .map_err(|_| GpgError::ParseFail("Invalid key id length"))
+    }
+}
+
+impl AsRef<str> for KeyId {
+    fn as_ref(&self) -> &str {
+        std::str::from_utf8(&self.0).unwrap()
+    }
+}
+
+impl Debug for KeyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("KeyId").field(&self.as_ref()).finish()
+    }
+}
+
+#[derive(Debug)]
+enum Key {
+    Named(Option<String>),
+    Resolved(KeyId),
+}
+
+impl GpgSigner {
+    pub fn new(settings: GpgSettings) -> Self {
+        Self {
+            program: settings.program,
+            key: RwLock::new(Key::Named(settings.key)),
+        }
+    }
+
+    fn _run<const CHECK_RES: bool>(
+        &self,
+        input: &[u8],
+        args: &[&OsStr],
+    ) -> Result<Vec<u8>, GpgError> {
+        let process = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(if CHECK_RES {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .args(args)
+            .spawn()?;
+        process.stdin.as_ref().unwrap().write_all(input)?;
+        let output = process.wait_with_output()?;
+        if CHECK_RES && !output.status.success() {
+            Err(GpgError::Command {
+                exit_status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            })
+        } else {
+            Ok(output.stdout)
+        }
+    }
+
+    fn run(&self, input: &[u8], args: &[&OsStr]) -> Result<Vec<u8>, GpgError> {
+        self._run::<true>(input, args)
+    }
+
+    fn run_ignoring(&self, input: &[u8], args: &[&OsStr]) -> Result<Vec<u8>, GpgError> {
+        self._run::<false>(input, args)
+    }
+
+    fn get_key_id(&self) -> Result<KeyId, GpgError> {
+        let user_id = match &*self.key.read().unwrap() {
+            Key::Resolved(key_id) => return Ok(*key_id),
+            Key::Named(user_id) => user_id.clone(),
+        };
+        let mut args = vec!["--with-colons".as_ref(), "--list-secret-keys".as_ref()];
+        if let Some(user_id) = &user_id {
+            args.push(user_id.as_ref());
+        }
+        let output = self.run(b"", &args)?;
+
+        // gpg uses the first matched key with it's -u option, and so do we
+        let fpr = output
+            .split(|b| *b == b'\n')
+            .find(|line| line.starts_with(b"fpr:")) // get *the first* fpr line
+            .ok_or(GpgError::ParseFail("No key found found for given user id"))?
+            .split(|b| *b == b':')
+            .nth(9)
+            .ok_or(GpgError::ParseFail("Invalid fpr line"))?;
+        if fpr.len() != 40 {
+            return Err(GpgError::ParseFail("Invalid fingerprint length"));
+        }
+        let key_id = fpr[24..40].try_into().unwrap();
+        *self.key.write().unwrap() = Key::Resolved(key_id);
+
+        Ok(key_id)
+    }
+}
+
+impl SigningBackend for GpgSigner {
+    fn is_own(&self, signature: &[u8]) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+        // output of verify also contains both the fingerprint and even the full user id
+        // but calling it with some dummy data feels more hacky, and this works anyway
+        let output = self.run(
+            signature,
+            &["--list-packets".as_ref(), "--keyid-format=long".as_ref()],
+        )?;
+
+        let key_id = output
+            .split(|b| *b == b'\n')
+            .find(|line| line.starts_with(b":signature packet:"))
+            .ok_or(GpgError::ParseFail("No signature packets found"))?
+            .rsplitn(2, |b| *b == b' ') // take the last "field"
+            .next()
+            .ok_or(GpgError::ParseFail("Invalid signature packet line"))?;
+
+        Ok(KeyId::try_from(key_id)? == self.get_key_id()?)
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        let key_id = self.get_key_id()?;
+        Ok(self.run(data, &["-abu".as_ref(), key_id.as_ref().as_ref()])?)
+    }
+
+    fn verify(
+        &self,
+        data: &[u8],
+        signature: &[u8],
+    ) -> Result<SigCheck, Box<dyn std::error::Error + Send + Sync>> {
+        let mut signature_file = tempfile::Builder::new()
+            .prefix(".jj-gpg-sig-tmp-")
+            .tempfile()?;
+        signature_file.write_all(signature)?;
+        signature_file.flush()?;
+
+        let output = self.run_ignoring(
+            data,
+            &[
+                "--status-fd=1".as_ref(),
+                "--verify".as_ref(),
+                signature_file.path().as_os_str(), /* the only reason we have those .as_refs
+                                                    * transmuting to &OsStr everywhere.. */
+                "-".as_ref(),
+            ],
+        )?;
+
+        fn contains(output: &[u8], needle: &[u8]) -> bool {
+            output.windows(needle.len()).any(|window| window == needle)
+        }
+
+        if contains(&output, b"VALIDSIG") {
+            Ok(SigCheck::Good)
+        } else if contains(&output, b"NO_PUBKEY") {
+            Ok(SigCheck::Unknown)
+        } else if contains(&output, b"BADSIG") {
+            Ok(SigCheck::Bad)
+        } else {
+            Ok(SigCheck::Invalid)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires having gpg in path, just a temp manual test with printouts"]
+    fn test_gpg_signer() {
+        let signer = GpgSigner::new(GpgSettings {
+            program: "gpg".into(),
+            key: None,
+        });
+
+        println!("identity before: {:x?}", signer.key.read().unwrap());
+
+        let data = b"Hello, world!";
+        let signature = signer.sign(data).unwrap();
+
+        println!("identity after: {:x?}", signer.key.read().unwrap());
+
+        let verify = signer.verify(data, &signature).unwrap();
+        let verify2 = signer
+            .verify(
+                b"",
+                b"-----BEGIN PGP SIGNATURE-----
+
+            iQIzBAEBCAAdFiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmQ5B+cACgkQgJqNfOsQ
+            tGSmOBAAnQVdrztVVw+SPkJnY2bM8icmCZvEQxsN7zglhc6IubA710HtbO03vrsr
+            1p7V/DoSOOsegXd9KIH618Li/6O2zx6tELzhZVaHOKvT/xlM7jh/ZqcUVhop65Jy
+            sXiCIdKabfyxkHoq0GBzsGGmU3n3GUlQmsNfvUXoghawUNKOE1+VgV4RLGEuUNrT
+            5IViT4Ct6Ojq+Sk9Gj9b7ghepRzQZ0ZpZJ19ms8pK2CEPHSEnKWOMGFp7Ho0iEzG
+            9u+DLY20De1GV8cdxQ+vCGcc8KL3wFHkZvZkU5TrlHODUa/+NvihdCzLtNuRM4u4
+            ckJo9WitN4FpySlv0WKR2jC3WTi1Zsw/lvR2uXv4DSsa9hdu2DpUOYCvCCIMtoXw
+            j5lE4/2fNLlahsgD8NACtI3ulomM/VkhIHtGR7dT43jTCsrmkPSbTeGcwUSgGTjM
+            vZ24gJHHb3y84jF6o3VbfNfHRAVZx3H02MQOlRlresleOgVXwWWwYroxGtdYSsQK
+            p/bCOoaOlmFcrG7rLqR0SG1IqBhdW5egT/U/Et+7xPztbxR3SmRd8CShLYD2VTFp
+            UAtn9w/qGAo/BSuS+5XPpAiX9KxOhhK01bB+Hc26tzAeEYp4O6382DVdTDmuvv/v
+            IbQa9yao7yboowsKbe3Cv6axMlVqNcZsulawmQ2r8YVEzBPUrgQ=
+            =7dH0
+            -----END PGP SIGNATURE-----",
+            )
+            .unwrap();
+        let verify3 = signer
+            .verify(
+                // b"\n",
+                b"",
+                b"-----BEGIN PGP SIGNATURE-----
+
+                iQJGBAABCAAwFiEEaW8UKZw5HuvbGCSh1mZ5mv/YUCoFAmSZYZISHHNlbGZAbmVj
+                YXVxdWEuZGV2AAoJENZmeZr/2FAqFQQP/3tSY0Xiq8XCG/vLeT4M+nGEh+Hjg8yn
+                dUgAM+7D4l0BsHoRfH8I/TWbV7cVCXBNrEaeT8db8sSkvjqr3YX3050cYGxbIkMO
+                /QIifcb8TINZtVYM2gJ3wlTiEyjn6O70YG7yFsR3/61Ih6DRL2dIZyfTWkdKj/sm
+                EOUcmsKxV4sT2q4mK38BmNCfT00PtbooFilN9YEebMFWrfSwzkrixTraExnPnyW0
+                b7YdmZJaVJdBBLodqzt13BkznzY7rWkX7S9d7N4RHOo+MKAqs5M4o7TgYk8JtOVY
+                3AbAHyvCd+guG2Up458knk3Q2xQ3SfLD7obk0WZ+dF/ZstFDiSi6Qp+U54dzwim1
+                Kq1okzW4hlTOdzWpY+1/AmdIx5+RbAYK9p2nBotuG/UkqVrjtt3Hy4VUV+/PZ7Sc
+                tzpW/BpVD2s8TbezBxo/gcwuVSJNnRWk0j4Q0C4TxxntaxrDIJ0fw8NjzvVdnijB
+                YpD/0o9nmwKtL05WRu+EVj1Q37VrMxXarjeVTzjTpiqyQM/E97TQinAFwivIEmv6
+                JM3zXnI4xIX/BsEtQMjKo546gbcVRCjABvkc820udTFPPRwXXznFWZqOQaomhCZ8
+                ZwjdGUdKQmAv0iyoVAHwgnDvQ5f5ziGXODj7qtEkpSnHBGO8/tlyQ+OasAYH1KuX
+                9PGm4YHqrSzn
+                =L53R
+                -----END PGP SIGNATURE-----",
+            )
+            .unwrap();
+        let verify4 = signer.verify(b"", b"hello there").unwrap();
+
+        // Good (was just signed, reflexive)
+        dbg!(verify);
+        // Unknown (some fedora download signature, we don't have the public key)
+        dbg!(verify2);
+        // Bad (a \n signed by my git signing key, but we check empty bytestring)
+        dbg!(verify3);
+        // Invalid (well, it is)
+        dbg!(verify4);
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -51,6 +51,7 @@ pub mod repo_path;
 pub mod revset;
 pub mod rewrite;
 pub mod settings;
+pub mod signing;
 pub mod simple_op_heads_store;
 pub mod simple_op_store;
 pub mod stacked_table;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,6 +32,7 @@ pub mod files;
 pub mod git;
 pub mod git_backend;
 pub mod gitignore;
+pub mod gpg_signer;
 pub mod hex_util;
 pub mod id_prefix;
 pub mod index;

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -301,6 +301,7 @@ fn commit_from_proto(proto: crate::protos::local_store::Commit) -> Commit {
         description: proto.description,
         author: signature_from_proto(proto.author.unwrap_or_default()),
         committer: signature_from_proto(proto.committer.unwrap_or_default()),
+        sig: None,
     }
 }
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -26,6 +26,7 @@ use crate::repo::{MutableRepo, Repo};
 use crate::repo_path::RepoPath;
 use crate::revset::{RevsetExpression, RevsetIteratorExt};
 use crate::settings::UserSettings;
+use crate::signing::SignConfig;
 use crate::store::Store;
 use crate::tree::{merge_trees, Tree, TreeMergeError};
 use crate::view::RefName;
@@ -66,6 +67,8 @@ pub fn rebase_commit(
     old_commit: &Commit,
     new_parents: &[Commit],
 ) -> Result<Commit, TreeMergeError> {
+    let sign_config = SignConfig::rebase(settings.signer().is_enabled());
+
     let old_parents = old_commit.parents();
     let old_parent_trees = old_parents
         .iter()
@@ -93,6 +96,7 @@ pub fn rebase_commit(
         .rewrite_commit(settings, old_commit)
         .set_parents(new_parent_ids)
         .set_tree(new_tree_id)
+        .set_sign_config(sign_config)
         .write()?)
 }
 

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -1,0 +1,247 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::iter;
+use std::sync::{Arc, RwLock};
+
+use thiserror::Error;
+
+use crate::backend::{CommitId, Sig};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerificationStatus {
+    /// Valid signature that matches the data.
+    Good,
+    /// Valid signature that could not be verified (e.g. due to an unknown key).
+    Unknown,
+    /// Valid signature that does not match the signed data.
+    Bad,
+    /// Invalid signature.
+    Invalid,
+}
+
+#[derive(Debug, Clone)]
+pub struct Verification {
+    pub status: VerificationStatus,
+    pub key: Option<String>,
+    pub display: Option<String>,
+}
+
+impl Verification {
+    pub fn unknown() -> Self {
+        Self {
+            status: VerificationStatus::Unknown,
+            key: None,
+            display: None,
+        }
+    }
+    pub fn invalid() -> Self {
+        Self {
+            status: VerificationStatus::Invalid,
+            key: None,
+            display: None,
+        }
+    }
+}
+
+/// The backend for signing and verifying cryptographic signatures.
+///
+/// This allows using different signers, such as GPG or SSH, or different
+/// versions of them.
+///
+/// The instance of the backend carries the principal that is used to make
+/// signatures, e.g. for GPG it's a key id (and a GPG-managed key itself).
+pub trait SigningBackend: Debug + Send + Sync {
+    /// Update the principal that the backend should use.
+    ///
+    /// The parameter is what `jj sign` receives as key argument,
+    fn update_key(&self, key: Option<String>);
+
+    /// Check if the signature was created by this backend implementation.
+    ///
+    /// Should check the signature format, usually just looks at the prefix.
+    fn is_of_this_type(&self, signature: &[u8]) -> bool;
+
+    /// Check if the signature was created by this backend instance.
+    ///
+    /// Should check if e.g. the key fingerprint of the signature matches the
+    /// one of the current signer.
+    fn is_own(&self, signature: &[u8]) -> Result<bool, SignError>;
+
+    /// Create a signature for arbitrary data.
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, SignError>;
+
+    /// Verify a signature. Should be reflexive with `sign`:
+    /// ```rust,ignore
+    /// verify(data, sign(data)?) == Ok(SigCheck::Good)
+    /// ```
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<Verification, SignError>;
+}
+
+#[derive(Debug, Error)]
+pub enum SignError {
+    #[error("Cannot re-sign a commit that was already signed")]
+    CannotRewrite,
+    #[error("Signing error: {0}")]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SignConfig {
+    /// Drop existing signatures (what jj did before signing support)
+    #[default]
+    Drop,
+    /// Only sign commits that were already signed, fails if the signature was
+    /// foreign
+    Own,
+    /// Sign commits that are not signed or were signed by self, fails if the
+    /// signature was foreign
+    New,
+    /// Re-sign commits that were already signed, regardless of who signed them
+    ReSign,
+}
+
+impl SignConfig {
+    pub fn setting(enabled: bool) -> Self {
+        if enabled {
+            Self::New
+        } else {
+            Self::Drop
+        }
+    }
+
+    pub fn rebase(enabled: bool) -> Self {
+        if enabled {
+            Self::Own
+        } else {
+            Self::Drop
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Signer {
+    main_backend: Box<dyn SigningBackend>,
+    other_backends: Vec<Box<dyn SigningBackend>>,
+    config: RwLock<SignConfig>,
+    enabled: RwLock<bool>,
+    own_cache: RwLock<HashMap<CommitId, bool>>,
+    verification_cache: RwLock<HashMap<CommitId, Verification>>,
+}
+
+impl Signer {
+    pub fn new(
+        main_backend: Box<dyn SigningBackend>,
+        other_backends: Vec<Box<dyn SigningBackend>>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            main_backend,
+            other_backends,
+            config: Default::default(),
+            enabled: Default::default(),
+            own_cache: Default::default(),
+            verification_cache: Default::default(),
+        })
+    }
+
+    pub fn enable(&self, key: Option<String>) {
+        *self.enabled.write().unwrap() = true;
+        self.main_backend.update_key(key);
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        *self.enabled.read().unwrap()
+    }
+
+    pub fn config(&self, config: SignConfig) {
+        *self.config.write().unwrap() = config;
+    }
+
+    /// There are several returns this function can have:
+    /// - Ok(true) -> proceed with signing
+    /// - Ok(false) -> do not sign - for rewrites this means dropping the
+    ///   signature if it was there
+    /// - Err(SigningError::CannotRewrite) -> abort the commit as the signature
+    ///   cannot be created nor dropped, e.g. because we don't want to rewrite a
+    ///   foreign signature
+    /// - Err(_) -> downstream errors from signing backend, this return is
+    ///   listed for completeness
+    pub fn will_sign(&self, existing: Option<&Sig>) -> Result<bool, SignError> {
+        match *self.config.read().unwrap() {
+            SignConfig::Drop => Ok(false),
+            c @ (SignConfig::Own | SignConfig::New) => {
+                if let Some(sig) = existing {
+                    if self.main_backend.is_own(&sig.signature)? {
+                        Ok(true)
+                    } else {
+                        Err(SignError::CannotRewrite)
+                    }
+                } else {
+                    Ok(c == SignConfig::New)
+                }
+            }
+            SignConfig::ReSign => Ok(existing.is_some()),
+        }
+    }
+
+    /// This is just a pass-through to the main backend that unconditionally
+    /// creates a signature.
+    pub fn sign(&self, data: &[u8]) -> Result<Vec<u8>, SignError> {
+        self.main_backend.sign(data)
+    }
+
+    pub fn is_own(&self, commit_id: &CommitId, signature: &[u8]) -> Result<bool, SignError> {
+        if let Some(cached) = self.own_cache.read().unwrap().get(commit_id) {
+            return Ok(*cached);
+        }
+        let check = self.main_backend.is_own(signature)?;
+        self.own_cache
+            .write()
+            .unwrap()
+            .insert(commit_id.clone(), check);
+        Ok(check)
+    }
+
+    pub fn verify(
+        &self,
+        commit_id: &CommitId,
+        data: &[u8],
+        signature: &[u8],
+    ) -> Result<Verification, SignError> {
+        let cached = self
+            .verification_cache
+            .read()
+            .unwrap()
+            .get(commit_id)
+            .cloned();
+        if let Some(check) = cached {
+            return Ok(check);
+        }
+        if let Some(backend) = iter::once(&self.main_backend)
+            .chain(self.other_backends.iter())
+            .find(|b| b.is_of_this_type(signature))
+        {
+            let check = backend.verify(data, signature)?;
+
+            // a key might get imported before next call?.
+            // realistically this is unlikely, but technically
+            // it's correct to not cache unknowns here
+            if check.status != VerificationStatus::Unknown {
+                self.verification_cache
+                    .write()
+                    .unwrap()
+                    .insert(commit_id.clone(), check.clone());
+            }
+            Ok(check)
+        } else {
+            // now here it's correct to cache unknowns, as we don't
+            // have a backend that knows how to handle this signature
+            //
+            // not sure about how much of an optimization this is
+            self.verification_cache
+                .write()
+                .unwrap()
+                .insert(commit_id.clone(), Verification::unknown());
+            Ok(Verification::unknown())
+        }
+    }
+}

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -304,6 +304,45 @@
                     "type": "string"
                 }
             }
+        },
+        "sign": {
+            "type": "object",
+            "description": "Commit signing settings",
+            "properties": {
+                "enable": {
+                    "type": "boolean",
+                    "description": "Whether to sign commits by default",
+                    "default": false
+                },
+                "backend": {
+                    "description": "The signing backend to use",
+                    "enum": [
+                        "gpg"
+                    ],
+                    "default": "gpg"
+                },
+                "key": {
+                    "type": "string",
+                    "description": "The key to use for signing, exact meaning depends on the backend"
+                },
+                "backends": {
+                    "type": "object",
+                    "description": "Settings for individual signing backends",
+                    "properties": {
+                        "gpg": {
+                            "type": "object",
+                            "description": "Settings for the gpg signing backend",
+                            "properties": {
+                                "program": {
+                                    "type": "string",
+                                    "description": "The path to gpg executable to use",
+                                    "default": "gpg"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/config/misc.toml
+++ b/src/config/misc.toml
@@ -7,3 +7,11 @@
 [ui]
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false
+
+[sign]
+enable = false
+backend = "gpg"
+# key = "anything that gpg -u accepts"
+
+[sign.backends.gpg]
+program = "gpg"

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -14,6 +14,7 @@ show = 'builtin_log_detailed'
 'builtin_log_oneline' = '''label(if(current_working_copy, "working_copy"),
   concat(
     separate(" ",
+      signature,
       label(
         separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
         separate(" ",
@@ -36,6 +37,7 @@ show = 'builtin_log_detailed'
 'builtin_log_compact' = '''label(if(current_working_copy, "working_copy"),
   concat(
     separate(" ",
+      signature,
       label(
         separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
         separate(" ",


### PR DESCRIPTION

This is a small revised subset of my draft that I am comfortable to merge into the main tree.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
