### PR TITLE
feat(nix): use mold by default for linking inside 'nix develop'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689078114,
-        "narHash": "sha256-osG8BrX5RpKJ7wH+vI6auOU+ctvNOblT4XXCgknK47c=",
+        "lastModified": 1689352711,
+        "narHash": "sha256-xWYFt8vWnstDIVsZ26y9mf6h3714lVmXd6l+hTQz6tw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6cc7ff8fee93789bc871a267ab876c3fca042cb",
+        "rev": "2047c642ce0f75307e8a0f2ec94715218c481184",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689129196,
-        "narHash": "sha256-/z/Al4sFcIh5oPQWA9MclQmJR9g3RO8UDiHGaj/T9R8=",
+        "lastModified": 1689302058,
+        "narHash": "sha256-yD74lcHTrw4niXcE9goJLbzsgyce48rQQoy5jK5ZK40=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "db8d909c9526d4406579ee7343bf2d7de3d15eac",
+        "rev": "7b8dbbf4c67ed05a9bf3d9e658c12d4108bc24c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow up from #1833 since mold was mentioned. This basically makes all Linux builds faster at no cost; it takes re-linking time for `jj-cli` down to sub-1s for me in all cases in practice.

This is only enabled when `nix develop .` or `direnv` are used to hack on jj. Mold is not enabled for release packaging or builds in any other configuration. So, this is just a pure win for anyone using Nix, because we can ensure that everyone can rely on it.

**NOTE**: ~~This pull request is NOT ready to be merged. As @yuja noted in #1833, there is an upstream bug in mold wrt handling `--debug-strip` that causes *all* debug info to be stripped, killing `RUST_BACKTRACE` in all builds; luckily, the patch is trivial, and I backported it to nixpkgs in NixOS/nixpkgs#243384, which I merged this morning.~~ My bugfix is now in `nixpkgs-unstable`, so this PR can be pulled in.