### PR TITLE
revset: don't resolve deleted branch symbol to empty set, suggest remote branches

### DIFF
--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -478,10 +478,17 @@ fn test_resolve_symbol_branches() {
     "###);
 
     // Remote only (or locally deleted)
-    assert_eq!(
-        resolve_symbol(mut_repo, "remote", None).unwrap(),
-        vec![], // TODO: NoSuchRevision
-    );
+    // TODO: shouldn't suggest deleted local branch
+    insta::assert_debug_snapshot!(
+        resolve_symbol(mut_repo, "remote", None).unwrap_err(), @r###"
+    NoSuchRevision {
+        name: "remote",
+        candidates: [
+            "remote",
+            "remote-conflicted",
+        ],
+    }
+    "###);
     assert_eq!(
         resolve_symbol(mut_repo, "remote@origin", None).unwrap(),
         vec![commit2.id().clone()],

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -532,7 +532,7 @@ fn test_branch_list_filtered_by_revset() {
     "###);
     insta::assert_snapshot!(query_error("remote-delete"), @r###"
     Error: Revision "remote-delete" doesn't exist
-    Hint: Did you mean "remote-delete", "remote-keep", "remote-rewrite"?
+    Hint: Did you mean "remote-delete@origin", "remote-keep", "remote-rewrite", "remote-rewrite@origin"?
     "###);
 }
 

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -500,6 +500,8 @@ fn test_branch_list_filtered_by_revset() {
     "###);
 
     let query = |revset| test_env.jj_cmd_success(&local_path, &["branch", "list", "-r", revset]);
+    let query_error =
+        |revset| test_env.jj_cmd_failure(&local_path, &["branch", "list", "-r", revset]);
 
     // "all()" doesn't include deleted branches since they have no local targets.
     // So "all()" is identical to "branches()".
@@ -526,7 +528,11 @@ fn test_branch_list_filtered_by_revset() {
     "###);
 
     // Can't select deleted branch.
-    insta::assert_snapshot!(query("remote-delete"), @r###"
+    insta::assert_snapshot!(query("branches(remote-delete)"), @r###"
+    "###);
+    insta::assert_snapshot!(query_error("remote-delete"), @r###"
+    Error: Revision "remote-delete" doesn't exist
+    Hint: Did you mean "remote-delete", "remote-keep", "remote-rewrite"?
     "###);
 }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
