### PR TITLE
view: add default formatting to RefName, use it to print unexported branches

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -55,7 +55,7 @@ fn parse_git_ref(ref_name: &str) -> Option<RefName> {
     }
 }
 
-pub fn to_git_ref_name(parsed_ref: &RefName) -> String {
+fn to_git_ref_name(parsed_ref: &RefName) -> String {
     match parsed_ref {
         RefName::LocalBranch(branch) => format!("refs/heads/{branch}"),
         RefName::RemoteBranch { branch, remote } => format!("refs/remotes/{remote}/{branch}"),

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
 
 use itertools::Itertools;
 
@@ -28,6 +29,17 @@ pub enum RefName {
     RemoteBranch { branch: String, remote: String },
     Tag(String),
     GitRef(String),
+}
+
+impl fmt::Display for RefName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RefName::LocalBranch(name) => write!(f, "{name}"),
+            RefName::RemoteBranch { branch, remote } => write!(f, "{branch}@{remote}"),
+            RefName::Tag(name) => write!(f, "{name}"),
+            RefName::GitRef(name) => write!(f, "{name}"),
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -31,7 +31,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use jujutsu_lib::backend::{BackendError, ChangeId, CommitId, ObjectId, TreeId};
 use jujutsu_lib::commit::Commit;
-use jujutsu_lib::git::{to_git_ref_name, GitConfigParseError, GitExportError, GitImportError};
+use jujutsu_lib::git::{GitConfigParseError, GitExportError, GitImportError};
 use jujutsu_lib::git_backend::GitBackend;
 use jujutsu_lib::gitignore::GitIgnoreFile;
 use jujutsu_lib::hex_util::to_reverse_hex;
@@ -1517,16 +1517,7 @@ pub fn print_failed_git_export(
         let mut formatter = ui.stderr_formatter();
         for branch_ref in failed_branches {
             formatter.write_str("  ")?;
-            write!(
-                formatter.labeled("branch"),
-                "{}",
-                match branch_ref {
-                    RefName::LocalBranch(name) => name.to_string(),
-                    RefName::RemoteBranch { branch, remote } => format!("{branch}@{remote}"),
-                    // Should never happen, tags and git_refs should never be exported
-                    branch_ref => to_git_ref_name(branch_ref),
-                }
-            )?;
+            write!(formatter.labeled("branch"), "{branch_ref}")?;
             formatter.write_str("\n")?;
         }
         drop(formatter);


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
