### PR TITLE
refs: reimplement `RefTarget` as `Conflict<Option<CommitId>>` wrapper

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -257,7 +257,7 @@ pub fn import_some_refs(
     }
     for (ref_name, (old_git_target, new_git_target)) in &changed_git_refs {
         // Apply the change that happened in git since last time we imported refs
-        mut_repo.merge_single_ref(ref_name, old_git_target.as_ref(), new_git_target.as_ref());
+        mut_repo.merge_single_ref(ref_name, old_git_target, new_git_target);
         // If a git remote-tracking branch changed, apply the change to the local branch
         // as well
         if !git_settings.auto_local_branch {
@@ -265,11 +265,7 @@ pub fn import_some_refs(
         }
         if let RefName::RemoteBranch { branch, remote: _ } = ref_name {
             let local_ref_name = RefName::LocalBranch(branch.clone());
-            mut_repo.merge_single_ref(
-                &local_ref_name,
-                old_git_target.as_ref(),
-                new_git_target.as_ref(),
-            );
+            mut_repo.merge_single_ref(&local_ref_name, old_git_target, new_git_target);
             let target = mut_repo.get_local_branch(branch);
             if target.is_absent() {
                 pinned_git_heads.remove(&local_ref_name);

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 
 use crate::backend::{CommitId, ObjectId};
 use crate::git_backend::NO_GC_REF_NAMESPACE;
-use crate::op_store::{BranchTarget, RefTarget, RefTargetExt as _, RefTargetOptionExt};
+use crate::op_store::{BranchTarget, RefTarget, RefTargetOptionExt};
 use crate::repo::{MutableRepo, Repo};
 use crate::revset;
 use crate::settings::GitSettings;
@@ -82,7 +82,7 @@ fn to_remote_branch<'a>(parsed_ref: &'a RefName, remote_name: &str) -> Option<&'
 /// should be faster than `git_ref.peel_to_commit()`.
 fn resolve_git_ref_to_commit_id(
     git_ref: &git2::Reference<'_>,
-    known_target: &Option<RefTarget>,
+    known_target: &RefTarget,
 ) -> Option<CommitId> {
     // Try fast path if we have a candidate id which is known to be a commit object.
     if let Some(id) = known_target.as_normal() {
@@ -137,7 +137,7 @@ pub fn build_unified_branches_map(view: &View) -> (BTreeMap<String, BranchTarget
     (all_branches, bad_branch_names)
 }
 
-fn local_branch_git_tracking_refs(view: &View) -> impl Iterator<Item = (&str, &Option<RefTarget>)> {
+fn local_branch_git_tracking_refs(view: &View) -> impl Iterator<Item = (&str, &RefTarget)> {
     view.git_refs().iter().filter_map(|(ref_name, target)| {
         ref_name
             .strip_prefix("refs/heads/")
@@ -145,7 +145,7 @@ fn local_branch_git_tracking_refs(view: &View) -> impl Iterator<Item = (&str, &O
     })
 }
 
-pub fn get_local_git_tracking_branch<'a>(view: &'a View, branch: &str) -> &'a Option<RefTarget> {
+pub fn get_local_git_tracking_branch<'a>(view: &'a View, branch: &str) -> &'a RefTarget {
     view.git_refs()
         .get(&format!("refs/heads/{branch}"))
         .flatten()

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -151,15 +151,16 @@ mod tests {
 
     use super::*;
     use crate::backend::ObjectId;
+    use crate::op_store::RefTargetMap;
 
     #[test]
     fn test_classify_branch_push_action_unchanged() {
         let commit_id1 = CommitId::from_hex("11");
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id1.clone()),
-            remote_targets: btreemap! {
+            remote_targets: RefTargetMap(btreemap! {
                 "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
-            },
+            }),
         };
         assert_eq!(
             classify_branch_push_action(&branch, "origin"),
@@ -172,7 +173,7 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id1.clone()),
-            remote_targets: btreemap! {},
+            remote_targets: RefTargetMap::new(),
         };
         assert_eq!(
             classify_branch_push_action(&branch, "origin"),
@@ -188,9 +189,9 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let branch = BranchTarget {
             local_target: RefTarget::absent(),
-            remote_targets: btreemap! {
+            remote_targets: RefTargetMap(btreemap! {
                 "origin".to_string() => RefTarget::normal(commit_id1.clone()).unwrap(),
-            },
+            }),
         };
         assert_eq!(
             classify_branch_push_action(&branch, "origin"),
@@ -207,9 +208,9 @@ mod tests {
         let commit_id2 = CommitId::from_hex("22");
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id2.clone()),
-            remote_targets: btreemap! {
+            remote_targets: RefTargetMap(btreemap! {
                 "origin".to_string() => RefTarget::normal(commit_id1.clone()).unwrap(),
-            },
+            }),
         };
         assert_eq!(
             classify_branch_push_action(&branch, "origin"),
@@ -226,9 +227,9 @@ mod tests {
         let commit_id2 = CommitId::from_hex("22");
         let branch = BranchTarget {
             local_target: RefTarget::from_legacy_form([], [commit_id1.clone(), commit_id2]),
-            remote_targets: btreemap! {
+            remote_targets: RefTargetMap(btreemap! {
                 "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
-            },
+            }),
         };
         assert_eq!(
             classify_branch_push_action(&branch, "origin"),
@@ -242,12 +243,12 @@ mod tests {
         let commit_id2 = CommitId::from_hex("22");
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id1.clone()),
-            remote_targets: btreemap! {
+            remote_targets: RefTargetMap(btreemap! {
                 "origin".to_string() => RefTarget::from_legacy_form(
                     [],
                     [commit_id1, commit_id2],
                 ).unwrap(),
-            },
+            }),
         };
         assert_eq!(
             classify_branch_push_action(&branch, "origin"),

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -18,7 +18,7 @@ use crate::backend::CommitId;
 use crate::conflicts::Conflict;
 use crate::index::Index;
 use crate::merge::trivial_merge;
-use crate::op_store::{BranchTarget, RefTarget, RefTargetExt as _};
+use crate::op_store::{BranchTarget, RefTarget, RefTargetExt as _, RefTargetOptionExt};
 
 pub fn merge_ref_targets(
     index: &dyn Index,
@@ -129,8 +129,8 @@ pub fn classify_branch_push_action(
     branch_target: &BranchTarget,
     remote_name: &str,
 ) -> BranchPushAction {
-    let local_target = branch_target.local_target.as_ref();
-    let remote_target = branch_target.remote_targets.get(remote_name);
+    let local_target = &branch_target.local_target;
+    let remote_target = branch_target.remote_targets.get(remote_name).flatten();
     if local_target == remote_target {
         BranchPushAction::AlreadyMatches
     } else if local_target.is_conflict() {
@@ -159,7 +159,7 @@ mod tests {
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id1.clone()),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
+                "origin".to_string() => RefTarget::normal(commit_id1),
             }),
         };
         assert_eq!(
@@ -190,7 +190,7 @@ mod tests {
         let branch = BranchTarget {
             local_target: RefTarget::absent(),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(commit_id1.clone()).unwrap(),
+                "origin".to_string() => RefTarget::normal(commit_id1.clone()),
             }),
         };
         assert_eq!(
@@ -209,7 +209,7 @@ mod tests {
         let branch = BranchTarget {
             local_target: RefTarget::normal(commit_id2.clone()),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(commit_id1.clone()).unwrap(),
+                "origin".to_string() => RefTarget::normal(commit_id1.clone()),
             }),
         };
         assert_eq!(
@@ -228,7 +228,7 @@ mod tests {
         let branch = BranchTarget {
             local_target: RefTarget::from_legacy_form([], [commit_id1.clone(), commit_id2]),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(commit_id1).unwrap(),
+                "origin".to_string() => RefTarget::normal(commit_id1),
             }),
         };
         assert_eq!(
@@ -247,7 +247,7 @@ mod tests {
                 "origin".to_string() => RefTarget::from_legacy_form(
                     [],
                     [commit_id1, commit_id2],
-                ).unwrap(),
+                ),
             }),
         };
         assert_eq!(

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -22,12 +22,12 @@ use crate::op_store::{BranchTarget, RefTarget, RefTargetExt as _, RefTargetOptio
 
 pub fn merge_ref_targets(
     index: &dyn Index,
-    left: Option<&RefTarget>,
-    base: Option<&RefTarget>,
-    right: Option<&RefTarget>,
+    left: &Option<RefTarget>,
+    base: &Option<RefTarget>,
+    right: &Option<RefTarget>,
 ) -> Option<RefTarget> {
-    if let Some(resolved) = trivial_merge(&[base], &[left, right]) {
-        return resolved.cloned();
+    if let Some(&resolved) = trivial_merge(&[base], &[left, right]) {
+        return resolved.clone();
     }
 
     let conflict = Conflict::new(
@@ -60,7 +60,7 @@ fn conflict_to_ref_target(conflict: Conflict<Option<CommitId>>) -> Option<RefTar
 // TODO: Make RefTarget store or be aliased to Conflict<Option<CommitId>>.
 // Since new conflict type can represent a deleted/absent ref, we might have
 // to replace Option<RefTarget> with it. Map API might be a bit trickier.
-fn ref_target_to_conflict(maybe_target: Option<&RefTarget>) -> Conflict<Option<CommitId>> {
+fn ref_target_to_conflict(maybe_target: &Option<RefTarget>) -> Conflict<Option<CommitId>> {
     if let Some(target) = maybe_target {
         Conflict::from_legacy_form(target.removed_ids().cloned(), target.added_ids().cloned())
     } else {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1134,16 +1134,16 @@ impl MutableRepo {
             self.view.get_mut().merge_single_ref(
                 self.index.as_index(),
                 &ref_name,
-                base_target.as_ref(),
-                other_target.as_ref(),
+                &base_target,
+                &other_target,
             );
         }
 
         let new_git_head_target = merge_ref_targets(
             self.index(),
-            self.view().git_head().as_ref(),
-            base.git_head().as_ref(),
-            other.git_head().as_ref(),
+            self.view().git_head(),
+            base.git_head(),
+            other.git_head(),
         );
         self.set_git_head_target(new_git_head_target);
     }
@@ -1199,8 +1199,8 @@ impl MutableRepo {
     pub fn merge_single_ref(
         &mut self,
         ref_name: &RefName,
-        base_target: Option<&RefTarget>,
-        other_target: Option<&RefTarget>,
+        base_target: &Option<RefTarget>,
+        other_target: &Option<RefTarget>,
     ) {
         self.view.get_mut().merge_single_ref(
             self.index.as_index(),

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -41,9 +41,7 @@ use crate::git_backend::GitBackend;
 use crate::index::{HexPrefix, Index, IndexStore, MutableIndex, PrefixResolution, ReadonlyIndex};
 use crate::local_backend::LocalBackend;
 use crate::op_heads_store::{self, OpHeadResolutionError, OpHeadsStore};
-use crate::op_store::{
-    BranchTarget, OpStore, OperationId, RefTarget, RefTargetExt as _, WorkspaceId,
-};
+use crate::op_store::{BranchTarget, OpStore, OperationId, RefTarget, WorkspaceId};
 use crate::operation::Operation;
 use crate::refs::merge_ref_targets;
 use crate::revset::{self, ChangeIdIndex, Revset, RevsetExpression};
@@ -967,25 +965,20 @@ impl MutableRepo {
         self.view_mut().remove_branch(name);
     }
 
-    pub fn get_local_branch(&self, name: &str) -> Option<RefTarget> {
+    pub fn get_local_branch(&self, name: &str) -> RefTarget {
         self.view.with_ref(|v| v.get_local_branch(name))
     }
 
-    pub fn set_local_branch_target(&mut self, name: &str, target: Option<RefTarget>) {
+    pub fn set_local_branch_target(&mut self, name: &str, target: RefTarget) {
         self.view_mut().set_local_branch_target(name, target);
     }
 
-    pub fn get_remote_branch(&self, name: &str, remote_name: &str) -> Option<RefTarget> {
+    pub fn get_remote_branch(&self, name: &str, remote_name: &str) -> RefTarget {
         self.view
             .with_ref(|v| v.get_remote_branch(name, remote_name))
     }
 
-    pub fn set_remote_branch_target(
-        &mut self,
-        name: &str,
-        remote_name: &str,
-        target: Option<RefTarget>,
-    ) {
+    pub fn set_remote_branch_target(&mut self, name: &str, remote_name: &str, target: RefTarget) {
         self.view_mut()
             .set_remote_branch_target(name, remote_name, target);
     }
@@ -994,27 +987,27 @@ impl MutableRepo {
         self.view_mut().rename_remote(old, new);
     }
 
-    pub fn get_tag(&self, name: &str) -> Option<RefTarget> {
+    pub fn get_tag(&self, name: &str) -> RefTarget {
         self.view.with_ref(|v| v.get_tag(name))
     }
 
-    pub fn set_tag_target(&mut self, name: &str, target: Option<RefTarget>) {
+    pub fn set_tag_target(&mut self, name: &str, target: RefTarget) {
         self.view_mut().set_tag_target(name, target);
     }
 
-    pub fn get_git_ref(&self, name: &str) -> Option<RefTarget> {
+    pub fn get_git_ref(&self, name: &str) -> RefTarget {
         self.view.with_ref(|v| v.get_git_ref(name))
     }
 
-    pub fn set_git_ref_target(&mut self, name: &str, target: Option<RefTarget>) {
+    pub fn set_git_ref_target(&mut self, name: &str, target: RefTarget) {
         self.view_mut().set_git_ref_target(name, target);
     }
 
-    pub fn git_head(&self) -> Option<RefTarget> {
+    pub fn git_head(&self) -> RefTarget {
         self.view.with_ref(|v| v.git_head().clone())
     }
 
-    pub fn set_git_head_target(&mut self, target: Option<RefTarget>) {
+    pub fn set_git_head_target(&mut self, target: RefTarget) {
         self.view_mut().set_git_head_target(target);
     }
 
@@ -1199,8 +1192,8 @@ impl MutableRepo {
     pub fn merge_single_ref(
         &mut self,
         ref_name: &RefName,
-        base_target: &Option<RefTarget>,
-        other_target: &Option<RefTarget>,
+        base_target: &RefTarget,
+        other_target: &RefTarget,
     ) {
         self.view.get_mut().merge_single_ref(
             self.index.as_index(),

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1011,7 +1011,7 @@ impl MutableRepo {
     }
 
     pub fn git_head(&self) -> Option<RefTarget> {
-        self.view.with_ref(|v| v.git_head().cloned())
+        self.view.with_ref(|v| v.git_head().clone())
     }
 
     pub fn set_git_head_target(&mut self, target: Option<RefTarget>) {
@@ -1141,9 +1141,9 @@ impl MutableRepo {
 
         let new_git_head_target = merge_ref_targets(
             self.index(),
-            self.view().git_head(),
-            base.git_head(),
-            other.git_head(),
+            self.view().git_head().as_ref(),
+            base.git_head().as_ref(),
+            other.git_head().as_ref(),
         );
         self.set_git_head_target(new_git_head_target);
     }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1673,12 +1673,12 @@ fn collect_branch_symbols(repo: &dyn Repo, include_synced_remotes: bool) -> Vec<
     all_branches
         .iter()
         .flat_map(|(name, branch_target)| {
-            let local_target = branch_target.local_target.as_ref();
+            let local_target = &branch_target.local_target;
             let local_symbol = local_target.is_present().then(|| name.to_owned());
             let remote_symbols = branch_target
                 .remote_targets
                 .iter()
-                .filter(move |&(_, target)| include_synced_remotes || Some(target) != local_target)
+                .filter(move |&(_, target)| include_synced_remotes || target != local_target)
                 .map(move |(remote_name, _)| format!("{name}@{remote_name}"));
             local_symbol.into_iter().chain(remote_symbols)
         })

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -36,7 +36,7 @@ use crate::commit::Commit;
 use crate::git::{self, get_local_git_tracking_branch};
 use crate::hex_util::to_forward_hex;
 use crate::index::{HexPrefix, PrefixResolution};
-use crate::op_store::{RefTargetExt as _, WorkspaceId};
+use crate::op_store::WorkspaceId;
 use crate::repo::Repo;
 use crate::repo_path::{FsPathParseError, RepoPath};
 use crate::store::Store;

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -23,7 +23,7 @@ use crate::backend::{BackendError, CommitId, ObjectId};
 use crate::commit::Commit;
 use crate::dag_walk;
 use crate::index::Index;
-use crate::op_store::{RefTarget, RefTargetExt as _};
+use crate::op_store::RefTarget;
 use crate::repo::{MutableRepo, Repo};
 use crate::repo_path::RepoPath;
 use crate::revset::{RevsetExpression, RevsetIteratorExt};
@@ -276,10 +276,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         new_ids
     }
 
-    fn ref_target_update(
-        old_id: CommitId,
-        new_ids: Vec<CommitId>,
-    ) -> (Option<RefTarget>, Option<RefTarget>) {
+    fn ref_target_update(old_id: CommitId, new_ids: Vec<CommitId>) -> (RefTarget, RefTarget) {
         let old_ids = std::iter::repeat(old_id).take(new_ids.len());
         (
             RefTarget::from_legacy_form([], old_ids),
@@ -305,7 +302,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
                         .or_default()
                         .insert(branch_name.clone());
                 }
-                let local_target = self.mut_repo.get_local_branch(branch_name).unwrap();
+                let local_target = self.mut_repo.get_local_branch(branch_name);
                 for old_add in local_target.added_ids() {
                     if *old_add == old_commit_id {
                         branch_updates.push(branch_name.clone());

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -317,8 +317,8 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
             for branch_name in branch_updates {
                 self.mut_repo.merge_single_ref(
                     &RefName::LocalBranch(branch_name),
-                    old_target.as_ref(),
-                    new_target.as_ref(),
+                    &old_target,
+                    &new_target,
                 );
             }
         }

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -27,7 +27,7 @@ use crate::content_hash::blake2b_hash;
 use crate::file_util::persist_content_addressed_temp_file;
 use crate::op_store::{
     BranchTarget, OpStore, OpStoreError, OpStoreResult, Operation, OperationId, OperationMetadata,
-    RefTarget, RefTargetExt as _, RefTargetMap, View, ViewId, WorkspaceId,
+    RefTarget, RefTargetMap, View, ViewId, WorkspaceId,
 };
 
 impl From<std::io::Error> for OpStoreError {
@@ -315,7 +315,7 @@ fn view_from_proto(proto: crate::protos::op_store::View) -> View {
     view
 }
 
-fn ref_target_to_proto(value: &Option<RefTarget>) -> Option<crate::protos::op_store::RefTarget> {
+fn ref_target_to_proto(value: &RefTarget) -> Option<crate::protos::op_store::RefTarget> {
     if let Some(id) = value.as_normal() {
         let proto = crate::protos::op_store::RefTarget {
             value: Some(crate::protos::op_store::ref_target::Value::CommitId(
@@ -341,10 +341,10 @@ fn ref_target_to_proto(value: &Option<RefTarget>) -> Option<crate::protos::op_st
     }
 }
 
-fn ref_target_from_proto(
-    maybe_proto: Option<crate::protos::op_store::RefTarget>,
-) -> Option<RefTarget> {
-    let proto = maybe_proto?;
+fn ref_target_from_proto(maybe_proto: Option<crate::protos::op_store::RefTarget>) -> RefTarget {
+    let Some(proto) = maybe_proto else {
+        return RefTarget::absent();
+    };
     match proto.value.unwrap() {
         crate::protos::op_store::ref_target::Value::CommitId(id) => {
             RefTarget::normal(CommitId::new(id))

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -301,13 +301,12 @@ impl View {
         &mut self,
         index: &dyn Index,
         ref_name: &RefName,
-        base_target: Option<&RefTarget>,
-        other_target: Option<&RefTarget>,
+        base_target: &Option<RefTarget>,
+        other_target: &Option<RefTarget>,
     ) {
         if base_target != other_target {
             let self_target = self.get_ref(ref_name);
-            let new_target =
-                merge_ref_targets(index, self_target.as_ref(), base_target, other_target);
+            let new_target = merge_ref_targets(index, &self_target, base_target, other_target);
             if new_target != self_target {
                 self.set_ref_target(ref_name, new_target);
             }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -27,7 +27,7 @@ use jj_lib::commit_builder::CommitBuilder;
 use jj_lib::git;
 use jj_lib::git::{GitFetchError, GitPushError, GitRefUpdate, SubmoduleConfig};
 use jj_lib::git_backend::GitBackend;
-use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetMap};
+use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetMap, RefTargetOptionExt as _};
 use jj_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
 use jj_lib::settings::{GitSettings, UserSettings};
 use jj_lib::view::RefName;
@@ -111,7 +111,7 @@ fn test_import_refs() {
     let expected_main_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit2)),
         remote_targets: RefTargetMap(btreemap! {
-          "origin".to_string() => RefTarget::normal(jj_id(&commit1)).unwrap(),
+          "origin".to_string() => RefTarget::normal(jj_id(&commit1)),
         }),
     };
     assert_eq!(
@@ -137,7 +137,7 @@ fn test_import_refs() {
     let expected_feature3_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit6)),
         remote_targets: RefTargetMap(btreemap! {
-          "origin".to_string() => RefTarget::normal(jj_id(&commit6)).unwrap(),
+          "origin".to_string() => RefTarget::normal(jj_id(&commit6)),
         }),
     };
     assert_eq!(
@@ -146,8 +146,8 @@ fn test_import_refs() {
     );
 
     assert_eq!(
-        view.tags().get("v1.0"),
-        RefTarget::normal(jj_id(&commit5)).as_ref()
+        view.tags().get("v1.0").flatten(),
+        &RefTarget::normal(jj_id(&commit5))
     );
 
     assert_eq!(view.git_refs().len(), 6);
@@ -175,7 +175,7 @@ fn test_import_refs() {
         view.get_git_ref("refs/tags/v1.0"),
         RefTarget::normal(jj_id(&commit5))
     );
-    assert_eq!(view.git_head(), RefTarget::normal(jj_id(&commit2)).as_ref());
+    assert_eq!(view.git_head(), &RefTarget::normal(jj_id(&commit2)));
 }
 
 #[test]
@@ -241,7 +241,7 @@ fn test_import_refs_reimport() {
     let expected_main_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit2)),
         remote_targets: RefTargetMap(btreemap! {
-          "origin".to_string() => commit1_target.clone().unwrap(),
+          "origin".to_string() => commit1_target.clone(),
         }),
     };
     assert_eq!(
@@ -439,7 +439,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
             // creates one. This follows the model explained in docs/branches.md.
             local_target: RefTarget::normal(jj_id(&commit_remote_only)),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_only)).unwrap(),
+                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_only)),
             }),
         }),
     );
@@ -448,7 +448,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
         Some(&BranchTarget {
             local_target: RefTarget::normal(jj_id(&commit_remote_and_local)),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_and_local)).unwrap(),
+                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_and_local)),
             }),
         }),
     );
@@ -528,7 +528,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
             // creates one. This follows the model explained in docs/branches.md.
             local_target: RefTarget::normal(jj_id(&commit_remote_only)),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_only)).unwrap(),
+                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_only)),
             }),
         }),
     );
@@ -537,7 +537,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         Some(&BranchTarget {
             local_target: RefTarget::normal(jj_id(&commit_remote_and_local)),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_and_local)).unwrap(),
+                "origin".to_string() => RefTarget::normal(jj_id(&commit_remote_and_local)),
             }),
         }),
     );
@@ -572,7 +572,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         Some(&BranchTarget {
             local_target: RefTarget::normal(jj_id(&new_commit_remote_only)),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(jj_id(&new_commit_remote_only)).unwrap(),
+                "origin".to_string() => RefTarget::normal(jj_id(&new_commit_remote_only)),
             }),
         }),
     );
@@ -581,7 +581,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         Some(&BranchTarget {
             local_target: RefTarget::normal(jj_id(&new_commit_remote_and_local)),
             remote_targets: RefTargetMap(btreemap! {
-                "origin".to_string() => RefTarget::normal(jj_id(&new_commit_remote_and_local)).unwrap(),
+                "origin".to_string() => RefTarget::normal(jj_id(&new_commit_remote_and_local)),
             }),
         }),
     );
@@ -713,7 +713,7 @@ fn test_import_some_refs() {
     let expected_feature1_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit_feat1)),
         remote_targets: RefTargetMap(btreemap! {
-            "origin".to_string() => commit_feat1_target.unwrap(),
+            "origin".to_string() => commit_feat1_target,
         }),
     };
     assert_eq!(
@@ -723,7 +723,7 @@ fn test_import_some_refs() {
     let expected_feature2_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit_feat2)),
         remote_targets: RefTargetMap(btreemap! {
-            "origin".to_string() => commit_feat2_target.unwrap(),
+            "origin".to_string() => commit_feat2_target,
         }),
     };
     assert_eq!(
@@ -733,7 +733,7 @@ fn test_import_some_refs() {
     let expected_feature3_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit_feat3)),
         remote_targets: RefTargetMap(btreemap! {
-            "origin".to_string() => commit_feat3_target.unwrap(),
+            "origin".to_string() => commit_feat3_target,
         }),
     };
     assert_eq!(
@@ -743,7 +743,7 @@ fn test_import_some_refs() {
     let expected_feature4_branch = BranchTarget {
         local_target: RefTarget::normal(jj_id(&commit_feat4)),
         remote_targets: RefTargetMap(btreemap! {
-            "origin".to_string() => commit_feat4_target.unwrap(),
+            "origin".to_string() => commit_feat4_target,
         }),
     };
     assert_eq!(
@@ -926,10 +926,7 @@ fn test_import_refs_detached_head() {
     let expected_heads = hashset! { jj_id(&commit1) };
     assert_eq!(*repo.view().heads(), expected_heads);
     assert_eq!(repo.view().git_refs().len(), 0);
-    assert_eq!(
-        repo.view().git_head(),
-        RefTarget::normal(jj_id(&commit1)).as_ref()
-    );
+    assert_eq!(repo.view().git_head(), &RefTarget::normal(jj_id(&commit1)));
 }
 
 #[test]
@@ -1153,7 +1150,7 @@ fn test_import_export_no_auto_local_branch() {
     let expected_branch = BranchTarget {
         local_target: RefTarget::absent(),
         remote_targets: RefTargetMap(btreemap! {
-            "origin".to_string() => RefTarget::normal(jj_id(&git_commit)).unwrap(),
+            "origin".to_string() => RefTarget::normal(jj_id(&git_commit)),
         }),
     };
     assert_eq!(
@@ -1403,15 +1400,15 @@ fn test_export_reexport_transitions() {
     assert_eq!(
         *mut_repo.view().git_refs(),
         btreemap! {
-            "refs/heads/AAX".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
-            "refs/heads/AAB".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
-            "refs/heads/ABA".to_string() => RefTarget::normal(commit_b.id().clone()).unwrap(),
-            "refs/heads/ABB".to_string() => RefTarget::normal(commit_b.id().clone()).unwrap(),
-            "refs/heads/ABC".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
-            "refs/heads/ABX".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
-            "refs/heads/AXB".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
-            "refs/heads/XAA".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
-            "refs/heads/XAX".to_string() => RefTarget::normal(commit_a.id().clone()).unwrap(),
+            "refs/heads/AAX".to_string() => RefTarget::normal(commit_a.id().clone()),
+            "refs/heads/AAB".to_string() => RefTarget::normal(commit_a.id().clone()),
+            "refs/heads/ABA".to_string() => RefTarget::normal(commit_b.id().clone()),
+            "refs/heads/ABB".to_string() => RefTarget::normal(commit_b.id().clone()),
+            "refs/heads/ABC".to_string() => RefTarget::normal(commit_a.id().clone()),
+            "refs/heads/ABX".to_string() => RefTarget::normal(commit_a.id().clone()),
+            "refs/heads/AXB".to_string() => RefTarget::normal(commit_a.id().clone()),
+            "refs/heads/XAA".to_string() => RefTarget::normal(commit_a.id().clone()),
+            "refs/heads/XAX".to_string() => RefTarget::normal(commit_a.id().clone()),
         }
     );
 }
@@ -1496,7 +1493,7 @@ fn test_fetch_initial_commit() {
     assert_eq!(
         *view.git_refs(),
         btreemap! {
-            "refs/remotes/origin/main".to_string() => initial_commit_target.clone().unwrap(),
+            "refs/remotes/origin/main".to_string() => initial_commit_target.clone(),
         }
     );
     assert_eq!(
@@ -1505,7 +1502,7 @@ fn test_fetch_initial_commit() {
             "main".to_string() => BranchTarget {
                 local_target: initial_commit_target.clone(),
                 remote_targets: RefTargetMap(btreemap! {
-                    "origin".to_string() => initial_commit_target.unwrap(),
+                    "origin".to_string() => initial_commit_target,
                 })
             },
         }
@@ -1561,7 +1558,7 @@ fn test_fetch_success() {
     assert_eq!(
         *view.git_refs(),
         btreemap! {
-            "refs/remotes/origin/main".to_string() => new_commit_target.clone().unwrap(),
+            "refs/remotes/origin/main".to_string() => new_commit_target.clone(),
         }
     );
     assert_eq!(
@@ -1570,7 +1567,7 @@ fn test_fetch_success() {
             "main".to_string() => BranchTarget {
                 local_target: new_commit_target.clone(),
                 remote_targets: RefTargetMap(btreemap! {
-                    "origin".to_string() => new_commit_target.unwrap(),
+                    "origin".to_string() => new_commit_target,
                 }),
             },
         }

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use jj_lib::conflicts::Conflict;
 use jj_lib::op_store::RefTarget;
 use jj_lib::refs::merge_ref_targets;
 use jj_lib::repo::Repo;
@@ -166,13 +167,19 @@ fn test_merge_ref_targets() {
     // Left removed, right moved forward
     assert_eq!(
         merge_ref_targets(index, RefTarget::absent_ref(), &target1, &target3),
-        RefTarget::from_legacy_form([commit1.id().clone()], [commit3.id().clone()])
+        RefTarget::from_conflict(Conflict::new(
+            vec![Some(commit1.id().clone())],
+            vec![None, Some(commit3.id().clone())],
+        ))
     );
 
     // Right removed, left moved forward
     assert_eq!(
         merge_ref_targets(index, &target3, &target1, RefTarget::absent_ref()),
-        RefTarget::from_legacy_form([commit1.id().clone()], [commit3.id().clone()])
+        RefTarget::from_conflict(Conflict::new(
+            vec![Some(commit1.id().clone())],
+            vec![Some(commit3.id().clone()), None],
+        ))
     );
 
     // Left became conflicted, right moved forward

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -54,79 +54,79 @@ fn test_merge_ref_targets() {
 
     // Left moved forward
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target1.as_ref()),
+        merge_ref_targets(index, &target3, &target1, &target1),
         target3
     );
 
     // Right moved forward
     assert_eq!(
-        merge_ref_targets(index, target1.as_ref(), target1.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, &target1, &target1, &target3),
         target3
     );
 
     // Left moved backward
     assert_eq!(
-        merge_ref_targets(index, target1.as_ref(), target3.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, &target1, &target3, &target3),
         target1
     );
 
     // Right moved backward
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target3.as_ref(), target1.as_ref()),
+        merge_ref_targets(index, &target3, &target3, &target1),
         target1
     );
 
     // Left moved sideways
     assert_eq!(
-        merge_ref_targets(index, target4.as_ref(), target3.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, &target4, &target3, &target3),
         target4
     );
 
     // Right moved sideways
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target3.as_ref(), target4.as_ref()),
+        merge_ref_targets(index, &target3, &target3, &target4),
         target4
     );
 
     // Both added same target
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), None, target3.as_ref()),
+        merge_ref_targets(index, &target3, RefTarget::absent_ref(), &target3),
         target3
     );
 
     // Left added target, right added descendant target
     assert_eq!(
-        merge_ref_targets(index, target2.as_ref(), None, target3.as_ref()),
+        merge_ref_targets(index, &target2, RefTarget::absent_ref(), &target3),
         target3
     );
 
     // Right added target, left added descendant target
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), None, target2.as_ref()),
+        merge_ref_targets(index, &target3, RefTarget::absent_ref(), &target2),
         target3
     );
 
     // Both moved forward to same target
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, &target3, &target1, &target3),
         target3
     );
 
     // Both moved forward, left moved further
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target2.as_ref()),
+        merge_ref_targets(index, &target3, &target1, &target2),
         target3
     );
 
     // Both moved forward, right moved further
     assert_eq!(
-        merge_ref_targets(index, target2.as_ref(), target1.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, &target2, &target1, &target3),
         target3
     );
 
     // Left and right moved forward to divergent targets
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), target4.as_ref()),
+        merge_ref_targets(index, &target3, &target1, &target4),
         RefTarget::from_legacy_form(
             [commit1.id().clone()],
             [commit3.id().clone(), commit4.id().clone()]
@@ -135,7 +135,7 @@ fn test_merge_ref_targets() {
 
     // Left moved back, right moved forward
     assert_eq!(
-        merge_ref_targets(index, target1.as_ref(), target2.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, &target1, &target2, &target3),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
             [commit1.id().clone(), commit3.id().clone()]
@@ -144,7 +144,7 @@ fn test_merge_ref_targets() {
 
     // Right moved back, left moved forward
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target2.as_ref(), target1.as_ref()),
+        merge_ref_targets(index, &target3, &target2, &target1),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
             [commit3.id().clone(), commit1.id().clone()]
@@ -153,25 +153,25 @@ fn test_merge_ref_targets() {
 
     // Left removed
     assert_eq!(
-        merge_ref_targets(index, None, target3.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, RefTarget::absent_ref(), &target3, &target3),
         RefTarget::absent()
     );
 
     // Right removed
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target3.as_ref(), None),
+        merge_ref_targets(index, &target3, &target3, RefTarget::absent_ref()),
         RefTarget::absent()
     );
 
     // Left removed, right moved forward
     assert_eq!(
-        merge_ref_targets(index, None, target1.as_ref(), target3.as_ref()),
+        merge_ref_targets(index, RefTarget::absent_ref(), &target1, &target3),
         RefTarget::from_legacy_form([commit1.id().clone()], [commit3.id().clone()])
     );
 
     // Right removed, left moved forward
     assert_eq!(
-        merge_ref_targets(index, target3.as_ref(), target1.as_ref(), None),
+        merge_ref_targets(index, &target3, &target1, RefTarget::absent_ref()),
         RefTarget::from_legacy_form([commit1.id().clone()], [commit3.id().clone()])
     );
 
@@ -179,13 +179,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            RefTarget::from_legacy_form(
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
-            target1.as_ref(),
-            target3.as_ref()
+            ),
+            &target1,
+            &target3
         ),
         // TODO: "removes" should have commit 2, just like it does in the next test case
         RefTarget::from_legacy_form(
@@ -198,13 +197,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            target3.as_ref(),
-            target1.as_ref(),
-            RefTarget::from_legacy_form(
+            &target3,
+            &target1,
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
+            ),
         ),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
@@ -223,13 +221,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            RefTarget::from_legacy_form(
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
-            target3.as_ref(),
-            target5.as_ref()
+            ),
+            &target3,
+            &target5
         ),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
