### PR TITLE
github: tell Dependabot to group all deps when possible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
   open-pull-requests-limit: 10
   commit-message:
     prefix: "github:"
+  groups:
+    all-dependencies:
+      patterns:
+      - "*"


### PR DESCRIPTION
This should reduce the number of PRs to review, and the number of uninteresting commits in the repo history.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
