### PR TITLE
feat(nix): enable watchman support in nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           pname = "jujutsu";
           version = "unstable-${self.shortRev or "dirty"}";
           buildNoDefaultFeatures = true;
-          buildFeatures = [];
+          buildFeatures = [ "watchman" ];
           cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
           useNextest = true;
           src = filterSrc ./. [


### PR DESCRIPTION
Summary: Nix packages tend to come "full extra pack of batteries"-included, so adding watchman support makes sense. I'll also want it for my own experiments.