@@ -248,13 +245,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            target5.as_ref(),
-            target3.as_ref(),
-            RefTarget::from_legacy_form(
+            &target5,
+            &target3,
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
+            ),
         ),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
@@ -274,13 +270,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            RefTarget::from_legacy_form(
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
-            target3.as_ref(),
-            target1.as_ref()
+            ),
+            &target3,
+            &target1
         ),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
@@ -300,13 +295,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            target1.as_ref(),
-            target3.as_ref(),
-            RefTarget::from_legacy_form(
+            &target1,
+            &target3,
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
+            ),
         ),
         RefTarget::from_legacy_form(
             [commit2.id().clone()],
@@ -318,13 +312,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            RefTarget::from_legacy_form(
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
-            target3.as_ref(),
-            target2.as_ref()
+            ),
+            &target3,
+            &target2
         ),
         target4
     );
@@ -333,13 +326,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            target2.as_ref(),
-            target3.as_ref(),
-            RefTarget::from_legacy_form(
+            &target2,
+            &target3,
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
+            ),
         ),
         target4
     );
@@ -348,13 +340,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            RefTarget::from_legacy_form(
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
-            target5.as_ref(),
-            target6.as_ref()
+            ),
+            &target5,
+            &target6
         ),
         RefTarget::from_legacy_form(
             [commit2.id().clone(), commit5.id().clone()],
@@ -370,13 +361,12 @@ fn test_merge_ref_targets() {
     assert_eq!(
         merge_ref_targets(
             index,
-            target6.as_ref(),
-            target5.as_ref(),
-            RefTarget::from_legacy_form(
+            &target6,
+            &target5,
+            &RefTarget::from_legacy_form(
                 [commit2.id().clone()],
                 [commit3.id().clone(), commit4.id().clone()]
-            )
-            .as_ref(),
+            ),
         ),
         RefTarget::from_legacy_form(
             [commit5.id().clone(), commit2.id().clone()],

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use itertools::Itertools as _;
-use jj_lib::op_store::{RefTarget, RefTargetExt as _, WorkspaceId};
+use jj_lib::op_store::{RefTarget, WorkspaceId};
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::rewrite::DescendantRebaser;

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use jj_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
+use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetMap, WorkspaceId};
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::settings::UserSettings;
 use jj_lib::transaction::Transaction;
@@ -309,14 +309,14 @@ fn test_merge_views_branches() {
                 main_branch_local_tx2.id().clone(),
             ],
         ),
-        remote_targets: btreemap! {
+        remote_targets: RefTargetMap(btreemap! {
             "origin".to_string() => RefTarget::normal(main_branch_origin_tx1.id().clone()).unwrap(),
             "alternate".to_string() => RefTarget::normal(main_branch_alternate_tx0.id().clone()).unwrap(),
-        },
+        }),
     };
     let expected_feature_branch = BranchTarget {
         local_target: RefTarget::normal(feature_branch_tx1.id().clone()),
-        remote_targets: btreemap! {},
+        remote_targets: RefTargetMap::new(),
     };
     assert_eq!(
         repo.view().branches(),

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -310,8 +310,8 @@ fn test_merge_views_branches() {
             ],
         ),
         remote_targets: RefTargetMap(btreemap! {
-            "origin".to_string() => RefTarget::normal(main_branch_origin_tx1.id().clone()).unwrap(),
-            "alternate".to_string() => RefTarget::normal(main_branch_alternate_tx0.id().clone()).unwrap(),
+            "origin".to_string() => RefTarget::normal(main_branch_origin_tx1.id().clone()),
+            "alternate".to_string() => RefTarget::normal(main_branch_alternate_tx0.id().clone()),
         }),
     };
     let expected_feature_branch = BranchTarget {
@@ -367,8 +367,8 @@ fn test_merge_views_tags() {
     assert_eq!(
         repo.view().tags(),
         &btreemap! {
-            "v1.0".to_string() => expected_v1.unwrap(),
-            "v2.0".to_string() => expected_v2.unwrap(),
+            "v1.0".to_string() => expected_v1,
+            "v2.0".to_string() => expected_v2,
         }
     );
 }
@@ -425,8 +425,8 @@ fn test_merge_views_git_refs() {
     assert_eq!(
         repo.view().git_refs(),
         &btreemap! {
-            "refs/heads/main".to_string() => expected_main_branch.unwrap(),
-            "refs/heads/feature".to_string() => expected_feature_branch.unwrap(),
+            "refs/heads/main".to_string() => expected_main_branch,
+            "refs/heads/feature".to_string() => expected_feature_branch,
         }
     );
 }
@@ -460,7 +460,7 @@ fn test_merge_views_git_heads() {
         [tx0_head.id().clone()],
         [tx1_head.id().clone(), tx2_head.id().clone()],
     );
-    assert_eq!(repo.view().git_head(), expected_git_head.as_ref());
+    assert_eq!(repo.view().git_head(), &expected_git_head);
 }
 
 fn commit_transactions(settings: &UserSettings, txs: Vec<Transaction>) -> Arc<ReadonlyRepo> {

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -39,9 +39,7 @@ use jj_lib::hex_util::to_reverse_hex;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::matchers::{EverythingMatcher, Matcher, PrefixMatcher, Visit};
 use jj_lib::op_heads_store::{self, OpHeadResolutionError, OpHeadsStore};
-use jj_lib::op_store::{
-    OpStore, OpStoreError, OperationId, RefTarget, RefTargetExt as _, WorkspaceId,
-};
+use jj_lib::op_store::{OpStore, OpStoreError, OperationId, RefTarget, WorkspaceId};
 use jj_lib::operation::Operation;
 use jj_lib::repo::{
     CheckOutCommitError, EditCommitError, MutableRepo, ReadonlyRepo, Repo, RepoLoader,

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -733,8 +733,8 @@ impl WorkspaceCommandHelper {
         let mut tx = self.start_transaction("import git refs").into_inner();
         git::import_refs(tx.mut_repo(), git_repo, &self.settings.git_settings())?;
         if tx.mut_repo().has_changes() {
-            let old_git_head = self.repo().view().git_head().cloned();
-            let new_git_head = tx.mut_repo().view().git_head().cloned();
+            let old_git_head = self.repo().view().git_head().clone();
+            let new_git_head = tx.mut_repo().view().git_head().clone();
             // If the Git HEAD has changed, abandon our old checkout and check out the new
             // Git HEAD.
             match new_git_head.as_normal() {

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -4,7 +4,7 @@ use clap::builder::NonEmptyStringValueParser;
 use itertools::Itertools;
 use jj_lib::backend::{CommitId, ObjectId};
 use jj_lib::git;
-use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetExt as _};
+use jj_lib::op_store::{BranchTarget, RefTarget};
 use jj_lib::repo::Repo;
 use jj_lib::revset::{self, RevsetExpression};
 use jj_lib::view::View;
@@ -369,7 +369,7 @@ fn cmd_branch_list(
     }
 
     let print_branch_target =
-        |formatter: &mut dyn Formatter, target: &Option<RefTarget>| -> Result<(), CommandError> {
+        |formatter: &mut dyn Formatter, target: &RefTarget| -> Result<(), CommandError> {
             if let Some(id) = target.as_normal() {
                 write!(formatter, ": ")?;
                 let commit = repo.store().get_commit(id)?;

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -369,7 +369,7 @@ fn cmd_branch_list(
     }
 
     let print_branch_target =
-        |formatter: &mut dyn Formatter, target: &RefTarget| -> Result<(), CommandError> {
+        |formatter: &mut dyn Formatter, target: &Option<RefTarget>| -> Result<(), CommandError> {
             if let Some(id) = target.as_normal() {
                 write!(formatter, ": ")?;
                 let commit = repo.store().get_commit(id)?;
@@ -406,8 +406,8 @@ fn cmd_branch_list(
         };
 
         write!(formatter.labeled("branch"), "{name}")?;
-        if let Some(target) = branch_target.local_target.as_ref() {
-            print_branch_target(formatter, target)?;
+        if branch_target.local_target.is_present() {
+            print_branch_target(formatter, &branch_target.local_target)?;
         } else if found_non_git_remote {
             writeln!(formatter, " (deleted)")?;
         } else {
@@ -415,7 +415,7 @@ fn cmd_branch_list(
         }
 
         for (remote, remote_target) in branch_target.remote_targets.iter() {
-            if Some(remote_target) == branch_target.local_target.as_ref() {
+            if remote_target == &branch_target.local_target {
                 continue;
             }
             write!(formatter, "  ")?;

--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use jj_lib::backend::{CommitId, ObjectId, TreeValue};
 use jj_lib::git::{self, parse_gitmodules, GitFetchError, GitPushError, GitRefUpdate};
 use jj_lib::git_backend::GitBackend;
-use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetExt as _};
+use jj_lib::op_store::{BranchTarget, RefTarget};
 use jj_lib::refs::{classify_branch_push_action, BranchPushAction, BranchPushUpdate};
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -37,7 +37,7 @@ use jj_lib::conflicts::Conflict;
 use jj_lib::dag_walk::topo_order_reverse;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::matchers::EverythingMatcher;
-use jj_lib::op_store::{RefTargetExt as _, WorkspaceId};
+use jj_lib::op_store::WorkspaceId;
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::repo_path::RepoPath;
 use jj_lib::revset::{

--- a/src/commands/operation.rs
+++ b/src/commands/operation.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use clap::Subcommand;
-use jj_lib::op_store::{BranchTarget, RefTarget, RefTargetExt as _};
+use jj_lib::op_store::{BranchTarget, RefTarget};
 use jj_lib::operation;
 use jj_lib::repo::Repo;
 

--- a/src/commit_templater.rs
+++ b/src/commit_templater.rs
@@ -22,7 +22,7 @@ use jj_lib::backend::{ChangeId, CommitId, ObjectId as _};
 use jj_lib::commit::Commit;
 use jj_lib::hex_util::to_reverse_hex;
 use jj_lib::id_prefix::IdPrefixContext;
-use jj_lib::op_store::{RefTarget, RefTargetExt as _, WorkspaceId};
+use jj_lib::op_store::{RefTarget, WorkspaceId};
 use jj_lib::repo::Repo;
 use jj_lib::{git, rewrite};
 use once_cell::unsync::OnceCell;
@@ -383,7 +383,7 @@ fn build_branches_index(repo: &dyn Repo) -> RefNamesIndex {
 }
 
 fn build_ref_names_index<'a>(
-    ref_pairs: impl IntoIterator<Item = (&'a String, &'a Option<RefTarget>)>,
+    ref_pairs: impl IntoIterator<Item = (&'a String, &'a RefTarget)>,
 ) -> RefNamesIndex {
     let mut index = RefNamesIndex::default();
     for (name, target) in ref_pairs {

--- a/src/commit_templater.rs
+++ b/src/commit_templater.rs
@@ -354,11 +354,11 @@ fn build_branches_index(repo: &dyn Repo) -> RefNamesIndex {
     let mut index = RefNamesIndex::default();
     let (all_branches, _) = git::build_unified_branches_map(repo.view());
     for (branch_name, branch_target) in &all_branches {
-        let local_target = branch_target.local_target.as_ref();
+        let local_target = &branch_target.local_target;
         let mut unsynced_remote_targets = branch_target
             .remote_targets
             .iter()
-            .filter(|&(_, target)| Some(target) != local_target)
+            .filter(|&(_, target)| target != local_target)
             .peekable();
         if local_target.is_present() {
             let decorated_name = if local_target.is_conflict() {
@@ -383,7 +383,7 @@ fn build_branches_index(repo: &dyn Repo) -> RefNamesIndex {
 }
 
 fn build_ref_names_index<'a>(
-    ref_pairs: impl IntoIterator<Item = (&'a String, &'a RefTarget)>,
+    ref_pairs: impl IntoIterator<Item = (&'a String, &'a Option<RefTarget>)>,
 ) -> RefNamesIndex {
     let mut index = RefNamesIndex::default();
     for (name, target) in ref_pairs {


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
