### PR TITLE
Allow editing non-existent configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* `jj config edit --user` and `jj config set --user` will now pick a default
+  config location if no existing file is found, potentially creating parent directories.
+
 * `jj log` output is now topologically grouped.
   [#242](https://github.com/martinvonz/jj/issues/242)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "assert_cmd"
@@ -997,6 +997,7 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 name = "jj-cli"
 version = "0.8.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "assert_matches",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 libc = { version = "0.2.147" }
 
 [dev-dependencies]
+anyhow = "1.0.72"
 assert_cmd = "2.0.8"
 assert_matches = "1.5.0"
 insta = { version = "1.31.0", features = ["filters"] }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -68,7 +68,7 @@ use tracing_chrome::ChromeLayerBuilder;
 use tracing_subscriber::prelude::*;
 
 use crate::config::{
-    config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
+    new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
 };
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
 use crate::merge_tools::{ConflictResolveError, DiffEditError};
@@ -2001,14 +2001,14 @@ pub fn write_config_value_to_file(
     })
 }
 
-pub fn get_config_file_path(
+pub fn get_new_config_file_path(
     config_source: &ConfigSource,
     workspace_loader: &WorkspaceLoader,
 ) -> Result<PathBuf, CommandError> {
     let edit_path = match config_source {
         // TODO(#531): Special-case for editors that can't handle viewing directories?
         ConfigSource::User => {
-            config_path()?.ok_or_else(|| user_error("No repo config path found to edit"))?
+            new_config_path()?.ok_or_else(|| user_error("No repo config path found to edit"))?
         }
         ConfigSource::Repo => workspace_loader.repo_path().join("config.toml"),
         _ => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -55,7 +55,7 @@ use jj_lib::{file_util, revset};
 use maplit::{hashmap, hashset};
 
 use crate::cli_util::{
-    check_stale_working_copy, get_config_file_path, print_checkout_stats,
+    check_stale_working_copy, get_new_config_file_path, print_checkout_stats,
     resolve_multiple_nonempty_revsets, resolve_multiple_nonempty_revsets_flag_guarded,
     run_ui_editor, serialize_config_value, short_commit_hash, user_error, user_error_with_hint,
     write_config_value_to_file, Args, CommandError, CommandHelper, DescriptionArg,
@@ -1234,7 +1234,7 @@ fn cmd_config_set(
     command: &CommandHelper,
     args: &ConfigSetArgs,
 ) -> Result<(), CommandError> {
-    let config_path = get_config_file_path(
+    let config_path = get_new_config_file_path(
         &args.config_args.get_source_kind(),
         command.workspace_loader()?,
     )?;
@@ -1252,7 +1252,7 @@ fn cmd_config_edit(
     command: &CommandHelper,
     args: &ConfigEditArgs,
 ) -> Result<(), CommandError> {
-    let config_path = get_config_file_path(
+    let config_path = get_new_config_file_path(
         &args.config_args.get_source_kind(),
         command.workspace_loader()?,
     )?;


### PR DESCRIPTION
Addresses #1571.

`jj config edit --user` and `jj config set --user` will now pick a default config location if no existing is found.

Platform-specific config directory is preferred over the home directory.