### PR TITLE
cargo: release 0.7.1 with pointer to new crate names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "jujutsu"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "jujutsu-lib"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "testutils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "config",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "jujutsu"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
 rust-version = "1.61"  # Remember to update CI, contributing.md, and flake.nix
 license = "Apache-2.0"
-description = "Jujutsu (an experimental VCS)"
+description = """This crate has been replaced by the jj-cli crate.
+
+Please upgrade to jj-cli version 0.8+, or specify jujutsu of version "=0.7.0" if you need to compile an obsolete version."""
 homepage = "https://github.com/martinvonz/jj"
 repository = "https://github.com/martinvonz/jj"
 documentation = "https://docs.rs/jujutsu"
@@ -46,7 +48,7 @@ esl01-renderdag = "0.3.0"
 glob = "0.3.1"
 hex = "0.4.3"
 itertools = "0.10.5"
-jujutsu-lib = { version = "=0.7.0", path = "lib", default-features = false }
+jujutsu-lib = { version = "=0.7.1", path = "lib", default-features = false }
 maplit = "1.0.2"
 once_cell = "1.17.1"
 pest = "2.5.5"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Deprecated
+
+The `jujutsu` and `jujutsu-lib` crates have been replaced by the `jj-cli`
+and `jj-lib` crates, respectively.
+
+Please upgrade to `jj-cli`/`jj-lib` version 0.8+, or
+specify `jujutsu`/`jujutsu-lib` of version "=0.7.0" if you need to compile an
+obsolete version.
+
+---
+
 # Jujutsu VCS
 
 ![](https://img.shields.io/github/license/martinvonz/jj) ![](https://img.shields.io/github/v/release/martinvonz/jj) ![](https://img.shields.io/github/release-date/martinvonz/jj) ![](https://img.shields.io/crates/v/jujutsu)

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "jujutsu-lib"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0"
-description = "Library for Jujutsu (an experimental VCS)"
+description = """This crate has been replaced by the jj-lib crate.
+
+Please upgrade to jj-lib version 0.8+, or specify jujutsu-lib of version "=0.7.0" if you need to compile an obsolete version."""
 homepage = "https://github.com/martinvonz/jj"
 repository = "https://github.com/martinvonz/jj"
 documentation = "https://docs.rs/jujutsu"

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testutils"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
 rust-version = "1.61"


### PR DESCRIPTION
This PR is based directly on v0.7.0. I don't plan to merge it; I'm just going to push the updated crates to crates.io after this has been reviewed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
