### PR TITLE
view: pass `Option<RefTarget>` in to setter functions (prep for migration to `Conflict<T>`)

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -203,10 +203,10 @@ pub fn import_some_refs(
             let head_commit = store.get_commit(&head_commit_id).unwrap();
             prevent_gc(git_repo, &head_commit_id)?;
             mut_repo.add_head(&head_commit);
-            mut_repo.set_git_head(RefTarget::Normal(head_commit_id));
+            mut_repo.set_git_head_target(Some(RefTarget::Normal(head_commit_id)));
         }
     } else {
-        mut_repo.clear_git_head();
+        mut_repo.set_git_head_target(None);
     }
 
     let mut changed_git_refs = BTreeMap::new();

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -540,7 +540,7 @@ pub fn remove_remote(
         .filter_map(|r| r.starts_with(&prefix).then(|| r.clone()))
         .collect_vec();
     for branch in branches_to_delete {
-        mut_repo.remove_remote_branch(&branch, remote_name);
+        mut_repo.set_remote_branch_target(&branch, remote_name, None);
     }
     for git_ref in git_refs_to_delete {
         mut_repo.set_git_ref_target(&git_ref, None);

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -970,12 +970,8 @@ impl MutableRepo {
         self.view.with_ref(|v| v.get_local_branch(name))
     }
 
-    pub fn set_local_branch(&mut self, name: String, target: RefTarget) {
-        self.view_mut().set_local_branch(name, target);
-    }
-
-    pub fn remove_local_branch(&mut self, name: &str) {
-        self.view_mut().remove_local_branch(name);
+    pub fn set_local_branch_target(&mut self, name: &str, target: Option<RefTarget>) {
+        self.view_mut().set_local_branch_target(name, target);
     }
 
     pub fn get_remote_branch(&self, name: &str, remote_name: &str) -> Option<RefTarget> {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1011,12 +1011,8 @@ impl MutableRepo {
         self.view.with_ref(|v| v.get_git_ref(name))
     }
 
-    pub fn set_git_ref(&mut self, name: String, target: RefTarget) {
-        self.view_mut().set_git_ref(name, target);
-    }
-
-    pub fn remove_git_ref(&mut self, name: &str) {
-        self.view_mut().remove_git_ref(name);
+    pub fn set_git_ref_target(&mut self, name: &str, target: Option<RefTarget>) {
+        self.view_mut().set_git_ref_target(name, target);
     }
 
     pub fn git_head(&self) -> Option<RefTarget> {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -999,12 +999,8 @@ impl MutableRepo {
         self.view.with_ref(|v| v.get_tag(name))
     }
 
-    pub fn set_tag(&mut self, name: String, target: RefTarget) {
-        self.view_mut().set_tag(name, target);
-    }
-
-    pub fn remove_tag(&mut self, name: &str) {
-        self.view_mut().remove_tag(name);
+    pub fn set_tag_target(&mut self, name: &str, target: Option<RefTarget>) {
+        self.view_mut().set_tag_target(name, target);
     }
 
     pub fn get_git_ref(&self, name: &str) -> Option<RefTarget> {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1023,12 +1023,8 @@ impl MutableRepo {
         self.view.with_ref(|v| v.git_head().cloned())
     }
 
-    pub fn set_git_head(&mut self, target: RefTarget) {
-        self.view_mut().set_git_head(target);
-    }
-
-    pub fn clear_git_head(&mut self) {
-        self.view_mut().clear_git_head();
+    pub fn set_git_head_target(&mut self, target: Option<RefTarget>) {
+        self.view_mut().set_git_head_target(target);
     }
 
     pub fn set_view(&mut self, data: op_store::View) {
@@ -1152,16 +1148,13 @@ impl MutableRepo {
             );
         }
 
-        if let Some(new_git_head) = merge_ref_targets(
+        let new_git_head_target = merge_ref_targets(
             self.index(),
             self.view().git_head(),
             base.git_head(),
             other.git_head(),
-        ) {
-            self.set_git_head(new_git_head);
-        } else {
-            self.clear_git_head();
-        }
+        );
+        self.set_git_head_target(new_git_head_target);
     }
 
     /// Finds and records commits that were rewritten or abandoned between

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -983,12 +983,14 @@ impl MutableRepo {
             .with_ref(|v| v.get_remote_branch(name, remote_name))
     }
 
-    pub fn set_remote_branch(&mut self, name: String, remote_name: String, target: RefTarget) {
-        self.view_mut().set_remote_branch(name, remote_name, target);
-    }
-
-    pub fn remove_remote_branch(&mut self, name: &str, remote_name: &str) {
-        self.view_mut().remove_remote_branch(name, remote_name);
+    pub fn set_remote_branch_target(
+        &mut self,
+        name: &str,
+        remote_name: &str,
+        target: Option<RefTarget>,
+    ) {
+        self.view_mut()
+            .set_remote_branch_target(name, remote_name, target);
     }
 
     pub fn rename_remote(&mut self, old: &str, new: &str) {

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -131,7 +131,7 @@ impl View {
             RefName::LocalBranch(name) => self.get_local_branch(name),
             RefName::RemoteBranch { branch, remote } => self.get_remote_branch(branch, remote),
             RefName::Tag(name) => self.get_tag(name),
-            RefName::GitRef(name) => self.git_refs().get(name).cloned(),
+            RefName::GitRef(name) => self.get_git_ref(name),
         }
     }
 

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -148,7 +148,7 @@ impl View {
                     self.set_tag(name, target);
                 }
                 RefName::GitRef(name) => {
-                    self.set_git_ref(name, target);
+                    self.set_git_ref_target(&name, Some(target));
                 }
             }
         } else {
@@ -163,7 +163,7 @@ impl View {
                     self.remove_tag(&name);
                 }
                 RefName::GitRef(name) => {
-                    self.remove_git_ref(&name);
+                    self.set_git_ref_target(&name, None);
                 }
             }
         }
@@ -250,12 +250,14 @@ impl View {
         self.data.git_refs.get(name).cloned()
     }
 
-    pub fn set_git_ref(&mut self, name: String, target: RefTarget) {
-        self.data.git_refs.insert(name, target);
-    }
-
-    pub fn remove_git_ref(&mut self, name: &str) {
-        self.data.git_refs.remove(name);
+    /// Sets the last imported Git ref to point to the given target. If the
+    /// target is absent, the reference will be removed.
+    pub fn set_git_ref_target(&mut self, name: &str, target: Option<RefTarget>) {
+        if let Some(target) = target {
+            self.data.git_refs.insert(name.to_owned(), target);
+        } else {
+            self.data.git_refs.remove(name);
+        }
     }
 
     /// Sets `HEAD@git` to point to the given target. If the target is absent,

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -145,7 +145,7 @@ impl View {
                     self.set_remote_branch(branch, remote, target);
                 }
                 RefName::Tag(name) => {
-                    self.set_tag(name, target);
+                    self.set_tag_target(&name, Some(target));
                 }
                 RefName::GitRef(name) => {
                     self.set_git_ref_target(&name, Some(target));
@@ -160,7 +160,7 @@ impl View {
                     self.remove_remote_branch(&branch, &remote);
                 }
                 RefName::Tag(name) => {
-                    self.remove_tag(&name);
+                    self.set_tag_target(&name, None);
                 }
                 RefName::GitRef(name) => {
                     self.set_git_ref_target(&name, None);
@@ -238,12 +238,14 @@ impl View {
         self.data.tags.get(name).cloned()
     }
 
-    pub fn set_tag(&mut self, name: String, target: RefTarget) {
-        self.data.tags.insert(name, target);
-    }
-
-    pub fn remove_tag(&mut self, name: &str) {
-        self.data.tags.remove(name);
+    /// Sets tag to point to the given target. If the target is absent, the tag
+    /// will be removed.
+    pub fn set_tag_target(&mut self, name: &str, target: Option<RefTarget>) {
+        if let Some(target) = target {
+            self.data.tags.insert(name.to_owned(), target);
+        } else {
+            self.data.tags.remove(name);
+        }
     }
 
     pub fn get_git_ref(&self, name: &str) -> Option<RefTarget> {

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -258,12 +258,10 @@ impl View {
         self.data.git_refs.remove(name);
     }
 
-    pub fn set_git_head(&mut self, target: RefTarget) {
-        self.data.git_head = Some(target);
-    }
-
-    pub fn clear_git_head(&mut self) {
-        self.data.git_head = None;
+    /// Sets `HEAD@git` to point to the given target. If the target is absent,
+    /// the reference will be cleared.
+    pub fn set_git_head_target(&mut self, target: Option<RefTarget>) {
+        self.data.git_head = target;
     }
 
     pub fn set_view(&mut self, data: op_store::View) {

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -135,37 +135,16 @@ impl View {
         }
     }
 
-    pub fn set_or_remove_ref(&mut self, name: RefName, target: Option<RefTarget>) {
-        if let Some(target) = target {
-            match name {
-                RefName::LocalBranch(name) => {
-                    self.set_local_branch_target(&name, Some(target));
-                }
-                RefName::RemoteBranch { branch, remote } => {
-                    self.set_remote_branch_target(&branch, &remote, Some(target));
-                }
-                RefName::Tag(name) => {
-                    self.set_tag_target(&name, Some(target));
-                }
-                RefName::GitRef(name) => {
-                    self.set_git_ref_target(&name, Some(target));
-                }
+    /// Sets reference of the specified kind to point to the given target. If
+    /// the target is absent, the reference will be removed.
+    pub fn set_ref_target(&mut self, name: &RefName, target: Option<RefTarget>) {
+        match name {
+            RefName::LocalBranch(name) => self.set_local_branch_target(name, target),
+            RefName::RemoteBranch { branch, remote } => {
+                self.set_remote_branch_target(branch, remote, target)
             }
-        } else {
-            match name {
-                RefName::LocalBranch(name) => {
-                    self.set_local_branch_target(&name, None);
-                }
-                RefName::RemoteBranch { branch, remote } => {
-                    self.set_remote_branch_target(&branch, &remote, None);
-                }
-                RefName::Tag(name) => {
-                    self.set_tag_target(&name, None);
-                }
-                RefName::GitRef(name) => {
-                    self.set_git_ref_target(&name, None);
-                }
-            }
+            RefName::Tag(name) => self.set_tag_target(name, target),
+            RefName::GitRef(name) => self.set_git_ref_target(name, target),
         }
     }
 
@@ -317,7 +296,7 @@ impl View {
             let new_target =
                 merge_ref_targets(index, self_target.as_ref(), base_target, other_target);
             if new_target != self_target {
-                self.set_or_remove_ref(ref_name.clone(), new_target);
+                self.set_ref_target(ref_name, new_target);
             }
         }
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -152,28 +152,28 @@ fn test_import_refs() {
 
     assert_eq!(view.git_refs().len(), 6);
     assert_eq!(
-        view.git_refs().get("refs/heads/main"),
-        Some(RefTarget::Normal(jj_id(&commit2))).as_ref()
+        view.get_git_ref("refs/heads/main"),
+        Some(RefTarget::Normal(jj_id(&commit2)))
     );
     assert_eq!(
-        view.git_refs().get("refs/heads/feature1"),
-        Some(RefTarget::Normal(jj_id(&commit3))).as_ref()
+        view.get_git_ref("refs/heads/feature1"),
+        Some(RefTarget::Normal(jj_id(&commit3)))
     );
     assert_eq!(
-        view.git_refs().get("refs/heads/feature2"),
-        Some(RefTarget::Normal(jj_id(&commit4))).as_ref()
+        view.get_git_ref("refs/heads/feature2"),
+        Some(RefTarget::Normal(jj_id(&commit4)))
     );
     assert_eq!(
-        view.git_refs().get("refs/remotes/origin/main"),
-        Some(RefTarget::Normal(jj_id(&commit1))).as_ref()
+        view.get_git_ref("refs/remotes/origin/main"),
+        Some(RefTarget::Normal(jj_id(&commit1)))
     );
     assert_eq!(
-        view.git_refs().get("refs/remotes/origin/feature3"),
-        Some(RefTarget::Normal(jj_id(&commit6))).as_ref()
+        view.get_git_ref("refs/remotes/origin/feature3"),
+        Some(RefTarget::Normal(jj_id(&commit6)))
     );
     assert_eq!(
-        view.git_refs().get("refs/tags/v1.0"),
-        Some(RefTarget::Normal(jj_id(&commit5))).as_ref()
+        view.get_git_ref("refs/tags/v1.0"),
+        Some(RefTarget::Normal(jj_id(&commit5)))
     );
     assert_eq!(view.git_head(), Some(&RefTarget::Normal(jj_id(&commit2))));
 }
@@ -263,18 +263,15 @@ fn test_import_refs_reimport() {
     assert!(view.tags().is_empty());
 
     assert_eq!(view.git_refs().len(), 3);
+    assert_eq!(view.get_git_ref("refs/heads/main"), Some(commit2_target));
     assert_eq!(
-        view.git_refs().get("refs/heads/main"),
-        Some(commit2_target).as_ref()
-    );
-    assert_eq!(
-        view.git_refs().get("refs/remotes/origin/main"),
-        Some(commit1_target).as_ref()
+        view.get_git_ref("refs/remotes/origin/main"),
+        Some(commit1_target)
     );
     let commit5_target = RefTarget::Normal(jj_id(&commit5));
     assert_eq!(
-        view.git_refs().get("refs/heads/feature2"),
-        Some(commit5_target).as_ref()
+        view.get_git_ref("refs/heads/feature2"),
+        Some(commit5_target)
     );
 }
 

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -473,10 +473,10 @@ fn test_has_changed(use_git: bool) {
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
     mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit1.id().clone()));
-    mut_repo.set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(commit1.id().clone())),
     );
     let repo = tx.commit();
     // Test the setup
@@ -492,17 +492,17 @@ fn test_has_changed(use_git: bool) {
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
     mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit1.id().clone()));
-    mut_repo.set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(commit1.id().clone())),
     );
     assert!(!mut_repo.has_changes());
 
     mut_repo.remove_public_head(commit2.id());
     mut_repo.remove_head(commit2.id());
     mut_repo.remove_local_branch("stable");
-    mut_repo.remove_remote_branch("stable", "origin");
+    mut_repo.set_remote_branch_target("stable", "origin", None);
     assert!(!mut_repo.has_changes());
 
     mut_repo.add_head(&commit2);
@@ -532,16 +532,16 @@ fn test_has_changed(use_git: bool) {
     mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit1.id().clone()));
     assert!(!mut_repo.has_changes());
 
-    mut_repo.set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     assert!(mut_repo.has_changes());
-    mut_repo.set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(commit1.id().clone())),
     );
     assert!(!mut_repo.has_changes());
 }
@@ -629,9 +629,9 @@ fn test_rename_remote(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let mut_repo = tx.mut_repo();
     let commit = write_random_commit(mut_repo, &settings);
-    let target = RefTarget::Normal(commit.id().clone());
-    mut_repo.set_remote_branch("main".to_string(), "origin".to_string(), target.clone());
+    let target = Some(RefTarget::Normal(commit.id().clone()));
+    mut_repo.set_remote_branch_target("main", "origin", target.clone());
     mut_repo.rename_remote("origin", "upstream");
-    assert_eq!(mut_repo.get_remote_branch("main", "upstream"), Some(target));
+    assert_eq!(mut_repo.get_remote_branch("main", "upstream"), target);
     assert_eq!(mut_repo.get_remote_branch("main", "origin"), None);
 }

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -170,10 +170,7 @@ fn test_checkout_previous_empty_with_local_branch(use_git: bool) {
         )
         .write()
         .unwrap();
-    mut_repo.set_local_branch(
-        "b".to_owned(),
-        RefTarget::Normal(old_wc_commit.id().clone()),
-    );
+    mut_repo.set_local_branch_target("b", Some(RefTarget::Normal(old_wc_commit.id().clone())));
     let ws_id = WorkspaceId::default();
     mut_repo.edit(ws_id.clone(), &old_wc_commit).unwrap();
     let repo = tx.commit();
@@ -472,7 +469,7 @@ fn test_has_changed(use_git: bool) {
     mut_repo
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
-    mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit1.id().clone()));
+    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit1.id().clone())));
     mut_repo.set_remote_branch_target(
         "main",
         "origin",
@@ -491,7 +488,7 @@ fn test_has_changed(use_git: bool) {
     mut_repo
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
-    mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit1.id().clone()));
+    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit1.id().clone())));
     mut_repo.set_remote_branch_target(
         "main",
         "origin",
@@ -501,7 +498,7 @@ fn test_has_changed(use_git: bool) {
 
     mut_repo.remove_public_head(commit2.id());
     mut_repo.remove_head(commit2.id());
-    mut_repo.remove_local_branch("stable");
+    mut_repo.set_local_branch_target("stable", None);
     mut_repo.set_remote_branch_target("stable", "origin", None);
     assert!(!mut_repo.has_changes());
 
@@ -527,9 +524,9 @@ fn test_has_changed(use_git: bool) {
     mut_repo.set_wc_commit(ws_id, commit1.id().clone()).unwrap();
     assert!(!mut_repo.has_changes());
 
-    mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit2.id().clone()));
+    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit2.id().clone())));
     assert!(mut_repo.has_changes());
