### PR TITLE
Don't snapshot new files larger than 1MiB by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The default editor on Windows is now `Notepad` instead of `pico`.
 
+* `jj` will fail attempts to snapshot new files larger than 1MiB by default. This behavior
+  can be customized with the `snapshot.max-new-file-size` config option.
+
+
 ### New features
 
 * `jj init --git-repo` now works with bare repositories.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "rayon",
  "regex",
  "rustix",
+ "serde",
  "serde_json",
  "smallvec",
  "strsim",

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1288,6 +1288,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             base_ignores,
             fsmonitor_kind: self.settings.fsmonitor_kind()?,
             progress: progress.as_ref().map(|x| x as _),
+            max_new_file_size: self.settings.max_new_file_size()?,
         })?;
         drop(progress);
         if new_tree_id != *wc_commit.tree_id() {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1333,6 +1333,7 @@ fn cmd_untrack(
         base_ignores,
         fsmonitor_kind: command.settings().fsmonitor_kind()?,
         progress: None,
+        max_new_file_size: command.settings().max_new_file_size()?,
     })?;
     if wc_tree_id != new_tree_id {
         let wc_tree = store.get_tree(&RepoPath::root(), &wc_tree_id)?;

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -334,9 +334,9 @@
             "description": "Parameters governing automatic capture of files into the working copy commit",
             "properties": {
                 "max-new-file-size": {
-                    "type": "integer",
+                    "type": ["integer", "string"],
                     "description": "New files with a size in bytes above this threshold are not snapshotted, unless the threshold is 0",
-                    "default": "1048576"
+                    "default": "1MiB"
                 }
             }
         }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -328,6 +328,17 @@
                     "type": "string"
                 }
             }
+        },
+        "snapshot": {
+            "type": "object",
+            "description": "Parameters governing automatic capture of files into the working copy commit",
+            "properties": {
+                "max-new-file-size": {
+                    "type": "integer",
+                    "description": "New files with a size in bytes above this threshold are not snapshotted, unless the threshold is 0",
+                    "default": "1048576"
+                }
+            }
         }
     }
 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -10,4 +10,4 @@ pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false
 
 [snapshot]
-max-new-file-size = 1048576
+max-new-file-size = "1MiB"

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -8,3 +8,6 @@
 paginate = "auto"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false
+
+[snapshot]
+max-new-file-size = 1048576

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -414,6 +414,7 @@ pub fn edit_diff_external(
         base_ignores,
         fsmonitor_kind: settings.fsmonitor_kind()?,
         progress: None,
+        max_new_file_size: settings.max_new_file_size()?,
     })?;
     Ok(right_tree_state.current_tree_id().clone())
 }

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -4,6 +4,7 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crossterm::terminal::{Clear, ClearType};
+use jj_lib::fmt_util::binary_prefix;
 use jj_lib::git;
 use jj_lib::repo_path::RepoPath;
 
