### PR TITLE
chore(github): reduce compile time in build, nix, and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: read-all
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 
 permissions: read-all
 
+env:
+  CARGO_INCREMENTAL: 0
+
 jobs:
   build-release:
     name: build-release

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
           ZSTD_SYS_USE_PKG_CONFIG = "1";
           LIBSSH2_SYS_USE_PKG_CONFIG = "1";
           NIX_JJ_GIT_HASH = self.rev or "";
+          CARGO_INCREMENTAL = "0";
           postInstall = ''
             $out/bin/jj util mangen > ./jj.1
             installManPage ./jj.1


### PR DESCRIPTION
Summary: When building in CI, we just build everything from scratch in the `dev` profile, so just turn off debuginfo and incremental compilation data. These aren't reused, but more importantly take up more space and CPU time to generate; that's more expensive on slower machines and when using The Cloud(TM) to build.

Together, these take a fresh build (`rm -rf target/` ahead of time) from about 40s to 30s on my machine.