### PR TITLE
clippy: fix nightly clippy warnings *except* for `needless_raw_string_hashes`

### DIFF
--- a/lib/src/dag_walk.rs
+++ b/lib/src/dag_walk.rs
@@ -288,7 +288,7 @@ where
 {
     let start: Vec<T> = start.into_iter().collect();
     let mut reachable: HashSet<T> = start.iter().cloned().collect();
-    for _node in dfs(start.into_iter(), id_fn, |node| {
+    for _node in dfs(start, id_fn, |node| {
         let neighbors: Vec<T> = neighbors_fn(node).into_iter().collect();
         for neighbor in &neighbors {
             reachable.remove(neighbor);

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -294,7 +294,7 @@ pub fn import_some_refs(
     // come from branches which were never fetched.
     let mut pinned_git_heads_set = HashSet::new();
     for heads_for_ref in pinned_git_heads.into_values() {
-        pinned_git_heads_set.extend(heads_for_ref.into_iter());
+        pinned_git_heads_set.extend(heads_for_ref);
     }
     pinned_git_heads_set.retain(|id| mut_repo.index().has_id(id));
     // We could use mut_repo.record_rewrites() here but we know we only need to care
@@ -986,7 +986,7 @@ pub fn parse_gitmodules(
     // Partial config value for each submodule name
     let mut partial_configs: BTreeMap<String, PartialSubmoduleConfig> = BTreeMap::new();
 
-    let entries = git_config.entries(Some(r#"submodule\..+\."#))?;
+    let entries = git_config.entries(Some(r"submodule\..+\."))?;
     entries.for_each(|entry| {
         let (config_name, config_value) = match (entry.name(), entry.value()) {
             // Reject non-utf8 entries

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -239,7 +239,7 @@ fn find_globs(
         if names.is_empty() {
             failed_globs.push(glob);
         }
-        matching_branches.extend(names.into_iter());
+        matching_branches.extend(names);
     }
     match &failed_globs[..] {
         [] => { /* No problem */ }


### PR DESCRIPTION
This is (almost) a result of running

    cargo +nightly clippy --workspace --all-targets --fix \
      --  -A 'clippy::needless_raw_string_hashes'

with yesterday's nightly clippy.

https://github.com/mitsuhiko/insta/issues/389 causes numerous additional
`needless_raw_string_hashes` warnings, but it will hopefully be fixed soon.
For now, I recommend appending the second line to your invocations if you
use nightly clippy.