@@ -104,20 +105,6 @@ fn draw_progress(progress: f32, buffer: &mut String, width: usize) {
 
 const UPDATE_HZ: u32 = 30;
 const INITIAL_DELAY: Duration = Duration::from_millis(250);
-
-/// Find the smallest binary prefix with which the whole part of `x` is at most
-/// three digits, and return the scaled `x` and that prefix.
-fn binary_prefix(x: f32) -> (f32, &'static str) {
-    const TABLE: [&str; 9] = ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"];
-
-    let mut i = 0;
-    let mut scaled = x;
-    while scaled.abs() >= 1000.0 && i < TABLE.len() - 1 {
-        i += 1;
-        scaled /= 1024.0;
-    }
-    (scaled, TABLE[i])
-}
 
 struct RateEstimate {
     state: Option<RateEstimateState>,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,6 +38,7 @@ rand.workspace = true
 rand_chacha.workspace = true
 rayon.workspace = true
 regex.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
 strsim.workspace = true

--- a/lib/src/fmt_util.rs
+++ b/lib/src/fmt_util.rs
@@ -1,0 +1,32 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Common formatting helpers
+
+/// Find the smallest binary prefix with which the whole part of `x` is at most
+/// three digits, and return the scaled `x`, that prefix, and the associated
+/// base-1024 exponent.
+pub fn binary_prefix(x: f32) -> (f32, &'static str) {
+    /// Binary prefixes in ascending order, starting with the empty prefix. The
+    /// index of each prefix is the base-1024 exponent it represents.
+    const TABLE: [&str; 9] = ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"];
+
+    let mut i = 0;
+    let mut scaled = x;
+    while scaled.abs() >= 1000.0 && i < TABLE.len() - 1 {
+        i += 1;
+        scaled /= 1024.0;
+    }
+    (scaled, TABLE[i])
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,6 +32,7 @@ pub mod default_submodule_store;
 pub mod diff;
 pub mod file_util;
 pub mod files;
+pub mod fmt_util;
 pub mod fsmonitor;
 pub mod git;
 pub mod git_backend;

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -190,6 +190,16 @@ impl UserSettings {
             .get_string("ui.graph.style")
             .unwrap_or_else(|_| "curved".to_string())
     }
+
+    pub fn max_new_file_size(&self) -> Result<u64, config::ConfigError> {
+        let cfg = self.config.get::<u64>("snapshot.max-new-file-size");
+        match cfg {
+            Ok(0) => Ok(u64::MAX),
+            x @ Ok(_) => x,
+            Err(config::ConfigError::NotFound(_)) => Ok(1024 * 1024),
+            e @ Err(_) => e,
+        }
+    }
 }
 
 /// This Rng uses interior mutability to allow generating random values using an

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -22,6 +22,7 @@ use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 
 use crate::backend::{ChangeId, ObjectId, Signature, Timestamp};
+use crate::fmt_util::binary_prefix;
 use crate::fsmonitor::FsmonitorKind;
 
 #[derive(Debug, Clone)]
@@ -192,7 +193,10 @@ impl UserSettings {
     }
 
     pub fn max_new_file_size(&self) -> Result<u64, config::ConfigError> {
-        let cfg = self.config.get::<u64>("snapshot.max-new-file-size");
+        let cfg = self
+            .config
+            .get::<HumanByteSize>("snapshot.max-new-file-size")
+            .map(|x| x.0);
         match cfg {
             Ok(0) => Ok(u64::MAX),
             x @ Ok(_) => x,
@@ -239,5 +243,109 @@ impl<T> ConfigResultExt<T> for Result<T, config::ConfigError> {
             Err(config::ConfigError::NotFound(_)) => Ok(None),
             Err(err) => Err(err),
         }
+    }
+}
+
+/// A size in bytes optionally formatted/serialized with binary prefixes
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct HumanByteSize(pub u64);
+
+impl std::fmt::Display for HumanByteSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (value, prefix) = binary_prefix(self.0 as f32);
+        write!(f, "{value:.1}{prefix}B")
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HumanByteSize {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = HumanByteSize;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(formatter, "a size in bytes with an optional binary unit")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(HumanByteSize(v))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let bytes = parse_human_byte_size(v).map_err(Error::custom)?;
+                Ok(HumanByteSize(bytes))
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_any(Visitor)
+        } else {
+            deserializer.deserialize_u64(Visitor)
+        }
+    }
+}
+
+fn parse_human_byte_size(v: &str) -> Result<u64, &str> {
+    let digit_end = v.find(|c: char| !c.is_ascii_digit()).unwrap_or(v.len());
+    if digit_end == 0 {
+        return Err("must start with a number");
+    }
+    let (digits, trailing) = v.split_at(digit_end);
+    let exponent = match trailing.trim_start() {
+        "" | "B" => 0,
+        unit => {
+            const PREFIXES: [char; 8] = ['K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+            let Some(prefix) = PREFIXES.iter().position(|&x| unit.starts_with(x)) else {
+                return Err("unrecognized unit prefix");
+            };
+            let ("" | "B" | "i" | "iB") = &unit[1..] else {
+                return Err("unrecognized unit");
+            };
+            prefix as u32 + 1
+        }
+    };
+    // A string consisting only of base 10 digits is either a valid u64 or really
+    // huge.
+    let factor = digits.parse::<u64>().unwrap_or(u64::MAX);
+    Ok(factor.saturating_mul(1024u64.saturating_pow(exponent)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_size_parse() {
+        assert_eq!(parse_human_byte_size("0"), Ok(0));
+        assert_eq!(parse_human_byte_size("42"), Ok(42));
+        assert_eq!(parse_human_byte_size("42B"), Ok(42));
+        assert_eq!(parse_human_byte_size("42 B"), Ok(42));
+        assert_eq!(parse_human_byte_size("42K"), Ok(42 * 1024));
+        assert_eq!(parse_human_byte_size("42 K"), Ok(42 * 1024));
+        assert_eq!(parse_human_byte_size("42 KB"), Ok(42 * 1024));
+        assert_eq!(parse_human_byte_size("42 KiB"), Ok(42 * 1024));
+        assert_eq!(
+            parse_human_byte_size("42 LiB"),
+            Err("unrecognized unit prefix")
+        );
+        assert_eq!(parse_human_byte_size("42 KiC"), Err("unrecognized unit"));
+        assert_eq!(parse_human_byte_size("42 KC"), Err("unrecognized unit"));
+        assert_eq!(
+            parse_human_byte_size("KiB"),
+            Err("must start with a number")
+        );
+        assert_eq!(parse_human_byte_size(""), Err("must start with a number"));
     }
 }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -53,6 +53,7 @@ use crate::matchers::{
 };
 use crate::op_store::{OperationId, WorkspaceId};
 use crate::repo_path::{FsPathParseError, RepoPath, RepoPathComponent, RepoPathJoin};
+use crate::settings::HumanByteSize;
 use crate::store::Store;
 use crate::tree::{Diff, Tree};
 
@@ -308,11 +309,11 @@ pub enum SnapshotError {
     InternalBackendError(#[from] BackendError),
     #[error(transparent)]
     TreeStateError(#[from] TreeStateError),
-    #[error("New file {path} of size {size} exceeds snapshot.max-new-file-size ({max_size})")]
+    #[error("New file {path} of size ~{size} exceeds snapshot.max-new-file-size ({max_size})")]
     NewFileTooLarge {
         path: PathBuf,
-        size: u64,
-        max_size: u64,
+        size: HumanByteSize,
+        max_size: HumanByteSize,
     },
 }
 
@@ -863,8 +864,8 @@ impl TreeState {
                         {
                             return Err(SnapshotError::NewFileTooLarge {
                                 path: entry.path().clone(),
-                                size: metadata.len(),
-                                max_size: max_new_file_size,
+                                size: HumanByteSize(metadata.len()),
+                                max_size: HumanByteSize(max_new_file_size),
                             });
                         }
                         if let Some(new_file_state) = file_state(&metadata) {

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Remove when MSRV passes 1.72
+// https://github.com/frondeus/test-case/issues/126#issuecomment-1635916592
+#![allow(clippy::items_after_test_module)]
+
 use std::fs::OpenOptions;
 use std::io::Write;
 #[cfg(unix)]

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -166,7 +166,7 @@ fn test_racy_checkout() {
         // A file written right after checkout (hopefully, from the test's perspective,
         // within the file system timestamp granularity) is detected as changed.
         write_working_copy_file(&workspace_root, &path, "x");
-        let modified_tree = test_workspace.snapshot();
+        let modified_tree = test_workspace.snapshot().unwrap();
         if modified_tree.id() == tree.id() {
             num_matches += 1;
         }

--- a/lib/tests/test_working_copy_sparse.rs
+++ b/lib/tests/test_working_copy_sparse.rs
@@ -167,7 +167,7 @@ fn test_sparse_commit() {
 
     // Create a tree from the working copy. Only dir1/file1 should be updated in the
     // tree.
-    let modified_tree = test_workspace.snapshot();
+    let modified_tree = test_workspace.snapshot().unwrap();
     let diff = tree.diff(&modified_tree, &EverythingMatcher).collect_vec();
     assert_eq!(diff.len(), 1);
     assert_eq!(diff[0].0, dir1_file1_path);
@@ -181,7 +181,7 @@ fn test_sparse_commit() {
 
     // Create a tree from the working copy. Only dir1/file1 and dir2/file1 should be
     // updated in the tree.
-    let modified_tree = test_workspace.snapshot();
+    let modified_tree = test_workspace.snapshot().unwrap();
     let diff = tree.diff(&modified_tree, &EverythingMatcher).collect_vec();
     assert_eq!(diff.len(), 2);
     assert_eq!(diff[0].0, dir1_file1_path);
@@ -216,7 +216,7 @@ fn test_sparse_commit_gitignore() {
 
     // Create a tree from the working copy. Only dir1/file2 should be updated in the
     // tree because dir1/file1 is ignored.
-    let modified_tree = test_workspace.snapshot();
+    let modified_tree = test_workspace.snapshot().unwrap();
     let entries = modified_tree.entries().collect_vec();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].0, dir1_file2_path);

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -31,7 +31,7 @@ use jj_lib::store::Store;
 use jj_lib::transaction::Transaction;
 use jj_lib::tree::Tree;
 use jj_lib::tree_builder::TreeBuilder;
-use jj_lib::working_copy::SnapshotOptions;
+use jj_lib::working_copy::{SnapshotOptions, SnapshotError};
 use jj_lib::workspace::Workspace;
 use tempfile::TempDir;
 
@@ -162,18 +162,17 @@ impl TestWorkspace {
     /// Snapshots the working copy and returns the tree. Updates the working
     /// copy state on disk, but does not update the working-copy commit (no
     /// new operation).
-    pub fn snapshot(&mut self) -> Tree {
+    pub fn snapshot(&mut self) -> Result<Tree, SnapshotError> {
         let mut locked_wc = self.workspace.working_copy_mut().start_mutation().unwrap();
         let tree_id = locked_wc
-            .snapshot(SnapshotOptions::empty_for_test())
-            .unwrap();
+            .snapshot(SnapshotOptions::empty_for_test());
         // arbitrary operation id
         locked_wc.finish(self.repo.op_id().clone()).unwrap();
-        return self
+        Ok(self
             .repo
             .store()
-            .get_tree(&RepoPath::root(), &tree_id)
-            .unwrap();
+            .get_tree(&RepoPath::root(), &tree_id?)
+            .unwrap())
     }
 }
 


### PR DESCRIPTION
Still needs a test (and test code updates), but impl should be in good shape for review/feedback.

Future work: similar behavior for binary files.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
