### PR TITLE
tree: simplify diff iterator by leveraging `Tree::value()`

### DIFF
--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -301,6 +301,10 @@ impl Tree {
         self.entries.is_empty()
     }
 
+    pub fn names(&self) -> impl Iterator<Item = &RepoPathComponent> {
+        self.entries.keys()
+    }
+
     pub fn entries(&self) -> TreeEntriesNonRecursiveIterator {
         TreeEntriesNonRecursiveIterator {
             iter: self.entries.iter(),


### PR DESCRIPTION
This is much simpler and I was slightly surprised that it doesn't have much impact on performance. I tried `jj --ignore-working-copy diff -s --from root --to v5.15` in the Linux kernel repo, and there was perhaps a 1.5% slowdown. In more normal cases (like diffing a single commit against its parent), I couldn't measure any difference at all.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
