### PR TITLE
rewrite: do not insert "removed" refs to reverse branch lookup table

### DIFF
--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -224,12 +224,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         let mut branches: HashMap<_, HashSet<_>> = HashMap::new();
         for (branch_name, branch_target) in mut_repo.view().branches() {
             if let Some(local_target) = &branch_target.local_target {
-                for commit in local_target.removes() {
-                    branches
-                        .entry(commit.clone())
-                        .or_default()
-                        .insert(branch_name.clone());
-                }
                 for commit in local_target.adds() {
                     branches
                         .entry(commit.clone())


### PR DESCRIPTION
It should no longer be needed since e3254fa5c412 "rewrite: don't rewrite the "removed" side of a branch conflict."

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
