### PR TITLE
refactor(cargo): ease release build settings, add new 'cooked-release' mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,24 @@ packaging = ["watchman"]
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]
 
+# It's often really useful to profile and run benchmarks on jj in --release
+# mode, at the expense of some peak performance; so bump codegen-units to a
+# high explicit number, and enable incremental builds to speed things up when
+# iterating on patches
 [profile.release]
+incremental = true # normally off in --release mode
+codegen-units = 16 # normally 256 when incremental=true; tone it down a bit...
+debug = true
+strip = "none"
+
+# But when we cook a release for users to eat at the table, we should be more
+# sophisticated: strip debug info (leaving symbols), codegen-units=1 to improve
+# performance and binary size even further, and turn off incremental builds
+# since they aren't needed.
+[profile.cooked-release]
+# Inherit from the "release" profile, as there may be other release defaults
+# we haven't tweaked ourselves; inheriting them properly is good form.
+inherits = "release"
+incremental = false
+codegen-units = 1 # see issue #1833 for details
 strip = "debuginfo"
-codegen-units = 1


### PR DESCRIPTION
Summary: Waleed noted on Discord that the changes from #1833 negatively impacted an important workflow of his: testing patches under `--release` mode while incremental builds enabled e.g. imagine running and testing hyperfine benchmarks on `jj` binaries, as you iterate on a patch. Yuja also noted that he has a separate profile of his own in his global cargo config to cancel out those changes and iterate faster.

Let's rework things a bit to try and make everyone happier: make the `--release` mode more polite for development than it was before, by adding incremental builds, more debug info, set codegen-units=16 (the default incremental setting of 256 is probably a *little* too much?), and no stripping.

For the release mode build, there's now a new `cooked-release` profile that can be used instead to generate optimized binaries with better performance, effectively what we do now. In theory we could *also* enable something like ThinLTO/FatLTO here as it's now purely opt-in, but... It's probably not worth pessimizing those cases even more unless we can actually prove that those toggles improve things measurably (LTO bugs aren't exactly unheard of, either, so just flipping it on for nothing makes me uneasy.)


Change-Id: If48c956152c4277a86d3e04ca17cde59

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
