### PR TITLE
chore(nix): use latest stable rustc in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
         buildInputs = with pkgs; [
           # Using the minimal profile with explicit "clippy" extension to avoid
           # two versions of rustfmt
-          (rust-bin.stable."1.64.0".minimal.override {
+          (rust-bin.stable.latest.minimal.override {
             extensions = [
               "rust-src" # for rust-analyzer
               "clippy"


### PR DESCRIPTION
Summary: The CI already checks the MSRV in the build matrix for every submitted change, so putting the user on an older rustc can be annoying for various reasons (e.g. cargo may get a nifty new feature). Just use the latest stable rustc version for development.
