### PR TITLE
refs: don't rely on `RefTarget` enum API

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -203,7 +203,7 @@ pub fn import_some_refs(
             let head_commit = store.get_commit(&head_commit_id).unwrap();
             prevent_gc(git_repo, &head_commit_id)?;
             mut_repo.add_head(&head_commit);
-            mut_repo.set_git_head_target(Some(RefTarget::Normal(head_commit_id)));
+            mut_repo.set_git_head_target(RefTarget::normal(head_commit_id));
         }
     } else {
         mut_repo.set_git_head_target(None);
@@ -240,10 +240,10 @@ pub fn import_some_refs(
         // TODO: Make it configurable which remotes are publishing and update public
         // heads here.
         let old_target = jj_view_git_refs.remove(full_name);
-        let new_target = Some(RefTarget::Normal(id.clone()));
+        let new_target = RefTarget::normal(id.clone());
         if new_target != old_target {
             prevent_gc(git_repo, &id)?;
-            mut_repo.set_git_ref_target(full_name, Some(RefTarget::Normal(id.clone())));
+            mut_repo.set_git_ref_target(full_name, RefTarget::normal(id.clone()));
             let commit = store.get_commit(&id).unwrap();
             mut_repo.add_head(&commit);
             changed_git_refs.insert(ref_name, (old_target, new_target));
@@ -511,7 +511,7 @@ pub fn export_some_refs(
         if success {
             mut_repo.set_git_ref_target(
                 &git_ref_name,
-                Some(RefTarget::Normal(CommitId::from_bytes(new_oid.as_bytes()))),
+                RefTarget::normal(CommitId::from_bytes(new_oid.as_bytes())),
             );
         } else {
             failed_branches.push(parsed_ref_name);

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -143,6 +143,11 @@ impl ContentHash for RefTarget {
 }
 
 impl RefTarget {
+    /// Creates non-conflicting target pointing to a commit.
+    pub fn normal(id: CommitId) -> Option<Self> {
+        Some(RefTarget::Normal(id))
+    }
+
     pub fn is_conflict(&self) -> bool {
         matches!(self, RefTarget::Conflict { .. })
     }

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -148,6 +148,18 @@ impl RefTarget {
         Some(RefTarget::Normal(id))
     }
 
+    /// Creates conflicting target from removed/added ids.
+    pub fn from_legacy_form(
+        removed_ids: impl IntoIterator<Item = CommitId>,
+        added_ids: impl IntoIterator<Item = CommitId>,
+    ) -> Option<Self> {
+        // TODO: This function will create non-conflicting target if there're only one
+        // add id and no removed ids.
+        let removes = removed_ids.into_iter().collect();
+        let adds = added_ids.into_iter().collect();
+        Some(RefTarget::Conflict { removes, adds })
+    }
+
     pub fn is_conflict(&self) -> bool {
         matches!(self, RefTarget::Conflict { .. })
     }

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -160,6 +160,14 @@ impl RefTarget {
         Some(RefTarget::Conflict { removes, adds })
     }
 
+    /// Returns id if this target is non-conflicting and points to a commit.
+    pub fn as_normal(&self) -> Option<&CommitId> {
+        match self {
+            RefTarget::Normal(id) => Some(id),
+            RefTarget::Conflict { .. } => None,
+        }
+    }
+
     pub fn is_conflict(&self) -> bool {
         matches!(self, RefTarget::Conflict { .. })
     }
@@ -176,6 +184,22 @@ impl RefTarget {
             RefTarget::Normal(id) => slice::from_ref(id),
             RefTarget::Conflict { removes: _, adds } => adds,
         }
+    }
+}
+
+// TODO: These methods will be migrate to new Conflict-based RefTarget type.
+pub trait RefTargetExt {
+    fn as_normal(&self) -> Option<&CommitId>;
+    fn is_conflict(&self) -> bool;
+}
+
+impl RefTargetExt for Option<&RefTarget> {
+    fn as_normal(&self) -> Option<&CommitId> {
+        self.and_then(|target| target.as_normal())
+    }
+
+    fn is_conflict(&self) -> bool {
+        self.map(|target| target.is_conflict()).unwrap_or(false)
     }
 }
 

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -197,6 +197,38 @@ pub trait RefTargetExt {
     fn adds(&self) -> &[CommitId];
 }
 
+impl RefTargetExt for Option<RefTarget> {
+    fn as_normal(&self) -> Option<&CommitId> {
+        self.as_ref().and_then(|target| target.as_normal())
+    }
+
+    fn is_absent(&self) -> bool {
+        self.is_none()
+    }
+
+    fn is_present(&self) -> bool {
+        self.is_some()
+    }
+
+    fn is_conflict(&self) -> bool {
+        self.as_ref()
+            .map(|target| target.is_conflict())
+            .unwrap_or(false)
+    }
+
+    fn removes(&self) -> &[CommitId] {
+        self.as_ref()
+            .map(|target| target.removes())
+            .unwrap_or_default()
+    }
+
+    fn adds(&self) -> &[CommitId] {
+        self.as_ref()
+            .map(|target| target.adds())
+            .unwrap_or_default()
+    }
+}
+
 impl RefTargetExt for Option<&RefTarget> {
     fn as_normal(&self) -> Option<&CommitId> {
         self.and_then(|target| target.as_normal())

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -190,7 +190,11 @@ impl RefTarget {
 // TODO: These methods will be migrate to new Conflict-based RefTarget type.
 pub trait RefTargetExt {
     fn as_normal(&self) -> Option<&CommitId>;
+    fn is_absent(&self) -> bool;
+    fn is_present(&self) -> bool;
     fn is_conflict(&self) -> bool;
+    fn removes(&self) -> &[CommitId];
+    fn adds(&self) -> &[CommitId];
 }
 
 impl RefTargetExt for Option<&RefTarget> {
@@ -198,8 +202,24 @@ impl RefTargetExt for Option<&RefTarget> {
         self.and_then(|target| target.as_normal())
     }
 
+    fn is_absent(&self) -> bool {
+        self.is_none()
+    }
+
+    fn is_present(&self) -> bool {
+        self.is_some()
+    }
+
     fn is_conflict(&self) -> bool {
         self.map(|target| target.is_conflict()).unwrap_or(false)
+    }
+
+    fn removes(&self) -> &[CommitId] {
+        self.map(|target| target.removes()).unwrap_or_default()
+    }
+
+    fn adds(&self) -> &[CommitId] {
+        self.map(|target| target.adds()).unwrap_or_default()
     }
 }
 

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -171,9 +171,9 @@ mod tests {
     fn test_classify_branch_push_action_unchanged() {
         let commit_id1 = CommitId::from_hex("11");
         let branch = BranchTarget {
-            local_target: Some(RefTarget::Normal(commit_id1.clone())),
+            local_target: RefTarget::normal(commit_id1.clone()),
             remote_targets: btreemap! {
-                "origin".to_string() => RefTarget::Normal(commit_id1)
+                "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
             },
         };
         assert_eq!(
@@ -186,7 +186,7 @@ mod tests {
     fn test_classify_branch_push_action_added() {
         let commit_id1 = CommitId::from_hex("11");
         let branch = BranchTarget {
-            local_target: Some(RefTarget::Normal(commit_id1.clone())),
+            local_target: RefTarget::normal(commit_id1.clone()),
             remote_targets: btreemap! {},
         };
         assert_eq!(
@@ -204,7 +204,7 @@ mod tests {
         let branch = BranchTarget {
             local_target: None,
             remote_targets: btreemap! {
-                "origin".to_string() => RefTarget::Normal(commit_id1.clone())
+                "origin".to_string() => RefTarget::normal(commit_id1.clone()).unwrap(),
             },
         };
         assert_eq!(
@@ -221,9 +221,9 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
         let branch = BranchTarget {
-            local_target: Some(RefTarget::Normal(commit_id2.clone())),
+            local_target: RefTarget::normal(commit_id2.clone()),
             remote_targets: btreemap! {
-                "origin".to_string() => RefTarget::Normal(commit_id1.clone())
+                "origin".to_string() => RefTarget::normal(commit_id1.clone()).unwrap(),
             },
         };
         assert_eq!(
@@ -245,7 +245,7 @@ mod tests {
                 adds: vec![commit_id1.clone(), commit_id2],
             }),
             remote_targets: btreemap! {
-                "origin".to_string() => RefTarget::Normal(commit_id1)
+                "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
             },
         };
         assert_eq!(
@@ -259,7 +259,7 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
         let branch = BranchTarget {
-            local_target: Some(RefTarget::Normal(commit_id1.clone())),
+            local_target: RefTarget::normal(commit_id1.clone()),
             remote_targets: btreemap! {
                 "origin".to_string() => RefTarget::Conflict {
                 removes: vec![],

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -240,10 +240,7 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
         let branch = BranchTarget {
-            local_target: Some(RefTarget::Conflict {
-                removes: vec![],
-                adds: vec![commit_id1.clone(), commit_id2],
-            }),
+            local_target: RefTarget::from_legacy_form([], [commit_id1.clone(), commit_id2]),
             remote_targets: btreemap! {
                 "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
             },
@@ -261,10 +258,10 @@ mod tests {
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id1.clone()),
             remote_targets: btreemap! {
-                "origin".to_string() => RefTarget::Conflict {
-                removes: vec![],
-                adds: vec![commit_id1, commit_id2]
-            }
+                "origin".to_string() => RefTarget::from_legacy_form(
+                    [],
+                    [commit_id1, commit_id2],
+                ).unwrap(),
             },
         };
         assert_eq!(

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -278,17 +278,14 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         new_ids
     }
 
-    fn ref_target_update(old_id: CommitId, new_ids: Vec<CommitId>) -> (RefTarget, RefTarget) {
-        let old_ids = std::iter::repeat(old_id).take(new_ids.len()).collect_vec();
+    fn ref_target_update(
+        old_id: CommitId,
+        new_ids: Vec<CommitId>,
+    ) -> (Option<RefTarget>, Option<RefTarget>) {
+        let old_ids = std::iter::repeat(old_id).take(new_ids.len());
         (
-            RefTarget::Conflict {
-                removes: vec![],
-                adds: old_ids,
-            },
-            RefTarget::Conflict {
-                removes: vec![],
-                adds: new_ids,
-            },
+            RefTarget::from_legacy_form([], old_ids),
+            RefTarget::from_legacy_form([], new_ids),
         )
     }
 
@@ -322,8 +319,8 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
             for branch_name in branch_updates {
                 self.mut_repo.merge_single_ref(
                     &RefName::LocalBranch(branch_name),
-                    Some(&old_target),
-                    Some(&new_target),
+                    old_target.as_ref(),
+                    new_target.as_ref(),
                 );
             }
         }

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -387,10 +387,10 @@ mod tests {
         let branch_deleted_origin_target = RefTarget::normal(CommitId::from_hex("ccc333"));
         let tag_v1_target = RefTarget::normal(CommitId::from_hex("ddd111"));
         let git_refs_main_target = RefTarget::normal(CommitId::from_hex("fff111"));
-        let git_refs_feature_target = RefTarget::Conflict {
-            removes: vec![CommitId::from_hex("fff111")],
-            adds: vec![CommitId::from_hex("fff222"), CommitId::from_hex("fff333")],
-        };
+        let git_refs_feature_target = RefTarget::from_legacy_form(
+            [CommitId::from_hex("fff111")],
+            [CommitId::from_hex("fff222"), CommitId::from_hex("fff333")],
+        );
         let default_wc_commit_id = CommitId::from_hex("abc111");
         let test_wc_commit_id = CommitId::from_hex("abc222");
         View {
@@ -415,7 +415,7 @@ mod tests {
             },
             git_refs: btreemap! {
                 "refs/heads/main".to_string() => git_refs_main_target.unwrap(),
-                "refs/heads/feature".to_string() => git_refs_feature_target
+                "refs/heads/feature".to_string() => git_refs_feature_target.unwrap(),
             },
             git_head: RefTarget::normal(CommitId::from_hex("fff111")),
             wc_commit_ids: hashmap! {

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -320,7 +320,7 @@ fn view_from_proto(proto: crate::protos::op_store::View) -> View {
     if let Some(git_head) = proto.git_head.as_ref() {
         view.git_head = Some(ref_target_from_proto(git_head.clone()));
     } else if !proto.git_head_legacy.is_empty() {
-        view.git_head = Some(RefTarget::Normal(CommitId::new(proto.git_head_legacy)));
+        view.git_head = RefTarget::normal(CommitId::new(proto.git_head_legacy));
     }
 
     view
@@ -382,11 +382,11 @@ mod tests {
         let head_id2 = CommitId::from_hex("aaa222");
         let public_head_id1 = CommitId::from_hex("bbb444");
         let public_head_id2 = CommitId::from_hex("bbb555");
-        let branch_main_local_target = RefTarget::Normal(CommitId::from_hex("ccc111"));
-        let branch_main_origin_target = RefTarget::Normal(CommitId::from_hex("ccc222"));
-        let branch_deleted_origin_target = RefTarget::Normal(CommitId::from_hex("ccc333"));
-        let tag_v1_target = RefTarget::Normal(CommitId::from_hex("ddd111"));
-        let git_refs_main_target = RefTarget::Normal(CommitId::from_hex("fff111"));
+        let branch_main_local_target = RefTarget::normal(CommitId::from_hex("ccc111"));
+        let branch_main_origin_target = RefTarget::normal(CommitId::from_hex("ccc222"));
+        let branch_deleted_origin_target = RefTarget::normal(CommitId::from_hex("ccc333"));
+        let tag_v1_target = RefTarget::normal(CommitId::from_hex("ddd111"));
+        let git_refs_main_target = RefTarget::normal(CommitId::from_hex("fff111"));
         let git_refs_feature_target = RefTarget::Conflict {
             removes: vec![CommitId::from_hex("fff111")],
             adds: vec![CommitId::from_hex("fff222"), CommitId::from_hex("fff333")],
@@ -398,26 +398,26 @@ mod tests {
             public_head_ids: hashset! {public_head_id1, public_head_id2},
             branches: btreemap! {
                 "main".to_string() => BranchTarget {
-                    local_target: Some(branch_main_local_target),
+                    local_target: branch_main_local_target,
                     remote_targets: btreemap! {
-                        "origin".to_string() => branch_main_origin_target,
+                        "origin".to_string() => branch_main_origin_target.unwrap(),
                     }
                 },
                 "deleted".to_string() => BranchTarget {
                     local_target: None,
                     remote_targets: btreemap! {
-                        "origin".to_string() => branch_deleted_origin_target,
+                        "origin".to_string() => branch_deleted_origin_target.unwrap(),
                     }
                 },
             },
             tags: btreemap! {
-                "v1.0".to_string() => tag_v1_target,
+                "v1.0".to_string() => tag_v1_target.unwrap(),
             },
             git_refs: btreemap! {
-                "refs/heads/main".to_string() => git_refs_main_target,
+                "refs/heads/main".to_string() => git_refs_main_target.unwrap(),
                 "refs/heads/feature".to_string() => git_refs_feature_target
             },
-            git_head: Some(RefTarget::Normal(CommitId::from_hex("fff111"))),
+            git_head: RefTarget::normal(CommitId::from_hex("fff111")),
             wc_commit_ids: hashmap! {
                 WorkspaceId::default() => default_wc_commit_id,
                 WorkspaceId::new("test".to_string()) => test_wc_commit_id,

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -249,10 +249,10 @@ fn test_import_refs_reimport() {
         Some(expected_main_branch).as_ref()
     );
     let expected_feature2_branch = BranchTarget {
-        local_target: Some(RefTarget::Conflict {
-            removes: vec![jj_id(&commit4)],
-            adds: vec![commit6.id().clone(), jj_id(&commit5)],
-        }),
+        local_target: RefTarget::from_legacy_form(
+            [jj_id(&commit4)],
+            [commit6.id().clone(), jj_id(&commit5)],
+        ),
         remote_targets: btreemap! {},
     };
     assert_eq!(
@@ -1183,10 +1183,10 @@ fn test_export_conflicts() {
     mut_repo.set_local_branch_target("main", RefTarget::normal(commit_b.id().clone()));
     mut_repo.set_local_branch_target(
         "feature",
-        Some(RefTarget::Conflict {
-            removes: vec![commit_a.id().clone()],
-            adds: vec![commit_b.id().clone(), commit_c.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit_a.id().clone()],
+            [commit_b.id().clone(), commit_c.id().clone()],
+        ),
     );
     assert_eq!(git::export_refs(mut_repo, &git_repo), Ok(vec![]));
     assert_eq!(

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -170,7 +170,7 @@ fn test_checkout_previous_empty_with_local_branch(use_git: bool) {
         )
         .write()
         .unwrap();
-    mut_repo.set_local_branch_target("b", Some(RefTarget::Normal(old_wc_commit.id().clone())));
+    mut_repo.set_local_branch_target("b", RefTarget::normal(old_wc_commit.id().clone()));
     let ws_id = WorkspaceId::default();
     mut_repo.edit(ws_id.clone(), &old_wc_commit).unwrap();
     let repo = tx.commit();
@@ -469,12 +469,8 @@ fn test_has_changed(use_git: bool) {
     mut_repo
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
-    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit1.id().clone())));
-    mut_repo.set_remote_branch_target(
-        "main",
-        "origin",
-        Some(RefTarget::Normal(commit1.id().clone())),
-    );
+    mut_repo.set_local_branch_target("main", RefTarget::normal(commit1.id().clone()));
+    mut_repo.set_remote_branch_target("main", "origin", RefTarget::normal(commit1.id().clone()));
     let repo = tx.commit();
     // Test the setup
     assert_eq!(repo.view().heads(), &hashset! {commit1.id().clone()});
@@ -488,12 +484,8 @@ fn test_has_changed(use_git: bool) {
     mut_repo
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
-    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit1.id().clone())));
-    mut_repo.set_remote_branch_target(
-        "main",
-        "origin",
-        Some(RefTarget::Normal(commit1.id().clone())),
-    );
+    mut_repo.set_local_branch_target("main", RefTarget::normal(commit1.id().clone()));
+    mut_repo.set_remote_branch_target("main", "origin", RefTarget::normal(commit1.id().clone()));
     assert!(!mut_repo.has_changes());
 
     mut_repo.remove_public_head(commit2.id());
@@ -524,22 +516,14 @@ fn test_has_changed(use_git: bool) {
     mut_repo.set_wc_commit(ws_id, commit1.id().clone()).unwrap();
     assert!(!mut_repo.has_changes());
 
-    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit2.id().clone())));
+    mut_repo.set_local_branch_target("main", RefTarget::normal(commit2.id().clone()));
     assert!(mut_repo.has_changes());
-    mut_repo.set_local_branch_target("main", Some(RefTarget::Normal(commit1.id().clone())));
+    mut_repo.set_local_branch_target("main", RefTarget::normal(commit1.id().clone()));
     assert!(!mut_repo.has_changes());
 
-    mut_repo.set_remote_branch_target(
-        "main",
-        "origin",
-        Some(RefTarget::Normal(commit2.id().clone())),
-    );
+    mut_repo.set_remote_branch_target("main", "origin", RefTarget::normal(commit2.id().clone()));
     assert!(mut_repo.has_changes());
-    mut_repo.set_remote_branch_target(
-        "main",
-        "origin",
-        Some(RefTarget::Normal(commit1.id().clone())),
-    );
+    mut_repo.set_remote_branch_target("main", "origin", RefTarget::normal(commit1.id().clone()));
     assert!(!mut_repo.has_changes());
 }
 
@@ -626,7 +610,7 @@ fn test_rename_remote(use_git: bool) {
     let mut tx = repo.start_transaction(&settings, "test");
     let mut_repo = tx.mut_repo();
     let commit = write_random_commit(mut_repo, &settings);
-    let target = Some(RefTarget::Normal(commit.id().clone()));
+    let target = RefTarget::normal(commit.id().clone());
     mut_repo.set_remote_branch_target("main", "origin", target.clone());
     mut_repo.rename_remote("origin", "upstream");
     assert_eq!(mut_repo.get_remote_branch("main", "upstream"), target);

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -127,28 +127,28 @@ fn test_merge_ref_targets() {
     // Left and right moved forward to divergent targets
     assert_eq!(
         merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target4.as_ref()),
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit3.id().clone(), commit4.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit1.id().clone()],
+            [commit3.id().clone(), commit4.id().clone()]
+        )
     );
 
     // Left moved back, right moved forward
     assert_eq!(
         merge_ref_targets(index, target1.as_ref(), target2.as_ref(), target3.as_ref()),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit1.id().clone(), commit3.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit1.id().clone(), commit3.id().clone()]
+        )
     );
 
     // Right moved back, left moved forward
     assert_eq!(
         merge_ref_targets(index, target3.as_ref(), target2.as_ref(), target1.as_ref()),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit3.id().clone(), commit1.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit3.id().clone(), commit1.id().clone()]
+        )
     );
 
     // Left removed
@@ -166,37 +166,32 @@ fn test_merge_ref_targets() {
     // Left removed, right moved forward
     assert_eq!(
         merge_ref_targets(index, None, target1.as_ref(), target3.as_ref()),
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit3.id().clone()]
-        })
+        RefTarget::from_legacy_form([commit1.id().clone()], [commit3.id().clone()])
     );
 
     // Right removed, left moved forward
     assert_eq!(
         merge_ref_targets(index, target3.as_ref(), target1.as_ref(), None),
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit3.id().clone()]
-        })
+        RefTarget::from_legacy_form([commit1.id().clone()], [commit3.id().clone()])
     );
 
     // Left became conflicted, right moved forward
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            }),
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
             target1.as_ref(),
             target3.as_ref()
         ),
         // TODO: "removes" should have commit 2, just like it does in the next test case
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit4.id().clone(), commit3.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit1.id().clone()],
+            [commit4.id().clone(), commit3.id().clone()]
+        )
     );
 
     // Right became conflicted, left moved forward
@@ -205,15 +200,16 @@ fn test_merge_ref_targets() {
             index,
             target3.as_ref(),
             target1.as_ref(),
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            })
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit3.id().clone(), commit4.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit3.id().clone(), commit4.id().clone()]
+        )
     );
 
     // Existing conflict on left, right moves an "add" sideways
@@ -227,17 +223,18 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            }),
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
             target3.as_ref(),
             target5.as_ref()
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit5.id().clone(), commit4.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit5.id().clone(), commit4.id().clone()]
+        )
     );
 
     // Existing conflict on right, left moves an "add" sideways
