### PR TITLE
dependabot: also group cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
   open-pull-requests-limit: 10
   commit-message:
     prefix: "cargo:"
+  groups:
+    cargo-dependencies:
+      patterns:
+      - "*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -15,6 +19,6 @@ updates:
   commit-message:
     prefix: "github:"
   groups:
-    all-dependencies:
+    github-dependencies:
       patterns:
       - "*"


### PR DESCRIPTION
It looks like I accidentally applied the grouping only to GitHub actions updates.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
