### PR TITLE
Cleanup `.jj` on `jj init` failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ result
 
 # Editor specific ignores
 .idea
+.nova
+.vscode


### PR DESCRIPTION
An initial attempt to fix the underlying issue that led me to #1794. I will follow up with a test case for this in the integration test, add a `CHANGELOG` entry, etc. Fun times: I am doing all of this [using Jujutsu](https://v5.chriskrycho.com/journal/trying-out-jujutsu/), and I am liking it!

A few other notes/question:

- It may be that there are other failure modes where this should happen? I have not yet gone poking at that. I am happy to help clean up some of those as well if so.

- This is the most direct/naïve approach to adding this kind of handling, minimizing the changes to the existing implementation's flow—but another approach to this check might start even earlier: given this argument, just checking whether the `.git` directory exists in the current directory and failing immediately if it does not. In that case, the flow would be much simpler, because instead of cleaning up an already-created directory structure, it would just issue a user error and bail *before* completing it. That's my preference, but I didn't know if there was some invariant the existing logic was intended to preserve in terms of ordering of operations or any such!

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