@@ -253,15 +250,16 @@ fn test_merge_ref_targets() {
             index,
             target5.as_ref(),
             target3.as_ref(),
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            })
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit5.id().clone(), commit4.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit5.id().clone(), commit4.id().clone()]
+        )
     );
 
     // Existing conflict on left, right moves an "add" backwards, past point of
@@ -276,17 +274,18 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            }),
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
             target3.as_ref(),
             target1.as_ref()
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit1.id().clone(), commit4.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit1.id().clone(), commit4.id().clone()]
+        )
     );
 
     // Existing conflict on right, left moves an "add" backwards, past point of
@@ -303,25 +302,27 @@ fn test_merge_ref_targets() {
             index,
             target1.as_ref(),
             target3.as_ref(),
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            })
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit1.id().clone(), commit4.id().clone()]
-        })
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit1.id().clone(), commit4.id().clone()]
+        )
     );
 
     // Existing conflict on left, right undoes one side of conflict
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            }),
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
             target3.as_ref(),
             target2.as_ref()
         ),
@@ -334,10 +335,11 @@ fn test_merge_ref_targets() {
             index,
             target2.as_ref(),
             target3.as_ref(),
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            })
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
         ),
         target4
     );
@@ -346,21 +348,22 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            }),
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
             target5.as_ref(),
             target6.as_ref()
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone(), commit5.id().clone()],
-            adds: vec![
+        RefTarget::from_legacy_form(
+            [commit2.id().clone(), commit5.id().clone()],
+            [
                 commit3.id().clone(),
                 commit4.id().clone(),
                 commit6.id().clone()
             ]
-        })
+        )
     );
 
     // Existing conflict on right, left makes unrelated update
