### PR TITLE
Support the option of colocating a git repo with a jj repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj log` output is now topologically grouped.
   [#242](https://github.com/martinvonz/jj/issues/242)
 
+* `jj git clone` now supports the `--colocate` flag to create the git repo
+  in the same directory as the jj repo.
+
 ### Fixed bugs
 
 ## [0.8.0] - 2023-07-09


### PR DESCRIPTION
This adds the new `--colocate` flag to `jj git clone`.

```
jj git clone --colocate https://github.com/foo/bar
```

is effectively equivalent to:

```
git clone https://github.com/foo/bar
cd bar
jj init --git-repo=.
```

Closes #1873 

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
