### PR TITLE
protobuf: add `--experimental_allow_proto3_optional`

### DIFF
--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -29,6 +29,7 @@ fn main() -> Result<()> {
     prost_build::Config::new()
         .out_dir(&protos_dir)
         .include_file("mod.rs")
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &input
                 .into_iter()


### PR DESCRIPTION
Throwaway PR. I didn't need this, but posting in case someone wants to use it in the future.