@@ -369,18 +372,19 @@ fn test_merge_ref_targets() {
             index,
             target6.as_ref(),
             target5.as_ref(),
-            Some(&RefTarget::Conflict {
-                removes: vec![commit2.id().clone()],
-                adds: vec![commit3.id().clone(), commit4.id().clone()]
-            })
+            RefTarget::from_legacy_form(
+                [commit2.id().clone()],
+                [commit3.id().clone(), commit4.id().clone()]
+            )
+            .as_ref(),
         ),
-        Some(RefTarget::Conflict {
-            removes: vec![commit5.id().clone(), commit2.id().clone()],
-            adds: vec![
+        RefTarget::from_legacy_form(
+            [commit5.id().clone(), commit2.id().clone()],
+            [
                 commit6.id().clone(),
                 commit3.id().clone(),
                 commit4.id().clone()
             ]
-        })
+        )
     );
 }

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -42,91 +42,91 @@ fn test_merge_ref_targets() {
     let commit7 = graph_builder.commit_with_parents(&[&commit5]);
     let repo = tx.commit();
 
-    let target1 = RefTarget::Normal(commit1.id().clone());
-    let target2 = RefTarget::Normal(commit2.id().clone());
-    let target3 = RefTarget::Normal(commit3.id().clone());
-    let target4 = RefTarget::Normal(commit4.id().clone());
-    let target5 = RefTarget::Normal(commit5.id().clone());
-    let target6 = RefTarget::Normal(commit6.id().clone());
-    let _target7 = RefTarget::Normal(commit7.id().clone());
+    let target1 = RefTarget::normal(commit1.id().clone());
+    let target2 = RefTarget::normal(commit2.id().clone());
+    let target3 = RefTarget::normal(commit3.id().clone());
+    let target4 = RefTarget::normal(commit4.id().clone());
+    let target5 = RefTarget::normal(commit5.id().clone());
+    let target6 = RefTarget::normal(commit6.id().clone());
+    let _target7 = RefTarget::normal(commit7.id().clone());
 
     let index = repo.index();
 
     // Left moved forward
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target1), Some(&target1)),
-        Some(target3.clone())
+        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target1.as_ref()),
+        target3
     );
 
     // Right moved forward
     assert_eq!(
-        merge_ref_targets(index, Some(&target1), Some(&target1), Some(&target3)),
-        Some(target3.clone())
+        merge_ref_targets(index, target1.as_ref(), target1.as_ref(), target3.as_ref()),
+        target3
     );
 
     // Left moved backward
     assert_eq!(
-        merge_ref_targets(index, Some(&target1), Some(&target3), Some(&target3)),
-        Some(target1.clone())
+        merge_ref_targets(index, target1.as_ref(), target3.as_ref(), target3.as_ref()),
+        target1
     );
 
     // Right moved backward
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target3), Some(&target1)),
-        Some(target1.clone())
+        merge_ref_targets(index, target3.as_ref(), target3.as_ref(), target1.as_ref()),
+        target1
     );
 
     // Left moved sideways
     assert_eq!(
-        merge_ref_targets(index, Some(&target4), Some(&target3), Some(&target3)),
-        Some(target4.clone())
+        merge_ref_targets(index, target4.as_ref(), target3.as_ref(), target3.as_ref()),
+        target4
     );
 
     // Right moved sideways
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target3), Some(&target4)),
-        Some(target4.clone())
+        merge_ref_targets(index, target3.as_ref(), target3.as_ref(), target4.as_ref()),
+        target4
     );
 
     // Both added same target
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), None, Some(&target3)),
-        Some(target3.clone())
+        merge_ref_targets(index, target3.as_ref(), None, target3.as_ref()),
+        target3
     );
 
     // Left added target, right added descendant target
     assert_eq!(
-        merge_ref_targets(index, Some(&target2), None, Some(&target3)),
-        Some(target3.clone())
+        merge_ref_targets(index, target2.as_ref(), None, target3.as_ref()),
+        target3
     );
 
     // Right added target, left added descendant target
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), None, Some(&target2)),
-        Some(target3.clone())
+        merge_ref_targets(index, target3.as_ref(), None, target2.as_ref()),
+        target3
     );
 
     // Both moved forward to same target
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target1), Some(&target3)),
-        Some(target3.clone())
+        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target3.as_ref()),
+        target3
     );
 
     // Both moved forward, left moved further
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target1), Some(&target2)),
-        Some(target3.clone())
+        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target2.as_ref()),
+        target3
     );
 
     // Both moved forward, right moved further
     assert_eq!(
-        merge_ref_targets(index, Some(&target2), Some(&target1), Some(&target3)),
-        Some(target3.clone())
+        merge_ref_targets(index, target2.as_ref(), target1.as_ref(), target3.as_ref()),
+        target3
     );
 
     // Left and right moved forward to divergent targets
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target1), Some(&target4)),
+        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target4.as_ref()),
         Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit3.id().clone(), commit4.id().clone()]
