### PR TITLE
cli: make `jj debug operation --display operation` work with broken view

### DIFF
--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -1615,7 +1615,7 @@ fn expand_git_path(path_str: String) -> PathBuf {
     PathBuf::from(path_str)
 }
 
-fn resolve_op_for_load(
+pub fn resolve_op_for_load(
     op_store: &Arc<dyn OpStore>,
     op_heads_store: &Arc<dyn OpHeadsStore>,
     op_str: &str,


### PR DESCRIPTION
This is to aid debugging in cases like #1907, where the operation object has an invalid view object.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
