### PR TITLE
Change the short commit template to show branches

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -368,12 +368,18 @@ fn cmd_branch_list(
         });
     }
 
+    let no_branches_template = workspace_command.parse_commit_template(
+        &command
+            .settings()
+            .config()
+            .get_string("templates.commit_summary_no_branches")?,
+    )?;
     let print_branch_target =
         |formatter: &mut dyn Formatter, target: &RefTarget| -> Result<(), CommandError> {
             if let Some(id) = target.as_normal() {
                 write!(formatter, ": ")?;
                 let commit = repo.store().get_commit(id)?;
-                workspace_command.write_commit_summary(formatter, &commit)?;
+                no_branches_template.format(&commit, formatter)?;
                 writeln!(formatter)?;
             } else {
                 write!(formatter, " ")?;
@@ -382,13 +388,13 @@ fn cmd_branch_list(
                 for id in target.removed_ids() {
                     let commit = repo.store().get_commit(id)?;
                     write!(formatter, "  - ")?;
-                    workspace_command.write_commit_summary(formatter, &commit)?;
+                    no_branches_template.format(&commit, formatter)?;
                     writeln!(formatter)?;
                 }
                 for id in target.added_ids() {
                     let commit = repo.store().get_commit(id)?;
                     write!(formatter, "  + ")?;
-                    workspace_command.write_commit_summary(formatter, &commit)?;
+                    no_branches_template.format(&commit, formatter)?;
                     writeln!(formatter)?;
                 }
             }

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -32,6 +32,7 @@
 "divergent change_id"="red"
 "conflict" = "red"
 "empty" = "green"
+"separator" = "bright black"
 
 "working_copy" = { bold = true }
 "working_copy commit_id" = "bright blue"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -9,6 +9,16 @@ separate(" ",
 )
 '''
 
+commit_summary_no_branches = '''
+separate(" ",
+  format_short_change_id(change_id),
+  format_short_commit_id(commit_id),
+  if(conflict, label("conflict", "(conflict)")),
+  if(empty, label("empty", "(empty)")),
+  if(description, description.first_line(), description_placeholder),
+)
+'''
+
 log = 'builtin_log_compact'
 op_log = 'builtin_op_log_compact'
 show = 'builtin_log_detailed'

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -3,9 +3,14 @@ commit_summary = '''
 separate(" ",
   format_short_change_id(change_id),
   format_short_commit_id(commit_id),
-  if(conflict, label("conflict", "(conflict)")),
-  if(empty, label("empty", "(empty)")),
-  if(description, description.first_line(), description_placeholder),
+  separate(commit_summary_separator,
+    branches,
+    separate(" ",
+      if(conflict, label("conflict", "(conflict)")),
+      if(empty, label("empty", "(empty)")),
+      if(description, description.first_line(), description_placeholder),
+    )
+  )
 )
 '''
 
@@ -100,6 +105,7 @@ label(if(current_operation, "current_operation"),
 builtin_op_log_comfortable = 'builtin_op_log_compact ++ "\n"'
 
 'description_placeholder' = 'label("description", "(no description set)")'
+'commit_summary_separator' = 'label("separator", " | ")'
 
 # Hook points for users to customize the default templates:
 'format_short_id(id)' = 'id.shortest(8)'

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -58,9 +58,9 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(stdout, @r###"
     Abandoned commit vruxwmqv b7c62f28 d
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy now at: znkkpsqq 11a2e10e e
-    Parent commit      : rlvkpnrz 2443ea76 a
-    Parent commit      : royxmykx fe2e8e8b c
+    Working copy now at: znkkpsqq 11a2e10e e | e
+    Parent commit      : rlvkpnrz 2443ea76 a | a
+    Parent commit      : royxmykx fe2e8e8b c d | c
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -79,7 +79,7 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(stdout, @r###"
     Abandoned commit znkkpsqq 5557ece3 e
     Working copy now at: nkmrtpmo 6b527513 (empty) (no description set)
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -95,13 +95,18 @@ fn test_rebase_branch_with_merge() {
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
+    // TODO(ilyagr): Minor Bug: The branch `e` should be shown next
+    // to the commit with description `e` below. This is because the commits are
+    // printed in the state *after* abandonment. This will be fixed together with
+    // adding (hidden) to the commit template, which causes a more obvious version
+    // of the same problem.
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
       znkkpsqq 5557ece3 e
       vruxwmqv b7c62f28 d
       royxmykx fe2e8e8b c
     Working copy now at: xtnwkqum e7bb0612 (empty) (no description set)
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -138,7 +143,7 @@ fn test_rebase_branch_with_merge() {
       zsuskuln 1394f625 b
       rlvkpnrz 2443ea76 a
     Working copy now at: xlzxqlsl af874bff (empty) (no description set)
-    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    Parent commit      : zzzzzzzz 00000000 a b e?? | (empty) (no description set)
     Added 0 files, modified 0 files, removed 4 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/cli/tests/test_chmod_command.rs
+++ b/cli/tests/test_chmod_command.rs
@@ -187,9 +187,9 @@ fn test_chmod_file_dir_deletion_conflicts() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["chmod", "x", "file", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: kmkuslsw 85942d95 (conflict) file_deletion
-    Parent commit      : zsuskuln c51c9c55 file
-    Parent commit      : royxmykx 6b18b3c1 deletion
+    Working copy now at: kmkuslsw 85942d95 file_deletion | (conflict) file_deletion
+    Parent commit      : zsuskuln c51c9c55 file | file
+    Parent commit      : royxmykx 6b18b3c1 deletion | deletion
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["cat", "-r=file_deletion", "file"]);

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -306,8 +306,8 @@ fn test_rebase_duplicates() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 commits
-    Working copy now at: zsuskuln 29bd36b6 b
-    Parent commit      : rlvkpnrz 2f6dc5a1 a
+    Working copy now at: zsuskuln 29bd36b6 b | b
+    Parent commit      : rlvkpnrz 2f6dc5a1 a | a
     "###);
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -56,7 +56,7 @@ fn test_git_clone() {
     insta::assert_snapshot!(stdout, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
     Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
-    Parent commit      : mzyxwzks 9f01a0e0 message
+    Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
     "###);
     assert!(test_env.env_root().join("clone").join("file").exists());
@@ -174,7 +174,7 @@ fn test_git_clone_colocate() {
     insta::assert_snapshot!(stdout, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
     Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
-    Parent commit      : mzyxwzks 9f01a0e0 message
+    Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
     "###);
     assert!(test_env.env_root().join("clone").join("file").exists());

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -94,7 +94,7 @@ fn test_init_git_external(bare: bool) {
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @r###"
         Working copy now at: sqpuoqvx f6950fc1 (empty) (no description set)
-        Parent commit      : mwrttmos 8d698d4a My commit message
+        Parent commit      : mwrttmos 8d698d4a my-branch | My commit message
         Added 1 files, modified 0 files, removed 0 files
         Initialized repo in "repo"
         "###);

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -86,8 +86,8 @@ fn test_move() {
     // Can move from sibling, which results in the source being abandoned
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: kmkuslsw 1c03e3d3 (no description set)
-    Parent commit      : znkkpsqq e9515f21 (no description set)
+    Working copy now at: kmkuslsw 1c03e3d3 f | (no description set)
+    Parent commit      : znkkpsqq e9515f21 e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -114,8 +114,8 @@ fn test_move() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: kmkuslsw c8d83075 (no description set)
-    Parent commit      : znkkpsqq 2c50bfc5 (no description set)
+    Working copy now at: kmkuslsw c8d83075 f | (no description set)
+    Parent commit      : znkkpsqq 2c50bfc5 e | (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
@@ -140,8 +140,8 @@ fn test_move() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "e", "--to", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: kmkuslsw 2b723b1d (no description set)
-    Parent commit      : vruxwmqv 4293930d (no description set)
+    Working copy now at: kmkuslsw 2b723b1d f | (no description set)
+    Parent commit      : vruxwmqv 4293930d d e | (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
@@ -203,8 +203,8 @@ fn test_move_partial() {
     // If we don't make any changes in the diff-editor, the whole change is moved
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: vruxwmqv 71b69e43 (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv 71b69e43 d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -234,8 +234,8 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: vruxwmqv 63f1a6e9 (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv 63f1a6e9 d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -268,8 +268,8 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: vruxwmqv 17c2e663 (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv 17c2e663 d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -329,8 +329,8 @@ fn test_move_partial() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: vruxwmqv b670567d (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv b670567d d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     "###);
 }
 

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -130,8 +130,8 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 descendant commits
     Working copy now at: kxryzmor ca7c6481 (empty) G
-    Parent commit      : kkmpptxz 6041917c (empty) B
-    Parent commit      : vruxwmqv c9257eff (empty) D
+    Parent commit      : kkmpptxz 6041917c B | (empty) B
+    Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  C
@@ -152,7 +152,7 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 descendant commits
     Working copy now at: uyznsvlq fcf8281b (empty) H
-    Parent commit      : vruxwmqv c9257eff (empty) D
+    Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  C
@@ -197,8 +197,8 @@ fn test_new_insert_after_children() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "G", "A", "C"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy now at: kxryzmor b48d4d73 (empty) G
-    Parent commit      : qpvuntsm 65b1ef43 (empty) A
-    Parent commit      : mzvwutvl ec18c57d (empty) C
+    Parent commit      : qpvuntsm 65b1ef43 A | (empty) A
+    Parent commit      : mzvwutvl ec18c57d C | (empty) C
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
@@ -241,9 +241,9 @@ fn test_new_insert_before() {
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 descendant commits
     Working copy now at: kxryzmor ff6bbbc7 (empty) G
-    Parent commit      : znkkpsqq 41a89ffc (empty) E
-    Parent commit      : vruxwmqv c9257eff (empty) D
-    Parent commit      : kkmpptxz 6041917c (empty) B
+    Parent commit      : znkkpsqq 41a89ffc E | (empty) E
+    Parent commit      : vruxwmqv c9257eff D | (empty) D
+    Parent commit      : kkmpptxz 6041917c B | (empty) B
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  F
@@ -354,7 +354,7 @@ fn test_new_insert_before_no_root_merge() {
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 descendant commits
     Working copy now at: kxryzmor bf9fc493 (empty) G
-    Parent commit      : qpvuntsm 65b1ef43 (empty) A
+    Parent commit      : qpvuntsm 65b1ef43 A | (empty) A
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉    F

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -127,8 +127,8 @@ fn test_rebase_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b=e", "-b=d", "-d=b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: znkkpsqq 9ca2a154 e
-    Parent commit      : zsuskuln 1394f625 b
+    Working copy now at: znkkpsqq 9ca2a154 e | e
+    Parent commit      : zsuskuln 1394f625 b | b
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -148,15 +148,15 @@ fn test_rebase_branch() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "e|d" resolved to more than one revision
     Hint: The revset "e|d" resolved to these revisions:
-    znkkpsqq e52756c8 e
-    vruxwmqv 514fa6b2 d
+    znkkpsqq e52756c8 e | e
+    vruxwmqv 514fa6b2 d | d
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:e|d').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b=all:e|d", "-d=b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: znkkpsqq 817e3fb0 e
-    Parent commit      : zsuskuln 1394f625 b
+    Working copy now at: znkkpsqq 817e3fb0 e | e
+    Parent commit      : zsuskuln 1394f625 b | b
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -198,8 +198,8 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: znkkpsqq 391c91a7 e
-    Parent commit      : vruxwmqv 1677f795 d
+    Working copy now at: znkkpsqq 391c91a7 e | e
+    Parent commit      : vruxwmqv 1677f795 d | d
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -215,8 +215,8 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: znkkpsqq 040ae3a6 e
-    Parent commit      : vruxwmqv 3d0f3644 d
+    Working copy now at: znkkpsqq 040ae3a6 e | e
+    Parent commit      : vruxwmqv 3d0f3644 d | d
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -259,8 +259,8 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 2 descendant commits onto parent of rebased commit
-    Working copy now at: vruxwmqv 7e15b97a d
-    Parent commit      : royxmykx 934236c8 c
+    Working copy now at: vruxwmqv 7e15b97a d | d
+    Parent commit      : royxmykx 934236c8 c | c
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -278,9 +278,9 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "root"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 1 descendant commits onto parent of rebased commit
-    Working copy now at: vruxwmqv bf87078f d
-    Parent commit      : zsuskuln d370aee1 b
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Working copy now at: vruxwmqv bf87078f d | d
+    Parent commit      : zsuskuln d370aee1 b | b
+    Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -321,9 +321,9 @@ fn test_rebase_single_revision_merge_parent() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 1 descendant commits onto parent of rebased commit
-    Working copy now at: vruxwmqv c62d0789 d
-    Parent commit      : zsuskuln d370aee1 b
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Working copy now at: vruxwmqv c62d0789 d | d
+    Parent commit      : zsuskuln d370aee1 b | b
+    Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -372,8 +372,8 @@ fn test_rebase_multiple_destinations() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|c" resolved to more than one revision
     Hint: The revset "b|c" resolved to these revisions:
-    royxmykx fe2e8e8b c
-    zsuskuln d370aee1 b
+    royxmykx fe2e8e8b c | c
+    zsuskuln d370aee1 b | b
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:b|c').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
@@ -432,8 +432,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: vruxwmqv 309336ff d
-    Parent commit      : royxmykx 244fa794 c
+    Working copy now at: vruxwmqv 309336ff d | d
+    Parent commit      : royxmykx 244fa794 c | c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
@@ -448,8 +448,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=c", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: vruxwmqv 92c2bc9a d
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Working copy now at: vruxwmqv 92c2bc9a d | d
+    Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -479,8 +479,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=b", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: vruxwmqv f1e71cb7 d
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Working copy now at: vruxwmqv f1e71cb7 d | d
+    Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -498,15 +498,15 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|d" resolved to more than one revision
     Hint: The revset "b|d" resolved to these revisions:
-    vruxwmqv df54a9fd d
-    zsuskuln d370aee1 b
+    vruxwmqv df54a9fd d | d
+    zsuskuln d370aee1 b | b
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:b|d').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=all:b|d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: vruxwmqv d17539f7 d
-    Parent commit      : rlvkpnrz 2443ea76 a
+    Working copy now at: vruxwmqv d17539f7 d | d
+    Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -87,9 +87,9 @@ fn test_resolution() {
     .unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
-    Working copy now at: vruxwmqv e069f073 conflict
-    Parent commit      : zsuskuln aa493daf a
-    Parent commit      : royxmykx db6a4daf b
+    Working copy now at: vruxwmqv e069f073 conflict | conflict
+    Parent commit      : zsuskuln aa493daf a | a
+    Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -183,9 +183,9 @@ conflict
             ],
         ),
         @r###"
-    Working copy now at: vruxwmqv 0bb40c90 (conflict) conflict
-    Parent commit      : zsuskuln aa493daf a
-    Parent commit      : royxmykx db6a4daf b
+    Working copy now at: vruxwmqv 0bb40c90 conflict | (conflict) conflict
+    Parent commit      : zsuskuln aa493daf a | a
+    Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     file    2-sided conflict
@@ -242,9 +242,9 @@ conflict
     .unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
-    Working copy now at: vruxwmqv 95418cb8 conflict
-    Parent commit      : zsuskuln aa493daf a
-    Parent commit      : royxmykx db6a4daf b
+    Working copy now at: vruxwmqv 95418cb8 conflict | conflict
+    Parent commit      : zsuskuln aa493daf a | a
+    Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -632,9 +632,9 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "another_file"]), @r###"
-    Working copy now at: vruxwmqv 07feb084 (conflict) conflict
-    Parent commit      : zsuskuln de7553ef a
-    Parent commit      : royxmykx f68bc2f0 b
+    Working copy now at: vruxwmqv 07feb084 conflict | (conflict) conflict
+    Parent commit      : zsuskuln de7553ef a | a
+    Parent commit      : royxmykx f68bc2f0 b | b
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
@@ -660,9 +660,9 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "--quiet", "another_file"]), @r###"
-    Working copy now at: vruxwmqv ff142405 (conflict) conflict
-    Parent commit      : zsuskuln de7553ef a
-    Parent commit      : royxmykx f68bc2f0 b
+    Working copy now at: vruxwmqv ff142405 conflict | (conflict) conflict
+    Parent commit      : zsuskuln de7553ef a | a
+    Parent commit      : royxmykx f68bc2f0 b | b
     Added 0 files, modified 1 files, removed 0 files
     "###);
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -191,9 +191,9 @@ fn test_restore_conflicted_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file"]);
     insta::assert_snapshot!(stdout, @r###"
     Created vruxwmqv 63198ca2 (conflict) (empty) conflict
-    Working copy now at: vruxwmqv 63198ca2 (conflict) (empty) conflict
-    Parent commit      : zsuskuln aa493daf a
-    Parent commit      : royxmykx db6a4daf b
+    Working copy now at: vruxwmqv 63198ca2 conflict | (conflict) (empty) conflict
+    Parent commit      : zsuskuln aa493daf a | a
+    Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -229,9 +229,9 @@ fn test_restore_conflicted_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
     Created vruxwmqv d955febc (conflict) (empty) conflict
-    Working copy now at: vruxwmqv d955febc (conflict) (empty) conflict
-    Parent commit      : zsuskuln aa493daf a
-    Parent commit      : royxmykx db6a4daf b
+    Working copy now at: vruxwmqv d955febc conflict | (conflict) (empty) conflict
+    Parent commit      : zsuskuln aa493daf a | a
+    Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -44,7 +44,7 @@ fn test_squash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy now at: vruxwmqv b9280a98 (empty) (no description set)
-    Parent commit      : kkmpptxz 6ca29c9d (no description set)
+    Parent commit      : kkmpptxz 6ca29c9d b c | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b9280a9898cb
@@ -62,8 +62,8 @@ fn test_squash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl e87cf8eb (no description set)
-    Parent commit      : qpvuntsm 893c93ae (no description set)
+    Working copy now at: mzvwutvl e87cf8eb c | (no description set)
+    Parent commit      : qpvuntsm 893c93ae a b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e87cf8ebc7e1 c
@@ -109,7 +109,7 @@ fn test_squash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy now at: xlzxqlsl 959145c1 (empty) (no description set)
-    Parent commit      : nmzmmopx 80960125 (no description set)
+    Parent commit      : nmzmmopx 80960125 e | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  959145c11426
@@ -159,8 +159,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl f03d5ce4 (no description set)
-    Parent commit      : qpvuntsm c9f931cd (no description set)
+    Working copy now at: mzvwutvl f03d5ce4 c | (no description set)
+    Parent commit      : qpvuntsm c9f931cd a b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f03d5ce4a973 c
@@ -178,8 +178,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl e7a40106 (no description set)
-    Parent commit      : kkmpptxz 05d95164 (no description set)
+    Working copy now at: mzvwutvl e7a40106 c | (no description set)
+    Parent commit      : kkmpptxz 05d95164 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e7a40106bee6 c
@@ -211,8 +211,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl a911fa1d (no description set)
-    Parent commit      : kkmpptxz fb73ad17 (no description set)
+    Working copy now at: mzvwutvl a911fa1d c | (no description set)
+    Parent commit      : kkmpptxz fb73ad17 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a911fa1d0627 c
@@ -243,8 +243,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl 5e297967 (no description set)
-    Parent commit      : kkmpptxz ac258609 (no description set)
+    Working copy now at: mzvwutvl 5e297967 c | (no description set)
+    Parent commit      : kkmpptxz ac258609 b | (no description set)
     "###);
 
     // We get a warning if we pass a positional argument that looks like a revset
@@ -254,8 +254,8 @@ fn test_squash_partial() {
     warning: The argument "b" is being interpreted as a path. To specify a revset, pass -r "b" instead.
     "###);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: mzvwutvl 1c4e5596 (no description set)
-    Parent commit      : kkmpptxz 16cc94b4 (no description set)
+    Working copy now at: mzvwutvl 1c4e5596 c | (no description set)
+    Parent commit      : kkmpptxz 16cc94b4 b | (no description set)
     "###);
 }
 

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -35,7 +35,7 @@ fn test_status_merge() {
     insta::assert_snapshot!(stdout, @r###"
     The working copy is clean
     Working copy : mzvwutvl c965365c (empty) (no description set)
-    Parent commit: rlvkpnrz 9ae48ddb (empty) left
+    Parent commit: rlvkpnrz 9ae48ddb left | (empty) left
     Parent commit: zsuskuln 29b991e9 right
     "###);
 }

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -43,8 +43,8 @@ fn test_unsquash() {
     // Unsquashes into the working copy from its parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: mzvwutvl 1b10d78f (no description set)
-    Parent commit      : qpvuntsm 90aeefd0 (no description set)
+    Working copy now at: mzvwutvl 1b10d78f c | (no description set)
+    Parent commit      : qpvuntsm 90aeefd0 a b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1b10d78f6136 c
@@ -61,8 +61,8 @@ fn test_unsquash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl 45b8b3dd (no description set)
-    Parent commit      : kkmpptxz 9146bcc8 (no description set)
+    Working copy now at: mzvwutvl 45b8b3dd c | (no description set)
+    Parent commit      : kkmpptxz 9146bcc8 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  45b8b3ddc25a c
@@ -108,8 +108,8 @@ fn test_unsquash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy now at: pzsxstzt 3217340c merge
-    Parent commit      : mzvwutvl 90fe0a96 (no description set)
-    Parent commit      : xznxytkn 5658521e (no description set)
+    Parent commit      : mzvwutvl 90fe0a96 c e?? | (no description set)
+    Parent commit      : xznxytkn 5658521e d e?? | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    3217340cb761
@@ -158,8 +158,8 @@ fn test_unsquash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl 37c961d0 (no description set)
-    Parent commit      : kkmpptxz 000af220 (no description set)
+    Working copy now at: mzvwutvl 37c961d0 c | (no description set)
+    Parent commit      : kkmpptxz 000af220 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  37c961d0d1e2 c
@@ -177,8 +177,8 @@ fn test_unsquash_partial() {
     std::fs::write(edit_script, "reset file1").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: mzvwutvl a8e8fded (no description set)
-    Parent commit      : kkmpptxz 46cc0667 (no description set)
+    Working copy now at: mzvwutvl a8e8fded c | (no description set)
+    Parent commit      : kkmpptxz 46cc0667 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a8e8fded1021 c


### PR DESCRIPTION
This changes the short commit template and `jj status` to show which commits have branches at them.

I initially had branches come after the description (see "Older version" below), but I think it's more logical to put them next to the other names the commit can be referred by (change and commit id)

I also added a grey `|` before the branches, mostly so that one can tell apart the branches from the description without color (e.g. in tests).

The result looks like this (3rd version)

![image](https://github.com/martinvonz/jj/assets/4123047/a38aff7b-2b47-49e6-8461-c42e8eb535a4)


## Older version V2

![image](https://github.com/martinvonz/jj/assets/4123047/4036d569-7b2b-4def-8af6-ebed8f2a2fd3)

Some notes:

- The `|` seems vital when branches are shown and color is disabled (not to confuse them with the description), and showing it consistently looks better.
- I tried all the options of whether to have a space before or after the `|`. IMO, this looks best. Without a space before, the `|` blends together with the commit id.

For reference, after this PR, the remaining TODOs in this area are:

- [ ] Show `(hidden)` in short commit template. This requires making `abandon` show changes as they were before the abandonment.
- [ ] Show `??` for divergent change ids in the short commit template. This requires making a bunch of commands show changes as they are after the transaction finishes.
- [ ] (Perhaps) trim the description to a sensible length and limit the number of branches that can be shown so that the short commit description fits in 70-80 characters usually.

    Alternatively or additionally, wrap the description in beautiful and clever ways when it takes up more than a line.
- [ ] Adjust the tutorial and demos to match.



### Older version V1

Most notably, this version shows branches **after** the description. It also doesn't show change ids, use your imagination to put them back in.



![image](https://github.com/martinvonz/jj/assets/4123047/3d217e91-4acd-4910-a77d-212a381269d0)

Example in a different repo state:

![image](https://github.com/martinvonz/jj/assets/4123047/622ddaa9-a490-497e-b8eb-5fc1d47f5ded)

TODO for future PRs: trim the description to a sensible length and limit the number of branches that
can be shown so that the short commit description fits in 70-80 characters usually.

We may or may not want to regenerate the demos/ screenshots if this goes in.

# Checklist

If applicable:
- (not planned) I have updated `CHANGELOG.md`
- [ ] Screenshots in demos/ (may or may not want to deal with them)
- [ ] `tutorial.md`'s status commands would need to be updated.
- [ ] Check if other docs are affected.
- (not planned) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
