### PR TITLE
Fix bug where a forgotten branch couldn't be fetched (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remote, just like in a non-colocated repo.
   [#864](https://github.com/martinvonz/jj/issues/864)
 
+* `jj git fetch` can now fetch forgotten branches even if they didn't move on
+  the remote.
+  [#1714](https://github.com/martinvonz/jj/pull/1714)
+  [#1771](https://github.com/martinvonz/jj/pull/1771)
+
 * It is now possible to `jj branch forget` deleted branches.
   [#1537](https://github.com/martinvonz/jj/issues/1537)
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -499,6 +499,47 @@ pub fn fetch(
     callbacks: RemoteCallbacks<'_>,
     git_settings: &GitSettings,
 ) -> Result<Option<String>, GitFetchError> {
+    // In non-colocated repositories, it's possible that `jj branch forget` was run
+    // at some point and no `jj git export` happened since.
+    //
+    // This would mean that remote-tracking branches, forgotten in the jj repo,
+    // still exist in the git repo. If the branches didn't move on the remote, and
+    // we fetched them, jj would think that they are unmodified and wouldn't
+    // resurrect them.
+    //
+    // Export will delete the remote-tracking branches in the git repo, so it's
+    // possible to fetch them again.
+    //
+    // For more details, see the `test_branch_forget_fetched_branch` test, and PRs
+    // #1714 and #1771
+    //
+    // Apart from `jj branch forget`, jj doesn't provide commands to manipulate
+    // remote-tracking branches, and local git branches don't affect fetch
+    // behaviors. So, it's unnecessary to export anything else.
+    //
+    // TODO: Create a command the user can use to reset jj's
+    // branch state to the git repo's state. In this case, `jj branch forget`
+    // doesn't work as it tries to delete the latter. One possible name is `jj
+    // git import --reset BRANCH`.
+    // TODO: Once the command described above exists, it should be mentioned in `jj
+    // help branch forget`.
+    let nonempty_branches = mut_repo
+        .view()
+        .branches()
+        .iter()
+        .filter_map(|(branch, target)| target.local_target.as_ref().map(|_| branch.to_owned()))
+        .collect_vec();
+    // TODO: Inform the user if the export failed? In most cases, export is not
+    // essential for fetch to work.
+    let _ = export_some_refs(mut_repo, git_repo, |ref_name| {
+        // Short-term TODO: filter this by the glob filter
+        matches!(
+            ref_name,
+            RefName::RemoteBranch { branch, remote:_ }
+               if !nonempty_branches.contains(branch)
+        )
+    });
+
     let mut remote =
         git_repo
             .find_remote(remote_name)

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -31,7 +31,7 @@ use thiserror::Error;
 
 use crate::backend::{BackendError, BackendResult, ChangeId, CommitId, ObjectId};
 use crate::commit::Commit;
-use crate::git::get_git_tracking_branch;
+use crate::git::get_local_git_tracking_branch;
 use crate::hex_util::to_forward_hex;
 use crate::index::{HexPrefix, PrefixResolution};
 use crate::op_store::WorkspaceId;
@@ -1658,7 +1658,7 @@ fn resolve_branch(repo: &dyn Repo, symbol: &str) -> Option<Vec<CommitId>> {
         }
         // A remote with name "git" will shadow local-git tracking branches
         if remote_name == "git" {
-            if let Some(target) = get_git_tracking_branch(repo.view(), name) {
+            if let Some(target) = get_local_git_tracking_branch(repo.view(), name) {
                 return Some(target.adds().to_vec());
             }
         }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1249,7 +1249,10 @@ fn test_export_partial_failure() {
     mut_repo.set_local_branch("main/sub".to_string(), target);
     assert_eq!(
         git::export_refs(mut_repo, &git_repo),
-        Ok(vec!["".to_string(), "main/sub".to_string()])
+        Ok(vec![
+            RefName::LocalBranch("".to_string()),
+            RefName::LocalBranch("main/sub".to_string())
+        ])
     );
 
     // The `main` branch should have succeeded but the other should have failed
@@ -1269,7 +1272,7 @@ fn test_export_partial_failure() {
     mut_repo.remove_local_branch("main");
     assert_eq!(
         git::export_refs(mut_repo, &git_repo),
-        Ok(vec!["".to_string()])
+        Ok(vec![RefName::LocalBranch("".to_string())])
     );
     assert!(git_repo.find_reference("refs/heads/").is_err());
     assert!(git_repo.find_reference("refs/heads/main").is_err());
@@ -1364,7 +1367,7 @@ fn test_export_reexport_transitions() {
         git::export_refs(mut_repo, &git_repo),
         Ok(["AXB", "ABC", "ABX", "XAB"]
             .into_iter()
-            .map(String::from)
+            .map(|s| RefName::LocalBranch(s.to_string()))
             .collect_vec())
     );
     for branch in ["AAX", "ABX", "AXA", "AXX"] {

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1522,7 +1522,8 @@ pub fn print_failed_git_export(
                 "{}",
                 match branch_ref {
                     RefName::LocalBranch(name) => name.to_string(),
-                    // Should never happen, only local branches are exported
+                    RefName::RemoteBranch { branch, remote } => format!("{branch}@{remote}"),
+                    // Should never happen, tags and git_refs should never be exported
                     branch_ref => to_git_ref_name(branch_ref),
                 }
             )?;

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashSet};
 use clap::builder::NonEmptyStringValueParser;
 use itertools::Itertools;
 use jujutsu_lib::backend::{CommitId, ObjectId};
-use jujutsu_lib::git::git_tracking_branches;
+use jujutsu_lib::git::local_branch_git_tracking_refs;
 use jujutsu_lib::op_store::{BranchTarget, RefTarget};
 use jujutsu_lib::repo::Repo;
 use jujutsu_lib::revset::{self, RevsetExpression};
@@ -324,7 +324,7 @@ fn cmd_branch_list(
     let repo = workspace_command.repo();
 
     let mut all_branches = repo.view().branches().clone();
-    for (branch_name, git_tracking_target) in git_tracking_branches(repo.view()) {
+    for (branch_name, git_tracking_target) in local_branch_git_tracking_refs(repo.view()) {
         let branch_target = all_branches.entry(branch_name.to_owned()).or_default();
         if branch_target.remote_targets.contains_key("git") {
             // TODO(#1690): There should be a mechanism to prevent importing a

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -320,6 +320,7 @@ fn test_branch_forget_fetched_branch() {
     feature1: 9f01a0e04879 message
     "###);
 
+    // TEST 1: with export-import
     // Forget the branch
     test_env.jj_cmd_success(&repo_path, &["branch", "forget", "feature1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
@@ -332,14 +333,24 @@ fn test_branch_forget_fetched_branch() {
     // the ref in jj view's `git_refs` tracking the local git repo's remote-tracking
     // branch.
     // TODO: Show that jj git push is also a no-op
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @r###"
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
 
+    // We can fetch feature1 again.
+    let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    feature1: 9f01a0e04879 message
+    "###);
+
+    // TEST 2: No export/import (otherwise the same as test 1)
+    // Short-term TODO: While it looks like the bug above is fixed, correct behavior
+    // now actually depends on export/import.
+    test_env.jj_cmd_success(&repo_path, &["branch", "forget", "feature1"]);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
     // Short-term TODO: Fix this BUG. It should be possible to fetch `feature1`
     // again.
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
@@ -347,6 +358,8 @@ fn test_branch_forget_fetched_branch() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
+
+    // TEST 3: fetch branch that was moved & forgotten
 
     // Move the branch in the git repo.
     git_repo

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -238,9 +238,8 @@ fn test_branch_forget_export() {
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "forget", "foo"]);
     insta::assert_snapshot!(stdout, @"");
-    // Forgetting a branch does not delete its local-git tracking branch. This is
-    // the opposite of what happens to remote-tracking branches.
-    // TODO: Consider allowing forgetting local-git tracking branches as an option
+    // Forgetting a branch does not delete its local-git tracking branch. The
+    // git-tracking branch is kept.
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     foo (forgotten)
@@ -347,17 +346,14 @@ fn test_branch_forget_fetched_branch() {
     "###);
 
     // TEST 2: No export/import (otherwise the same as test 1)
-    // Short-term TODO: While it looks like the bug above is fixed, correct behavior
-    // now actually depends on export/import.
     test_env.jj_cmd_success(&repo_path, &["branch", "forget", "feature1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-    // Short-term TODO: Fix this BUG. It should be possible to fetch `feature1`
-    // again.
+    // Fetch works even without the export-import
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
-    insta::assert_snapshot!(stdout, @r###"
-    Nothing changed.
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    feature1: 9f01a0e04879 message
     "###);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
 
     // TEST 3: fetch branch that was moved & forgotten
 
@@ -372,18 +368,14 @@ fn test_branch_forget_fetched_branch() {
             &[&git_repo.find_commit(first_git_repo_commit).unwrap()],
         )
         .unwrap();
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["branch", "forget", "feature1"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such branch: feature1
-    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "forget", "feature1"]);
+    insta::assert_snapshot!(stdout, @"");
 
-    // BUG: fetching a moved branch creates a move-deletion conflict
+    // Fetching a moved branch does not create a conflict
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1 (conflicted):
-      - 9f01a0e04879 message
-      + 38aefb173976 another message
+    feature1: 38aefb173976 another message
     "###);
 }
 


### PR DESCRIPTION
New approach to fix the bug described in the (now closed) PR #1714

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
