### PR TITLE
fix zsh completion guidance

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -993,7 +993,7 @@ struct UtilCompletionArgs {
     ///
     /// autoload -U compinit
     /// compinit
-    /// source <(jj util completion --zsh | sed '$d')  # remove the last line
+    /// source <(jj util completion --zsh)
     /// compdef _jj jj
     #[arg(long, verbatim_doc_comment)]
     zsh: bool,


### PR DESCRIPTION
We upgraded to clap 4.1 in 8f1dc490 (cargo: upgrade to clap 4.1, 2023-03-17), and the pipe to `sed` was removed in the README.md file in that same commit. However the documentation was not updated in mod.rs, which leads us to give the obsolete (now incorrect) advice when we run `jj util completion --help`.

See #1393.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