@@ -135,7 +135,7 @@ fn test_merge_ref_targets() {
 
     // Left moved back, right moved forward
     assert_eq!(
-        merge_ref_targets(index, Some(&target1), Some(&target2), Some(&target3)),
+        merge_ref_targets(index, target1.as_ref(), target2.as_ref(), target3.as_ref()),
         Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
             adds: vec![commit1.id().clone(), commit3.id().clone()]
@@ -144,7 +144,7 @@ fn test_merge_ref_targets() {
 
     // Right moved back, left moved forward
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target2), Some(&target1)),
+        merge_ref_targets(index, target3.as_ref(), target2.as_ref(), target1.as_ref()),
         Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
             adds: vec![commit3.id().clone(), commit1.id().clone()]
@@ -153,19 +153,19 @@ fn test_merge_ref_targets() {
 
     // Left removed
     assert_eq!(
-        merge_ref_targets(index, None, Some(&target3), Some(&target3)),
+        merge_ref_targets(index, None, target3.as_ref(), target3.as_ref()),
         None
     );
 
     // Right removed
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target3), None),
+        merge_ref_targets(index, target3.as_ref(), target3.as_ref(), None),
         None
     );
 
     // Left removed, right moved forward
     assert_eq!(
-        merge_ref_targets(index, None, Some(&target1), Some(&target3)),
+        merge_ref_targets(index, None, target1.as_ref(), target3.as_ref()),
         Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit3.id().clone()]
@@ -174,7 +174,7 @@ fn test_merge_ref_targets() {
 
     // Right removed, left moved forward
     assert_eq!(
-        merge_ref_targets(index, Some(&target3), Some(&target1), None),
+        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), None),
         Some(RefTarget::Conflict {
             removes: vec![commit1.id().clone()],
             adds: vec![commit3.id().clone()]
@@ -189,8 +189,8 @@ fn test_merge_ref_targets() {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
             }),
-            Some(&target1),
-            Some(&target3)
+            target1.as_ref(),
+            target3.as_ref()
         ),
         // TODO: "removes" should have commit 2, just like it does in the next test case
         Some(RefTarget::Conflict {
@@ -203,8 +203,8 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&target3),
-            Some(&target1),
+            target3.as_ref(),
+            target1.as_ref(),
             Some(&RefTarget::Conflict {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
@@ -231,8 +231,8 @@ fn test_merge_ref_targets() {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
             }),
-            Some(&target3),
-            Some(&target5)
+            target3.as_ref(),
+            target5.as_ref()
         ),
         Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
@@ -251,8 +251,8 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&target5),
-            Some(&target3),
+            target5.as_ref(),
+            target3.as_ref(),
             Some(&RefTarget::Conflict {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
@@ -280,8 +280,8 @@ fn test_merge_ref_targets() {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
             }),
-            Some(&target3),
-            Some(&target1)
+            target3.as_ref(),
+            target1.as_ref()
         ),
         Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone()],
@@ -301,8 +301,8 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&target1),
-            Some(&target3),
+            target1.as_ref(),
+            target3.as_ref(),
             Some(&RefTarget::Conflict {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
@@ -322,24 +322,24 @@ fn test_merge_ref_targets() {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
             }),
-            Some(&target3),
-            Some(&target2)
+            target3.as_ref(),
+            target2.as_ref()
         ),
-        Some(target4.clone())
+        target4
     );
 
     // Existing conflict on right, left undoes one side of conflict
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&target2),
-            Some(&target3),
+            target2.as_ref(),
+            target3.as_ref(),
             Some(&RefTarget::Conflict {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
             })
         ),
-        Some(target4)
+        target4
     );
 
     // Existing conflict on left, right makes unrelated update
@@ -350,8 +350,8 @@ fn test_merge_ref_targets() {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]
             }),
