### PR TITLE
working_copy: add test of racy checkout followed by file write

### DIFF
--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -825,11 +825,9 @@ impl TreeState {
                 }
                 // If the file's mtime was set at the same time as this state file's own mtime,
                 // then we don't know if the file was modified before or after this state file.
-                // We set the file's mtime to 0 to simplify later code.
-                if current_file_state.mtime >= self.own_mtime {
-                    current_file_state.mtime = MillisSinceEpoch(0);
-                }
-                if current_file_state != &new_file_state {
+                if current_file_state != &new_file_state
+                    || current_file_state.mtime >= self.own_mtime
+                {
                     let new_file_type = new_file_state.file_type.clone();
                     *current_file_state = new_file_state;
                     let current_tree_value = current_tree.path_value(&repo_path);

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -20,16 +20,14 @@ use jj_lib::repo::{Repo, StoreFactories};
 use jj_lib::repo_path::RepoPath;
 use jj_lib::working_copy::{CheckoutError, SnapshotOptions};
 use jj_lib::workspace::Workspace;
-use test_case::test_case;
 use testutils::TestWorkspace;
 
-#[test_case(false ; "local backend")]
-#[test_case(true ; "git backend")]
-fn test_concurrent_checkout(use_git: bool) {
+#[test]
+fn test_concurrent_checkout() {
     // Test that we error out if a concurrent checkout is detected (i.e. if the
     // working-copy commit changed on disk after we read it).
     let settings = testutils::user_settings();
-    let mut test_workspace1 = TestWorkspace::init(&settings, use_git);
+    let mut test_workspace1 = TestWorkspace::init(&settings, true);
     let repo1 = test_workspace1.repo.clone();
     let workspace1_root = test_workspace1.workspace.workspace_root().clone();
 
@@ -78,13 +76,12 @@ fn test_concurrent_checkout(use_git: bool) {
     );
 }
 
-#[test_case(false ; "local backend")]
-#[test_case(true ; "git backend")]
-fn test_checkout_parallel(use_git: bool) {
+#[test]
+fn test_checkout_parallel() {
     // Test that concurrent checkouts by different processes (simulated by using
     // different repo instances) is safe.
     let settings = testutils::user_settings();
-    let mut test_workspace = TestWorkspace::init(&settings, use_git);
+    let mut test_workspace = TestWorkspace::init(&settings, true);
     let repo = &test_workspace.repo;
     let workspace_root = test_workspace.workspace.workspace_root().clone();
 

--- a/lib/tests/test_working_copy_concurrent.rs
+++ b/lib/tests/test_working_copy_concurrent.rs
@@ -16,11 +16,13 @@ use std::cmp::max;
 use std::thread;
 
 use assert_matches::assert_matches;
+use jj_lib::backend::TreeId;
+use jj_lib::op_store::OperationId;
 use jj_lib::repo::{Repo, StoreFactories};
 use jj_lib::repo_path::RepoPath;
 use jj_lib::working_copy::{CheckoutError, SnapshotOptions};
 use jj_lib::workspace::Workspace;
-use testutils::TestWorkspace;
+use testutils::{write_working_copy_file, TestWorkspace};
 
 #[test]
 fn test_concurrent_checkout() {
@@ -142,4 +144,44 @@ fn test_checkout_parallel() {
             });
         }
     });
+}
+
+#[test]
+fn test_racy_checkout() {
+    let settings = testutils::user_settings();
+    let mut test_workspace = TestWorkspace::init(&settings, true);
+    let repo = &test_workspace.repo;
+    let workspace_root = test_workspace.workspace.workspace_root().clone();
+
+    let path = RepoPath::from_internal_string("file");
+    let tree = testutils::create_tree(repo, &[(&path, "1")]);
+
+    fn snapshot(workspace: &mut Workspace) -> TreeId {
+        let mut locked_wc = workspace.working_copy_mut().start_mutation().unwrap();
+        let tree_id = locked_wc
+            .snapshot(SnapshotOptions::empty_for_test())
+            .unwrap();
+        locked_wc.finish(OperationId::from_hex("abc123")).unwrap();
+        tree_id
+    }
+
+    let mut num_matches = 0;
+    for _ in 0..100 {
+        let wc = test_workspace.workspace.working_copy_mut();
+        wc.check_out(repo.op_id().clone(), None, &tree).unwrap();
+        assert_eq!(
+            std::fs::read(path.to_fs_path(&workspace_root)).unwrap(),
+            b"1".to_vec()
+        );
+        // A file written right after checkout (hopefully, from the test's perspective,
+        // within the file system timestamp granularity) is detected as changed.
+        write_working_copy_file(&workspace_root, &path, "x");
+        let modified_tree_id = snapshot(&mut test_workspace.workspace);
+        if modified_tree_id == *tree.id() {
+            num_matches += 1;
+        }
+        // Reset the state for the next round
+        write_working_copy_file(&workspace_root, &path, "1");
+    }
+    assert_eq!(num_matches, 0);
 }


### PR DESCRIPTION
We don't seem to have any tests that our protection from undetected changes caused by writes happening right after checkout, so let's add one. The test case loops 100 times and each iteration fails slightly more than 80% of the time on my machine (if I remove the protection in `TreeState::update_file_state()`), so it seems quite good at triggering the race.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