-    mut_repo.set_local_branch("main".to_string(), RefTarget::Normal(commit1.id().clone()));
+    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit1.id().clone())));
     assert!(!mut_repo.has_changes());
 
     mut_repo.set_remote_branch_target(

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -425,15 +425,15 @@ fn test_resolve_symbol_branches() {
     let commit4 = write_random_commit(mut_repo, &settings);
     let commit5 = write_random_commit(mut_repo, &settings);
 
-    mut_repo.set_local_branch("local".to_owned(), RefTarget::Normal(commit1.id().clone()));
+    mut_repo.set_local_branch_target("local", Some(RefTarget::Normal(commit1.id().clone())));
     mut_repo.set_remote_branch_target(
         "remote",
         "origin",
         Some(RefTarget::Normal(commit2.id().clone())),
     );
-    mut_repo.set_local_branch(
-        "local-remote".to_owned(),
-        RefTarget::Normal(commit3.id().clone()),
+    mut_repo.set_local_branch_target(
+        "local-remote",
+        Some(RefTarget::Normal(commit3.id().clone())),
     );
     mut_repo.set_remote_branch_target(
         "local-remote",
@@ -450,12 +450,12 @@ fn test_resolve_symbol_branches() {
         mut_repo.get_local_branch("local-remote"),
     );
 
-    mut_repo.set_local_branch(
-        "local-conflicted".to_owned(),
-        RefTarget::Conflict {
+    mut_repo.set_local_branch_target(
+        "local-conflicted",
+        Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit3.id().clone(), commit2.id().clone()],
-        },
+        }),
     );
     mut_repo.set_remote_branch_target(
         "remote-conflicted",
@@ -1702,14 +1702,8 @@ fn test_evaluate_expression_branches(use_git: bool) {
     // Can get branches when there are none
     assert_eq!(resolve_commit_ids(mut_repo, "branches()"), vec![]);
     // Can get a few branches
-    mut_repo.set_local_branch(
-        "branch1".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
-    );
-    mut_repo.set_local_branch(
-        "branch2".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
-    );
+    mut_repo.set_local_branch_target("branch1", Some(RefTarget::Normal(commit1.id().clone())));
+    mut_repo.set_local_branch_target("branch2", Some(RefTarget::Normal(commit2.id().clone())));
     assert_eq!(
         resolve_commit_ids(mut_repo, "branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
@@ -1727,30 +1721,27 @@ fn test_evaluate_expression_branches(use_git: bool) {
     assert_eq!(resolve_commit_ids(mut_repo, "branches(branch3)"), vec![]);
     // Two branches pointing to the same commit does not result in a duplicate in
     // the revset
-    mut_repo.set_local_branch(
-        "branch3".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
-    );
+    mut_repo.set_local_branch_target("branch3", Some(RefTarget::Normal(commit2.id().clone())));
     assert_eq!(
         resolve_commit_ids(mut_repo, "branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     // Can get branches when there are conflicted refs
-    mut_repo.set_local_branch(
-        "branch1".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_local_branch_target(
+        "branch1",
+        Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit2.id().clone(), commit3.id().clone()],
-        },
+        }),
     );
-    mut_repo.set_local_branch(
-        "branch2".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_local_branch_target(
+        "branch2",
+        Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
             adds: vec![commit3.id().clone(), commit4.id().clone()],
-        },
+        }),
     );
-    mut_repo.remove_local_branch("branch3");
+    mut_repo.set_local_branch_target("branch3", None);
     assert_eq!(
         resolve_commit_ids(mut_repo, "branches()"),
         vec![

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -445,9 +445,9 @@ fn test_resolve_symbol_branches() {
         "mirror".to_owned(),
         mut_repo.get_local_branch("local-remote").unwrap(),
     );
-    mut_repo.set_git_ref(
-        "refs/heads/local-remote".to_owned(),
-        mut_repo.get_local_branch("local-remote").unwrap(),
+    mut_repo.set_git_ref_target(
+        "refs/heads/local-remote",
+        mut_repo.get_local_branch("local-remote"),
     );
 
     mut_repo.set_local_branch(
@@ -680,28 +680,28 @@ fn test_resolve_symbol_git_refs() {
     let commit3 = write_random_commit(mut_repo, &settings);
     let commit4 = write_random_commit(mut_repo, &settings);
     let commit5 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_git_ref(
-        "refs/heads/branch1".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/branch1",
+        Some(RefTarget::Normal(commit1.id().clone())),
     );
-    mut_repo.set_git_ref(
-        "refs/heads/branch2".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/branch2",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
-    mut_repo.set_git_ref(
-        "refs/heads/conflicted".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_git_ref_target(
+        "refs/heads/conflicted",
+        Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
             adds: vec![commit1.id().clone(), commit3.id().clone()],
-        },
+        }),
     );
-    mut_repo.set_git_ref(
-        "refs/tags/tag1".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/tags/tag1",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
-    mut_repo.set_git_ref(
-        "refs/tags/remotes/origin/branch1".to_string(),
-        RefTarget::Normal(commit3.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/tags/remotes/origin/branch1",
+        Some(RefTarget::Normal(commit3.id().clone())),
     );
 
     // Nonexistent ref
@@ -712,9 +712,9 @@ fn test_resolve_symbol_git_refs() {
     );
 
     // Full ref
-    mut_repo.set_git_ref(
-        "refs/heads/branch".to_string(),
-        RefTarget::Normal(commit4.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/branch",
+        Some(RefTarget::Normal(commit4.id().clone())),
     );
     assert_eq!(
         resolve_symbol(mut_repo, "refs/heads/branch", None).unwrap(),
@@ -722,9 +722,9 @@ fn test_resolve_symbol_git_refs() {
     );
 
     // Qualified with only heads/
-    mut_repo.set_git_ref(
-        "refs/heads/branch".to_string(),
-        RefTarget::Normal(commit5.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/branch",
+        Some(RefTarget::Normal(commit5.id().clone())),
     );
     // branch alone is not recognized
     insta::assert_debug_snapshot!(
@@ -738,9 +738,9 @@ fn test_resolve_symbol_git_refs() {
         ],
     }
     "###);
-    mut_repo.set_git_ref(
-        "refs/tags/branch".to_string(),
-        RefTarget::Normal(commit4.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/tags/branch",
+        Some(RefTarget::Normal(commit4.id().clone())),
     );
     // The *tag* branch is recognized
     assert_eq!(
@@ -754,9 +754,9 @@ fn test_resolve_symbol_git_refs() {
     );
 
     // Unqualified tag name
-    mut_repo.set_git_ref(
-        "refs/tags/tag".to_string(),
-        RefTarget::Normal(commit4.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/tags/tag",
+        Some(RefTarget::Normal(commit4.id().clone())),
     );
     assert_eq!(
         resolve_symbol(mut_repo, "tag", None).unwrap(),
@@ -764,9 +764,9 @@ fn test_resolve_symbol_git_refs() {
     );
 
     // Unqualified remote-tracking branch name
-    mut_repo.set_git_ref(
-        "refs/remotes/origin/remote-branch".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/remotes/origin/remote-branch",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     assert_eq!(
         resolve_symbol(mut_repo, "origin/remote-branch", None).unwrap(),
@@ -778,8 +778,8 @@ fn test_resolve_symbol_git_refs() {
     mut_repo
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
-    mut_repo.set_git_ref("@".to_string(), RefTarget::Normal(commit2.id().clone()));
-    mut_repo.set_git_ref("root".to_string(), RefTarget::Normal(commit3.id().clone()));
+    mut_repo.set_git_ref_target("@", Some(RefTarget::Normal(commit2.id().clone())));
+    mut_repo.set_git_ref_target("root", Some(RefTarget::Normal(commit3.id().clone())));
     assert_eq!(
         resolve_symbol(mut_repo, "@", Some(&ws_id)).unwrap(),
         vec![mut_repo.view().get_wc_commit_id(&ws_id).unwrap().clone()]
@@ -1615,13 +1615,13 @@ fn test_evaluate_expression_git_refs(use_git: bool) {
     // Can get git refs when there are none
     assert_eq!(resolve_commit_ids(mut_repo, "git_refs()"), vec![]);
     // Can get a mix of git refs
-    mut_repo.set_git_ref(
-        "refs/heads/branch1".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/branch1",
+        Some(RefTarget::Normal(commit1.id().clone())),
     );
-    mut_repo.set_git_ref(
-        "refs/tags/tag1".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/tags/tag1",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_refs()"),
@@ -1629,30 +1629,30 @@ fn test_evaluate_expression_git_refs(use_git: bool) {
     );
     // Two refs pointing to the same commit does not result in a duplicate in the
     // revset
-    mut_repo.set_git_ref(
-        "refs/tags/tag2".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/tags/tag2",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_refs()"),
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     // Can get git refs when there are conflicted refs
-    mut_repo.set_git_ref(
-        "refs/heads/branch1".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_git_ref_target(
+        "refs/heads/branch1",
+        Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit2.id().clone(), commit3.id().clone()],
-        },
+        }),
     );
-    mut_repo.set_git_ref(
-        "refs/tags/tag1".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_git_ref_target(
+        "refs/tags/tag1",
+        Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
             adds: vec![commit3.id().clone(), commit4.id().clone()],
-        },
+        }),
     );
-    mut_repo.remove_git_ref("refs/tags/tag2");
+    mut_repo.set_git_ref_target("refs/tags/tag2", None);
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_refs()"),
         vec![

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -426,24 +426,24 @@ fn test_resolve_symbol_branches() {
     let commit5 = write_random_commit(mut_repo, &settings);
 
     mut_repo.set_local_branch("local".to_owned(), RefTarget::Normal(commit1.id().clone()));
-    mut_repo.set_remote_branch(
-        "remote".to_owned(),
-        "origin".to_owned(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "remote",
+        "origin",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     mut_repo.set_local_branch(
         "local-remote".to_owned(),
         RefTarget::Normal(commit3.id().clone()),
     );
-    mut_repo.set_remote_branch(
-        "local-remote".to_owned(),
-        "origin".to_owned(),
-        RefTarget::Normal(commit4.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "local-remote",
+        "origin",
+        Some(RefTarget::Normal(commit4.id().clone())),
     );
-    mut_repo.set_remote_branch(
-        "local-remote".to_owned(),
-        "mirror".to_owned(),
-        mut_repo.get_local_branch("local-remote").unwrap(),
+    mut_repo.set_remote_branch_target(
+        "local-remote",
+        "mirror",
+        mut_repo.get_local_branch("local-remote"),
     );
     mut_repo.set_git_ref_target(
         "refs/heads/local-remote",
@@ -457,13 +457,13 @@ fn test_resolve_symbol_branches() {
             adds: vec![commit3.id().clone(), commit2.id().clone()],
         },
     );
-    mut_repo.set_remote_branch(
-        "remote-conflicted".to_owned(),
-        "origin".to_owned(),
-        RefTarget::Conflict {
+    mut_repo.set_remote_branch_target(
+        "remote-conflicted",
+        "origin",
+        Some(RefTarget::Conflict {
             removes: vec![commit3.id().clone()],
             adds: vec![commit5.id().clone(), commit4.id().clone()],
-        },
+        }),
     );
 
     // Local only
@@ -1779,15 +1779,15 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
     // Can get branches when there are none
     assert_eq!(resolve_commit_ids(mut_repo, "remote_branches()"), vec![]);
     // Can get a few branches
-    mut_repo.set_remote_branch(
-        "branch1".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit1.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "branch1",
+        "origin",
+        Some(RefTarget::Normal(commit1.id().clone())),
     );
-    mut_repo.set_remote_branch(
-        "branch2".to_string(),
-        "private".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "branch2",
+        "private",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_branches()"),
@@ -1835,10 +1835,10 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
     );
     // Two branches pointing to the same commit does not result in a duplicate in
     // the revset
-    mut_repo.set_remote_branch(
-        "branch3".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit2.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "branch3",
+        "origin",
+        Some(RefTarget::Normal(commit2.id().clone())),
     );
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_branches()"),
@@ -1851,23 +1851,23 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     // Can get branches when there are conflicted refs
-    mut_repo.set_remote_branch(
-        "branch1".to_string(),
-        "origin".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_remote_branch_target(
+        "branch1",
+        "origin",
+        Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit2.id().clone(), commit3.id().clone()],
-        },
+        }),
     );
-    mut_repo.set_remote_branch(
-        "branch2".to_string(),
-        "private".to_string(),
-        RefTarget::Conflict {
+    mut_repo.set_remote_branch_target(
+        "branch2",
+        "private",
+        Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
             adds: vec![commit3.id().clone(), commit4.id().clone()],
-        },
+        }),
     );
-    mut_repo.remove_remote_branch("branch3", "origin");
+    mut_repo.set_remote_branch_target("branch3", "origin", None);
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_branches()"),
         vec![

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -649,7 +649,7 @@ fn test_resolve_symbol_git_head() {
     "###);
 
     // With HEAD@git
-    mut_repo.set_git_head(RefTarget::Normal(commit1.id().clone()));
+    mut_repo.set_git_head_target(Some(RefTarget::Normal(commit1.id().clone())));
     insta::assert_debug_snapshot!(
         resolve_symbol(mut_repo, "HEAD", None).unwrap_err(), @r###"
     NoSuchRevision {
@@ -1677,7 +1677,7 @@ fn test_evaluate_expression_git_head(use_git: bool) {
 
     // Can get git head when it's not set
     assert_eq!(resolve_commit_ids(mut_repo, "git_head()"), vec![]);
-    mut_repo.set_git_head(RefTarget::Normal(commit1.id().clone()));
+    mut_repo.set_git_head_target(Some(RefTarget::Normal(commit1.id().clone())));
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_head()"),
         vec![commit1.id().clone()]

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1031,7 +1031,7 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
         RefTarget::Normal(commit_b.id().clone()),
     );
     tx.mut_repo()
-        .set_tag("v1".to_string(), RefTarget::Normal(commit_b.id().clone()));
+        .set_tag_target("v1", Some(RefTarget::Normal(commit_b.id().clone())));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -935,7 +935,7 @@ fn test_rebase_descendants_basic_branch_update() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));
+        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -978,7 +978,7 @@ fn test_rebase_descendants_branch_move_two_steps() {
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     let commit_c = graph_builder.commit_with_parents(&[&commit_b]);
     tx.mut_repo()
-        .set_local_branch("main".to_string(), RefTarget::Normal(commit_c.id().clone()));
+        .set_local_branch_target("main", Some(RefTarget::Normal(commit_c.id().clone())));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1024,7 +1024,7 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));
+        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
     tx.mut_repo().set_remote_branch_target(
         "main",
         "origin",
@@ -1080,7 +1080,7 @@ fn test_rebase_descendants_update_branch_after_abandon() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));
+        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1116,7 +1116,7 @@ fn test_rebase_descendants_update_branches_after_divergent_rewrite() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));
+        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1180,12 +1180,12 @@ fn test_rebase_descendants_rewrite_updates_branch_conflict() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.initial_commit();
     let commit_c = graph_builder.initial_commit();
-    tx.mut_repo().set_local_branch(
-        "main".to_string(),
-        RefTarget::Conflict {
+    tx.mut_repo().set_local_branch_target(
+        "main",
+        Some(RefTarget::Conflict {
             removes: vec![commit_a.id().clone()],
             adds: vec![commit_b.id().clone(), commit_c.id().clone()],
-        },
+        }),
     );
     let repo = tx.commit();
 
@@ -1261,12 +1261,12 @@ fn test_rebase_descendants_rewrite_resolves_branch_conflict() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     let commit_c = graph_builder.commit_with_parents(&[&commit_a]);
-    tx.mut_repo().set_local_branch(
-        "main".to_string(),
-        RefTarget::Conflict {
+    tx.mut_repo().set_local_branch_target(
+        "main",
+        Some(RefTarget::Conflict {
             removes: vec![commit_a.id().clone()],
             adds: vec![commit_b.id().clone(), commit_c.id().clone()],
-        },
+        }),
     );
     let repo = tx.commit();
 
@@ -1304,12 +1304,12 @@ fn test_rebase_descendants_branch_delete_modify_abandon() {
     let mut graph_builder = CommitGraphBuilder::new(&settings, tx.mut_repo());
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
-    tx.mut_repo().set_local_branch(
-        "main".to_string(),
-        RefTarget::Conflict {
+    tx.mut_repo().set_local_branch_target(
+        "main",
+        Some(RefTarget::Conflict {
             removes: vec![commit_a.id().clone()],
             adds: vec![commit_b.id().clone()],
-        },
+        }),
     );
     let repo = tx.commit();
 

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1025,10 +1025,10 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
         .set_local_branch("main".to_string(), RefTarget::Normal(commit_b.id().clone()));
-    tx.mut_repo().set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(commit_b.id().clone()),
+    tx.mut_repo().set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(commit_b.id().clone())),
     );
     tx.mut_repo()
         .set_tag_target("v1", Some(RefTarget::Normal(commit_b.id().clone())));

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -252,15 +252,15 @@ fn test_merge_views_branches() {
         "main".to_string(),
         RefTarget::Normal(main_branch_local_tx0.id().clone()),
     );
-    mut_repo.set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(main_branch_origin_tx0.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(main_branch_origin_tx0.id().clone())),
     );
-    mut_repo.set_remote_branch(
-        "main".to_string(),
-        "alternate".to_string(),
-        RefTarget::Normal(main_branch_alternate_tx0.id().clone()),
+    mut_repo.set_remote_branch_target(
+        "main",
+        "alternate",
+        Some(RefTarget::Normal(main_branch_alternate_tx0.id().clone())),
     );
     let feature_branch_local_tx0 = write_random_commit(mut_repo, &settings);
     mut_repo.set_git_ref_target(
@@ -275,10 +275,10 @@ fn test_merge_views_branches() {
         "main".to_string(),
         RefTarget::Normal(main_branch_local_tx1.id().clone()),
     );
-    tx1.mut_repo().set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(main_branch_origin_tx1.id().clone()),
+    tx1.mut_repo().set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(main_branch_origin_tx1.id().clone())),
     );
     let feature_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo().set_local_branch(
@@ -293,10 +293,10 @@ fn test_merge_views_branches() {
         "main".to_string(),
         RefTarget::Normal(main_branch_local_tx2.id().clone()),
     );
-    tx2.mut_repo().set_remote_branch(
-        "main".to_string(),
-        "origin".to_string(),
-        RefTarget::Normal(main_branch_origin_tx1.id().clone()),
+    tx2.mut_repo().set_remote_branch_target(
+        "main",
+        "origin",
+        Some(RefTarget::Normal(main_branch_origin_tx1.id().clone())),
     );
     tx2.commit();
 

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -263,9 +263,9 @@ fn test_merge_views_branches() {
         RefTarget::Normal(main_branch_alternate_tx0.id().clone()),
     );
     let feature_branch_local_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_git_ref(
-        "feature".to_string(),
-        RefTarget::Normal(feature_branch_local_tx0.id().clone()),
+    mut_repo.set_git_ref_target(
+        "feature",
+        Some(RefTarget::Normal(feature_branch_local_tx0.id().clone())),
     );
     let repo = tx.commit();
 
@@ -384,35 +384,35 @@ fn test_merge_views_git_refs() {
     let mut tx = repo.start_transaction(&settings, "test");
     let mut_repo = tx.mut_repo();
     let main_branch_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_git_ref(
-        "refs/heads/main".to_string(),
-        RefTarget::Normal(main_branch_tx0.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/main",
+        Some(RefTarget::Normal(main_branch_tx0.id().clone())),
     );
     let feature_branch_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_git_ref(
-        "refs/heads/feature".to_string(),
-        RefTarget::Normal(feature_branch_tx0.id().clone()),
+    mut_repo.set_git_ref_target(
+        "refs/heads/feature",
+        Some(RefTarget::Normal(feature_branch_tx0.id().clone())),
     );
     let repo = tx.commit();
 
     let mut tx1 = repo.start_transaction(&settings, "test");
     let main_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
-    tx1.mut_repo().set_git_ref(
-        "refs/heads/main".to_string(),
-        RefTarget::Normal(main_branch_tx1.id().clone()),
+    tx1.mut_repo().set_git_ref_target(
+        "refs/heads/main",
+        Some(RefTarget::Normal(main_branch_tx1.id().clone())),
     );
     let feature_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
-    tx1.mut_repo().set_git_ref(
-        "refs/heads/feature".to_string(),
-        RefTarget::Normal(feature_branch_tx1.id().clone()),
+    tx1.mut_repo().set_git_ref_target(
+        "refs/heads/feature",
+        Some(RefTarget::Normal(feature_branch_tx1.id().clone())),
     );
     tx1.commit();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let main_branch_tx2 = write_random_commit(tx2.mut_repo(), &settings);
-    tx2.mut_repo().set_git_ref(
-        "refs/heads/main".to_string(),
-        RefTarget::Normal(main_branch_tx2.id().clone()),
+    tx2.mut_repo().set_git_ref_target(
+        "refs/heads/main",
+        Some(RefTarget::Normal(main_branch_tx2.id().clone())),
     );
     tx2.commit();
 

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -338,24 +338,24 @@ fn test_merge_views_tags() {
     let mut tx = repo.start_transaction(&settings, "test");
     let mut_repo = tx.mut_repo();
     let v1_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_tag("v1.0".to_string(), RefTarget::Normal(v1_tx0.id().clone()));
+    mut_repo.set_tag_target("v1.0", Some(RefTarget::Normal(v1_tx0.id().clone())));
     let v2_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_tag("v2.0".to_string(), RefTarget::Normal(v2_tx0.id().clone()));
+    mut_repo.set_tag_target("v2.0", Some(RefTarget::Normal(v2_tx0.id().clone())));
     let repo = tx.commit();
 
     let mut tx1 = repo.start_transaction(&settings, "test");
     let v1_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo()
-        .set_tag("v1.0".to_string(), RefTarget::Normal(v1_tx1.id().clone()));
+        .set_tag_target("v1.0", Some(RefTarget::Normal(v1_tx1.id().clone())));
     let v2_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo()
-        .set_tag("v2.0".to_string(), RefTarget::Normal(v2_tx1.id().clone()));
+        .set_tag_target("v2.0", Some(RefTarget::Normal(v2_tx1.id().clone())));
     tx1.commit();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let v1_tx2 = write_random_commit(tx2.mut_repo(), &settings);
     tx2.mut_repo()
-        .set_tag("v1.0".to_string(), RefTarget::Normal(v1_tx2.id().clone()));
+        .set_tag_target("v1.0", Some(RefTarget::Normal(v1_tx2.id().clone())));
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -442,19 +442,19 @@ fn test_merge_views_git_heads() {
     let mut tx0 = repo.start_transaction(&settings, "test");
     let tx0_head = write_random_commit(tx0.mut_repo(), &settings);
     tx0.mut_repo()
-        .set_git_head(RefTarget::Normal(tx0_head.id().clone()));
+        .set_git_head_target(Some(RefTarget::Normal(tx0_head.id().clone())));
     let repo = tx0.commit();
 
     let mut tx1 = repo.start_transaction(&settings, "test");
     let tx1_head = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo()
-        .set_git_head(RefTarget::Normal(tx1_head.id().clone()));
+        .set_git_head_target(Some(RefTarget::Normal(tx1_head.id().clone())));
     tx1.commit();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let tx2_head = write_random_commit(tx2.mut_repo(), &settings);
     tx2.mut_repo()
-        .set_git_head(RefTarget::Normal(tx2_head.id().clone()));
+        .set_git_head_target(Some(RefTarget::Normal(tx2_head.id().clone())));
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -248,9 +248,9 @@ fn test_merge_views_branches() {
     let main_branch_origin_tx0 = write_random_commit(mut_repo, &settings);
     let main_branch_origin_tx1 = write_random_commit(mut_repo, &settings);
     let main_branch_alternate_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_local_branch(
-        "main".to_string(),
-        RefTarget::Normal(main_branch_local_tx0.id().clone()),
+    mut_repo.set_local_branch_target(
+        "main",
+        Some(RefTarget::Normal(main_branch_local_tx0.id().clone())),
     );
     mut_repo.set_remote_branch_target(
         "main",
@@ -271,9 +271,9 @@ fn test_merge_views_branches() {
 
     let mut tx1 = repo.start_transaction(&settings, "test");
     let main_branch_local_tx1 = write_random_commit(tx1.mut_repo(), &settings);
-    tx1.mut_repo().set_local_branch(
-        "main".to_string(),
-        RefTarget::Normal(main_branch_local_tx1.id().clone()),
+    tx1.mut_repo().set_local_branch_target(
+        "main",
+        Some(RefTarget::Normal(main_branch_local_tx1.id().clone())),
     );
     tx1.mut_repo().set_remote_branch_target(
         "main",
@@ -281,17 +281,17 @@ fn test_merge_views_branches() {
         Some(RefTarget::Normal(main_branch_origin_tx1.id().clone())),
     );
     let feature_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
-    tx1.mut_repo().set_local_branch(
-        "feature".to_string(),
-        RefTarget::Normal(feature_branch_tx1.id().clone()),
+    tx1.mut_repo().set_local_branch_target(
+        "feature",
+        Some(RefTarget::Normal(feature_branch_tx1.id().clone())),
     );
     tx1.commit();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let main_branch_local_tx2 = write_random_commit(tx2.mut_repo(), &settings);
-    tx2.mut_repo().set_local_branch(
-        "main".to_string(),
-        RefTarget::Normal(main_branch_local_tx2.id().clone()),
+    tx2.mut_repo().set_local_branch_target(
+        "main",
+        Some(RefTarget::Normal(main_branch_local_tx2.id().clone())),
     );
     tx2.mut_repo().set_remote_branch_target(
         "main",

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -786,7 +786,7 @@ impl WorkspaceCommandHelper {
                 let new_git_commit_id = Oid::from_bytes(first_parent_id.as_bytes()).unwrap();
                 let new_git_commit = git_repo.find_commit(new_git_commit_id)?;
                 git_repo.reset(new_git_commit.as_object(), git2::ResetType::Mixed, None)?;
-                mut_repo.set_git_head(RefTarget::Normal(first_parent_id));
+                mut_repo.set_git_head_target(Some(RefTarget::Normal(first_parent_id)));
             }
         } else {
             // The workspace was removed (maybe the user undid the

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -156,9 +156,9 @@ fn cmd_branch_create(
         target_commit.id().hex()
     ));
     for branch_name in branch_names {
-        tx.mut_repo().set_local_branch(
-            branch_name.to_string(),
-            RefTarget::Normal(target_commit.id().clone()),
+        tx.mut_repo().set_local_branch_target(
+            branch_name,
+            Some(RefTarget::Normal(target_commit.id().clone())),
         );
     }
     tx.finish(ui)?;
@@ -203,9 +203,9 @@ fn cmd_branch_set(
         target_commit.id().hex()
     ));
     for branch_name in branch_names {
-        tx.mut_repo().set_local_branch(
-            branch_name.to_string(),
-            RefTarget::Normal(target_commit.id().clone()),
+        tx.mut_repo().set_local_branch_target(
+            branch_name,
+            Some(RefTarget::Normal(target_commit.id().clone())),
         );
     }
     tx.finish(ui)?;
@@ -280,7 +280,7 @@ fn cmd_branch_delete(
     let branch_term = make_branch_term(names.iter().collect_vec().as_slice());
     let mut tx = workspace_command.start_transaction(&format!("delete {branch_term}"));
     for branch_name in names.iter() {
-        tx.mut_repo().remove_local_branch(branch_name);
+        tx.mut_repo().set_local_branch_target(branch_name, None);
     }
     tx.finish(ui)?;
     if names.len() > 1 {

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -717,8 +717,10 @@ fn cmd_git_push(
                     change_str.deref()
                 )?;
             }
-            tx.mut_repo()
-                .set_local_branch(branch_name.clone(), RefTarget::Normal(commit.id().clone()));
+            tx.mut_repo().set_local_branch_target(
+                &branch_name,
+                Some(RefTarget::Normal(commit.id().clone())),
+            );
             let branch_target = tx.repo().view().get_branch(&branch_name).unwrap();
             match classify_branch_update(&branch_name, branch_target, &remote) {
                 Ok(Some(update)) => branch_updates.push((branch_name.clone(), update)),


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