-            Some(&target5),
-            Some(&target6)
+            target5.as_ref(),
+            target6.as_ref()
         ),
         Some(RefTarget::Conflict {
             removes: vec![commit2.id().clone(), commit5.id().clone()],
@@ -367,8 +367,8 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            Some(&target6),
-            Some(&target5),
+            target6.as_ref(),
+            target5.as_ref(),
             Some(&RefTarget::Conflict {
                 removes: vec![commit2.id().clone()],
                 adds: vec![commit3.id().clone(), commit4.id().clone()]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -425,20 +425,13 @@ fn test_resolve_symbol_branches() {
     let commit4 = write_random_commit(mut_repo, &settings);
     let commit5 = write_random_commit(mut_repo, &settings);
 
-    mut_repo.set_local_branch_target("local", Some(RefTarget::Normal(commit1.id().clone())));
-    mut_repo.set_remote_branch_target(
-        "remote",
-        "origin",
-        Some(RefTarget::Normal(commit2.id().clone())),
-    );
-    mut_repo.set_local_branch_target(
-        "local-remote",
-        Some(RefTarget::Normal(commit3.id().clone())),
-    );
+    mut_repo.set_local_branch_target("local", RefTarget::normal(commit1.id().clone()));
+    mut_repo.set_remote_branch_target("remote", "origin", RefTarget::normal(commit2.id().clone()));
+    mut_repo.set_local_branch_target("local-remote", RefTarget::normal(commit3.id().clone()));
     mut_repo.set_remote_branch_target(
         "local-remote",
         "origin",
-        Some(RefTarget::Normal(commit4.id().clone())),
+        RefTarget::normal(commit4.id().clone()),
     );
     mut_repo.set_remote_branch_target(
         "local-remote",
@@ -649,7 +642,7 @@ fn test_resolve_symbol_git_head() {
     "###);
 
     // With HEAD@git
-    mut_repo.set_git_head_target(Some(RefTarget::Normal(commit1.id().clone())));
+    mut_repo.set_git_head_target(RefTarget::normal(commit1.id().clone()));
     insta::assert_debug_snapshot!(
         resolve_symbol(mut_repo, "HEAD", None).unwrap_err(), @r###"
     NoSuchRevision {
@@ -682,11 +675,11 @@ fn test_resolve_symbol_git_refs() {
     let commit5 = write_random_commit(mut_repo, &settings);
     mut_repo.set_git_ref_target(
         "refs/heads/branch1",
-        Some(RefTarget::Normal(commit1.id().clone())),
+        RefTarget::normal(commit1.id().clone()),
     );
     mut_repo.set_git_ref_target(
         "refs/heads/branch2",
-        Some(RefTarget::Normal(commit2.id().clone())),
+        RefTarget::normal(commit2.id().clone()),
     );
     mut_repo.set_git_ref_target(
         "refs/heads/conflicted",
@@ -695,13 +688,10 @@ fn test_resolve_symbol_git_refs() {
             adds: vec![commit1.id().clone(), commit3.id().clone()],
         }),
     );
-    mut_repo.set_git_ref_target(
-        "refs/tags/tag1",
-        Some(RefTarget::Normal(commit2.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/tags/tag1", RefTarget::normal(commit2.id().clone()));
     mut_repo.set_git_ref_target(
         "refs/tags/remotes/origin/branch1",
-        Some(RefTarget::Normal(commit3.id().clone())),
+        RefTarget::normal(commit3.id().clone()),
     );
 
     // Nonexistent ref
@@ -712,20 +702,14 @@ fn test_resolve_symbol_git_refs() {
     );
 
     // Full ref
-    mut_repo.set_git_ref_target(
-        "refs/heads/branch",
-        Some(RefTarget::Normal(commit4.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/heads/branch", RefTarget::normal(commit4.id().clone()));
     assert_eq!(
         resolve_symbol(mut_repo, "refs/heads/branch", None).unwrap(),
         vec![commit4.id().clone()]
     );
 
     // Qualified with only heads/
-    mut_repo.set_git_ref_target(
-        "refs/heads/branch",
-        Some(RefTarget::Normal(commit5.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/heads/branch", RefTarget::normal(commit5.id().clone()));
     // branch alone is not recognized
     insta::assert_debug_snapshot!(
         resolve_symbol(mut_repo, "branch", None).unwrap_err(), @r###"
@@ -738,10 +722,7 @@ fn test_resolve_symbol_git_refs() {
         ],
     }
     "###);
-    mut_repo.set_git_ref_target(
-        "refs/tags/branch",
-        Some(RefTarget::Normal(commit4.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/tags/branch", RefTarget::normal(commit4.id().clone()));
     // The *tag* branch is recognized
     assert_eq!(
         resolve_symbol(mut_repo, "branch", None).unwrap(),
@@ -754,10 +735,7 @@ fn test_resolve_symbol_git_refs() {
     );
 
     // Unqualified tag name
-    mut_repo.set_git_ref_target(
-        "refs/tags/tag",
-        Some(RefTarget::Normal(commit4.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/tags/tag", RefTarget::normal(commit4.id().clone()));
     assert_eq!(
         resolve_symbol(mut_repo, "tag", None).unwrap(),
         vec![commit4.id().clone()]
@@ -766,7 +744,7 @@ fn test_resolve_symbol_git_refs() {
     // Unqualified remote-tracking branch name
     mut_repo.set_git_ref_target(
         "refs/remotes/origin/remote-branch",
-        Some(RefTarget::Normal(commit2.id().clone())),
+        RefTarget::normal(commit2.id().clone()),
     );
     assert_eq!(
         resolve_symbol(mut_repo, "origin/remote-branch", None).unwrap(),
@@ -778,8 +756,8 @@ fn test_resolve_symbol_git_refs() {
     mut_repo
         .set_wc_commit(ws_id.clone(), commit1.id().clone())
         .unwrap();
-    mut_repo.set_git_ref_target("@", Some(RefTarget::Normal(commit2.id().clone())));
-    mut_repo.set_git_ref_target("root", Some(RefTarget::Normal(commit3.id().clone())));
+    mut_repo.set_git_ref_target("@", RefTarget::normal(commit2.id().clone()));
+    mut_repo.set_git_ref_target("root", RefTarget::normal(commit3.id().clone()));
     assert_eq!(
         resolve_symbol(mut_repo, "@", Some(&ws_id)).unwrap(),
         vec![mut_repo.view().get_wc_commit_id(&ws_id).unwrap().clone()]
@@ -1617,22 +1595,16 @@ fn test_evaluate_expression_git_refs(use_git: bool) {
     // Can get a mix of git refs
     mut_repo.set_git_ref_target(
         "refs/heads/branch1",
-        Some(RefTarget::Normal(commit1.id().clone())),
+        RefTarget::normal(commit1.id().clone()),
     );
-    mut_repo.set_git_ref_target(
-        "refs/tags/tag1",
-        Some(RefTarget::Normal(commit2.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/tags/tag1", RefTarget::normal(commit2.id().clone()));
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_refs()"),
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     // Two refs pointing to the same commit does not result in a duplicate in the
     // revset
-    mut_repo.set_git_ref_target(
-        "refs/tags/tag2",
-        Some(RefTarget::Normal(commit2.id().clone())),
-    );
+    mut_repo.set_git_ref_target("refs/tags/tag2", RefTarget::normal(commit2.id().clone()));
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_refs()"),
         vec![commit2.id().clone(), commit1.id().clone()]
@@ -1677,7 +1649,7 @@ fn test_evaluate_expression_git_head(use_git: bool) {
 
     // Can get git head when it's not set
     assert_eq!(resolve_commit_ids(mut_repo, "git_head()"), vec![]);
-    mut_repo.set_git_head_target(Some(RefTarget::Normal(commit1.id().clone())));
+    mut_repo.set_git_head_target(RefTarget::normal(commit1.id().clone()));
     assert_eq!(
         resolve_commit_ids(mut_repo, "git_head()"),
         vec![commit1.id().clone()]
@@ -1702,8 +1674,8 @@ fn test_evaluate_expression_branches(use_git: bool) {
     // Can get branches when there are none
     assert_eq!(resolve_commit_ids(mut_repo, "branches()"), vec![]);
     // Can get a few branches
-    mut_repo.set_local_branch_target("branch1", Some(RefTarget::Normal(commit1.id().clone())));
-    mut_repo.set_local_branch_target("branch2", Some(RefTarget::Normal(commit2.id().clone())));
+    mut_repo.set_local_branch_target("branch1", RefTarget::normal(commit1.id().clone()));
+    mut_repo.set_local_branch_target("branch2", RefTarget::normal(commit2.id().clone()));
     assert_eq!(
         resolve_commit_ids(mut_repo, "branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
@@ -1721,7 +1693,7 @@ fn test_evaluate_expression_branches(use_git: bool) {
     assert_eq!(resolve_commit_ids(mut_repo, "branches(branch3)"), vec![]);
     // Two branches pointing to the same commit does not result in a duplicate in
     // the revset
-    mut_repo.set_local_branch_target("branch3", Some(RefTarget::Normal(commit2.id().clone())));
+    mut_repo.set_local_branch_target("branch3", RefTarget::normal(commit2.id().clone()));
     assert_eq!(
         resolve_commit_ids(mut_repo, "branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
@@ -1770,15 +1742,11 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
     // Can get branches when there are none
     assert_eq!(resolve_commit_ids(mut_repo, "remote_branches()"), vec![]);
     // Can get a few branches
-    mut_repo.set_remote_branch_target(
-        "branch1",
-        "origin",
-        Some(RefTarget::Normal(commit1.id().clone())),
-    );
+    mut_repo.set_remote_branch_target("branch1", "origin", RefTarget::normal(commit1.id().clone()));
     mut_repo.set_remote_branch_target(
         "branch2",
         "private",
-        Some(RefTarget::Normal(commit2.id().clone())),
+        RefTarget::normal(commit2.id().clone()),
     );
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_branches()"),
@@ -1826,11 +1794,7 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
     );
     // Two branches pointing to the same commit does not result in a duplicate in
     // the revset
-    mut_repo.set_remote_branch_target(
-        "branch3",
-        "origin",
-        Some(RefTarget::Normal(commit2.id().clone())),
-    );
+    mut_repo.set_remote_branch_target("branch3", "origin", RefTarget::normal(commit2.id().clone()));
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]
@@ -2766,7 +2730,7 @@ fn test_no_such_revision_suggestion() {
         mut_repo.set_branch(
             branch_name.to_string(),
             BranchTarget {
-                local_target: Some(RefTarget::Normal(commit.id().clone())),
+                local_target: RefTarget::normal(commit.id().clone()),
                 remote_targets: Default::default(),
             },
         );

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -445,18 +445,18 @@ fn test_resolve_symbol_branches() {
 
     mut_repo.set_local_branch_target(
         "local-conflicted",
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit3.id().clone(), commit2.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit1.id().clone()],
+            [commit3.id().clone(), commit2.id().clone()],
+        ),
     );
     mut_repo.set_remote_branch_target(
         "remote-conflicted",
         "origin",
-        Some(RefTarget::Conflict {
-            removes: vec![commit3.id().clone()],
-            adds: vec![commit5.id().clone(), commit4.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit3.id().clone()],
+            [commit5.id().clone(), commit4.id().clone()],
+        ),
     );
 
     // Local only
@@ -683,10 +683,10 @@ fn test_resolve_symbol_git_refs() {
     );
     mut_repo.set_git_ref_target(
         "refs/heads/conflicted",
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit1.id().clone(), commit3.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit1.id().clone(), commit3.id().clone()],
+        ),
     );
     mut_repo.set_git_ref_target("refs/tags/tag1", RefTarget::normal(commit2.id().clone()));
     mut_repo.set_git_ref_target(
@@ -1612,17 +1612,17 @@ fn test_evaluate_expression_git_refs(use_git: bool) {
     // Can get git refs when there are conflicted refs
     mut_repo.set_git_ref_target(
         "refs/heads/branch1",
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit2.id().clone(), commit3.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit1.id().clone()],
+            [commit2.id().clone(), commit3.id().clone()],
+        ),
     );
     mut_repo.set_git_ref_target(
         "refs/tags/tag1",
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit3.id().clone(), commit4.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit3.id().clone(), commit4.id().clone()],
+        ),
     );
     mut_repo.set_git_ref_target("refs/tags/tag2", None);
     assert_eq!(
@@ -1701,17 +1701,17 @@ fn test_evaluate_expression_branches(use_git: bool) {
     // Can get branches when there are conflicted refs
     mut_repo.set_local_branch_target(
         "branch1",
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit2.id().clone(), commit3.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit1.id().clone()],
+            [commit2.id().clone(), commit3.id().clone()],
+        ),
     );
     mut_repo.set_local_branch_target(
         "branch2",
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit3.id().clone(), commit4.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit3.id().clone(), commit4.id().clone()],
+        ),
     );
     mut_repo.set_local_branch_target("branch3", None);
     assert_eq!(
@@ -1809,18 +1809,18 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
     mut_repo.set_remote_branch_target(
         "branch1",
         "origin",
-        Some(RefTarget::Conflict {
-            removes: vec![commit1.id().clone()],
-            adds: vec![commit2.id().clone(), commit3.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit1.id().clone()],
+            [commit2.id().clone(), commit3.id().clone()],
+        ),
     );
     mut_repo.set_remote_branch_target(
         "branch2",
         "private",
-        Some(RefTarget::Conflict {
-            removes: vec![commit2.id().clone()],
-            adds: vec![commit3.id().clone(), commit4.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit2.id().clone()],
+            [commit3.id().clone(), commit4.id().clone()],
+        ),
     );
     mut_repo.set_remote_branch_target("branch3", "origin", None);
     assert_eq!(

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -935,7 +935,7 @@ fn test_rebase_descendants_basic_branch_update() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
+        .set_local_branch_target("main", RefTarget::normal(commit_b.id().clone()));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -947,7 +947,7 @@ fn test_rebase_descendants_basic_branch_update() {
     tx.mut_repo().rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
-        Some(RefTarget::Normal(commit_b2.id().clone()))
+        RefTarget::normal(commit_b2.id().clone())
     );
 
     assert_eq!(
@@ -978,7 +978,7 @@ fn test_rebase_descendants_branch_move_two_steps() {
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     let commit_c = graph_builder.commit_with_parents(&[&commit_b]);
     tx.mut_repo()
-        .set_local_branch_target("main", Some(RefTarget::Normal(commit_c.id().clone())));
+        .set_local_branch_target("main", RefTarget::normal(commit_c.id().clone()));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1001,7 +1001,7 @@ fn test_rebase_descendants_branch_move_two_steps() {
     assert_eq!(commit_c3.parent_ids(), vec![commit_b2.id().clone()]);
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
-        Some(RefTarget::Normal(commit_c3.id().clone()))
+        RefTarget::normal(commit_c3.id().clone())
     );
 }
 
@@ -1024,14 +1024,14 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
+        .set_local_branch_target("main", RefTarget::normal(commit_b.id().clone()));
     tx.mut_repo().set_remote_branch_target(
         "main",
         "origin",
-        Some(RefTarget::Normal(commit_b.id().clone())),
+        RefTarget::normal(commit_b.id().clone()),
     );
     tx.mut_repo()
-        .set_tag_target("v1", Some(RefTarget::Normal(commit_b.id().clone())));
+        .set_tag_target("v1", RefTarget::normal(commit_b.id().clone()));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1043,16 +1043,16 @@ fn test_rebase_descendants_basic_branch_update_with_non_local_branch() {
     tx.mut_repo().rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
-        Some(RefTarget::Normal(commit_b2.id().clone()))
+        RefTarget::normal(commit_b2.id().clone())
     );
     // The remote branch and tag should not get updated
     assert_eq!(
         tx.mut_repo().get_remote_branch("main", "origin"),
-        Some(RefTarget::Normal(commit_b.id().clone()))
+        RefTarget::normal(commit_b.id().clone())
     );
     assert_eq!(
         tx.mut_repo().get_tag("v1"),
-        Some(RefTarget::Normal(commit_b.id().clone()))
+        RefTarget::normal(commit_b.id().clone())
     );
 
     // Commit B is no longer visible even though the remote branch points to it.
@@ -1080,7 +1080,7 @@ fn test_rebase_descendants_update_branch_after_abandon() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
+        .set_local_branch_target("main", RefTarget::normal(commit_b.id().clone()));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1088,7 +1088,7 @@ fn test_rebase_descendants_update_branch_after_abandon() {
     tx.mut_repo().rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
-        Some(RefTarget::Normal(commit_a.id().clone()))
+        RefTarget::normal(commit_a.id().clone())
     );
 
     assert_eq!(
@@ -1116,7 +1116,7 @@ fn test_rebase_descendants_update_branches_after_divergent_rewrite() {
     let commit_a = graph_builder.initial_commit();
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo()
-        .set_local_branch_target("main", Some(RefTarget::Normal(commit_b.id().clone())));
+        .set_local_branch_target("main", RefTarget::normal(commit_b.id().clone()));
     let repo = tx.commit();
 
     let mut tx = repo.start_transaction(&settings, "test");
@@ -1280,7 +1280,7 @@ fn test_rebase_descendants_rewrite_resolves_branch_conflict() {
     tx.mut_repo().rebase_descendants(&settings).unwrap();
     assert_eq!(
         tx.mut_repo().get_local_branch("main"),
-        Some(RefTarget::Normal(commit_b2.id().clone()))
+        RefTarget::normal(commit_b2.id().clone())
     );
 
     assert_eq!(

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1182,10 +1182,10 @@ fn test_rebase_descendants_rewrite_updates_branch_conflict() {
     let commit_c = graph_builder.initial_commit();
     tx.mut_repo().set_local_branch_target(
         "main",
-        Some(RefTarget::Conflict {
-            removes: vec![commit_a.id().clone()],
-            adds: vec![commit_b.id().clone(), commit_c.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit_a.id().clone()],
+            [commit_b.id().clone(), commit_c.id().clone()],
+        ),
     );
     let repo = tx.commit();
 
@@ -1263,10 +1263,10 @@ fn test_rebase_descendants_rewrite_resolves_branch_conflict() {
     let commit_c = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo().set_local_branch_target(
         "main",
-        Some(RefTarget::Conflict {
-            removes: vec![commit_a.id().clone()],
-            adds: vec![commit_b.id().clone(), commit_c.id().clone()],
-        }),
+        RefTarget::from_legacy_form(
+            [commit_a.id().clone()],
+            [commit_b.id().clone(), commit_c.id().clone()],
+        ),
     );
     let repo = tx.commit();
 
@@ -1306,10 +1306,7 @@ fn test_rebase_descendants_branch_delete_modify_abandon() {
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     tx.mut_repo().set_local_branch_target(
         "main",
-        Some(RefTarget::Conflict {
-            removes: vec![commit_a.id().clone()],
-            adds: vec![commit_b.id().clone()],
-        }),
+        RefTarget::from_legacy_form([commit_a.id().clone()], [commit_b.id().clone()]),
     );
     let repo = tx.commit();
 

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -250,22 +250,22 @@ fn test_merge_views_branches() {
     let main_branch_alternate_tx0 = write_random_commit(mut_repo, &settings);
     mut_repo.set_local_branch_target(
         "main",
-        Some(RefTarget::Normal(main_branch_local_tx0.id().clone())),
+        RefTarget::normal(main_branch_local_tx0.id().clone()),
     );
     mut_repo.set_remote_branch_target(
         "main",
         "origin",
-        Some(RefTarget::Normal(main_branch_origin_tx0.id().clone())),
+        RefTarget::normal(main_branch_origin_tx0.id().clone()),
     );
     mut_repo.set_remote_branch_target(
         "main",
         "alternate",
-        Some(RefTarget::Normal(main_branch_alternate_tx0.id().clone())),
+        RefTarget::normal(main_branch_alternate_tx0.id().clone()),
     );
     let feature_branch_local_tx0 = write_random_commit(mut_repo, &settings);
     mut_repo.set_git_ref_target(
         "feature",
-        Some(RefTarget::Normal(feature_branch_local_tx0.id().clone())),
+        RefTarget::normal(feature_branch_local_tx0.id().clone()),
     );
     let repo = tx.commit();
 
@@ -273,17 +273,17 @@ fn test_merge_views_branches() {
     let main_branch_local_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo().set_local_branch_target(
         "main",
-        Some(RefTarget::Normal(main_branch_local_tx1.id().clone())),
+        RefTarget::normal(main_branch_local_tx1.id().clone()),
     );
     tx1.mut_repo().set_remote_branch_target(
         "main",
         "origin",
-        Some(RefTarget::Normal(main_branch_origin_tx1.id().clone())),
+        RefTarget::normal(main_branch_origin_tx1.id().clone()),
     );
     let feature_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo().set_local_branch_target(
         "feature",
-        Some(RefTarget::Normal(feature_branch_tx1.id().clone())),
+        RefTarget::normal(feature_branch_tx1.id().clone()),
     );
     tx1.commit();
 
@@ -291,12 +291,12 @@ fn test_merge_views_branches() {
     let main_branch_local_tx2 = write_random_commit(tx2.mut_repo(), &settings);
     tx2.mut_repo().set_local_branch_target(
         "main",
-        Some(RefTarget::Normal(main_branch_local_tx2.id().clone())),
+        RefTarget::normal(main_branch_local_tx2.id().clone()),
     );
     tx2.mut_repo().set_remote_branch_target(
         "main",
         "origin",
-        Some(RefTarget::Normal(main_branch_origin_tx1.id().clone())),
+        RefTarget::normal(main_branch_origin_tx1.id().clone()),
     );
     tx2.commit();
 
@@ -310,12 +310,12 @@ fn test_merge_views_branches() {
             ],
         }),
         remote_targets: btreemap! {
-            "origin".to_string() => RefTarget::Normal(main_branch_origin_tx1.id().clone()),
-            "alternate".to_string() => RefTarget::Normal(main_branch_alternate_tx0.id().clone()),
+            "origin".to_string() => RefTarget::normal(main_branch_origin_tx1.id().clone()).unwrap(),
+            "alternate".to_string() => RefTarget::normal(main_branch_alternate_tx0.id().clone()).unwrap(),
         },
     };
     let expected_feature_branch = BranchTarget {
-        local_target: Some(RefTarget::Normal(feature_branch_tx1.id().clone())),
+        local_target: RefTarget::normal(feature_branch_tx1.id().clone()),
         remote_targets: btreemap! {},
     };
     assert_eq!(
@@ -338,24 +338,24 @@ fn test_merge_views_tags() {
     let mut tx = repo.start_transaction(&settings, "test");
     let mut_repo = tx.mut_repo();
     let v1_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_tag_target("v1.0", Some(RefTarget::Normal(v1_tx0.id().clone())));
+    mut_repo.set_tag_target("v1.0", RefTarget::normal(v1_tx0.id().clone()));
     let v2_tx0 = write_random_commit(mut_repo, &settings);
-    mut_repo.set_tag_target("v2.0", Some(RefTarget::Normal(v2_tx0.id().clone())));
+    mut_repo.set_tag_target("v2.0", RefTarget::normal(v2_tx0.id().clone()));
     let repo = tx.commit();
 
     let mut tx1 = repo.start_transaction(&settings, "test");
     let v1_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo()
-        .set_tag_target("v1.0", Some(RefTarget::Normal(v1_tx1.id().clone())));
+        .set_tag_target("v1.0", RefTarget::normal(v1_tx1.id().clone()));
     let v2_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo()
-        .set_tag_target("v2.0", Some(RefTarget::Normal(v2_tx1.id().clone())));
+        .set_tag_target("v2.0", RefTarget::normal(v2_tx1.id().clone()));
     tx1.commit();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let v1_tx2 = write_random_commit(tx2.mut_repo(), &settings);
     tx2.mut_repo()
-        .set_tag_target("v1.0", Some(RefTarget::Normal(v1_tx2.id().clone())));
+        .set_tag_target("v1.0", RefTarget::normal(v1_tx2.id().clone()));
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();
@@ -363,12 +363,12 @@ fn test_merge_views_tags() {
         removes: vec![v1_tx0.id().clone()],
         adds: vec![v1_tx1.id().clone(), v1_tx2.id().clone()],
     };
-    let expected_v2 = RefTarget::Normal(v2_tx1.id().clone());
+    let expected_v2 = RefTarget::normal(v2_tx1.id().clone());
     assert_eq!(
         repo.view().tags(),
         &btreemap! {
             "v1.0".to_string() => expected_v1,
-            "v2.0".to_string() => expected_v2,
+            "v2.0".to_string() => expected_v2.unwrap(),
         }
     );
 }
@@ -386,12 +386,12 @@ fn test_merge_views_git_refs() {
     let main_branch_tx0 = write_random_commit(mut_repo, &settings);
     mut_repo.set_git_ref_target(
         "refs/heads/main",
-        Some(RefTarget::Normal(main_branch_tx0.id().clone())),
+        RefTarget::normal(main_branch_tx0.id().clone()),
     );
     let feature_branch_tx0 = write_random_commit(mut_repo, &settings);
     mut_repo.set_git_ref_target(
         "refs/heads/feature",
-        Some(RefTarget::Normal(feature_branch_tx0.id().clone())),
+        RefTarget::normal(feature_branch_tx0.id().clone()),
     );
     let repo = tx.commit();
 
@@ -399,12 +399,12 @@ fn test_merge_views_git_refs() {
     let main_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo().set_git_ref_target(
         "refs/heads/main",
-        Some(RefTarget::Normal(main_branch_tx1.id().clone())),
+        RefTarget::normal(main_branch_tx1.id().clone()),
     );
     let feature_branch_tx1 = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo().set_git_ref_target(
         "refs/heads/feature",
-        Some(RefTarget::Normal(feature_branch_tx1.id().clone())),
+        RefTarget::normal(feature_branch_tx1.id().clone()),
     );
     tx1.commit();
 
@@ -412,7 +412,7 @@ fn test_merge_views_git_refs() {
     let main_branch_tx2 = write_random_commit(tx2.mut_repo(), &settings);
     tx2.mut_repo().set_git_ref_target(
         "refs/heads/main",
-        Some(RefTarget::Normal(main_branch_tx2.id().clone())),
+        RefTarget::normal(main_branch_tx2.id().clone()),
     );
     tx2.commit();
 
@@ -421,12 +421,12 @@ fn test_merge_views_git_refs() {
         removes: vec![main_branch_tx0.id().clone()],
         adds: vec![main_branch_tx1.id().clone(), main_branch_tx2.id().clone()],
     };
-    let expected_feature_branch = RefTarget::Normal(feature_branch_tx1.id().clone());
+    let expected_feature_branch = RefTarget::normal(feature_branch_tx1.id().clone());
     assert_eq!(
         repo.view().git_refs(),
         &btreemap! {
             "refs/heads/main".to_string() => expected_main_branch,
-            "refs/heads/feature".to_string() => expected_feature_branch,
+            "refs/heads/feature".to_string() => expected_feature_branch.unwrap(),
         }
     );
 }
@@ -442,19 +442,19 @@ fn test_merge_views_git_heads() {
     let mut tx0 = repo.start_transaction(&settings, "test");
     let tx0_head = write_random_commit(tx0.mut_repo(), &settings);
     tx0.mut_repo()
-        .set_git_head_target(Some(RefTarget::Normal(tx0_head.id().clone())));
+        .set_git_head_target(RefTarget::normal(tx0_head.id().clone()));
     let repo = tx0.commit();
 
     let mut tx1 = repo.start_transaction(&settings, "test");
     let tx1_head = write_random_commit(tx1.mut_repo(), &settings);
     tx1.mut_repo()
-        .set_git_head_target(Some(RefTarget::Normal(tx1_head.id().clone())));
+        .set_git_head_target(RefTarget::normal(tx1_head.id().clone()));
     tx1.commit();
 
     let mut tx2 = repo.start_transaction(&settings, "test");
     let tx2_head = write_random_commit(tx2.mut_repo(), &settings);
     tx2.mut_repo()
-        .set_git_head_target(Some(RefTarget::Normal(tx2_head.id().clone())));
+        .set_git_head_target(RefTarget::normal(tx2_head.id().clone()));
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -302,13 +302,13 @@ fn test_merge_views_branches() {
 
     let repo = repo.reload_at_head(&settings).unwrap();
     let expected_main_branch = BranchTarget {
-        local_target: Some(RefTarget::Conflict {
-            removes: vec![main_branch_local_tx0.id().clone()],
-            adds: vec![
+        local_target: RefTarget::from_legacy_form(
+            [main_branch_local_tx0.id().clone()],
+            [
                 main_branch_local_tx1.id().clone(),
                 main_branch_local_tx2.id().clone(),
             ],
-        }),
+        ),
         remote_targets: btreemap! {
             "origin".to_string() => RefTarget::normal(main_branch_origin_tx1.id().clone()).unwrap(),
             "alternate".to_string() => RefTarget::normal(main_branch_alternate_tx0.id().clone()).unwrap(),
@@ -359,15 +359,15 @@ fn test_merge_views_tags() {
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();
-    let expected_v1 = RefTarget::Conflict {
-        removes: vec![v1_tx0.id().clone()],
-        adds: vec![v1_tx1.id().clone(), v1_tx2.id().clone()],
-    };
+    let expected_v1 = RefTarget::from_legacy_form(
+        [v1_tx0.id().clone()],
+        [v1_tx1.id().clone(), v1_tx2.id().clone()],
+    );
     let expected_v2 = RefTarget::normal(v2_tx1.id().clone());
     assert_eq!(
         repo.view().tags(),
         &btreemap! {
-            "v1.0".to_string() => expected_v1,
+            "v1.0".to_string() => expected_v1.unwrap(),
             "v2.0".to_string() => expected_v2.unwrap(),
         }
     );
@@ -417,15 +417,15 @@ fn test_merge_views_git_refs() {
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();
-    let expected_main_branch = RefTarget::Conflict {
-        removes: vec![main_branch_tx0.id().clone()],
-        adds: vec![main_branch_tx1.id().clone(), main_branch_tx2.id().clone()],
-    };
+    let expected_main_branch = RefTarget::from_legacy_form(
+        [main_branch_tx0.id().clone()],
+        [main_branch_tx1.id().clone(), main_branch_tx2.id().clone()],
+    );
     let expected_feature_branch = RefTarget::normal(feature_branch_tx1.id().clone());
     assert_eq!(
         repo.view().git_refs(),
         &btreemap! {
-            "refs/heads/main".to_string() => expected_main_branch,
+            "refs/heads/main".to_string() => expected_main_branch.unwrap(),
             "refs/heads/feature".to_string() => expected_feature_branch.unwrap(),
         }
     );
@@ -458,11 +458,11 @@ fn test_merge_views_git_heads() {
     tx2.commit();
 
     let repo = repo.reload_at_head(&settings).unwrap();
-    let expected_git_head = RefTarget::Conflict {
-        removes: vec![tx0_head.id().clone()],
-        adds: vec![tx1_head.id().clone(), tx2_head.id().clone()],
-    };
-    assert_eq!(repo.view().git_head(), Some(&expected_git_head));
+    let expected_git_head = RefTarget::from_legacy_form(
+        [tx0_head.id().clone()],
+        [tx1_head.id().clone(), tx2_head.id().clone()],
+    );
+    assert_eq!(repo.view().git_head(), expected_git_head.as_ref());
 }
 
 fn commit_transactions(settings: &UserSettings, txs: Vec<Transaction>) -> Arc<ReadonlyRepo> {

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -796,7 +796,7 @@ impl WorkspaceCommandHelper {
                 let new_git_commit_id = Oid::from_bytes(first_parent_id.as_bytes()).unwrap();
                 let new_git_commit = git_repo.find_commit(new_git_commit_id)?;
                 git_repo.reset(new_git_commit.as_object(), git2::ResetType::Mixed, None)?;
-                mut_repo.set_git_head_target(Some(RefTarget::Normal(first_parent_id)));
+                mut_repo.set_git_head_target(RefTarget::normal(first_parent_id));
             }
         } else {
             // The workspace was removed (maybe the user undid the

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -156,10 +156,8 @@ fn cmd_branch_create(
         target_commit.id().hex()
     ));
     for branch_name in branch_names {
-        tx.mut_repo().set_local_branch_target(
-            branch_name,
-            Some(RefTarget::Normal(target_commit.id().clone())),
-        );
+        tx.mut_repo()
+            .set_local_branch_target(branch_name, RefTarget::normal(target_commit.id().clone()));
     }
     tx.finish(ui)?;
     Ok(())
@@ -203,10 +201,8 @@ fn cmd_branch_set(
         target_commit.id().hex()
     ));
     for branch_name in branch_names {
-        tx.mut_repo().set_local_branch_target(
-            branch_name,
-            Some(RefTarget::Normal(target_commit.id().clone())),
-        );
+        tx.mut_repo()
+            .set_local_branch_target(branch_name, RefTarget::normal(target_commit.id().clone()));
     }
     tx.finish(ui)?;
     Ok(())

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -717,10 +717,8 @@ fn cmd_git_push(
                     change_str.deref()
                 )?;
             }
-            tx.mut_repo().set_local_branch_target(
-                &branch_name,
-                Some(RefTarget::Normal(commit.id().clone())),
-            );
+            tx.mut_repo()
+                .set_local_branch_target(&branch_name, RefTarget::normal(commit.id().clone()));
             let branch_target = tx.repo().view().get_branch(&branch_name).unwrap();
             match classify_branch_update(&branch_name, branch_target, &remote) {
                 Ok(Some(update)) => branch_updates.push((branch_name.clone(), update)),

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use jj_lib::backend::{CommitId, ObjectId, TreeValue};
 use jj_lib::git::{self, parse_gitmodules, GitFetchError, GitPushError, GitRefUpdate};
 use jj_lib::git_backend::GitBackend;
-use jj_lib::op_store::{BranchTarget, RefTarget};
+use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetExt as _};
 use jj_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
@@ -437,10 +437,10 @@ fn cmd_git_clone(
             .repo()
             .view()
             .get_remote_branch(&default_branch, "origin");
-        if let Some(RefTarget::Normal(commit_id)) = default_branch_target {
+        if let Some(commit_id) = default_branch_target.as_normal() {
             let mut checkout_tx =
                 workspace_command.start_transaction("check out git remote's default branch");
-            if let Ok(commit) = checkout_tx.repo().store().get_commit(&commit_id) {
+            if let Ok(commit) = checkout_tx.repo().store().get_commit(commit_id) {
                 checkout_tx.check_out(&commit)?;
             }
             checkout_tx.finish(ui)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -37,7 +37,7 @@ use jj_lib::conflicts::Conflict;
 use jj_lib::dag_walk::topo_order_reverse;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::matchers::EverythingMatcher;
-use jj_lib::op_store::{RefTarget, WorkspaceId};
+use jj_lib::op_store::{RefTargetExt as _, WorkspaceId};
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::repo_path::RepoPath;
 use jj_lib::revset::{
@@ -1100,7 +1100,7 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
         } else {
             let mut tx = workspace_command.start_transaction("import git refs");
             jj_lib::git::import_refs(tx.mut_repo(), &git_repo, &command.settings().git_settings())?;
-            if let Some(RefTarget::Normal(git_head_id)) = tx.mut_repo().view().git_head().cloned() {
+            if let Some(git_head_id) = tx.mut_repo().view().git_head().as_normal().cloned() {
                 let git_head_commit = tx.mut_repo().store().get_commit(&git_head_id)?;
                 tx.check_out(&git_head_commit)?;
             }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
