### PR TITLE
github: run only with MSRV, not stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,23 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        rust_version: [stable]
         cargo_flags: [""]
         include:
         - os: ubuntu-latest
-          rust_version: "1.71"
-          cargo_flags: ""
-        - os: ubuntu-latest
-          rust_version: stable
           cargo_flags: "--all-features"
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-    - name: Install Rust (${{ matrix.rust_version }})
+    - name: Install Rust
       uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e
       with:
-        toolchain:  ${{ matrix.rust_version }}
+        toolchain:  1.71
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
     - name: Test


### PR DESCRIPTION
We run a separate build on CI with the MSRV so we notice if we accidentally break the MSRV. However, as we talked about on Discord, the opposite is very unlikely - that we accidentally break the build with the stable release without breaking the MSRV build. Also, we explicitly run Clippy with the stable release, and formatting with the nightly release. So, let's just do the regular build and tests with the MSRV.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
