### PR TITLE
cargo: rename crates from `jujutsu`/`jujutsu-lib` to `jj-cli`/`jj-lib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* The `jujutsu` and `jujutsu-lib` crates were renamed to `jj-cli` and `jj-lib`,
+  respectively.
+
 * The `ui.oplog-relative-timestamps` option has been removed. Use the
   `format_time_range()` template alias instead. For details, see
   [the documentation](docs/config.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,25 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
-name = "jujutsu"
+name = "jj-cli"
 version = "0.7.0"
 dependencies = [
  "assert_cmd",
@@ -1000,7 +982,7 @@ dependencies = [
  "indexmap 2.0.0",
  "insta",
  "itertools 0.11.0",
- "jujutsu-lib",
+ "jj-lib",
  "libc",
  "maplit",
  "once_cell",
@@ -1021,7 +1003,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jujutsu-lib"
+name = "jj-lib"
 version = "0.7.0"
 dependencies = [
  "assert_matches",
@@ -1060,6 +1042,24 @@ dependencies = [
  "watchman_client",
  "whoami",
  "zstd",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2024,7 +2024,7 @@ dependencies = [
  "config",
  "git2",
  "itertools 0.11.0",
- "jujutsu-lib",
+ "jj-lib",
  "rand",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jujutsu"
+name = "jj-cli"
 version = "0.7.0"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 description = "Jujutsu (an experimental VCS)"
 homepage = "https://github.com/martinvonz/jj"
 repository = "https://github.com/martinvonz/jj"
-documentation = "https://docs.rs/jujutsu"
+documentation = "https://docs.rs/jj-cli"
 readme = "README.md"
 keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
 categories = ["command-line-utilities", "development-tools"]
@@ -47,7 +47,7 @@ glob = "0.3.1"
 hex = "0.4.3"
 indexmap = "2.0.0"
 itertools = "0.11.0"
-jujutsu-lib = { version = "=0.7.0", path = "lib", default-features = false }
+jj-lib = { version = "=0.7.0", path = "lib", default-features = false }
 maplit = "1.0.2"
 once_cell = "1.18.0"
 pest = "2.7.0"
@@ -76,5 +76,5 @@ testutils = { path = "lib/testutils" }
 [features]
 default = []
 bench = ["criterion"]
-vendored-openssl = ["git2/vendored-openssl", "jujutsu-lib/vendored-openssl"]
-watchman = ["jujutsu-lib/watchman"]
+vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
+watchman = ["jj-lib/watchman"]

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ sudo apt-get install libssl-dev openssl pkg-config
 
 Now run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujutsu
+cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jj-cli
 ```
 
 
@@ -227,7 +227,7 @@ export PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl@3/lib/pkgconfig"
 
 Now run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujutsu
+cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jj-cli
 ```
 
 
@@ -235,7 +235,7 @@ cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujut
 
 Run:
 ```shell script
-cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jujutsu --features vendored-openssl
+cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jj-cli --features vendored-openssl
 ```
 
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -8,14 +8,14 @@ to [Git's object model](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 
 ## Separation of library from UI
 
-The `jj` binary consists of two Rust crates: the library crate
-(`jujutsu-lib`) and the CLI crate (`jujutsu`). The library crate is currently
-only used by the CLI crate, but it is meant to also be usable from a GUI or TUI,
-or in a server serving requests from multiple users. As a result, the library
-should avoid interacting directly with the user via the terminal or by other
-means; all input/output is handled by the CLI crate [^1]. Since the library
-crate is meant to usable in a server, it also cannot read configuration from the
-user's home directory, or from user-specific environment variables.
+The `jj` binary consists of two Rust crates: the library crate (`jj-lib`) and
+the CLI crate (`jj-cli`). The library crate is currently only used by the CLI
+crate, but it is meant to also be usable from a GUI or TUI, or in a server
+serving requests from multiple users. As a result, the library should avoid
+interacting directly with the user via the terminal or by other means; all
+input/output is handled by the CLI crate [^1]. Since the library crate is meant
+to usable in a server, it also cannot read configuration from the user's home
+directory, or from user-specific environment variables.
 
 [^1]: There are a few exceptions, such as for messages printed during automatic
 upgrades of the repo format
@@ -227,7 +227,6 @@ There's no garbage collection of unreachable tables yet.
 The tables are named by their hash. We keep a separate directory of pointers to
 the current leaf tables, in the same way as we
 do [for the operation log](concurrency.md#storage).
-
 
 ## Design of the CLI crate
 

--- a/examples/custom-backend/main.rs
+++ b/examples/custom-backend/main.rs
@@ -16,16 +16,16 @@ use std::any::Any;
 use std::io::Read;
 use std::path::Path;
 
-use jujutsu::cli_util::{CliRunner, CommandError, CommandHelper};
-use jujutsu::ui::Ui;
-use jujutsu_lib::backend::{
+use jj_cli::cli_util::{CliRunner, CommandError, CommandHelper};
+use jj_cli::ui::Ui;
+use jj_lib::backend::{
     Backend, BackendInitError, BackendLoadError, BackendResult, ChangeId, Commit, CommitId,
     Conflict, ConflictId, FileId, SymlinkId, Tree, TreeId,
 };
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::repo::StoreFactories;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::git_backend::GitBackend;
+use jj_lib::repo::StoreFactories;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::workspace::Workspace;
 
 #[derive(clap::Parser, Clone, Debug)]
 enum CustomCommands {

--- a/examples/custom-command/main.rs
+++ b/examples/custom-command/main.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu::cli_util::{CliRunner, CommandError, CommandHelper};
-use jujutsu::ui::Ui;
+use jj_cli::cli_util::{CliRunner, CommandError, CommandHelper};
+use jj_cli::ui::Ui;
 
 #[derive(clap::Parser, Clone, Debug)]
 enum CustomCommands {

--- a/examples/custom-global-flag/main.rs
+++ b/examples/custom-global-flag/main.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu::cli_util::{CliRunner, CommandError};
-use jujutsu::ui::Ui;
+use jj_cli::cli_util::{CliRunner, CommandError};
+use jj_cli::ui::Ui;
 
 #[derive(clap::Args, Clone, Debug)]
 struct CustomGlobalArgs {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "jujutsu-lib"
+name = "jj-lib"
 version = "0.7.0"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 description = "Library for Jujutsu (an experimental VCS)"
 homepage = "https://github.com/martinvonz/jj"
 repository = "https://github.com/martinvonz/jj"
-documentation = "https://docs.rs/jujutsu"
+documentation = "https://docs.rs/jj-lib"
 readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/benches/diff_bench.rs
+++ b/lib/benches/diff_bench.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use jujutsu_lib::diff;
+use jj_lib::diff;
 
 fn unchanged_lines(count: usize) -> (String, String) {
     let mut lines = vec![];

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -14,8 +14,8 @@
 
 use std::path::Path;
 
-use jujutsu_lib::repo::{Repo, StoreFactories};
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::repo::{Repo, StoreFactories};
+use jj_lib::workspace::Workspace;
 use test_case::test_case;
 use testutils::{create_random_commit, load_repo_at_head, TestWorkspace};
 

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::backend::{ChangeId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
-use jujutsu_lib::matchers::EverythingMatcher;
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::tree::DiffSummary;
+use jj_lib::backend::{ChangeId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
+use jj_lib::matchers::EverythingMatcher;
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::settings::UserSettings;
+use jj_lib::tree::DiffSummary;
 use test_case::test_case;
 use testutils::{assert_rebased, CommitGraphBuilder, TestRepo};
 

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -16,8 +16,8 @@ use std::cmp::max;
 use std::sync::Arc;
 use std::thread;
 
-use jujutsu_lib::dag_walk;
-use jujutsu_lib::repo::{ReadonlyRepo, Repo};
+use jj_lib::dag_walk;
+use jj_lib::repo::{ReadonlyRepo, Repo};
 use test_case::test_case;
 use testutils::{load_repo_at_head, write_random_commit, TestWorkspace};
 

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::backend::{FileId, TreeValue};
-use jujutsu_lib::conflicts::{parse_conflict, Conflict};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::store::Store;
+use jj_lib::backend::{FileId, TreeValue};
+use jj_lib::conflicts::{parse_conflict, Conflict};
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::store::Store;
 use testutils::TestRepo;
 
 fn file_value(file_id: &FileId) -> TreeValue {

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::default_index_store::ReadonlyIndexWrapper;
-use jujutsu_lib::default_revset_engine::{evaluate, RevsetImpl};
-use jujutsu_lib::repo::{ReadonlyRepo, Repo as _};
-use jujutsu_lib::revset::{ResolvedExpression, RevsetGraphEdge};
+use jj_lib::commit::Commit;
+use jj_lib::default_index_store::ReadonlyIndexWrapper;
+use jj_lib::default_revset_engine::{evaluate, RevsetImpl};
+use jj_lib::repo::{ReadonlyRepo, Repo as _};
+use jj_lib::revset::{ResolvedExpression, RevsetGraphEdge};
 use test_case::test_case;
 use testutils::{CommitGraphBuilder, TestRepo};
 

--- a/lib/tests/test_diff_summary.rs
+++ b/lib/tests/test_diff_summary.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::matchers::{EverythingMatcher, FilesMatcher};
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::tree::DiffSummary;
+use jj_lib::matchers::{EverythingMatcher, FilesMatcher};
+use jj_lib::repo_path::RepoPath;
+use jj_lib::tree::DiffSummary;
 use test_case::test_case;
 use testutils::TestRepo;
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -19,18 +19,18 @@ use std::thread;
 
 use git2::Oid;
 use itertools::Itertools;
-use jujutsu_lib::backend::{
+use jj_lib::backend::{
     BackendError, ChangeId, CommitId, MillisSinceEpoch, ObjectId, Signature, Timestamp,
 };
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::commit_builder::CommitBuilder;
-use jujutsu_lib::git;
-use jujutsu_lib::git::{GitFetchError, GitPushError, GitRefUpdate, SubmoduleConfig};
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::op_store::{BranchTarget, RefTarget};
-use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
-use jujutsu_lib::settings::{GitSettings, UserSettings};
-use jujutsu_lib::view::RefName;
+use jj_lib::commit::Commit;
+use jj_lib::commit_builder::CommitBuilder;
+use jj_lib::git;
+use jj_lib::git::{GitFetchError, GitPushError, GitRefUpdate, SubmoduleConfig};
+use jj_lib::git_backend::GitBackend;
+use jj_lib::op_store::{BranchTarget, RefTarget};
+use jj_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
+use jj_lib::settings::{GitSettings, UserSettings};
+use jj_lib::view::RefName;
 use maplit::{btreemap, hashset};
 use tempfile::TempDir;
 use testutils::{create_random_commit, load_repo_at_head, write_random_commit, TestRepo};

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{CommitId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
-use jujutsu_lib::id_prefix::IdPrefixContext;
-use jujutsu_lib::index::HexPrefix;
-use jujutsu_lib::index::PrefixResolution::{AmbiguousMatch, NoMatch, SingleMatch};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::revset::RevsetExpression;
+use jj_lib::backend::{CommitId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
+use jj_lib::id_prefix::IdPrefixContext;
+use jj_lib::index::HexPrefix;
+use jj_lib::index::PrefixResolution::{AmbiguousMatch, NoMatch, SingleMatch};
+use jj_lib::repo::Repo;
+use jj_lib::revset::RevsetExpression;
 use testutils::TestRepo;
 
 #[test]

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -14,15 +14,15 @@
 
 use std::sync::Arc;
 
-use jujutsu_lib::backend::CommitId;
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::commit_builder::CommitBuilder;
-use jujutsu_lib::default_index_store::{
+use jj_lib::backend::CommitId;
+use jj_lib::commit::Commit;
+use jj_lib::commit_builder::CommitBuilder;
+use jj_lib::default_index_store::{
     CompositeIndex, IndexPosition, MutableIndexImpl, ReadonlyIndexWrapper,
 };
-use jujutsu_lib::index::Index as _;
-use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
-use jujutsu_lib::settings::UserSettings;
+use jj_lib::index::Index as _;
+use jj_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
+use jj_lib::settings::UserSettings;
 use test_case::test_case;
 use testutils::{
     create_random_commit, load_repo_at_head, write_random_commit, CommitGraphBuilder, TestRepo,

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -14,11 +14,11 @@
 
 use std::path::{Path, PathBuf};
 
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::op_store::WorkspaceId;
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::git_backend::GitBackend;
+use jj_lib::op_store::WorkspaceId;
+use jj_lib::repo::Repo;
+use jj_lib::settings::UserSettings;
+use jj_lib::workspace::Workspace;
 use test_case::test_case;
 use testutils::{write_random_commit, TestWorkspace};
 

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::repo::{RepoLoader, StoreFactories};
+use jj_lib::repo::{RepoLoader, StoreFactories};
 use test_case::test_case;
 use testutils::{write_random_commit, TestRepo};
 

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -14,11 +14,11 @@
 
 use assert_matches::assert_matches;
 use itertools::Itertools;
-use jujutsu_lib::backend::TreeValue;
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::{RepoPath, RepoPathComponent};
-use jujutsu_lib::rewrite::rebase_commit;
-use jujutsu_lib::tree::{merge_trees, Tree};
+use jj_lib::backend::TreeValue;
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::{RepoPath, RepoPathComponent};
+use jj_lib::rewrite::rebase_commit;
+use jj_lib::tree::{merge_trees, Tree};
 use test_case::test_case;
 use testutils::TestRepo;
 

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
-use jujutsu_lib::repo::Repo;
+use jj_lib::op_store::{RefTarget, WorkspaceId};
+use jj_lib::repo::Repo;
 use maplit::hashset;
 use test_case::test_case;
 use testutils::{

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -14,8 +14,8 @@
 
 use std::path::Path;
 
-use jujutsu_lib::backend::CommitId;
-use jujutsu_lib::repo::Repo;
+use jj_lib::backend::CommitId;
+use jj_lib::repo::Repo;
 use test_case::test_case;
 use testutils::{create_random_commit, write_random_commit, TestRepo};
 

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::op_store::RefTarget;
-use jujutsu_lib::refs::merge_ref_targets;
-use jujutsu_lib::repo::Repo;
+use jj_lib::op_store::RefTarget;
+use jj_lib::refs::merge_ref_targets;
+use jj_lib::repo::Repo;
 use testutils::{CommitGraphBuilder, TestWorkspace};
 
 #[test]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -21,22 +21,22 @@ use std::path::Path;
 
 use assert_matches::assert_matches;
 use itertools::Itertools;
-use jujutsu_lib::backend::{ChangeId, CommitId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::git;
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::index::{HexPrefix, PrefixResolution};
-use jujutsu_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::revset::{
+use jj_lib::backend::{ChangeId, CommitId, MillisSinceEpoch, ObjectId, Signature, Timestamp};
+use jj_lib::commit::Commit;
+use jj_lib::git;
+use jj_lib::git_backend::GitBackend;
+use jj_lib::index::{HexPrefix, PrefixResolution};
+use jj_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::revset::{
     optimize, parse, DefaultSymbolResolver, ReverseRevsetGraphIterator, Revset, RevsetAliasesMap,
     RevsetExpression, RevsetFilterPredicate, RevsetGraphEdge, RevsetResolutionError,
     RevsetWorkspaceContext, SymbolResolver as _,
 };
-use jujutsu_lib::settings::GitSettings;
-use jujutsu_lib::tree::merge_trees;
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::settings::GitSettings;
+use jj_lib::tree::merge_trees;
+use jj_lib::workspace::Workspace;
 use test_case::test_case;
 use testutils::{
     create_random_commit, write_random_commit, CommitGraphBuilder, TestRepo, TestWorkspace,

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::rewrite::DescendantRebaser;
+use jj_lib::op_store::{RefTarget, WorkspaceId};
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::rewrite::DescendantRebaser;
 use maplit::{hashmap, hashset};
 use test_case::test_case;
 use testutils::{

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -14,10 +14,10 @@
 
 use std::sync::Arc;
 
-use jujutsu_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
-use jujutsu_lib::repo::{ReadonlyRepo, Repo};
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::transaction::Transaction;
+use jj_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
+use jj_lib::repo::{ReadonlyRepo, Repo};
+use jj_lib::settings::UserSettings;
+use jj_lib::transaction::Transaction;
 use maplit::{btreemap, hashset};
 use test_case::test_case;
 use testutils::{create_random_commit, write_random_commit, CommitGraphBuilder, TestRepo};

--- a/lib/tests/test_working_copy.rs
+++ b/lib/tests/test_working_copy.rs
@@ -21,17 +21,17 @@ use std::os::unix::net::UnixListener;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{TreeId, TreeValue};
-use jujutsu_lib::conflicts::Conflict;
-use jujutsu_lib::fsmonitor::FsmonitorKind;
+use jj_lib::backend::{TreeId, TreeValue};
+use jj_lib::conflicts::Conflict;
+use jj_lib::fsmonitor::FsmonitorKind;
 #[cfg(unix)]
-use jujutsu_lib::op_store::OperationId;
-use jujutsu_lib::op_store::WorkspaceId;
-use jujutsu_lib::repo::{ReadonlyRepo, Repo};
-use jujutsu_lib::repo_path::{RepoPath, RepoPathComponent, RepoPathJoin};
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::tree_builder::TreeBuilder;
-use jujutsu_lib::working_copy::{LockedWorkingCopy, SnapshotOptions, WorkingCopy};
+use jj_lib::op_store::OperationId;
+use jj_lib::op_store::WorkspaceId;
+use jj_lib::repo::{ReadonlyRepo, Repo};
+use jj_lib::repo_path::{RepoPath, RepoPathComponent, RepoPathJoin};
+use jj_lib::settings::UserSettings;
+use jj_lib::tree_builder::TreeBuilder;
+use jj_lib::working_copy::{LockedWorkingCopy, SnapshotOptions, WorkingCopy};
 use test_case::test_case;
 use testutils::{write_random_commit, TestWorkspace};
 

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -16,10 +16,10 @@ use std::cmp::max;
 use std::thread;
 
 use assert_matches::assert_matches;
-use jujutsu_lib::repo::{Repo, StoreFactories};
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::working_copy::{CheckoutError, SnapshotOptions};
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::repo::{Repo, StoreFactories};
+use jj_lib::repo_path::RepoPath;
+use jj_lib::working_copy::{CheckoutError, SnapshotOptions};
+use jj_lib::workspace::Workspace;
 use test_case::test_case;
 use testutils::TestWorkspace;
 

--- a/lib/tests/test_working_copy_sparse.rs
+++ b/lib/tests/test_working_copy_sparse.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use jujutsu_lib::matchers::EverythingMatcher;
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::working_copy::{CheckoutStats, SnapshotOptions, WorkingCopy};
+use jj_lib::matchers::EverythingMatcher;
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::working_copy::{CheckoutStats, SnapshotOptions, WorkingCopy};
 use testutils::TestWorkspace;
 
 #[test]

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use assert_matches::assert_matches;
-use jujutsu_lib::op_store::WorkspaceId;
-use jujutsu_lib::repo::{Repo, StoreFactories};
-use jujutsu_lib::workspace::{Workspace, WorkspaceLoadError};
+use jj_lib::op_store::WorkspaceId;
+use jj_lib::repo::{Repo, StoreFactories};
+use jj_lib::workspace::{Workspace, WorkspaceLoadError};
 use test_case::test_case;
 use testutils::TestWorkspace;
 

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0"
-description = "Integration test utils for the jujutsu-lib crate"
+description = "Integration test utils for the jj-lib crate"
 homepage = "https://github.com/martinvonz/jj"
 repository = "https://github.com/martinvonz/jj"
-documentation = "https://docs.rs/jujutsu"
+documentation = "https://docs.rs/jj-lib"
 readme = "../..//README.md"
 publish = false
 
@@ -18,6 +18,6 @@ publish = false
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
 git2 = "0.17.2"
 itertools = "0.11.0"
-jujutsu-lib = { path = ".." }
+jj-lib = { path = ".." }
 rand = "0.8.5"
 tempfile = "3.6.0"

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -18,19 +18,19 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Once};
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{Backend, BackendInitError, FileId, ObjectId, TreeId, TreeValue};
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::commit_builder::CommitBuilder;
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::local_backend::LocalBackend;
-use jujutsu_lib::repo::{MutableRepo, ReadonlyRepo, Repo, RepoLoader, StoreFactories};
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::rewrite::RebasedDescendant;
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::store::Store;
-use jujutsu_lib::tree::Tree;
-use jujutsu_lib::tree_builder::TreeBuilder;
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::backend::{Backend, BackendInitError, FileId, ObjectId, TreeId, TreeValue};
+use jj_lib::commit::Commit;
+use jj_lib::commit_builder::CommitBuilder;
+use jj_lib::git_backend::GitBackend;
+use jj_lib::local_backend::LocalBackend;
+use jj_lib::repo::{MutableRepo, ReadonlyRepo, Repo, RepoLoader, StoreFactories};
+use jj_lib::repo_path::RepoPath;
+use jj_lib::rewrite::RebasedDescendant;
+use jj_lib::settings::UserSettings;
+use jj_lib::store::Store;
+use jj_lib::tree::Tree;
+use jj_lib::tree_builder::TreeBuilder;
+use jj_lib::workspace::Workspace;
 use tempfile::TempDir;
 
 pub fn hermetic_libgit2() {

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -29,36 +29,36 @@ use clap::{Arg, ArgAction, ArgMatches, Command, FromArgMatches};
 use git2::{Oid, Repository};
 use indexmap::IndexSet;
 use itertools::Itertools;
-use jujutsu_lib::backend::{BackendError, ChangeId, CommitId, ObjectId, TreeId};
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::git::{GitConfigParseError, GitExportError, GitImportError};
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::gitignore::GitIgnoreFile;
-use jujutsu_lib::hex_util::to_reverse_hex;
-use jujutsu_lib::id_prefix::IdPrefixContext;
-use jujutsu_lib::matchers::{EverythingMatcher, Matcher, PrefixMatcher, Visit};
-use jujutsu_lib::op_heads_store::{self, OpHeadResolutionError, OpHeadsStore};
-use jujutsu_lib::op_store::{OpStore, OpStoreError, OperationId, RefTarget, WorkspaceId};
-use jujutsu_lib::operation::Operation;
-use jujutsu_lib::repo::{
+use jj_lib::backend::{BackendError, ChangeId, CommitId, ObjectId, TreeId};
+use jj_lib::commit::Commit;
+use jj_lib::git::{GitConfigParseError, GitExportError, GitImportError};
+use jj_lib::git_backend::GitBackend;
+use jj_lib::gitignore::GitIgnoreFile;
+use jj_lib::hex_util::to_reverse_hex;
+use jj_lib::id_prefix::IdPrefixContext;
+use jj_lib::matchers::{EverythingMatcher, Matcher, PrefixMatcher, Visit};
+use jj_lib::op_heads_store::{self, OpHeadResolutionError, OpHeadsStore};
+use jj_lib::op_store::{OpStore, OpStoreError, OperationId, RefTarget, WorkspaceId};
+use jj_lib::operation::Operation;
+use jj_lib::repo::{
     CheckOutCommitError, EditCommitError, MutableRepo, ReadonlyRepo, Repo, RepoLoader,
     RewriteRootCommit, StoreFactories, StoreLoadError,
 };
-use jujutsu_lib::repo_path::{FsPathParseError, RepoPath};
-use jujutsu_lib::revset::{
+use jj_lib::repo_path::{FsPathParseError, RepoPath};
+use jj_lib::revset::{
     DefaultSymbolResolver, Revset, RevsetAliasesMap, RevsetEvaluationError, RevsetExpression,
     RevsetIteratorExt, RevsetParseError, RevsetParseErrorKind, RevsetResolutionError,
     RevsetWorkspaceContext,
 };
-use jujutsu_lib::settings::{ConfigResultExt as _, UserSettings};
-use jujutsu_lib::transaction::Transaction;
-use jujutsu_lib::tree::{Tree, TreeMergeError};
-use jujutsu_lib::view::RefName;
-use jujutsu_lib::working_copy::{
+use jj_lib::settings::{ConfigResultExt as _, UserSettings};
+use jj_lib::transaction::Transaction;
+use jj_lib::tree::{Tree, TreeMergeError};
+use jj_lib::view::RefName;
+use jj_lib::working_copy::{
     CheckoutStats, LockedWorkingCopy, ResetError, SnapshotError, SnapshotOptions, WorkingCopy,
 };
-use jujutsu_lib::workspace::{Workspace, WorkspaceInitError, WorkspaceLoadError, WorkspaceLoader};
-use jujutsu_lib::{dag_walk, file_util, git, revset};
+use jj_lib::workspace::{Workspace, WorkspaceInitError, WorkspaceLoadError, WorkspaceLoader};
+use jj_lib::{dag_walk, file_util, git, revset};
 use once_cell::unsync::OnceCell;
 use thiserror::Error;
 use toml_edit;

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -19,8 +19,8 @@ use std::time::Instant;
 use clap::Subcommand;
 use criterion::measurement::Measurement;
 use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
-use jujutsu_lib::index::HexPrefix;
-use jujutsu_lib::repo::Repo;
+use jj_lib::index::HexPrefix;
+use jj_lib::repo::Repo;
 
 use crate::cli_util::{CommandError, CommandHelper, WorkspaceCommandHelper};
 use crate::ui::Ui;

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -2,12 +2,12 @@ use std::collections::{BTreeSet, HashSet};
 
 use clap::builder::NonEmptyStringValueParser;
 use itertools::Itertools;
-use jujutsu_lib::backend::{CommitId, ObjectId};
-use jujutsu_lib::git;
-use jujutsu_lib::op_store::{BranchTarget, RefTarget};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::revset::{self, RevsetExpression};
-use jujutsu_lib::view::View;
+use jj_lib::backend::{CommitId, ObjectId};
+use jj_lib::git;
+use jj_lib::op_store::{BranchTarget, RefTarget};
+use jj_lib::repo::Repo;
+use jj_lib::revset::{self, RevsetExpression};
+use jj_lib::view::View;
 
 use crate::cli_util::{user_error, user_error_with_hint, CommandError, CommandHelper, RevisionArg};
 use crate::commands::make_branch_term;

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -15,9 +15,9 @@
 use std::fmt::Debug;
 
 use clap::Subcommand;
-use jujutsu_lib::backend::ObjectId;
-use jujutsu_lib::default_index_store::{DefaultIndexStore, ReadonlyIndexWrapper};
-use jujutsu_lib::revset;
+use jj_lib::backend::ObjectId;
+use jj_lib::default_index_store::{DefaultIndexStore, ReadonlyIndexWrapper};
+use jj_lib::revset;
 
 use crate::cli_util::{user_error, CommandError, CommandHelper};
 use crate::template_parser;

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -9,18 +9,18 @@ use std::time::Instant;
 
 use clap::{ArgGroup, Subcommand};
 use itertools::Itertools;
-use jujutsu_lib::backend::{CommitId, ObjectId, TreeValue};
-use jujutsu_lib::git::{self, parse_gitmodules, GitFetchError, GitPushError, GitRefUpdate};
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::op_store::{BranchTarget, RefTarget};
-use jujutsu_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::revset::{self, RevsetIteratorExt as _};
-use jujutsu_lib::settings::{ConfigResultExt as _, UserSettings};
-use jujutsu_lib::store::Store;
-use jujutsu_lib::view::View;
-use jujutsu_lib::workspace::Workspace;
+use jj_lib::backend::{CommitId, ObjectId, TreeValue};
+use jj_lib::git::{self, parse_gitmodules, GitFetchError, GitPushError, GitRefUpdate};
+use jj_lib::git_backend::GitBackend;
+use jj_lib::op_store::{BranchTarget, RefTarget};
+use jj_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
+use jj_lib::repo::Repo;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::revset::{self, RevsetIteratorExt as _};
+use jj_lib::settings::{ConfigResultExt as _, UserSettings};
+use jj_lib::store::Store;
+use jj_lib::view::View;
+use jj_lib::workspace::Workspace;
 use maplit::hashset;
 
 use crate::cli_util::{

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,25 +31,25 @@ use clap::parser::ValueSource;
 use clap::{ArgGroup, Command, CommandFactory, FromArgMatches, Subcommand};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
-use jujutsu_lib::backend::{CommitId, ObjectId, TreeValue};
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::conflicts::Conflict;
-use jujutsu_lib::dag_walk::topo_order_reverse;
-use jujutsu_lib::git_backend::GitBackend;
-use jujutsu_lib::matchers::EverythingMatcher;
-use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
-use jujutsu_lib::repo::{ReadonlyRepo, Repo};
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::revset::{
+use jj_lib::backend::{CommitId, ObjectId, TreeValue};
+use jj_lib::commit::Commit;
+use jj_lib::conflicts::Conflict;
+use jj_lib::dag_walk::topo_order_reverse;
+use jj_lib::git_backend::GitBackend;
+use jj_lib::matchers::EverythingMatcher;
+use jj_lib::op_store::{RefTarget, WorkspaceId};
+use jj_lib::repo::{ReadonlyRepo, Repo};
+use jj_lib::repo_path::RepoPath;
+use jj_lib::revset::{
     ReverseRevsetGraphIterator, RevsetAliasesMap, RevsetExpression, RevsetFilterPredicate,
     RevsetGraphEdge, RevsetGraphEdgeType, RevsetIteratorExt,
 };
-use jujutsu_lib::rewrite::{back_out_commit, merge_commit_trees, rebase_commit, DescendantRebaser};
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::tree::{merge_trees, Tree};
-use jujutsu_lib::working_copy::SnapshotOptions;
-use jujutsu_lib::workspace::Workspace;
-use jujutsu_lib::{file_util, revset};
+use jj_lib::rewrite::{back_out_commit, merge_commit_trees, rebase_commit, DescendantRebaser};
+use jj_lib::settings::UserSettings;
+use jj_lib::tree::{merge_trees, Tree};
+use jj_lib::working_copy::SnapshotOptions;
+use jj_lib::workspace::Workspace;
+use jj_lib::{file_util, revset};
 use maplit::{hashmap, hashset};
 
 use crate::cli_util::{
@@ -1099,11 +1099,7 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
             add_to_git_exclude(ui, &git_repo)?;
         } else {
             let mut tx = workspace_command.start_transaction("import git refs");
-            jujutsu_lib::git::import_refs(
-                tx.mut_repo(),
-                &git_repo,
-                &command.settings().git_settings(),
-            )?;
+            jj_lib::git::import_refs(tx.mut_repo(), &git_repo, &command.settings().git_settings())?;
             if let Some(RefTarget::Normal(git_head_id)) = tx.mut_repo().view().git_head().cloned() {
                 let git_head_commit = tx.mut_repo().store().get_commit(&git_head_id)?;
                 tx.check_out(&git_head_commit)?;
@@ -2725,7 +2721,7 @@ fn cmd_resolve(
 }
 
 fn print_conflicted_paths(
-    conflicts: &[(RepoPath, jujutsu_lib::backend::ConflictId)],
+    conflicts: &[(RepoPath, jj_lib::backend::ConflictId)],
     tree: &Tree,
     formatter: &mut dyn Formatter,
     workspace_command: &WorkspaceCommandHelper,

--- a/src/commands/operation.rs
+++ b/src/commands/operation.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use clap::Subcommand;
-use jujutsu_lib::op_store::BranchTarget;
-use jujutsu_lib::operation;
-use jujutsu_lib::repo::Repo;
+use jj_lib::op_store::BranchTarget;
+use jj_lib::operation;
+use jj_lib::repo::Repo;
 
 use crate::cli_util::{user_error, CommandError, CommandHelper, LogContentFormat};
 use crate::graphlog::{get_graphlog, Edge};
@@ -151,10 +151,10 @@ fn cmd_op_log(
 
 /// Restore only the portions of the view specified by the `what` argument
 fn view_with_desired_portions_restored(
-    view_being_restored: &jujutsu_lib::op_store::View,
-    current_view: &jujutsu_lib::op_store::View,
+    view_being_restored: &jj_lib::op_store::View,
+    current_view: &jj_lib::op_store::View,
     what: &[UndoWhatToRestore],
-) -> jujutsu_lib::op_store::View {
+) -> jj_lib::op_store::View {
     let mut new_view = if what.contains(&UndoWhatToRestore::Repo) {
         view_being_restored.clone()
     } else {

--- a/src/commit_templater.rs
+++ b/src/commit_templater.rs
@@ -18,13 +18,13 @@ use std::io;
 use std::rc::Rc;
 
 use itertools::Itertools as _;
-use jujutsu_lib::backend::{ChangeId, CommitId, ObjectId as _};
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::hex_util::to_reverse_hex;
-use jujutsu_lib::id_prefix::IdPrefixContext;
-use jujutsu_lib::op_store::{RefTarget, WorkspaceId};
-use jujutsu_lib::repo::Repo;
-use jujutsu_lib::{git, rewrite};
+use jj_lib::backend::{ChangeId, CommitId, ObjectId as _};
+use jj_lib::commit::Commit;
+use jj_lib::hex_util::to_reverse_hex;
+use jj_lib::id_prefix::IdPrefixContext;
+use jj_lib::op_store::{RefTarget, WorkspaceId};
+use jj_lib::repo::Repo;
+use jj_lib::{git, rewrite};
 use once_cell::unsync::OnceCell;
 
 use crate::formatter::Formatter;

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ use std::{env, fmt};
 
 use config::Source;
 use itertools::Itertools;
-use jujutsu_lib::settings::ConfigResultExt as _;
+use jj_lib::settings::ConfigResultExt as _;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/diff_util.rs
+++ b/src/diff_util.rs
@@ -18,16 +18,16 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use jujutsu_lib::backend::{ObjectId, TreeValue};
-use jujutsu_lib::commit::Commit;
-use jujutsu_lib::diff::{Diff, DiffHunk};
-use jujutsu_lib::files::DiffLine;
-use jujutsu_lib::matchers::Matcher;
-use jujutsu_lib::repo::{ReadonlyRepo, Repo};
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::settings::UserSettings;
-use jujutsu_lib::tree::{Tree, TreeDiffIterator};
-use jujutsu_lib::{diff, files, rewrite, tree};
+use jj_lib::backend::{ObjectId, TreeValue};
+use jj_lib::commit::Commit;
+use jj_lib::diff::{Diff, DiffHunk};
+use jj_lib::files::DiffLine;
+use jj_lib::matchers::Matcher;
+use jj_lib::repo::{ReadonlyRepo, Repo};
+use jj_lib::repo_path::RepoPath;
+use jj_lib::settings::UserSettings;
+use jj_lib::tree::{Tree, TreeDiffIterator};
+use jj_lib::{diff, files, rewrite, tree};
 
 use crate::cli_util::{CommandError, WorkspaceCommandHelper};
 use crate::formatter::Formatter;

--- a/src/graphlog.rs
+++ b/src/graphlog.rs
@@ -17,7 +17,7 @@ use std::io::Write;
 use std::{cmp, io};
 
 use itertools::Itertools;
-use jujutsu_lib::settings::UserSettings;
+use jj_lib::settings::UserSettings;
 use renderdag::{Ancestor, GraphRowRenderer, Renderer};
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jujutsu::cli_util::CliRunner;
+use jj_cli::cli_util::CliRunner;
 
 fn main() -> std::process::ExitCode {
     CliRunner::init().version(env!("JJ_VERSION")).run()

--- a/src/merge_tools.rs
+++ b/src/merge_tools.rs
@@ -21,15 +21,15 @@ use std::sync::Arc;
 
 use config::ConfigError;
 use itertools::Itertools;
-use jujutsu_lib::backend::{TreeId, TreeValue};
-use jujutsu_lib::conflicts::materialize_merge_result;
-use jujutsu_lib::gitignore::GitIgnoreFile;
-use jujutsu_lib::matchers::EverythingMatcher;
-use jujutsu_lib::repo_path::RepoPath;
-use jujutsu_lib::settings::{ConfigResultExt as _, UserSettings};
-use jujutsu_lib::store::Store;
-use jujutsu_lib::tree::Tree;
-use jujutsu_lib::working_copy::{CheckoutError, SnapshotError, SnapshotOptions, TreeState};
+use jj_lib::backend::{TreeId, TreeValue};
+use jj_lib::conflicts::materialize_merge_result;
+use jj_lib::gitignore::GitIgnoreFile;
+use jj_lib::matchers::EverythingMatcher;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::settings::{ConfigResultExt as _, UserSettings};
+use jj_lib::store::Store;
+use jj_lib::tree::Tree;
+use jj_lib::working_copy::{CheckoutError, SnapshotError, SnapshotOptions, TreeState};
 use regex::{Captures, Regex};
 use thiserror::Error;
 
@@ -102,7 +102,7 @@ pub enum ConflictResolveError {
     )]
     EmptyOrUnchanged,
     #[error("Backend error: {0:?}")]
-    BackendError(#[from] jujutsu_lib::backend::BackendError),
+    BackendError(#[from] jj_lib::backend::BackendError),
 }
 
 impl From<std::io::Error> for DiffEditError {

--- a/src/operation_templater.rs
+++ b/src/operation_templater.rs
@@ -15,9 +15,9 @@
 use std::io;
 
 use itertools::Itertools as _;
-use jujutsu_lib::op_store::{OperationId, OperationMetadata};
-use jujutsu_lib::operation::Operation;
-use jujutsu_lib::repo::ReadonlyRepo;
+use jj_lib::op_store::{OperationId, OperationMetadata};
+use jj_lib::operation::Operation;
+use jj_lib::repo::ReadonlyRepo;
 
 use crate::formatter::Formatter;
 use crate::template_builder::{

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,8 +4,8 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crossterm::terminal::{Clear, ClearType};
-use jujutsu_lib::git;
-use jujutsu_lib::repo_path::RepoPath;
+use jj_lib::git;
+use jj_lib::repo_path::RepoPath;
 
 use crate::cleanup_guard::CleanupGuard;
 use crate::ui::{OutputGuard, ProgressOutput, Ui};

--- a/src/template_builder.rs
+++ b/src/template_builder.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools as _;
-use jujutsu_lib::backend::{Signature, Timestamp};
+use jj_lib::backend::{Signature, Timestamp};
 
 use crate::template_parser::{
     self, ExpressionKind, ExpressionNode, FunctionCallNode, MethodCallNode, TemplateParseError,
@@ -92,8 +92,8 @@ macro_rules! impl_core_wrap_property_fns {
                 wrap_string_list(Vec<String>) => StringList,
                 wrap_boolean(bool) => Boolean,
                 wrap_integer(i64) => Integer,
-                wrap_signature(jujutsu_lib::backend::Signature) => Signature,
-                wrap_timestamp(jujutsu_lib::backend::Timestamp) => Timestamp,
+                wrap_signature(jj_lib::backend::Signature) => Signature,
+                wrap_timestamp(jj_lib::backend::Timestamp) => Timestamp,
                 wrap_timestamp_range($crate::templater::TimestampRange) => TimestampRange,
             }
         );

--- a/src/templater.rs
+++ b/src/templater.rs
@@ -16,7 +16,7 @@ use std::cell::RefCell;
 use std::io;
 use std::rc::Rc;
 
-use jujutsu_lib::backend::{Signature, Timestamp};
+use jj_lib::backend::{Signature, Timestamp};
 
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
 use crate::time_util;

--- a/src/time_util.rs
+++ b/src/time_util.rs
@@ -1,6 +1,6 @@
 use chrono::format::StrftimeItems;
 use chrono::{DateTime, FixedOffset, LocalResult, TimeZone, Utc};
-use jujutsu_lib::backend::Timestamp;
+use jj_lib::backend::Timestamp;
 use once_cell::sync::Lazy;
 
 /// Parsed formatting items which should never contain an error.

--- a/tests/test_git_import_export.rs
+++ b/tests/test_git_import_export.rs
@@ -14,7 +14,7 @@
 use std::path::Path;
 
 use itertools::Itertools as _;
-use jujutsu_lib::backend::{CommitId, ObjectId as _};
+use jj_lib::backend::{CommitId, ObjectId as _};
 
 use crate::common::TestEnvironment;
 

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -449,5 +449,5 @@ fn test_verbose_logging_enabled() {
         .split_at(36);
     // The log format is currently Pretty so we include the terminal markup.
     // Luckily, insta will print this in colour when reviewing.
-    insta::assert_snapshot!(log_line, @"[32m INFO[0m [2mjujutsu::cli_util[0m[2m:[0m verbose logging enabled");
+    insta::assert_snapshot!(log_line, @"[32m INFO[0m [2mjj_cli::cli_util[0m[2m:[0m verbose logging enabled");
 }


### PR DESCRIPTION
I plan to merge this soon before we release 0.8.0, which we should be able to do pretty soon, I think.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
