### PR TITLE
cargo: specify MSRV in rust-toolchain.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/testutils", "lib/gen-protos"]
 [workspace.package]
 version = "0.13.0"
 license = "Apache-2.0"
-rust-version = "1.71"                                 # NOTE: remember to update CI, contributing.md, changelog.md, and flake.nix
+rust-version = "1.71"                                 # NOTE: remember to update CI, contributing.md, changelog.md, and rust-toolchain.toml
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/martinvonz/jj"

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             pkgs.lib.all (re: builtins.match re relPath == null) regexes;
         };
 
-      rust-version = pkgs.rust-bin.stable."1.71.0".default;
+      rust-version = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
       ourRustPlatform = pkgs.makeRustPlatform {
         rustc = rust-version;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.71.0"


### PR DESCRIPTION
Summary: Split out from from #1851. This specifies the current project-wide MSRV in a `rust-toolchain.toml` file which — if installed — will cause 'rustup' to download and provision the correct version of the rust compiler.

The intent is to ensure most developers stay on the same page and people doing occasional development don't accidentally trip over themselves and submit something based on their own toolchain i.e. newer or older features than our MSRV.

This also migrates the Nix Flake to use `rust-toolchain.toml` and so it creates a single source of truth for both `nix develop` and `rustup`.

Change-Id: I56e48d399e541d7700c7e9652ac88c57

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
