### PR TITLE
cli: more info in the short commit template & jj status

### DIFF
--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -89,7 +89,7 @@ builtin_op_log_comfortable = 'builtin_op_log_compact ++ "\n"'
 'description_placeholder' = 'label("description", "(no description set)")'
 
 # Hook points for users to customize the default templates:
-'format_short_id(id)' = 'id.shortest(12)'
+'format_short_id(id)' = 'id.shortest(8)'
 'format_short_change_id(id)' = 'format_short_id(id)'
 'format_short_commit_id(id)' = 'format_short_id(id)'
 'format_short_signature(signature)' = 'signature.email()'

--- a/src/config/templates.toml
+++ b/src/config/templates.toml
@@ -1,7 +1,10 @@
 [templates]
 commit_summary = '''
 separate(" ",
+  format_short_change_id(change_id),
   format_short_commit_id(commit_id),
+  if(conflict, label("conflict", "(conflict)")),
+  if(empty, label("empty", "(empty)")),
   if(description, description.first_line(), description_placeholder),
 )
 '''

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -56,11 +56,11 @@ fn test_rebase_branch_with_merge() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d"]);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned commit b7c62f28ed10 d
+    Abandoned commit b7c62f28 d
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy now at: 11a2e10edf4e e
-    Parent commit      : 2443ea76b0b1 a
-    Parent commit      : fe2e8e8b50b3 c
+    Working copy now at: 11a2e10e e
+    Parent commit      : 2443ea76 a
+    Parent commit      : fe2e8e8b c
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -77,9 +77,9 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon"] /* abandons `e` */);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned commit 5557ece3e631 e
-    Working copy now at: 6b5275139632 (no description set)
-    Parent commit      : 2443ea76b0b1 a
+    Abandoned commit 5557ece3 e
+    Working copy now at: 6b527513 (no description set)
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -97,11 +97,11 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
-      5557ece3e631 e
-      b7c62f28ed10 d
-      fe2e8e8b50b3 c
-    Working copy now at: e7bb061217d5 (no description set)
-    Parent commit      : 2443ea76b0b1 a
+      5557ece3 e
+      b7c62f28 d
+      fe2e8e8b c
+    Working copy now at: e7bb0612 (no description set)
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -116,7 +116,7 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned commit 1394f625cbbd b
+    Abandoned commit 1394f625 b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
@@ -133,12 +133,12 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d::", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
-      5557ece3e631 e
-      b7c62f28ed10 d
-      1394f625cbbd b
-      2443ea76b0b1 a
-    Working copy now at: af874bffee6e (no description set)
-    Parent commit      : 000000000000 (no description set)
+      5557ece3 e
+      b7c62f28 d
+      1394f625 b
+      2443ea76 a
+    Working copy now at: af874bff (no description set)
+    Parent commit      : 00000000 (no description set)
     Added 0 files, modified 0 files, removed 4 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_abandon_command.rs
+++ b/tests/test_abandon_command.rs
@@ -56,11 +56,11 @@ fn test_rebase_branch_with_merge() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d"]);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned commit b7c62f28 d
+    Abandoned commit vruxwmqv b7c62f28 d
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy now at: 11a2e10e e
-    Parent commit      : 2443ea76 a
-    Parent commit      : fe2e8e8b c
+    Working copy now at: znkkpsqq 11a2e10e e
+    Parent commit      : rlvkpnrz 2443ea76 a
+    Parent commit      : royxmykx fe2e8e8b c
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -77,9 +77,9 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon"] /* abandons `e` */);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned commit 5557ece3 e
-    Working copy now at: 6b527513 (no description set)
-    Parent commit      : 2443ea76 a
+    Abandoned commit znkkpsqq 5557ece3 e
+    Working copy now at: nkmrtpmo 6b527513 (empty) (no description set)
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -97,11 +97,11 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
-      5557ece3 e
-      b7c62f28 d
-      fe2e8e8b c
-    Working copy now at: e7bb0612 (no description set)
-    Parent commit      : 2443ea76 a
+      znkkpsqq 5557ece3 e
+      vruxwmqv b7c62f28 d
+      royxmykx fe2e8e8b c
+    Working copy now at: xtnwkqum e7bb0612 (empty) (no description set)
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -116,7 +116,7 @@ fn test_rebase_branch_with_merge() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Abandoned commit 1394f625 b
+    Abandoned commit zsuskuln 1394f625 b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
@@ -133,12 +133,12 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d::", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
-      5557ece3 e
-      b7c62f28 d
-      1394f625 b
-      2443ea76 a
-    Working copy now at: af874bff (no description set)
-    Parent commit      : 00000000 (no description set)
+      znkkpsqq 5557ece3 e
+      vruxwmqv b7c62f28 d
+      zsuskuln 1394f625 b
+      rlvkpnrz 2443ea76 a
+    Working copy now at: xlzxqlsl af874bff (empty) (no description set)
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 4 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_alias.rs
+++ b/tests/test_alias.rs
@@ -137,7 +137,7 @@ fn test_alias_cannot_override_builtin() {
     // Alias should be ignored
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 }

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -196,17 +196,17 @@ fn test_branch_delete_glob() {
 
     // The deleted branches are still there
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    bar-2: 6fbf398c2d59 commit
+    bar-2: 6fbf398c commit
     foo-1 (deleted)
-      @origin: 6fbf398c2d59 commit
+      @origin: 6fbf398c commit
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     foo-3 (deleted)
-      @origin: 6fbf398c2d59 commit
+      @origin: 6fbf398c commit
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     foo-4 (deleted)
-      @origin: 6fbf398c2d59 commit
+      @origin: 6fbf398c commit
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -228,7 +228,7 @@ fn test_branch_forget_export() {
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "foo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    foo: 65b6b74e0897 (no description set)
+    foo: 65b6b74e (no description set)
     "###);
 
     // Exporting the branch to git creates a local-git tracking branch
@@ -241,7 +241,7 @@ fn test_branch_forget_export() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     foo (forgotten)
-      @git: 65b6b74e0897 (no description set)
+      @git: 65b6b74e (no description set)
       (this branch will be deleted from the underlying Git repo on the next `jj git export`)
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r=foo", "--no-graph"]);
@@ -251,7 +251,7 @@ fn test_branch_forget_export() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r=foo@git", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:08.000 +07:00 foo@git 65b6b74e0897
+    rlvkpnrz test.user@example.com 2001-02-03 04:05:08.000 +07:00 foo@git 65b6b74e
     (empty) (no description set)
     "###);
 
@@ -315,7 +315,7 @@ fn test_branch_forget_fetched_branch() {
     // Fetch normally
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
+    feature1: 9f01a0e0 message
     "###);
 
     // TEST 1: with export-import
@@ -341,7 +341,7 @@ fn test_branch_forget_fetched_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
+    feature1: 9f01a0e0 message
     "###);
 
     // TEST 2: No export/import (otherwise the same as test 1)
@@ -351,7 +351,7 @@ fn test_branch_forget_fetched_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
+    feature1: 9f01a0e0 message
     "###);
 
     // TEST 3: fetch branch that was moved & forgotten
@@ -374,7 +374,7 @@ fn test_branch_forget_fetched_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 38aefb173976 another message
+    feature1: 38aefb17 another message
     "###);
 }
 
@@ -420,7 +420,7 @@ fn test_branch_forget_deleted_or_nonexistent_branch() {
     test_env.jj_cmd_success(&repo_path, &["branch", "delete", "feature1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1 (deleted)
-      @origin: 9f01a0e04879 message
+      @origin: 9f01a0e0 message
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -490,14 +490,14 @@ fn test_branch_list_filtered_by_revset() {
 
     // All branches are listed by default.
     insta::assert_snapshot!(test_env.jj_cmd_success(&local_path, &["branch", "list"]), @r###"
-    local-keep: c7b4c09cd77c local-keep
+    local-keep: c7b4c09c local-keep
     remote-delete (deleted)
-      @origin: dad5f298ca57 remote-delete
+      @origin: dad5f298 remote-delete
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
-    remote-keep: 911e912015fb remote-keep
-    remote-rewrite: e31634b64294 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6ef15 remote-rewrite
+    remote-keep: 911e9120 remote-keep
+    remote-rewrite: e31634b6 rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
     "###);
 
     let query = |revset| test_env.jj_cmd_success(&local_path, &["branch", "list", "-r", revset]);
@@ -507,25 +507,25 @@ fn test_branch_list_filtered_by_revset() {
     // "all()" doesn't include deleted branches since they have no local targets.
     // So "all()" is identical to "branches()".
     insta::assert_snapshot!(query("all()"), @r###"
-    local-keep: c7b4c09cd77c local-keep
-    remote-keep: 911e912015fb remote-keep
-    remote-rewrite: e31634b64294 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6ef15 remote-rewrite
+    local-keep: c7b4c09c local-keep
+    remote-keep: 911e9120 remote-keep
+    remote-rewrite: e31634b6 rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
     "###);
 
     // Exclude remote-only branches. "remote-rewrite@origin" is included since
     // local "remote-rewrite" target matches.
     insta::assert_snapshot!(query("branches()"), @r###"
-    local-keep: c7b4c09cd77c local-keep
-    remote-keep: 911e912015fb remote-keep
-    remote-rewrite: e31634b64294 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6ef15 remote-rewrite
+    local-keep: c7b4c09c local-keep
+    remote-keep: 911e9120 remote-keep
+    remote-rewrite: e31634b6 rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
     "###);
 
     // Select branches by name.
     insta::assert_snapshot!(query("branches(remote-rewrite)"), @r###"
-    remote-rewrite: e31634b64294 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6ef15 remote-rewrite
+    remote-rewrite: e31634b6 rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
     "###);
 
     // Can't select deleted branch.

--- a/tests/test_branch_command.rs
+++ b/tests/test_branch_command.rs
@@ -196,17 +196,17 @@ fn test_branch_delete_glob() {
 
     // The deleted branches are still there
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    bar-2: 6fbf398c commit
+    bar-2: qpvuntsm 6fbf398c (empty) commit
     foo-1 (deleted)
-      @origin: 6fbf398c commit
+      @origin: qpvuntsm 6fbf398c (empty) commit
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     foo-3 (deleted)
-      @origin: 6fbf398c commit
+      @origin: qpvuntsm 6fbf398c (empty) commit
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     foo-4 (deleted)
-      @origin: 6fbf398c commit
+      @origin: qpvuntsm 6fbf398c (empty) commit
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -228,7 +228,7 @@ fn test_branch_forget_export() {
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "foo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    foo: 65b6b74e (no description set)
+    foo: rlvkpnrz 65b6b74e (empty) (no description set)
     "###);
 
     // Exporting the branch to git creates a local-git tracking branch
@@ -241,7 +241,7 @@ fn test_branch_forget_export() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     foo (forgotten)
-      @git: 65b6b74e (no description set)
+      @git: rlvkpnrz 65b6b74e (empty) (no description set)
       (this branch will be deleted from the underlying Git repo on the next `jj git export`)
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r=foo", "--no-graph"]);
@@ -315,7 +315,7 @@ fn test_branch_forget_fetched_branch() {
     // Fetch normally
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e0 message
+    feature1: mzyxwzks 9f01a0e0 message
     "###);
 
     // TEST 1: with export-import
@@ -341,7 +341,7 @@ fn test_branch_forget_fetched_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e0 message
+    feature1: mzyxwzks 9f01a0e0 message
     "###);
 
     // TEST 2: No export/import (otherwise the same as test 1)
@@ -351,7 +351,7 @@ fn test_branch_forget_fetched_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e0 message
+    feature1: mzyxwzks 9f01a0e0 message
     "###);
 
     // TEST 3: fetch branch that was moved & forgotten
@@ -374,7 +374,7 @@ fn test_branch_forget_fetched_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 38aefb17 another message
+    feature1: ooosovrs 38aefb17 (empty) another message
     "###);
 }
 
@@ -420,7 +420,7 @@ fn test_branch_forget_deleted_or_nonexistent_branch() {
     test_env.jj_cmd_success(&repo_path, &["branch", "delete", "feature1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1 (deleted)
-      @origin: 9f01a0e0 message
+      @origin: mzyxwzks 9f01a0e0 message
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -490,14 +490,14 @@ fn test_branch_list_filtered_by_revset() {
 
     // All branches are listed by default.
     insta::assert_snapshot!(test_env.jj_cmd_success(&local_path, &["branch", "list"]), @r###"
-    local-keep: c7b4c09c local-keep
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
-      @origin: dad5f298 remote-delete
+      @origin: yxusvupt dad5f298 (empty) remote-delete
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
-    remote-keep: 911e9120 remote-keep
-    remote-rewrite: e31634b6 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
+    remote-keep: nlwprzpn 911e9120 (empty) remote-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
     "###);
 
     let query = |revset| test_env.jj_cmd_success(&local_path, &["branch", "list", "-r", revset]);
@@ -507,25 +507,25 @@ fn test_branch_list_filtered_by_revset() {
     // "all()" doesn't include deleted branches since they have no local targets.
     // So "all()" is identical to "branches()".
     insta::assert_snapshot!(query("all()"), @r###"
-    local-keep: c7b4c09c local-keep
-    remote-keep: 911e9120 remote-keep
-    remote-rewrite: e31634b6 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
+    remote-keep: nlwprzpn 911e9120 (empty) remote-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
     "###);
 
     // Exclude remote-only branches. "remote-rewrite@origin" is included since
     // local "remote-rewrite" target matches.
     insta::assert_snapshot!(query("branches()"), @r###"
-    local-keep: c7b4c09c local-keep
-    remote-keep: 911e9120 remote-keep
-    remote-rewrite: e31634b6 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
+    remote-keep: nlwprzpn 911e9120 (empty) remote-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
     "###);
 
     // Select branches by name.
     insta::assert_snapshot!(query("branches(remote-rewrite)"), @r###"
-    remote-rewrite: e31634b6 rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): 3e9a5af6 remote-rewrite
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
     "###);
 
     // Can't select deleted branch.

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -30,8 +30,8 @@ fn test_checkout() {
     // Check out current commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["checkout", "@"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 05ce7118568d (no description set)
-    Parent commit      : 5c52832c3483 second
+    Working copy now at: 05ce7118 (no description set)
+    Parent commit      : 5c52832c second
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  05ce7118568d3007efc9163b055f9cb4a6becfde
@@ -67,11 +67,11 @@ fn test_checkout_not_single_rev() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@" resolved to more than one revision
     Hint: The revset "root..@" resolved to these revisions:
-    2f8593712db5 (no description set)
-    5c1afd8b074f fifth
-    009f88bf7141 fourth
-    3fa8931e7b89 third
-    5c52832c3483 second
+    2f859371 (no description set)
+    5c1afd8b fifth
+    009f88bf fourth
+    3fa8931e third
+    5c52832c second
     ...
     "###);
 
@@ -79,19 +79,19 @@ fn test_checkout_not_single_rev() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@-" resolved to more than one revision
     Hint: The revset "root..@-" resolved to these revisions:
-    5c1afd8b074f fifth
-    009f88bf7141 fourth
-    3fa8931e7b89 third
-    5c52832c3483 second
-    69542c1984c1 first
+    5c1afd8b fifth
+    009f88bf fourth
+    3fa8931e third
+    5c52832c second
+    69542c19 first
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "@-|@--"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "@-|@--" resolved to more than one revision
     Hint: The revset "@-|@--" resolved to these revisions:
-    5c1afd8b074f fifth
-    009f88bf7141 fourth
+    5c1afd8b fifth
+    009f88bf fourth
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "none()"]);

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -30,8 +30,8 @@ fn test_checkout() {
     // Check out current commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["checkout", "@"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 05ce7118 (no description set)
-    Parent commit      : 5c52832c second
+    Working copy now at: zsuskuln 05ce7118 (empty) (no description set)
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  05ce7118568d3007efc9163b055f9cb4a6becfde
@@ -67,11 +67,11 @@ fn test_checkout_not_single_rev() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@" resolved to more than one revision
     Hint: The revset "root..@" resolved to these revisions:
-    2f859371 (no description set)
-    5c1afd8b fifth
-    009f88bf fourth
-    3fa8931e third
-    5c52832c second
+    royxmykx 2f859371 (empty) (no description set)
+    mzvwutvl 5c1afd8b (empty) fifth
+    zsuskuln 009f88bf (empty) fourth
+    kkmpptxz 3fa8931e (empty) third
+    rlvkpnrz 5c52832c (empty) second
     ...
     "###);
 
@@ -79,19 +79,19 @@ fn test_checkout_not_single_rev() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "root..@-" resolved to more than one revision
     Hint: The revset "root..@-" resolved to these revisions:
-    5c1afd8b fifth
-    009f88bf fourth
-    3fa8931e third
-    5c52832c second
-    69542c19 first
+    mzvwutvl 5c1afd8b (empty) fifth
+    zsuskuln 009f88bf (empty) fourth
+    kkmpptxz 3fa8931e (empty) third
+    rlvkpnrz 5c52832c (empty) second
+    qpvuntsm 69542c19 (empty) first
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "@-|@--"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "@-|@--" resolved to more than one revision
     Hint: The revset "@-|@--" resolved to these revisions:
-    5c1afd8b fifth
-    009f88bf fourth
+    mzvwutvl 5c1afd8b (empty) fifth
+    zsuskuln 009f88bf (empty) fourth
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "none()"]);

--- a/tests/test_chmod_command.rs
+++ b/tests/test_chmod_command.rs
@@ -187,9 +187,9 @@ fn test_chmod_file_dir_deletion_conflicts() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["chmod", "x", "file", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 85942d95 file_deletion
-    Parent commit      : c51c9c55 file
-    Parent commit      : 6b18b3c1 deletion
+    Working copy now at: kmkuslsw 85942d95 (conflict) file_deletion
+    Parent commit      : zsuskuln c51c9c55 file
+    Parent commit      : royxmykx 6b18b3c1 deletion
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["cat", "-r=file_deletion", "file"]);

--- a/tests/test_chmod_command.rs
+++ b/tests/test_chmod_command.rs
@@ -187,9 +187,9 @@ fn test_chmod_file_dir_deletion_conflicts() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["chmod", "x", "file", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 85942d954f00 file_deletion
-    Parent commit      : c51c9c55bad4 file
-    Parent commit      : 6b18b3c1578d deletion
+    Working copy now at: 85942d95 file_deletion
+    Parent commit      : c51c9c55 file
+    Parent commit      : 6b18b3c1 deletion
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["cat", "-r=file_deletion", "file"]);

--- a/tests/test_commit_template.rs
+++ b/tests/test_commit_template.rs
@@ -124,33 +124,33 @@ fn test_log_default() {
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  kkmpptxzrspx test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178d59d
+    @  kkmpptxz test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178
     │  (empty) description 1
-    ◉  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264ae97
+    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264
     │  add a file
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mk[38;5;8mkmpptxzrspx[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178d59d[39m[0m
+    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     │  add a file
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;13mk[38;5;8mkmpptxzrspx[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178d59d[39m[0m
+    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
-    [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264ae97[39m
+    [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     add a file
-    [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     [38;5;2m(empty)[39m (no description set)
     "###);
 }
@@ -163,22 +163,22 @@ fn test_log_builtin_templates() {
     let render = |template| test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    @  qpvuntsmwlqt test.user 2001-02-03 04:05:07.000 +07:00 230dd059e1b0 (empty) (no description set)
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000 (empty) (no description set)
+    @  qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059 (empty) (no description set)
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000 (empty) (no description set)
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
     │
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
 
     "###);
@@ -212,9 +212,9 @@ fn test_log_obslog_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
     │  description 1
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 
@@ -226,44 +226,44 @@ fn test_log_obslog_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
-    ◉  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d4c67
+    ◉  qpvuntsm?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d
     │  description 2
-    │ @  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
+    │ @  qpvuntsm?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
     ├─╯  description 1
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsmwlqt??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [1m[38;5;4m8[0m[38;5;8m979953d4c67[39m
+    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [1m[38;5;4m8[0m[38;5;8m979953d[39m
     │  description 2
-    │ @  [1m[4m[38;5;1mq[24mpvuntsmwlqt[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e633c[39m[0m
+    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     ├─╯  [1mdescription 1[0m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 
     // Obslog and hidden divergent
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsmwlqt?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e633c
+    @  qpvuntsm?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
     │  description 1
-    ◉  qpvuntsmwlqt?? hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 3b68ce2550b4
+    ◉  qpvuntsm?? hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 3b68ce25
     │  (no description set)
-    ◉  qpvuntsmwlqt?? hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉  qpvuntsm?? hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
        (empty) (no description set)
     "###);
 
     // Colored obslog
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[4m[38;5;1mq[24mpvuntsmwlqt[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e633c[39m[0m
+    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     │  [1mdescription 1[0m
-    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsmwlqt[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m3[0m[38;5;8mb68ce2550b4[39m
+    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsm[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
     │  (no description set)
-    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsmwlqt[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059e1b0[39m
+    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsm[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 }
@@ -279,11 +279,11 @@ fn test_log_git_head() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrzqnoo[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[38;5;8m0aaf4754c1e[39m[0m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsmwlqt[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059e1b0[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m (no description set)
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m00000000000[39m
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
        [38;5;2m(empty)[39m (no description set)
     "###);
 }
@@ -326,9 +326,9 @@ fn test_log_customize_short_id() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  QPVUNTSMWLQT test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    @  QPVUNTSM test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
     │  (empty) first
-    ◉  ZZZZZZZZZZZZ 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  ZZZZZZZZ 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 }

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -191,8 +191,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     std::fs::write(repo_path.join("child2"), "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", "new child2"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 4011424e new child2
-    Parent commit      : e08863ee new child1
+    Working copy now at: kkmpptxz 4011424e new child2
+    Parent commit      : rlvkpnrz e08863ee new child1
     "###);
 
     // Since the repo can be reloaded before snapshotting, "child2" should be

--- a/tests/test_concurrent_operations.rs
+++ b/tests/test_concurrent_operations.rs
@@ -191,8 +191,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     std::fs::write(repo_path.join("child2"), "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", "new child2"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 4011424ea0a2 new child2
-    Parent commit      : e08863ee7a0d new child1
+    Working copy now at: 4011424e new child2
+    Parent commit      : e08863ee new child1
     "###);
 
     // Since the repo can be reloaded before snapshotting, "child2" should be

--- a/tests/test_describe_command.rs
+++ b/tests/test_describe_command.rs
@@ -27,8 +27,8 @@ fn test_describe() {
     // Set a description using `-m` flag
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description from CLI"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: cf3e8673 description from CLI
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm cf3e8673 (empty) description from CLI
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
     // Set the same description using `-m` flag, but with explicit newline
@@ -55,8 +55,8 @@ fn test_describe() {
     std::fs::write(&edit_script, "write\ndescription from editor").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 100943ae description from editor
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm 100943ae (empty) description from editor
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
     // Lines in editor starting with "JJ: " are ignored
@@ -67,16 +67,16 @@ fn test_describe() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: ccefa58b description among comment
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm ccefa58b (empty) description among comment
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
     // Multi-line description
     std::fs::write(&edit_script, "write\nline1\nline2\n\nline4\n\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: e932ba42 line1
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm e932ba42 (empty) line1
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
@@ -97,8 +97,8 @@ fn test_describe() {
     // Clear description
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", ""]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: d6957294 (no description set)
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm d6957294 (empty) (no description set)
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     std::fs::write(&edit_script, "write\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);

--- a/tests/test_describe_command.rs
+++ b/tests/test_describe_command.rs
@@ -27,8 +27,8 @@ fn test_describe() {
     // Set a description using `-m` flag
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description from CLI"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: cf3e86731c67 description from CLI
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: cf3e8673 description from CLI
+    Parent commit      : 00000000 (no description set)
     "###);
 
     // Set the same description using `-m` flag, but with explicit newline
@@ -55,8 +55,8 @@ fn test_describe() {
     std::fs::write(&edit_script, "write\ndescription from editor").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 100943aeee3f description from editor
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: 100943ae description from editor
+    Parent commit      : 00000000 (no description set)
     "###);
 
     // Lines in editor starting with "JJ: " are ignored
@@ -67,16 +67,16 @@ fn test_describe() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: ccefa58bef47 description among comment
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: ccefa58b description among comment
+    Parent commit      : 00000000 (no description set)
     "###);
 
     // Multi-line description
     std::fs::write(&edit_script, "write\nline1\nline2\n\nline4\n\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: e932ba42cef0 line1
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: e932ba42 line1
+    Parent commit      : 00000000 (no description set)
     "###);
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
@@ -97,8 +97,8 @@ fn test_describe() {
     // Clear description
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", ""]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: d6957294acdc (no description set)
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: d6957294 (no description set)
+    Parent commit      : 00000000 (no description set)
     "###);
     std::fs::write(&edit_script, "write\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);

--- a/tests/test_diffedit_command.rs
+++ b/tests/test_diffedit_command.rs
@@ -63,9 +63,9 @@ fn test_diffedit() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 1930da4a57e9 (no description set)
-    Working copy now at: 1930da4a57e9 (no description set)
-    Parent commit      : 613028a4693c (no description set)
+    Created 1930da4a (no description set)
+    Working copy now at: 1930da4a (no description set)
+    Parent commit      : 613028a4 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -78,10 +78,10 @@ fn test_diffedit() {
     std::fs::write(&edit_script, "write file3\nmodified\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created c03ae96780b6 (no description set)
+    Created c03ae967 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: 2a4dc204a6ab (no description set)
-    Parent commit      : c03ae96780b6 (no description set)
+    Working copy now at: 2a4dc204 (no description set)
+    Parent commit      : c03ae967 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let contents = String::from_utf8(std::fs::read(repo_path.join("file3")).unwrap()).unwrap();
@@ -98,9 +98,9 @@ fn test_diffedit() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 15f2c966d508 (no description set)
-    Working copy now at: 15f2c966d508 (no description set)
-    Parent commit      : 613028a4693c (no description set)
+    Created 15f2c966 (no description set)
+    Working copy now at: 15f2c966 (no description set)
+    Parent commit      : 613028a4 (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -148,10 +148,10 @@ fn test_diffedit_merge() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created a70eded7af9e merge
+    Created a70eded7 merge
     Rebased 1 descendant commits
-    Working copy now at: a5f1ce845f74 (no description set)
-    Parent commit      : a70eded7af9e merge
+    Working copy now at: a5f1ce84 (no description set)
+    Parent commit      : a70eded7 merge
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
@@ -215,9 +215,9 @@ fn test_diffedit_old_restore_interactive_tests() {
     std::fs::write(&edit_script, "reset file2\0reset file3").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created abdbf6271a1c (no description set)
-    Working copy now at: abdbf6271a1c (no description set)
-    Parent commit      : 2375fa164210 (no description set)
+    Created abdbf627 (no description set)
+    Working copy now at: abdbf627 (no description set)
+    Parent commit      : 2375fa16 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -230,9 +230,9 @@ fn test_diffedit_old_restore_interactive_tests() {
     std::fs::write(&edit_script, "write file3\nunrelated\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created e31f7f33ad07 (no description set)
-    Working copy now at: e31f7f33ad07 (no description set)
-    Parent commit      : 2375fa164210 (no description set)
+    Created e31f7f33 (no description set)
+    Working copy now at: e31f7f33 (no description set)
+    Parent commit      : 2375fa16 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);

--- a/tests/test_diffedit_command.rs
+++ b/tests/test_diffedit_command.rs
@@ -63,9 +63,9 @@ fn test_diffedit() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 1930da4a (no description set)
-    Working copy now at: 1930da4a (no description set)
-    Parent commit      : 613028a4 (no description set)
+    Created kkmpptxz 1930da4a (no description set)
+    Working copy now at: kkmpptxz 1930da4a (no description set)
+    Parent commit      : rlvkpnrz 613028a4 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -78,10 +78,10 @@ fn test_diffedit() {
     std::fs::write(&edit_script, "write file3\nmodified\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created c03ae967 (no description set)
+    Created rlvkpnrz c03ae967 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: 2a4dc204 (no description set)
-    Parent commit      : c03ae967 (no description set)
+    Working copy now at: kkmpptxz 2a4dc204 (no description set)
+    Parent commit      : rlvkpnrz c03ae967 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let contents = String::from_utf8(std::fs::read(repo_path.join("file3")).unwrap()).unwrap();
@@ -98,9 +98,9 @@ fn test_diffedit() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 15f2c966 (no description set)
-    Working copy now at: 15f2c966 (no description set)
-    Parent commit      : 613028a4 (no description set)
+    Created kkmpptxz 15f2c966 (no description set)
+    Working copy now at: kkmpptxz 15f2c966 (no description set)
+    Parent commit      : rlvkpnrz 613028a4 (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -148,10 +148,10 @@ fn test_diffedit_merge() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created a70eded7 merge
+    Created royxmykx a70eded7 (conflict) merge
     Rebased 1 descendant commits
-    Working copy now at: a5f1ce84 (no description set)
-    Parent commit      : a70eded7 merge
+    Working copy now at: yqosqzyt a5f1ce84 (conflict) (empty) (no description set)
+    Parent commit      : royxmykx a70eded7 (conflict) merge
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
@@ -215,9 +215,9 @@ fn test_diffedit_old_restore_interactive_tests() {
     std::fs::write(&edit_script, "reset file2\0reset file3").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created abdbf627 (no description set)
-    Working copy now at: abdbf627 (no description set)
-    Parent commit      : 2375fa16 (no description set)
+    Created rlvkpnrz abdbf627 (no description set)
+    Working copy now at: rlvkpnrz abdbf627 (no description set)
+    Parent commit      : qpvuntsm 2375fa16 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -230,9 +230,9 @@ fn test_diffedit_old_restore_interactive_tests() {
     std::fs::write(&edit_script, "write file3\nunrelated\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created e31f7f33 (no description set)
-    Working copy now at: e31f7f33 (no description set)
-    Parent commit      : 2375fa16 (no description set)
+    Created rlvkpnrz e31f7f33 (no description set)
+    Working copy now at: rlvkpnrz e31f7f33 (no description set)
+    Parent commit      : qpvuntsm 2375fa16 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -56,7 +56,7 @@ fn test_duplicate() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as 2f6dc5a1 a
+    Duplicated 2443ea76b0b1 as znkkpsqq 2f6dc5a1 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  2f6dc5a1ffc2   a
@@ -72,7 +72,7 @@ fn test_duplicate() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 17a00fc21654 as 1dd099ea c
+    Duplicated 17a00fc21654 as wqnwkozp 1dd099ea c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    1dd099ea963c   c
@@ -111,8 +111,8 @@ fn test_duplicate_many() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as 3b74d969 b
-    Duplicated 921dde6e55c0 as 8348ddce e
+    Duplicated 1394f625cbbd as wqnwkozp 3b74d969 b
+    Duplicated 921dde6e55c0 as mouksmqu 8348ddce e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    8348ddcec733   e
@@ -133,7 +133,7 @@ fn test_duplicate_many() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as 0276d3d7 b
+    Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  0276d3d7c24d   b
@@ -152,9 +152,9 @@ fn test_duplicate_many() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as fa167d18 b
-    Duplicated ebd06dba20ec as 2181781b d
-    Duplicated 921dde6e55c0 as 0f7430f2 e
+    Duplicated 1394f625cbbd as xtnwkqum fa167d18 b
+    Duplicated ebd06dba20ec as pqrnrkux 2181781b d
+    Duplicated 921dde6e55c0 as ztxkyksq 0f7430f2 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    0f7430f2727a   e
@@ -187,9 +187,9 @@ fn test_duplicate_many() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as c6f7f8c4 a
-    Duplicated ebd06dba20ec as d94e4c55 d
-    Duplicated 921dde6e55c0 as 9bd4389f e
+    Duplicated 2443ea76b0b1 as nlrtlrxv c6f7f8c4 a
+    Duplicated ebd06dba20ec as plymsszl d94e4c55 d
+    Duplicated 921dde6e55c0 as urrlptpw 9bd4389f e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    9bd4389f5d47   e
@@ -212,11 +212,11 @@ fn test_duplicate_many() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as 0fe67a05 a
-    Duplicated 1394f625cbbd as e13ac0ad b
-    Duplicated c0cb3a0b73e7 as df53fa58 c
-    Duplicated ebd06dba20ec as 2f2442db d
-    Duplicated 921dde6e55c0 as ee8fe64e e
+    Duplicated 2443ea76b0b1 as uuuvxpvw 0fe67a05 a
+    Duplicated 1394f625cbbd as nmpuuozl e13ac0ad b
+    Duplicated c0cb3a0b73e7 as kzpokyyw df53fa58 c
+    Duplicated ebd06dba20ec as yxrlprzz 2f2442db d
+    Duplicated 921dde6e55c0 as mvkzkxrl ee8fe64e e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    ee8fe64ed254   e
@@ -253,7 +253,7 @@ fn test_undo_after_duplicate() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as f5cefcbb a
+    Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  f5cefcbb65a4   a
@@ -287,11 +287,11 @@ fn test_rebase_duplicates() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as fdaaf395 b
+    Duplicated 1394f625cbbd as yqosqzyt fdaaf395 b
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as 870cf438 b
+    Duplicated 1394f625cbbd as vruxwmqv 870cf438 b
     "###);
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
     ◉  870cf438ccbb   b @ 2001-02-03 04:05:14.000 +07:00
@@ -306,8 +306,8 @@ fn test_rebase_duplicates() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 commits
-    Working copy now at: 29bd36b6 b
-    Parent commit      : 2f6dc5a1 a
+    Working copy now at: zsuskuln 29bd36b6 b
+    Parent commit      : rlvkpnrz 2f6dc5a1 a
     "###);
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.

--- a/tests/test_duplicate_command.rs
+++ b/tests/test_duplicate_command.rs
@@ -56,7 +56,7 @@ fn test_duplicate() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as 2f6dc5a1ffc2 a
+    Duplicated 2443ea76b0b1 as 2f6dc5a1 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  2f6dc5a1ffc2   a
@@ -72,7 +72,7 @@ fn test_duplicate() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 17a00fc21654 as 1dd099ea963c c
+    Duplicated 17a00fc21654 as 1dd099ea c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    1dd099ea963c   c
@@ -111,8 +111,8 @@ fn test_duplicate_many() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as 3b74d9691015 b
-    Duplicated 921dde6e55c0 as 8348ddcec733 e
+    Duplicated 1394f625cbbd as 3b74d969 b
+    Duplicated 921dde6e55c0 as 8348ddce e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    8348ddcec733   e
@@ -133,7 +133,7 @@ fn test_duplicate_many() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as 0276d3d7c24d b
+    Duplicated 1394f625cbbd as 0276d3d7 b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  0276d3d7c24d   b
@@ -152,9 +152,9 @@ fn test_duplicate_many() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as fa167d18a83a b
-    Duplicated ebd06dba20ec as 2181781b4f81 d
-    Duplicated 921dde6e55c0 as 0f7430f2727a e
+    Duplicated 1394f625cbbd as fa167d18 b
+    Duplicated ebd06dba20ec as 2181781b d
+    Duplicated 921dde6e55c0 as 0f7430f2 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    0f7430f2727a   e
@@ -187,9 +187,9 @@ fn test_duplicate_many() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as c6f7f8c4512e a
-    Duplicated ebd06dba20ec as d94e4c55a68b d
-    Duplicated 921dde6e55c0 as 9bd4389f5d47 e
+    Duplicated 2443ea76b0b1 as c6f7f8c4 a
+    Duplicated ebd06dba20ec as d94e4c55 d
+    Duplicated 921dde6e55c0 as 9bd4389f e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    9bd4389f5d47   e
@@ -212,11 +212,11 @@ fn test_duplicate_many() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as 0fe67a05989e a
-    Duplicated 1394f625cbbd as e13ac0adabdf b
-    Duplicated c0cb3a0b73e7 as df53fa589286 c
-    Duplicated ebd06dba20ec as 2f2442db08eb d
-    Duplicated 921dde6e55c0 as ee8fe64ed254 e
+    Duplicated 2443ea76b0b1 as 0fe67a05 a
+    Duplicated 1394f625cbbd as e13ac0ad b
+    Duplicated c0cb3a0b73e7 as df53fa58 c
+    Duplicated ebd06dba20ec as 2f2442db d
+    Duplicated 921dde6e55c0 as ee8fe64e e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    ee8fe64ed254   e
@@ -253,7 +253,7 @@ fn test_undo_after_duplicate() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as f5cefcbb65a4 a
+    Duplicated 2443ea76b0b1 as f5cefcbb a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  f5cefcbb65a4   a
@@ -287,11 +287,11 @@ fn test_rebase_duplicates() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as fdaaf3950f07 b
+    Duplicated 1394f625cbbd as fdaaf395 b
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as 870cf438ccbb b
+    Duplicated 1394f625cbbd as 870cf438 b
     "###);
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
     ◉  870cf438ccbb   b @ 2001-02-03 04:05:14.000 +07:00
@@ -306,8 +306,8 @@ fn test_rebase_duplicates() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "a", "-d", "a-"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 commits
-    Working copy now at: 29bd36b60e60 b
-    Parent commit      : 2f6dc5a1ffc2 a
+    Working copy now at: 29bd36b6 b
+    Parent commit      : 2f6dc5a1 a
     "###);
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -42,8 +42,8 @@ fn test_edit() {
     // Makes the specified commit the working-copy commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["edit", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: f41390a5efbf first
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: f41390a5 first
+    Parent commit      : 00000000 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_edit_command.rs
+++ b/tests/test_edit_command.rs
@@ -42,8 +42,8 @@ fn test_edit() {
     // Makes the specified commit the working-copy commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["edit", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: f41390a5 first
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm f41390a5 first
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_git_clone.rs
+++ b/tests/test_git_clone.rs
@@ -55,8 +55,8 @@ fn test_git_clone() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::assert_snapshot!(stdout, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
-    Working copy now at: 1f0b881a (no description set)
-    Parent commit      : 9f01a0e0 message
+    Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
+    Parent commit      : mzyxwzks 9f01a0e0 message
     Added 1 files, modified 0 files, removed 0 files
     "###);
     assert!(test_env.env_root().join("clone").join("file").exists());
@@ -133,8 +133,8 @@ fn test_git_clone_colocate() {
     );
     insta::assert_snapshot!(stdout, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
-    Working copy now at: 1f0b881a (no description set)
-    Parent commit      : 9f01a0e0 message
+    Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
+    Parent commit      : mzyxwzks 9f01a0e0 message
     Added 1 files, modified 0 files, removed 0 files
     "###);
     assert!(test_env.env_root().join("clone").join("file").exists());

--- a/tests/test_git_clone.rs
+++ b/tests/test_git_clone.rs
@@ -55,8 +55,8 @@ fn test_git_clone() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::assert_snapshot!(stdout, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
-    Working copy now at: 1f0b881a057d (no description set)
-    Parent commit      : 9f01a0e04879 message
+    Working copy now at: 1f0b881a (no description set)
+    Parent commit      : 9f01a0e0 message
     Added 1 files, modified 0 files, removed 0 files
     "###);
     assert!(test_env.env_root().join("clone").join("file").exists());
@@ -133,8 +133,8 @@ fn test_git_clone_colocate() {
     );
     insta::assert_snapshot!(stdout, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
-    Working copy now at: 1f0b881a057d (no description set)
-    Parent commit      : 9f01a0e04879 message
+    Working copy now at: 1f0b881a (no description set)
+    Parent commit      : 9f01a0e0 message
     Added 1 files, modified 0 files, removed 0 files
     "###);
     assert!(test_env.env_root().join("clone").join("file").exists());

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -206,8 +206,8 @@ fn test_git_colocated_branches() {
         )
         .unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    Working copy now at: 096dc80da670 (no description set)
-    Parent commit      : 230dd059e1b0 (no description set)
+    Working copy now at: 096dc80d (no description set)
+    Parent commit      : 230dd059 (no description set)
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
     │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
@@ -231,8 +231,8 @@ fn test_git_colocated_branch_forget() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    foo: 65b6b74e0897 (no description set)
-    master: 230dd059e1b0 (no description set)
+    foo: 65b6b74e (no description set)
+    master: 230dd059 (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "forget", "foo"]);
@@ -241,7 +241,7 @@ fn test_git_colocated_branch_forget() {
     // this, see `test_branch_forget_export` in `test_branch_command.rs`.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    master: 230dd059e1b0 (no description set)
+    master: 230dd059 (no description set)
     "###);
 }
 

--- a/tests/test_git_colocated.rs
+++ b/tests/test_git_colocated.rs
@@ -206,8 +206,8 @@ fn test_git_colocated_branches() {
         )
         .unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    Working copy now at: 096dc80d (no description set)
-    Parent commit      : 230dd059 (no description set)
+    Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
+    Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
     │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
@@ -231,8 +231,8 @@ fn test_git_colocated_branch_forget() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    foo: 65b6b74e (no description set)
-    master: 230dd059 (no description set)
+    foo: rlvkpnrz 65b6b74e (empty) (no description set)
+    master: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "forget", "foo"]);
@@ -241,7 +241,7 @@ fn test_git_colocated_branch_forget() {
     // this, see `test_branch_forget_export` in `test_branch_command.rs`.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    master: 230dd059 (no description set)
+    master: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 }
 

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -84,7 +84,7 @@ fn test_git_fetch_default_remote() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: ffecd2d67827 message
+    origin: ffecd2d6 message
     "###);
 }
 
@@ -101,7 +101,7 @@ fn test_git_fetch_single_remote() {
         .success()
         .stderr("Fetching from the only existing remote: rem1\n");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a21102783e8 message
+    rem1: 6a211027 message
     "###);
 }
 
@@ -114,7 +114,7 @@ fn test_git_fetch_single_remote_from_arg() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a21102783e8 message
+    rem1: 6a211027 message
     "###);
 }
 
@@ -128,7 +128,7 @@ fn test_git_fetch_single_remote_from_config() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a21102783e8 message
+    rem1: 6a211027 message
     "###);
 }
 
@@ -145,8 +145,8 @@ fn test_git_fetch_multiple_remotes() {
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a21102783e8 message
-    rem2: 2497a8a08f85 message
+    rem1: 6a211027 message
+    rem2: 2497a8a0 message
     "###);
 }
 
@@ -161,8 +161,8 @@ fn test_git_fetch_multiple_remotes_from_config() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a21102783e8 message
-    rem2: 2497a8a08f85 message
+    rem1: 6a211027 message
+    rem2: 2497a8a0 message
     "###);
 }
 
@@ -208,7 +208,7 @@ fn test_git_fetch_prune_before_updating_tips() {
     add_git_remote(&test_env, &repo_path, "origin");
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: ffecd2d67827 message
+    origin: ffecd2d6 message
     "###);
 
     // Remove origin branch in git repo and create origin/subname
@@ -221,7 +221,7 @@ fn test_git_fetch_prune_before_updating_tips() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin/subname: ffecd2d67827 message
+    origin/subname: ffecd2d6 message
     "###);
 }
 
@@ -236,7 +236,7 @@ fn test_git_fetch_conflicting_branches() {
     test_env.jj_cmd_success(&repo_path, &["new", "root"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: fcdbbd731496 (no description set)
+    rem1: fcdbbd73 (no description set)
     "###);
 
     test_env.jj_cmd_success(
@@ -246,9 +246,9 @@ fn test_git_fetch_conflicting_branches() {
     // This should result in a CONFLICTED branch
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1 (conflicted):
-      + fcdbbd731496 (no description set)
-      + 6a21102783e8 message
-      @rem1 (behind by 1 commits): 6a21102783e8 message
+      + fcdbbd73 (no description set)
+      + 6a211027 message
+      @rem1 (behind by 1 commits): 6a211027 message
     "###);
 }
 
@@ -266,7 +266,7 @@ fn test_git_fetch_conflicting_branches_colocated() {
     test_env.jj_cmd_success(&repo_path, &["new", "root"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: f652c32197cf (no description set)
+    rem1: f652c321 (no description set)
     "###);
 
     test_env.jj_cmd_success(
@@ -277,10 +277,10 @@ fn test_git_fetch_conflicting_branches_colocated() {
     // See https://github.com/martinvonz/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1 (conflicted):
-      + f652c32197cf (no description set)
-      + 6a21102783e8 message
-      @git (behind by 1 commits): f652c32197cf (no description set)
-      @rem1 (behind by 1 commits): 6a21102783e8 message
+      + f652c321 (no description set)
+      + 6a211027 message
+      @git (behind by 1 commits): f652c321 (no description set)
+      @rem1 (behind by 1 commits): 6a211027 message
     "###);
 }
 
@@ -349,11 +349,11 @@ fn test_git_fetch_all() {
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 359a9a02457d descr_for_a1
-    a2: decaa3966c83 descr_for_a2
-    b: c7d4bdcbc215 descr_for_b
-    master: ff36dc55760e descr_for_trunk1
-    trunk1: ff36dc55760e descr_for_trunk1
+    a1: 359a9a02 descr_for_a1
+    a2: decaa396 descr_for_a2
+    b: c7d4bdcb descr_for_b
+    master: ff36dc55 descr_for_trunk1
+    trunk1: ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b
@@ -400,25 +400,25 @@ fn test_git_fetch_all() {
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 359a9a02457d descr_for_a1
-    a2: decaa3966c83 descr_for_a2
-    b: 061eddbb43ab new_descr_for_b_to_create_conflict
-      @origin (ahead by 1 commits, behind by 1 commits): c7d4bdcbc215 descr_for_b
-    master: ff36dc55760e descr_for_trunk1
-    trunk1: ff36dc55760e descr_for_trunk1
+    a1: 359a9a02 descr_for_a1
+    a2: decaa396 descr_for_a2
+    b: 061eddbb new_descr_for_b_to_create_conflict
+      @origin (ahead by 1 commits, behind by 1 commits): c7d4bdcb descr_for_b
+    master: ff36dc55 descr_for_trunk1
+    trunk1: ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 0424f6dfc1ff descr_for_a1
-    a2: 91e46b4b2653 descr_for_a2
+    a1: 0424f6df descr_for_a1
+    a2: 91e46b4b descr_for_a2
     b (conflicted):
-      - c7d4bdcbc215 descr_for_b
-      + 061eddbb43ab new_descr_for_b_to_create_conflict
-      + babc49226c14 descr_for_b
-      @origin (behind by 1 commits): babc49226c14 descr_for_b
-    master: ff36dc55760e descr_for_trunk1
-    trunk1: ff36dc55760e descr_for_trunk1
-    trunk2: 8f1f14fbbf42 descr_for_trunk2
+      - c7d4bdcb descr_for_b
+      + 061eddbb new_descr_for_b_to_create_conflict
+      + babc4922 descr_for_b
+      @origin (behind by 1 commits): babc4922 descr_for_b
+    master: ff36dc55 descr_for_trunk1
+    trunk1: ff36dc55 descr_for_trunk1
+    trunk2: 8f1f14fb descr_for_trunk2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  babc49226c14 descr_for_b b?? b@origin
@@ -488,7 +488,7 @@ fn test_git_fetch_some_of_many_branches() {
     "###);
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    b: c7d4bdcbc215 descr_for_b
+    b: c7d4bdcb descr_for_b
     "###);
     // ...then fetch two others with a glob.
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a*"]);
@@ -575,13 +575,13 @@ fn test_git_fetch_some_of_many_branches() {
 
     // We left a2 where it was before, let's see how `jj branch list` sees this.
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 6f4e1c4dfe29 descr_for_a1
-    a2: decaa3966c83 descr_for_a2
+    a1: 6f4e1c4d descr_for_a1
+    a2: decaa396 descr_for_a2
     b (conflicted):
-      - c7d4bdcbc215 descr_for_b
-      + 2be688d8c664 new_descr_for_b_to_create_conflict
-      + 13ac032802f1 descr_for_b
-      @origin (behind by 1 commits): 13ac032802f1 descr_for_b
+      - c7d4bdcb descr_for_b
+      + 2be688d8 new_descr_for_b_to_create_conflict
+      + 13ac0328 descr_for_b
+      @origin (behind by 1 commits): 13ac0328 descr_for_b
     "###);
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
@@ -605,13 +605,13 @@ fn test_git_fetch_some_of_many_branches() {
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 6f4e1c4dfe29 descr_for_a1
-    a2: 010977d69c5b descr_for_a2
+    a1: 6f4e1c4d descr_for_a1
+    a2: 010977d6 descr_for_a2
     b (conflicted):
-      - c7d4bdcbc215 descr_for_b
-      + 2be688d8c664 new_descr_for_b_to_create_conflict
-      + 13ac032802f1 descr_for_b
-      @origin (behind by 1 commits): 13ac032802f1 descr_for_b
+      - c7d4bdcb descr_for_b
+      + 2be688d8 new_descr_for_b_to_create_conflict
+      + 13ac0328 descr_for_b
+      @origin (behind by 1 commits): 13ac0328 descr_for_b
     "###);
 }
 
@@ -724,7 +724,7 @@ fn test_fetch_undo_what() {
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    b: c7d4bdcbc215 descr_for_b
+    b: c7d4bdcb descr_for_b
     "###);
 
     // We can undo the change in the repo without moving the remote-tracking branch
@@ -735,7 +735,7 @@ fn test_fetch_undo_what() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b (deleted)
-      @origin: c7d4bdcbc215 descr_for_b
+      @origin: c7d4bdcb descr_for_b
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -745,10 +745,10 @@ fn test_fetch_undo_what() {
     test_env.jj_cmd_success(&repo_path, &["branch", "c", "newbranch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b (deleted)
-      @origin: c7d4bdcbc215 descr_for_b
+      @origin: c7d4bdcb descr_for_b
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
-    newbranch: 230dd059e1b0 (no description set)
+    newbranch: 230dd059 (no description set)
     "###);
     // Restoring just the remote-tracking state will not affect `newbranch`, but
     // will eliminate `b@origin`.
@@ -764,7 +764,7 @@ fn test_fetch_undo_what() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    newbranch: 230dd059e1b0 (no description set)
+    newbranch: 230dd059 (no description set)
     "###);
 }
 
@@ -777,22 +777,22 @@ fn test_git_fetch_remove_fetch() {
 
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: 230dd059e1b0 (no description set)
+    origin: 230dd059 (no description set)
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059e1b0 (no description set)
-      + ffecd2d67827 message
-      @origin (behind by 1 commits): ffecd2d67827 message
+      + 230dd059 (no description set)
+      + ffecd2d6 message
+      @origin (behind by 1 commits): ffecd2d6 message
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "remote", "remove", "origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059e1b0 (no description set)
-      + ffecd2d67827 message
+      + 230dd059 (no description set)
+      + ffecd2d6 message
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "remote", "add", "origin", "../origin"]);
@@ -802,9 +802,9 @@ fn test_git_fetch_remove_fetch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059e1b0 (no description set)
-      + ffecd2d67827 message
-      @origin (behind by 1 commits): ffecd2d67827 message
+      + 230dd059 (no description set)
+      + ffecd2d6 message
+      @origin (behind by 1 commits): ffecd2d6 message
     "###);
 }
 
@@ -817,15 +817,15 @@ fn test_git_fetch_rename_fetch() {
 
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: 230dd059e1b0 (no description set)
+    origin: 230dd059 (no description set)
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059e1b0 (no description set)
-      + ffecd2d67827 message
-      @origin (behind by 1 commits): ffecd2d67827 message
+      + 230dd059 (no description set)
+      + ffecd2d6 message
+      @origin (behind by 1 commits): ffecd2d6 message
     "###);
 
     test_env.jj_cmd_success(
@@ -834,9 +834,9 @@ fn test_git_fetch_rename_fetch() {
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059e1b0 (no description set)
-      + ffecd2d67827 message
-      @upstream (behind by 1 commits): ffecd2d67827 message
+      + 230dd059 (no description set)
+      + ffecd2d6 message
+      @upstream (behind by 1 commits): ffecd2d6 message
     "###);
 
     // Check that jj indicates that nothing has changed
@@ -1027,7 +1027,7 @@ fn test_git_fetch_remote_only_branch() {
     // Fetch normally
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
+    feature1: 9f01a0e0 message
     "###);
 
     git_repo
@@ -1045,9 +1045,9 @@ fn test_git_fetch_remote_only_branch() {
     test_env.add_config("git.auto-local-branch = false");
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e04879 message
+    feature1: 9f01a0e0 message
     feature2 (deleted)
-      @origin: 9f01a0e04879 message
+      @origin: 9f01a0e0 message
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);

--- a/tests/test_git_fetch.rs
+++ b/tests/test_git_fetch.rs
@@ -84,7 +84,7 @@ fn test_git_fetch_default_remote() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: ffecd2d6 message
+    origin: oputwtnw ffecd2d6 message
     "###);
 }
 
@@ -101,7 +101,7 @@ fn test_git_fetch_single_remote() {
         .success()
         .stderr("Fetching from the only existing remote: rem1\n");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a211027 message
+    rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -114,7 +114,7 @@ fn test_git_fetch_single_remote_from_arg() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a211027 message
+    rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -128,7 +128,7 @@ fn test_git_fetch_single_remote_from_config() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a211027 message
+    rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -145,8 +145,8 @@ fn test_git_fetch_multiple_remotes() {
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a211027 message
-    rem2: 2497a8a0 message
+    rem1: qxosxrvv 6a211027 message
+    rem2: yszkquru 2497a8a0 message
     "###);
 }
 
@@ -161,8 +161,8 @@ fn test_git_fetch_multiple_remotes_from_config() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: 6a211027 message
-    rem2: 2497a8a0 message
+    rem1: qxosxrvv 6a211027 message
+    rem2: yszkquru 2497a8a0 message
     "###);
 }
 
@@ -208,7 +208,7 @@ fn test_git_fetch_prune_before_updating_tips() {
     add_git_remote(&test_env, &repo_path, "origin");
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: ffecd2d6 message
+    origin: oputwtnw ffecd2d6 message
     "###);
 
     // Remove origin branch in git repo and create origin/subname
@@ -221,7 +221,7 @@ fn test_git_fetch_prune_before_updating_tips() {
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin/subname: ffecd2d6 message
+    origin/subname: oputwtnw ffecd2d6 message
     "###);
 }
 
@@ -236,7 +236,7 @@ fn test_git_fetch_conflicting_branches() {
     test_env.jj_cmd_success(&repo_path, &["new", "root"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: fcdbbd73 (no description set)
+    rem1: kkmpptxz fcdbbd73 (empty) (no description set)
     "###);
 
     test_env.jj_cmd_success(
@@ -246,9 +246,9 @@ fn test_git_fetch_conflicting_branches() {
     // This should result in a CONFLICTED branch
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1 (conflicted):
-      + fcdbbd73 (no description set)
-      + 6a211027 message
-      @rem1 (behind by 1 commits): 6a211027 message
+      + kkmpptxz fcdbbd73 (empty) (no description set)
+      + qxosxrvv 6a211027 message
+      @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
     "###);
 }
 
@@ -266,7 +266,7 @@ fn test_git_fetch_conflicting_branches_colocated() {
     test_env.jj_cmd_success(&repo_path, &["new", "root"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    rem1: f652c321 (no description set)
+    rem1: zsuskuln f652c321 (empty) (no description set)
     "###);
 
     test_env.jj_cmd_success(
@@ -277,10 +277,10 @@ fn test_git_fetch_conflicting_branches_colocated() {
     // See https://github.com/martinvonz/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1 (conflicted):
-      + f652c321 (no description set)
-      + 6a211027 message
-      @git (behind by 1 commits): f652c321 (no description set)
-      @rem1 (behind by 1 commits): 6a211027 message
+      + zsuskuln f652c321 (empty) (no description set)
+      + qxosxrvv 6a211027 message
+      @git (behind by 1 commits): zsuskuln f652c321 (empty) (no description set)
+      @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
     "###);
 }
 
@@ -349,11 +349,11 @@ fn test_git_fetch_all() {
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 359a9a02 descr_for_a1
-    a2: decaa396 descr_for_a2
-    b: c7d4bdcb descr_for_b
-    master: ff36dc55 descr_for_trunk1
-    trunk1: ff36dc55 descr_for_trunk1
+    a1: nknoxmzm 359a9a02 descr_for_a1
+    a2: qkvnknrk decaa396 descr_for_a2
+    b: vpupmnsl c7d4bdcb descr_for_b
+    master: zowqyktl ff36dc55 descr_for_trunk1
+    trunk1: zowqyktl ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b
@@ -400,25 +400,25 @@ fn test_git_fetch_all() {
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 359a9a02 descr_for_a1
-    a2: decaa396 descr_for_a2
-    b: 061eddbb new_descr_for_b_to_create_conflict
-      @origin (ahead by 1 commits, behind by 1 commits): c7d4bdcb descr_for_b
-    master: ff36dc55 descr_for_trunk1
-    trunk1: ff36dc55 descr_for_trunk1
+    a1: nknoxmzm 359a9a02 descr_for_a1
+    a2: qkvnknrk decaa396 descr_for_a2
+    b: vpupmnsl 061eddbb new_descr_for_b_to_create_conflict
+      @origin (ahead by 1 commits, behind by 1 commits): vpupmnsl c7d4bdcb descr_for_b
+    master: zowqyktl ff36dc55 descr_for_trunk1
+    trunk1: zowqyktl ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 0424f6df descr_for_a1
-    a2: 91e46b4b descr_for_a2
+    a1: quxllqov 0424f6df descr_for_a1
+    a2: osusxwst 91e46b4b descr_for_a2
     b (conflicted):
-      - c7d4bdcb descr_for_b
-      + 061eddbb new_descr_for_b_to_create_conflict
-      + babc4922 descr_for_b
-      @origin (behind by 1 commits): babc4922 descr_for_b
-    master: ff36dc55 descr_for_trunk1
-    trunk1: ff36dc55 descr_for_trunk1
-    trunk2: 8f1f14fb descr_for_trunk2
+      - vpupmnsl c7d4bdcb descr_for_b
+      + vpupmnsl 061eddbb new_descr_for_b_to_create_conflict
+      + vktnwlsu babc4922 descr_for_b
+      @origin (behind by 1 commits): vktnwlsu babc4922 descr_for_b
+    master: zowqyktl ff36dc55 descr_for_trunk1
+    trunk1: zowqyktl ff36dc55 descr_for_trunk1
+    trunk2: umznmzko 8f1f14fb descr_for_trunk2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  babc49226c14 descr_for_b b?? b@origin
@@ -488,7 +488,7 @@ fn test_git_fetch_some_of_many_branches() {
     "###);
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    b: c7d4bdcb descr_for_b
+    b: vpupmnsl c7d4bdcb descr_for_b
     "###);
     // ...then fetch two others with a glob.
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a*"]);
@@ -575,13 +575,13 @@ fn test_git_fetch_some_of_many_branches() {
 
     // We left a2 where it was before, let's see how `jj branch list` sees this.
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 6f4e1c4d descr_for_a1
-    a2: decaa396 descr_for_a2
+    a1: kmuktwqx 6f4e1c4d descr_for_a1
+    a2: qkvnknrk decaa396 descr_for_a2
     b (conflicted):
-      - c7d4bdcb descr_for_b
-      + 2be688d8 new_descr_for_b_to_create_conflict
-      + 13ac0328 descr_for_b
-      @origin (behind by 1 commits): 13ac0328 descr_for_b
+      - vpupmnsl c7d4bdcb descr_for_b
+      + vpupmnsl 2be688d8 new_descr_for_b_to_create_conflict
+      + twmruqrv 13ac0328 descr_for_b
+      @origin (behind by 1 commits): twmruqrv 13ac0328 descr_for_b
     "###);
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
@@ -605,13 +605,13 @@ fn test_git_fetch_some_of_many_branches() {
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
-    a1: 6f4e1c4d descr_for_a1
-    a2: 010977d6 descr_for_a2
+    a1: kmuktwqx 6f4e1c4d descr_for_a1
+    a2: xwxurvnt 010977d6 descr_for_a2
     b (conflicted):
-      - c7d4bdcb descr_for_b
-      + 2be688d8 new_descr_for_b_to_create_conflict
-      + 13ac0328 descr_for_b
-      @origin (behind by 1 commits): 13ac0328 descr_for_b
+      - vpupmnsl c7d4bdcb descr_for_b
+      + vpupmnsl 2be688d8 new_descr_for_b_to_create_conflict
+      + twmruqrv 13ac0328 descr_for_b
+      @origin (behind by 1 commits): twmruqrv 13ac0328 descr_for_b
     "###);
 }
 
@@ -724,7 +724,7 @@ fn test_fetch_undo_what() {
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    b: c7d4bdcb descr_for_b
+    b: vpupmnsl c7d4bdcb descr_for_b
     "###);
 
     // We can undo the change in the repo without moving the remote-tracking branch
@@ -735,7 +735,7 @@ fn test_fetch_undo_what() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b (deleted)
-      @origin: c7d4bdcb descr_for_b
+      @origin: vpupmnsl c7d4bdcb descr_for_b
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -745,10 +745,10 @@ fn test_fetch_undo_what() {
     test_env.jj_cmd_success(&repo_path, &["branch", "c", "newbranch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b (deleted)
-      @origin: c7d4bdcb descr_for_b
+      @origin: vpupmnsl c7d4bdcb descr_for_b
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
-    newbranch: 230dd059 (no description set)
+    newbranch: qpvuntsm 230dd059 (empty) (no description set)
     "###);
     // Restoring just the remote-tracking state will not affect `newbranch`, but
     // will eliminate `b@origin`.
@@ -764,7 +764,7 @@ fn test_fetch_undo_what() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    newbranch: 230dd059 (no description set)
+    newbranch: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 }
 
@@ -777,22 +777,22 @@ fn test_git_fetch_remove_fetch() {
 
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: 230dd059 (no description set)
+    origin: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059 (no description set)
-      + ffecd2d6 message
-      @origin (behind by 1 commits): ffecd2d6 message
+      + qpvuntsm 230dd059 (empty) (no description set)
+      + oputwtnw ffecd2d6 message
+      @origin (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "remote", "remove", "origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059 (no description set)
-      + ffecd2d6 message
+      + qpvuntsm 230dd059 (empty) (no description set)
+      + oputwtnw ffecd2d6 message
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "remote", "add", "origin", "../origin"]);
@@ -802,9 +802,9 @@ fn test_git_fetch_remove_fetch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059 (no description set)
-      + ffecd2d6 message
-      @origin (behind by 1 commits): ffecd2d6 message
+      + qpvuntsm 230dd059 (empty) (no description set)
+      + oputwtnw ffecd2d6 message
+      @origin (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
 }
 
@@ -817,15 +817,15 @@ fn test_git_fetch_rename_fetch() {
 
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    origin: 230dd059 (no description set)
+    origin: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059 (no description set)
-      + ffecd2d6 message
-      @origin (behind by 1 commits): ffecd2d6 message
+      + qpvuntsm 230dd059 (empty) (no description set)
+      + oputwtnw ffecd2d6 message
+      @origin (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
 
     test_env.jj_cmd_success(
@@ -834,9 +834,9 @@ fn test_git_fetch_rename_fetch() {
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin (conflicted):
-      + 230dd059 (no description set)
-      + ffecd2d6 message
-      @upstream (behind by 1 commits): ffecd2d6 message
+      + qpvuntsm 230dd059 (empty) (no description set)
+      + oputwtnw ffecd2d6 message
+      @upstream (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
 
     // Check that jj indicates that nothing has changed
@@ -1027,7 +1027,7 @@ fn test_git_fetch_remote_only_branch() {
     // Fetch normally
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e0 message
+    feature1: mzyxwzks 9f01a0e0 message
     "###);
 
     git_repo
@@ -1045,9 +1045,9 @@ fn test_git_fetch_remote_only_branch() {
     test_env.add_config("git.auto-local-branch = false");
     test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: 9f01a0e0 message
+    feature1: mzyxwzks 9f01a0e0 message
     feature2 (deleted)
-      @origin: 9f01a0e0 message
+      @origin: mzyxwzks 9f01a0e0 message
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);

--- a/tests/test_git_import_export.rs
+++ b/tests/test_git_import_export.rs
@@ -34,8 +34,8 @@ fn test_resolution_of_git_tracking_branches() {
     // Move the local branch somewhere else
     test_env.jj_cmd_success(&repo_path, &["describe", "-r", "main", "-m", "new_message"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 3af37026 new_message
-      @git (ahead by 1 commits, behind by 1 commits): 16d541ca old_message
+    main: qpvuntsm 3af37026 (empty) new_message
+      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm 16d541ca (empty) old_message
     "###);
 
     // Test that we can address both revisions
@@ -95,7 +95,7 @@ fn test_git_export_undo() {
 
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "a"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059 (no description set)
+    a: qpvuntsm 230dd059 (empty) (no description set)
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
 
@@ -139,7 +139,7 @@ fn test_git_import_undo() {
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059 (no description set)
+    a: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     // "git import" can be undone by default in non-colocated repositories.
@@ -150,7 +150,7 @@ fn test_git_import_undo() {
     // Try "git import" again, which should re-import the branch "a".
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059 (no description set)
+    a: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     // If we don't restore the git_refs, undoing the import removes the local branch
@@ -169,7 +169,7 @@ fn test_git_import_undo() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a (forgotten)
-      @git: 230dd059 (no description set)
+      @git: qpvuntsm 230dd059 (empty) (no description set)
       (this branch will be deleted from the underlying Git repo on the next `jj git export`)
     "###);
     // Try "git import" again, which should *not* re-import the branch "a" and be a
@@ -179,7 +179,7 @@ fn test_git_import_undo() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a (forgotten)
-      @git: 230dd059 (no description set)
+      @git: qpvuntsm 230dd059 (empty) (no description set)
       (this branch will be deleted from the underlying Git repo on the next `jj git export`)
     "###);
 
@@ -195,7 +195,7 @@ fn test_git_import_undo() {
     // Try "git import" again, which should again re-import the branch "a".
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059 (no description set)
+    a: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 }
 
@@ -221,27 +221,27 @@ fn test_git_import_move_export_with_default_undo() {
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059 (no description set)
+    a: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     // Move branch "a" and export to git repo
     test_env.jj_cmd_success(&repo_path, &["new"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "a"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 096dc80d (no description set)
-      @git (behind by 1 commits): 230dd059 (no description set)
+    a: yqosqzyt 096dc80d (empty) (no description set)
+      @git (behind by 1 commits): qpvuntsm 230dd059 (empty) (no description set)
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 096dc80d (no description set)
+    a: yqosqzyt 096dc80d (empty) (no description set)
     "###);
 
     // "git import" can be undone with the default `restore` behavior, as shown in
     // the previous test. However, "git export" can't: the branches in the git
     // repo stay where they were.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]), @r###"
-    Working copy now at: 230dd059 (no description set)
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: qpvuntsm 230dd059 (empty) (no description set)
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
@@ -259,7 +259,7 @@ fn test_git_import_move_export_with_default_undo() {
     // intuitive result here.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 096dc80d (no description set)
+    a: yqosqzyt 096dc80d (empty) (no description set)
     "###);
 }
 

--- a/tests/test_git_import_export.rs
+++ b/tests/test_git_import_export.rs
@@ -34,8 +34,8 @@ fn test_resolution_of_git_tracking_branches() {
     // Move the local branch somewhere else
     test_env.jj_cmd_success(&repo_path, &["describe", "-r", "main", "-m", "new_message"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 3af370264cdc new_message
-      @git (ahead by 1 commits, behind by 1 commits): 16d541ca40f4 old_message
+    main: 3af37026 new_message
+      @git (ahead by 1 commits, behind by 1 commits): 16d541ca old_message
     "###);
 
     // Test that we can address both revisions
@@ -95,7 +95,7 @@ fn test_git_export_undo() {
 
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "a"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059e1b0 (no description set)
+    a: 230dd059 (no description set)
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
 
@@ -139,7 +139,7 @@ fn test_git_import_undo() {
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059e1b0 (no description set)
+    a: 230dd059 (no description set)
     "###);
 
     // "git import" can be undone by default in non-colocated repositories.
@@ -150,7 +150,7 @@ fn test_git_import_undo() {
     // Try "git import" again, which should re-import the branch "a".
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059e1b0 (no description set)
+    a: 230dd059 (no description set)
     "###);
 
     // If we don't restore the git_refs, undoing the import removes the local branch
@@ -169,7 +169,7 @@ fn test_git_import_undo() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a (forgotten)
-      @git: 230dd059e1b0 (no description set)
+      @git: 230dd059 (no description set)
       (this branch will be deleted from the underlying Git repo on the next `jj git export`)
     "###);
     // Try "git import" again, which should *not* re-import the branch "a" and be a
@@ -179,7 +179,7 @@ fn test_git_import_undo() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a (forgotten)
-      @git: 230dd059e1b0 (no description set)
+      @git: 230dd059 (no description set)
       (this branch will be deleted from the underlying Git repo on the next `jj git export`)
     "###);
 
@@ -195,7 +195,7 @@ fn test_git_import_undo() {
     // Try "git import" again, which should again re-import the branch "a".
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059e1b0 (no description set)
+    a: 230dd059 (no description set)
     "###);
 }
 
@@ -221,27 +221,27 @@ fn test_git_import_move_export_with_default_undo() {
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 230dd059e1b0 (no description set)
+    a: 230dd059 (no description set)
     "###);
 
     // Move branch "a" and export to git repo
     test_env.jj_cmd_success(&repo_path, &["new"]);
     test_env.jj_cmd_success(&repo_path, &["branch", "set", "a"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 096dc80da670 (no description set)
-      @git (behind by 1 commits): 230dd059e1b0 (no description set)
+    a: 096dc80d (no description set)
+      @git (behind by 1 commits): 230dd059 (no description set)
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-     a: 096dc80da670 (no description set)
-     "###);
+    a: 096dc80d (no description set)
+    "###);
 
     // "git import" can be undone with the default `restore` behavior, as shown in
     // the previous test. However, "git export" can't: the branches in the git
     // repo stay where they were.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]), @r###"
-    Working copy now at: 230dd059e1b0 (no description set)
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: 230dd059 (no description set)
+    Parent commit      : 00000000 (no description set)
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
@@ -259,7 +259,7 @@ fn test_git_import_move_export_with_default_undo() {
     // intuitive result here.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a: 096dc80da670 (no description set)
+    a: 096dc80d (no description set)
     "###);
 }
 

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -73,11 +73,11 @@ fn test_git_push_current_branch() {
     // Check the setup
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    branch1: 19e00bf6 modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): 45a3aa29 description 1
-    branch2: 10ee3363 foo
-      @origin (behind by 1 commits): 8476341e description 2
-    my-branch: 10ee3363 foo
+    branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
+      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
+    branch2: yostqsxw 10ee3363 (empty) foo
+      @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
+    my-branch: yostqsxw 10ee3363 (empty) foo
     "###);
     // First dry-run. `branch1` should not get pushed.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--dry-run"]);
@@ -95,10 +95,10 @@ fn test_git_push_current_branch() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    branch1: 19e00bf6 modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): 45a3aa29 description 1
-    branch2: 10ee3363 foo
-    my-branch: 10ee3363 foo
+    branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
+      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
+    branch2: yostqsxw 10ee3363 (empty) foo
+    my-branch: yostqsxw 10ee3363 (empty) foo
     "###);
 }
 
@@ -183,12 +183,12 @@ fn test_git_push_multiple() {
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1 (deleted)
-      @origin: 45a3aa29 description 1
+      @origin: lzmmnrxq 45a3aa29 (empty) description 1
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
-    branch2: 15dcdaa4 foo
-      @origin (ahead by 1 commits, behind by 1 commits): 8476341e description 2
-    my-branch: 15dcdaa4 foo
+    branch2: yqosqzyt 15dcdaa4 (empty) foo
+      @origin (ahead by 1 commits, behind by 1 commits): rlzusymt 8476341e (empty) description 2
+    my-branch: yqosqzyt 15dcdaa4 (empty) foo
     "###);
     // First dry-run
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--all", "--dry-run"]);
@@ -238,8 +238,8 @@ fn test_git_push_multiple() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    branch2: 15dcdaa4 foo
-    my-branch: 15dcdaa4 foo
+    branch2: yqosqzyt 15dcdaa4 (empty) foo
+    my-branch: yqosqzyt 15dcdaa4 (empty) foo
     "###);
 }
 
@@ -525,11 +525,11 @@ fn test_git_push_conflicting_branches() {
     test_env.jj_cmd_success(&workspace_root, &["branch", "set", "branch2"]);
     test_env.jj_cmd_success(&workspace_root, &["git", "fetch"]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["branch", "list"]), @r###"
-    branch1: 45a3aa29 description 1
+    branch1: lzmmnrxq 45a3aa29 (empty) description 1
     branch2 (conflicted):
-      + 8e670e2d description 3
-      + 8476341e description 2
-      @origin (behind by 1 commits): 8476341e description 2
+      + yostqsxw 8e670e2d (empty) description 3
+      + rlzusymt 8476341e (empty) description 2
+      @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
     "###);
 
     let bump_branch1 = || {

--- a/tests/test_git_push.rs
+++ b/tests/test_git_push.rs
@@ -73,11 +73,11 @@ fn test_git_push_current_branch() {
     // Check the setup
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    branch1: 19e00bf64429 modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): 45a3aa29e907 description 1
-    branch2: 10ee3363b259 foo
-      @origin (behind by 1 commits): 8476341eb395 description 2
-    my-branch: 10ee3363b259 foo
+    branch1: 19e00bf6 modified branch1 commit
+      @origin (ahead by 1 commits, behind by 1 commits): 45a3aa29 description 1
+    branch2: 10ee3363 foo
+      @origin (behind by 1 commits): 8476341e description 2
+    my-branch: 10ee3363 foo
     "###);
     // First dry-run. `branch1` should not get pushed.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--dry-run"]);
@@ -95,10 +95,10 @@ fn test_git_push_current_branch() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    branch1: 19e00bf64429 modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): 45a3aa29e907 description 1
-    branch2: 10ee3363b259 foo
-    my-branch: 10ee3363b259 foo
+    branch1: 19e00bf6 modified branch1 commit
+      @origin (ahead by 1 commits, behind by 1 commits): 45a3aa29 description 1
+    branch2: 10ee3363 foo
+    my-branch: 10ee3363 foo
     "###);
 }
 
@@ -183,12 +183,12 @@ fn test_git_push_multiple() {
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1 (deleted)
-      @origin: 45a3aa29e907 description 1
+      @origin: 45a3aa29 description 1
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
-    branch2: 15dcdaa4f12f foo
-      @origin (ahead by 1 commits, behind by 1 commits): 8476341eb395 description 2
-    my-branch: 15dcdaa4f12f foo
+    branch2: 15dcdaa4 foo
+      @origin (ahead by 1 commits, behind by 1 commits): 8476341e description 2
+    my-branch: 15dcdaa4 foo
     "###);
     // First dry-run
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--all", "--dry-run"]);
@@ -238,8 +238,8 @@ fn test_git_push_multiple() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    branch2: 15dcdaa4f12f foo
-    my-branch: 15dcdaa4f12f foo
+    branch2: 15dcdaa4 foo
+    my-branch: 15dcdaa4 foo
     "###);
 }
 
@@ -525,11 +525,11 @@ fn test_git_push_conflicting_branches() {
     test_env.jj_cmd_success(&workspace_root, &["branch", "set", "branch2"]);
     test_env.jj_cmd_success(&workspace_root, &["git", "fetch"]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["branch", "list"]), @r###"
-    branch1: 45a3aa29e907 description 1
+    branch1: 45a3aa29 description 1
     branch2 (conflicted):
-      + 8e670e2d47e1 description 3
-      + 8476341eb395 description 2
-      @origin (behind by 1 commits): 8476341eb395 description 2
+      + 8e670e2d description 3
+      + 8476341e description 2
+      @origin (behind by 1 commits): 8476341e description 2
     "###);
 
     let bump_branch1 = || {

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -157,9 +157,9 @@ fn test_resolve_workspace_directory() {
     // Ancestor of cwd
     let stdout = test_env.jj_cmd_success(&subdir, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    Working copy : qpvuntsm 230dd059 (empty) (no description set)
     The working copy is clean
+    Working copy : qpvuntsm 230dd059 (empty) (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
     // Explicit subdirectory path
@@ -171,9 +171,9 @@ fn test_resolve_workspace_directory() {
     // Valid explicit path
     let stdout = test_env.jj_cmd_success(&subdir, &["status", "-R", "../.."]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    Working copy : qpvuntsm 230dd059 (empty) (no description set)
     The working copy is clean
+    Working copy : qpvuntsm 230dd059 (empty) (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
     // "../../..".ancestors() contains "../..", but it should never be looked up.

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -157,8 +157,8 @@ fn test_resolve_workspace_directory() {
     // Ancestor of cwd
     let stdout = test_env.jj_cmd_success(&subdir, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 00000000 (no description set)
-    Working copy : 230dd059 (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    Working copy : qpvuntsm 230dd059 (empty) (no description set)
     The working copy is clean
     "###);
 
@@ -171,8 +171,8 @@ fn test_resolve_workspace_directory() {
     // Valid explicit path
     let stdout = test_env.jj_cmd_success(&subdir, &["status", "-R", "../.."]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 00000000 (no description set)
-    Working copy : 230dd059 (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    Working copy : qpvuntsm 230dd059 (empty) (no description set)
     The working copy is clean
     "###);
 

--- a/tests/test_global_opts.rs
+++ b/tests/test_global_opts.rs
@@ -86,12 +86,12 @@ fn test_no_subcommand() {
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "show"]);
     // TODO: test_env.jj_cmd_success(&repo_path, &["-r", "help"])
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 help log show 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 help log show 230dd059
     │  (empty) (no description set)
     ~
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "show"]), @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 help log show 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 help log show 230dd059
     │  (empty) (no description set)
     ~
     "###);
@@ -157,8 +157,8 @@ fn test_resolve_workspace_directory() {
     // Ancestor of cwd
     let stdout = test_env.jj_cmd_success(&subdir, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 000000000000 (no description set)
-    Working copy : 230dd059e1b0 (no description set)
+    Parent commit: 00000000 (no description set)
+    Working copy : 230dd059 (no description set)
     The working copy is clean
     "###);
 
@@ -171,8 +171,8 @@ fn test_resolve_workspace_directory() {
     // Valid explicit path
     let stdout = test_env.jj_cmd_success(&subdir, &["status", "-R", "../.."]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 000000000000 (no description set)
-    Working copy : 230dd059e1b0 (no description set)
+    Parent commit: 00000000 (no description set)
+    Working copy : 230dd059 (no description set)
     The working copy is clean
     "###);
 

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -85,8 +85,8 @@ fn test_init_git_external() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: f6950fc1 (no description set)
-    Parent commit      : 8d698d4a My commit message
+    Working copy now at: sqpuoqvx f6950fc1 (empty) (no description set)
+    Parent commit      : mwrttmos 8d698d4a My commit message
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
     "###);

--- a/tests/test_init_command.rs
+++ b/tests/test_init_command.rs
@@ -85,8 +85,8 @@ fn test_init_git_external() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: f6950fc115ae (no description set)
-    Parent commit      : 8d698d4a8ee1 My commit message
+    Working copy now at: f6950fc1 (no description set)
+    Parent commit      : 8d698d4a My commit message
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
     "###);
@@ -108,7 +108,7 @@ fn test_init_git_external() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmoslwzp git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
+    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -168,7 +168,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmoslwzp git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a8ee1
+    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);

--- a/tests/test_log_command.rs
+++ b/tests/test_log_command.rs
@@ -38,7 +38,7 @@ fn test_log_legacy_range_operator() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r=@:"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
     ~
     "###);
@@ -47,9 +47,9 @@ fn test_log_legacy_range_operator() {
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r=:@"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(stderr, @r###"
@@ -57,9 +57,9 @@ fn test_log_legacy_range_operator() {
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r=root:@"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(stderr, @r###"
@@ -70,7 +70,7 @@ fn test_log_legacy_range_operator() {
         &["log", "-r=x", "--config-toml", "revset-aliases.x = '@:'"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
     ~
     "###);
@@ -650,7 +650,7 @@ fn test_log_author_format() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "--revisions=@"]),
         @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
     ~
     "###
@@ -668,7 +668,7 @@ fn test_log_author_format() {
             ],
         ),
         @r###"
-    @  qpvuntsmwlqt test.user 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    @  qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
     ~
     "###
@@ -1113,32 +1113,31 @@ fn test_log_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["log", "-r@"], 40, false), @r###"
-    @  mzvwutvlkqwt test.user@example.com 2001-02-03 04:05:11.000 +07:00 68518a7e6c9e
+    @  mzvwutvl test.user@example.com 2001-02-03 04:05:11.000 +07:00 68518a7e
     │  (empty) merge
     ~
     "###);
     insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @r###"
-    @  mzvwutvlkqwt test.user@example.com
+    @  mzvwutvl test.user@example.com
     │  2001-02-03 04:05:11.000 +07:00
-    ~  68518a7e6c9e
+    ~  68518a7e
        (empty) merge
     "###);
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @r###"
-    mzvwutvlkqwt test.user@example.com 2001-02-03 04:05:11.000 +07:00 68518a7e6c9e
+    mzvwutvl test.user@example.com 2001-02-03 04:05:11.000 +07:00 68518a7e
     (empty) merge
     "###);
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, true), @r###"
-    mzvwutvlkqwt test.user@example.com
-    2001-02-03 04:05:11.000 +07:00
-    68518a7e6c9e
+    mzvwutvl test.user@example.com
+    2001-02-03 04:05:11.000 +07:00 68518a7e
     (empty) merge
     "###);
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r###"
-    @  [1m[38;5;13mm[38;5;8mzvwutvlkqwt[39m [38;5;3mtest.user@example.com[39m[0m
+    @  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
     │  [1m[38;5;14m2001-02-03 04:05:11.000 +07:00[39m[0m
-    ~  [1m[38;5;12m6[38;5;8m8518a7e6c9e[39m[0m
+    ~  [1m[38;5;12m6[38;5;8m8518a7e[39m[0m
        [1m[38;5;10m(empty)[39m merge[0m
     "###);
 
@@ -1189,22 +1188,22 @@ fn test_log_word_wrap() {
 
     // Shouldn't panic with $COLUMNS < graph_width
     insta::assert_snapshot!(render(&["log", "-r@"], 0, true), @r###"
-    @  mzvwutvlkqwt
+    @  mzvwutvl
     │  test.user@example.com
     ~  2001-02-03
        04:05:11.000
        +07:00
-       68518a7e6c9e
+       68518a7e
        (empty)
        merge
     "###);
     insta::assert_snapshot!(render(&["log", "-r@"], 1, true), @r###"
-    @  mzvwutvlkqwt
+    @  mzvwutvl
     │  test.user@example.com
     ~  2001-02-03
        04:05:11.000
        +07:00
-       68518a7e6c9e
+       68518a7e
        (empty)
        merge
     "###);

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -86,8 +86,8 @@ fn test_move() {
     // Can move from sibling, which results in the source being abandoned
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1c03e3d3c63f (no description set)
-    Parent commit      : e9515f21068c (no description set)
+    Working copy now at: 1c03e3d3 (no description set)
+    Parent commit      : e9515f21 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -114,8 +114,8 @@ fn test_move() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: c8d83075e8c2 (no description set)
-    Parent commit      : 2c50bfc59c68 (no description set)
+    Working copy now at: c8d83075 (no description set)
+    Parent commit      : 2c50bfc5 (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
@@ -140,8 +140,8 @@ fn test_move() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "e", "--to", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 2b723b1d6033 (no description set)
-    Parent commit      : 4293930d6333 (no description set)
+    Working copy now at: 2b723b1d (no description set)
+    Parent commit      : 4293930d (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
@@ -203,8 +203,8 @@ fn test_move_partial() {
     // If we don't make any changes in the diff-editor, the whole change is moved
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 71b69e433fbc (no description set)
-    Parent commit      : 3db0a2f5b535 (no description set)
+    Working copy now at: 71b69e43 (no description set)
+    Parent commit      : 3db0a2f5 (no description set)
     Added 0 files, modified 2 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -234,8 +234,8 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 63f1a6e96edb (no description set)
-    Parent commit      : 3db0a2f5b535 (no description set)
+    Working copy now at: 63f1a6e9 (no description set)
+    Parent commit      : 3db0a2f5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -268,8 +268,8 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 17c2e6632cc5 (no description set)
-    Parent commit      : 3db0a2f5b535 (no description set)
+    Working copy now at: 17c2e663 (no description set)
+    Parent commit      : 3db0a2f5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -329,8 +329,8 @@ fn test_move_partial() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b670567d9438 (no description set)
-    Parent commit      : 3db0a2f5b535 (no description set)
+    Working copy now at: b670567d (no description set)
+    Parent commit      : 3db0a2f5 (no description set)
     "###);
 }
 

--- a/tests/test_move_command.rs
+++ b/tests/test_move_command.rs
@@ -86,8 +86,8 @@ fn test_move() {
     // Can move from sibling, which results in the source being abandoned
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1c03e3d3 (no description set)
-    Parent commit      : e9515f21 (no description set)
+    Working copy now at: kmkuslsw 1c03e3d3 (no description set)
+    Parent commit      : znkkpsqq e9515f21 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -114,8 +114,8 @@ fn test_move() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: c8d83075 (no description set)
-    Parent commit      : 2c50bfc5 (no description set)
+    Working copy now at: kmkuslsw c8d83075 (no description set)
+    Parent commit      : znkkpsqq 2c50bfc5 (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
@@ -140,8 +140,8 @@ fn test_move() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "e", "--to", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 2b723b1d (no description set)
-    Parent commit      : 4293930d (no description set)
+    Working copy now at: kmkuslsw 2b723b1d (no description set)
+    Parent commit      : vruxwmqv 4293930d (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
@@ -203,8 +203,8 @@ fn test_move_partial() {
     // If we don't make any changes in the diff-editor, the whole change is moved
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 71b69e43 (no description set)
-    Parent commit      : 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv 71b69e43 (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
     Added 0 files, modified 2 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -234,8 +234,8 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 63f1a6e9 (no description set)
-    Parent commit      : 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv 63f1a6e9 (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -268,8 +268,8 @@ fn test_move_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 17c2e663 (no description set)
-    Parent commit      : 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv 17c2e663 (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -329,8 +329,8 @@ fn test_move_partial() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["move", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b670567d (no description set)
-    Parent commit      : 3db0a2f5 (no description set)
+    Working copy now at: vruxwmqv b670567d (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 (no description set)
     "###);
 }
 

--- a/tests/test_new_command.rs
+++ b/tests/test_new_command.rs
@@ -129,9 +129,9 @@ fn test_new_insert_after() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "G", "B", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 descendant commits
-    Working copy now at: ca7c6481 G
-    Parent commit      : 6041917c B
-    Parent commit      : c9257eff D
+    Working copy now at: kxryzmor ca7c6481 (empty) G
+    Parent commit      : kkmpptxz 6041917c (empty) B
+    Parent commit      : vruxwmqv c9257eff (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  C
@@ -151,8 +151,8 @@ fn test_new_insert_after() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "H", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 descendant commits
-    Working copy now at: fcf8281b H
-    Parent commit      : c9257eff D
+    Working copy now at: uyznsvlq fcf8281b (empty) H
+    Parent commit      : vruxwmqv c9257eff (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  C
@@ -196,9 +196,9 @@ fn test_new_insert_after_children() {
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "G", "A", "C"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b48d4d73 G
-    Parent commit      : 65b1ef43 A
-    Parent commit      : ec18c57d C
+    Working copy now at: kxryzmor b48d4d73 (empty) G
+    Parent commit      : qpvuntsm 65b1ef43 (empty) A
+    Parent commit      : mzvwutvl ec18c57d (empty) C
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
@@ -240,10 +240,10 @@ fn test_new_insert_before() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-before", "-m", "G", "C", "F"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 descendant commits
-    Working copy now at: ff6bbbc7 G
-    Parent commit      : 41a89ffc E
-    Parent commit      : c9257eff D
-    Parent commit      : 6041917c B
+    Working copy now at: kxryzmor ff6bbbc7 (empty) G
+    Parent commit      : znkkpsqq 41a89ffc (empty) E
+    Parent commit      : vruxwmqv c9257eff (empty) D
+    Parent commit      : kkmpptxz 6041917c (empty) B
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  F
@@ -284,8 +284,8 @@ fn test_new_insert_before_root_successors() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-before", "-m", "G", "A", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 5 descendant commits
-    Working copy now at: 36541977 G
-    Parent commit      : 00000000 (no description set)
+    Working copy now at: kxryzmor 36541977 (empty) G
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉    F
@@ -353,8 +353,8 @@ fn test_new_insert_before_no_root_merge() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-before", "-m", "G", "B", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 descendant commits
-    Working copy now at: bf9fc493 G
-    Parent commit      : 65b1ef43 A
+    Working copy now at: kxryzmor bf9fc493 (empty) G
+    Parent commit      : qpvuntsm 65b1ef43 (empty) A
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉    F

--- a/tests/test_new_command.rs
+++ b/tests/test_new_command.rs
@@ -129,9 +129,9 @@ fn test_new_insert_after() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "G", "B", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 descendant commits
-    Working copy now at: ca7c6481a8dd G
-    Parent commit      : 6041917ceeb5 B
-    Parent commit      : c9257eff5bf9 D
+    Working copy now at: ca7c6481 G
+    Parent commit      : 6041917c B
+    Parent commit      : c9257eff D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  C
@@ -151,8 +151,8 @@ fn test_new_insert_after() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "H", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 descendant commits
-    Working copy now at: fcf8281b4135 H
-    Parent commit      : c9257eff5bf9 D
+    Working copy now at: fcf8281b H
+    Parent commit      : c9257eff D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  C
@@ -196,9 +196,9 @@ fn test_new_insert_after_children() {
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-after", "-m", "G", "A", "C"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b48d4d73a39c G
-    Parent commit      : 65b1ef43c737 A
-    Parent commit      : ec18c57d72d8 C
+    Working copy now at: b48d4d73 G
+    Parent commit      : 65b1ef43 A
+    Parent commit      : ec18c57d C
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
@@ -240,10 +240,10 @@ fn test_new_insert_before() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-before", "-m", "G", "C", "F"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 descendant commits
-    Working copy now at: ff6bbbc7b8df G
-    Parent commit      : 41a89ffcbba2 E
-    Parent commit      : c9257eff5bf9 D
-    Parent commit      : 6041917ceeb5 B
+    Working copy now at: ff6bbbc7 G
+    Parent commit      : 41a89ffc E
+    Parent commit      : c9257eff D
+    Parent commit      : 6041917c B
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉  F
@@ -284,8 +284,8 @@ fn test_new_insert_before_root_successors() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-before", "-m", "G", "A", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 5 descendant commits
-    Working copy now at: 3654197754f8 G
-    Parent commit      : 000000000000 (no description set)
+    Working copy now at: 36541977 G
+    Parent commit      : 00000000 (no description set)
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉    F
@@ -353,8 +353,8 @@ fn test_new_insert_before_no_root_merge() {
         test_env.jj_cmd_success(&repo_path, &["new", "--insert-before", "-m", "G", "B", "D"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 4 descendant commits
-    Working copy now at: bf9fc49331de G
-    Parent commit      : 65b1ef43c737 A
+    Working copy now at: bf9fc493 G
+    Parent commit      : 65b1ef43 A
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉    F

--- a/tests/test_obslog_command.rs
+++ b/tests/test_obslog_command.rs
@@ -31,26 +31,26 @@ fn test_obslog_with_or_without_diff() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
     │  my description
-    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5a conflict
     │  my description
-    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
     │  my description
-    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
        (empty) my description
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrzqnoo[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:10.000 +07:00[39m [38;5;12m6[38;5;8m6b42ad36073[39m[0m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:10.000 +07:00[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
     │  [1mmy description[0m
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrzqnoo[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4maf[0m[38;5;8m536e5af67e[39m [38;5;1mconflict[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4maf[0m[38;5;8m536e5a[39m [38;5;1mconflict[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrzqnoo[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4m6f[0m[38;5;8mbba7bcb590[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4m6f[0m[38;5;8mbba7bc[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrzqnoo[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4me[0m[38;5;8mac0d0dae082[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4me[0m[38;5;8mac0d0da[39m
        [38;5;2m(empty)[39m my description
     "###);
 
@@ -58,7 +58,7 @@ fn test_obslog_with_or_without_diff() {
     // (even even though it resulted in a conflict).
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
     │  my description
     │  Resolved conflict in file1:
     │     1    1: <<<<<<<resolved
@@ -67,36 +67,36 @@ fn test_obslog_with_or_without_diff() {
     │     4     : +bar
     │     5     : +++++++
     │     6     : >>>>>>>
-    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5a conflict
     │  my description
-    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ◉  rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
        (empty) my description
     "###);
 
     // Test `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
     my description
-    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5a conflict
     my description
-    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
     my description
-    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
     (empty) my description
     "###);
 
     // Test `--git` format, and that it implies `-p`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
-    rlvkpnrzqnoo test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad36073
+    rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
     my description
     diff --git a/file1 b/file1
     index e155302a24...2ab19ae607 100644
@@ -110,9 +110,9 @@ fn test_obslog_with_or_without_diff() {
     -+++++++
     ->>>>>>>
     +resolved
-    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5af67e conflict
+    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5a conflict
     my description
-    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bcb590
+    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -128,7 +128,7 @@ fn test_obslog_with_or_without_diff() {
     +++ b/file2
     @@ -1,0 +1,1 @@
     +foo
-    rlvkpnrzqnoo hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0dae082
+    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
     (empty) my description
     "###);
 }
@@ -156,35 +156,33 @@ fn test_obslog_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
-    @  qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    @  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
     │  (empty) first
-    ◉  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
-    @  qpvuntsmwlqt test.user@example.com
+    @  qpvuntsm test.user@example.com
     │  2001-02-03 04:05:08.000 +07:00
-    │  69542c1984c1
+    │  69542c19
     │  (empty) first
-    ◉  qpvuntsmwlqt hidden
-       test.user@example.com 2001-02-03
-       04:05:07.000 +07:00 230dd059e1b0
+    ◉  qpvuntsm hidden test.user@example.com
+       2001-02-03 04:05:07.000 +07:00
+       230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, false), @r###"
-    qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
     (empty) first
-    qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, true), @r###"
-    qpvuntsmwlqt test.user@example.com
-    2001-02-03 04:05:08.000 +07:00
-    69542c1984c1
+    qpvuntsm test.user@example.com
+    2001-02-03 04:05:08.000 +07:00 69542c19
     (empty) first
-    qpvuntsmwlqt hidden
-    test.user@example.com 2001-02-03
-    04:05:07.000 +07:00 230dd059e1b0
+    qpvuntsm hidden test.user@example.com
+    2001-02-03 04:05:07.000 +07:00 230dd059
     (empty) (no description set)
     "###);
 }
@@ -206,25 +204,25 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉    qpvuntsmwlqt test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5ba72
+    ◉    qpvuntsm test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5
     ├─╮  squashed
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    ◉ │  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503e1a9
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503
     │ │  first
     │ │  Added regular file file1:
     │ │          1: foo
-    ◉ │  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c1984c1
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
     │ │  (empty) first
-    ◉ │  qpvuntsmwlqt hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059e1b0
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
       │  (empty) (no description set)
-      ◉  kkmpptxzrspx hidden test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a38899f2b
+      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a3889
       │  second
       │  Modified regular file file1:
       │     1    1: foo
       │          2: bar
-      ◉  kkmpptxzrspx hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 579965369703
+      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 57996536
          (empty) second
     "###);
 }

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -127,8 +127,8 @@ fn test_rebase_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b=e", "-b=d", "-d=b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: 9ca2a154 e
-    Parent commit      : 1394f625 b
+    Working copy now at: znkkpsqq 9ca2a154 e
+    Parent commit      : zsuskuln 1394f625 b
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -148,15 +148,15 @@ fn test_rebase_branch() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "e|d" resolved to more than one revision
     Hint: The revset "e|d" resolved to these revisions:
-    e52756c8 e
-    514fa6b2 d
+    znkkpsqq e52756c8 e
+    vruxwmqv 514fa6b2 d
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:e|d').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b=all:e|d", "-d=b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: 817e3fb0 e
-    Parent commit      : 1394f625 b
+    Working copy now at: znkkpsqq 817e3fb0 e
+    Parent commit      : zsuskuln 1394f625 b
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -198,8 +198,8 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: 391c91a7 e
-    Parent commit      : 1677f795 d
+    Working copy now at: znkkpsqq 391c91a7 e
+    Parent commit      : vruxwmqv 1677f795 d
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -215,8 +215,8 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: 040ae3a6 e
-    Parent commit      : 3d0f3644 d
+    Working copy now at: znkkpsqq 040ae3a6 e
+    Parent commit      : vruxwmqv 3d0f3644 d
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -259,8 +259,8 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 2 descendant commits onto parent of rebased commit
-    Working copy now at: 7e15b97a d
-    Parent commit      : 934236c8 c
+    Working copy now at: vruxwmqv 7e15b97a d
+    Parent commit      : royxmykx 934236c8 c
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -278,9 +278,9 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "root"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 1 descendant commits onto parent of rebased commit
-    Working copy now at: bf87078f d
-    Parent commit      : d370aee1 b
-    Parent commit      : 2443ea76 a
+    Working copy now at: vruxwmqv bf87078f d
+    Parent commit      : zsuskuln d370aee1 b
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -321,9 +321,9 @@ fn test_rebase_single_revision_merge_parent() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 1 descendant commits onto parent of rebased commit
-    Working copy now at: c62d0789 d
-    Parent commit      : d370aee1 b
-    Parent commit      : 2443ea76 a
+    Working copy now at: vruxwmqv c62d0789 d
+    Parent commit      : zsuskuln d370aee1 b
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -372,8 +372,8 @@ fn test_rebase_multiple_destinations() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|c" resolved to more than one revision
     Hint: The revset "b|c" resolved to these revisions:
-    fe2e8e8b c
-    d370aee1 b
+    royxmykx fe2e8e8b c
+    zsuskuln d370aee1 b
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:b|c').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
@@ -432,8 +432,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: 309336ff d
-    Parent commit      : 244fa794 c
+    Working copy now at: vruxwmqv 309336ff d
+    Parent commit      : royxmykx 244fa794 c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
@@ -448,8 +448,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=c", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: 92c2bc9a d
-    Parent commit      : 2443ea76 a
+    Working copy now at: vruxwmqv 92c2bc9a d
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -479,8 +479,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=b", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: f1e71cb7 d
-    Parent commit      : 2443ea76 a
+    Working copy now at: vruxwmqv f1e71cb7 d
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -498,15 +498,15 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|d" resolved to more than one revision
     Hint: The revset "b|d" resolved to these revisions:
-    df54a9fd d
-    d370aee1 b
+    vruxwmqv df54a9fd d
+    zsuskuln d370aee1 b
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:b|d').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=all:b|d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: d17539f7 d
-    Parent commit      : 2443ea76 a
+    Working copy now at: vruxwmqv d17539f7 d
+    Parent commit      : rlvkpnrz 2443ea76 a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_rebase_command.rs
+++ b/tests/test_rebase_command.rs
@@ -127,8 +127,8 @@ fn test_rebase_branch() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b=e", "-b=d", "-d=b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: 9ca2a1544e5d e
-    Parent commit      : 1394f625cbbd b
+    Working copy now at: 9ca2a154 e
+    Parent commit      : 1394f625 b
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -148,15 +148,15 @@ fn test_rebase_branch() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "e|d" resolved to more than one revision
     Hint: The revset "e|d" resolved to these revisions:
-    e52756c82985 e
-    514fa6b265d4 d
+    e52756c8 e
+    514fa6b2 d
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:e|d').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b=all:e|d", "-d=b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: 817e3fb0dc64 e
-    Parent commit      : 1394f625cbbd b
+    Working copy now at: 817e3fb0 e
+    Parent commit      : 1394f625 b
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -198,8 +198,8 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: 391c91a7defa e
-    Parent commit      : 1677f79555e4 d
+    Working copy now at: 391c91a7 e
+    Parent commit      : 1677f795 d
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -215,8 +215,8 @@ fn test_rebase_branch_with_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-d", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: 040ae3a6d358 e
-    Parent commit      : 3d0f3644db16 d
+    Working copy now at: 040ae3a6 e
+    Parent commit      : 3d0f3644 d
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -259,8 +259,8 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 2 descendant commits onto parent of rebased commit
-    Working copy now at: 7e15b97a447f d
-    Parent commit      : 934236c8090e c
+    Working copy now at: 7e15b97a d
+    Parent commit      : 934236c8 c
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -278,9 +278,9 @@ fn test_rebase_single_revision() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "root"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 1 descendant commits onto parent of rebased commit
-    Working copy now at: bf87078f4560 d
-    Parent commit      : d370aee184ba b
-    Parent commit      : 2443ea76b0b1 a
+    Working copy now at: bf87078f d
+    Parent commit      : d370aee1 b
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -321,9 +321,9 @@ fn test_rebase_single_revision_merge_parent() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Also rebased 1 descendant commits onto parent of rebased commit
-    Working copy now at: c62d0789e7c7 d
-    Parent commit      : d370aee184ba b
-    Parent commit      : 2443ea76b0b1 a
+    Working copy now at: c62d0789 d
+    Parent commit      : d370aee1 b
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -372,8 +372,8 @@ fn test_rebase_multiple_destinations() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|c" resolved to more than one revision
     Hint: The revset "b|c" resolved to these revisions:
-    fe2e8e8b50b3 c
-    d370aee184ba b
+    fe2e8e8b c
+    d370aee1 b
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:b|c').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
@@ -432,8 +432,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: 309336ffce22 d
-    Parent commit      : 244fa794aa18 c
+    Working copy now at: 309336ff d
+    Parent commit      : 244fa794 c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
@@ -448,8 +448,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=c", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 2 commits
-    Working copy now at: 92c2bc9a8623 d
-    Parent commit      : 2443ea76b0b1 a
+    Working copy now at: 92c2bc9a d
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -479,8 +479,8 @@ fn test_rebase_with_descendants() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=b", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: f1e71cb78a06 d
-    Parent commit      : 2443ea76b0b1 a
+    Working copy now at: f1e71cb7 d
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -498,15 +498,15 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|d" resolved to more than one revision
     Hint: The revset "b|d" resolved to these revisions:
-    df54a9fd85ae d
-    d370aee184ba b
+    df54a9fd d
+    d370aee1 b
     Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:b|d').
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["rebase", "-s=all:b|d", "-d=a"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 3 commits
-    Working copy now at: d17539f7ea7c d
-    Parent commit      : 2443ea76b0b1 a
+    Working copy now at: d17539f7 d
+    Parent commit      : 2443ea76 a
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -87,9 +87,9 @@ fn test_resolution() {
     .unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
-    Working copy now at: e069f073 conflict
-    Parent commit      : aa493daf a
-    Parent commit      : db6a4daf b
+    Working copy now at: vruxwmqv e069f073 conflict
+    Parent commit      : zsuskuln aa493daf a
+    Parent commit      : royxmykx db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -183,9 +183,9 @@ conflict
             ],
         ),
         @r###"
-    Working copy now at: 0bb40c90 conflict
-    Parent commit      : aa493daf a
-    Parent commit      : db6a4daf b
+    Working copy now at: vruxwmqv 0bb40c90 (conflict) conflict
+    Parent commit      : zsuskuln aa493daf a
+    Parent commit      : royxmykx db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     file    2-sided conflict
@@ -242,9 +242,9 @@ conflict
     .unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
-    Working copy now at: 95418cb8 conflict
-    Parent commit      : aa493daf a
-    Parent commit      : db6a4daf b
+    Working copy now at: vruxwmqv 95418cb8 conflict
+    Parent commit      : zsuskuln aa493daf a
+    Parent commit      : royxmykx db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -632,9 +632,9 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "another_file"]), @r###"
-    Working copy now at: 07feb084 conflict
-    Parent commit      : de7553ef a
-    Parent commit      : f68bc2f0 b
+    Working copy now at: vruxwmqv 07feb084 (conflict) conflict
+    Parent commit      : zsuskuln de7553ef a
+    Parent commit      : royxmykx f68bc2f0 b
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
@@ -660,9 +660,9 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "--quiet", "another_file"]), @r###"
-    Working copy now at: ff142405 conflict
-    Parent commit      : de7553ef a
-    Parent commit      : f68bc2f0 b
+    Working copy now at: vruxwmqv ff142405 (conflict) conflict
+    Parent commit      : zsuskuln de7553ef a
+    Parent commit      : royxmykx f68bc2f0 b
     Added 0 files, modified 1 files, removed 0 files
     "###);
 

--- a/tests/test_resolve_command.rs
+++ b/tests/test_resolve_command.rs
@@ -87,9 +87,9 @@ fn test_resolution() {
     .unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
-    Working copy now at: e069f0736a79 conflict
-    Parent commit      : aa493daf6659 a
-    Parent commit      : db6a4daf6ee7 b
+    Working copy now at: e069f073 conflict
+    Parent commit      : aa493daf a
+    Parent commit      : db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -183,9 +183,9 @@ conflict
             ],
         ),
         @r###"
-    Working copy now at: 0bb40c908c8b conflict
-    Parent commit      : aa493daf6659 a
-    Parent commit      : db6a4daf6ee7 b
+    Working copy now at: 0bb40c90 conflict
+    Parent commit      : aa493daf a
+    Parent commit      : db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     file    2-sided conflict
@@ -242,9 +242,9 @@ conflict
     .unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve"]), @r###"
-    Working copy now at: 95418cb82ab1 conflict
-    Parent commit      : aa493daf6659 a
-    Parent commit      : db6a4daf6ee7 b
+    Working copy now at: 95418cb8 conflict
+    Parent commit      : aa493daf a
+    Parent commit      : db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -632,9 +632,9 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "another_file"]), @r###"
-    Working copy now at: 07feb084c0d2 conflict
-    Parent commit      : de7553ef5f05 a
-    Parent commit      : f68bc2f0a292 b
+    Working copy now at: 07feb084 conflict
+    Parent commit      : de7553ef a
+    Parent commit      : f68bc2f0 b
     Added 0 files, modified 1 files, removed 0 files
     After this operation, some files at this revision still have conflicts:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
@@ -660,9 +660,9 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["resolve", "--quiet", "another_file"]), @r###"
-    Working copy now at: ff142405c921 conflict
-    Parent commit      : de7553ef5f05 a
-    Parent commit      : f68bc2f0a292 b
+    Working copy now at: ff142405 conflict
+    Parent commit      : de7553ef a
+    Parent commit      : f68bc2f0 b
     Added 0 files, modified 1 files, removed 0 files
     "###);
 

--- a/tests/test_restore_command.rs
+++ b/tests/test_restore_command.rs
@@ -43,9 +43,9 @@ fn test_restore() {
     // Restores from parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created ed1678e3725a (no description set)
-    Working copy now at: ed1678e3725a (no description set)
-    Parent commit      : 1a986a275de6 (no description set)
+    Created ed1678e3 (no description set)
+    Working copy now at: ed1678e3 (no description set)
+    Parent commit      : 1a986a27 (no description set)
     Added 1 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -59,10 +59,10 @@ fn test_restore() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created e25100af9fff (no description set)
+    Created e25100af (no description set)
     Rebased 1 descendant commits
-    Working copy now at: fd42591eb9a3 (no description set)
-    Parent commit      : e25100af9fff (no description set)
+    Working copy now at: fd42591e (no description set)
+    Parent commit      : e25100af (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
@@ -78,9 +78,9 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 237116e2437f (no description set)
-    Working copy now at: 237116e2437f (no description set)
-    Parent commit      : 1a986a275de6 (no description set)
+    Created 237116e2 (no description set)
+    Working copy now at: 237116e2 (no description set)
+    Parent commit      : 1a986a27 (no description set)
     Added 1 files, modified 0 files, removed 2 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -92,10 +92,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 887f8f96c5a6 (no description set)
+    Created 887f8f96 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: d2725e6e14de (no description set)
-    Parent commit      : 887f8f96c5a6 (no description set)
+    Working copy now at: d2725e6e (no description set)
+    Parent commit      : 887f8f96 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -110,10 +110,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 50c1fe092f55 (no description set)
+    Created 50c1fe09 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: c63aab8ec732 (no description set)
-    Parent commit      : 50c1fe092f55 (no description set)
+    Working copy now at: c63aab8e (no description set)
+    Parent commit      : 50c1fe09 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -128,9 +128,9 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 48f89f52d23e (no description set)
-    Working copy now at: 48f89f52d23e (no description set)
-    Parent commit      : 1a986a275de6 (no description set)
+    Created 48f89f52 (no description set)
+    Working copy now at: 48f89f52 (no description set)
+    Parent commit      : 1a986a27 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -190,10 +190,10 @@ fn test_restore_conflicted_merge() {
     // ...and restore it back again.
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 63198ca2e4aa conflict
-    Working copy now at: 63198ca2e4aa conflict
-    Parent commit      : aa493daf6659 a
-    Parent commit      : db6a4daf6ee7 b
+    Created 63198ca2 conflict
+    Working copy now at: 63198ca2 conflict
+    Parent commit      : aa493daf a
+    Parent commit      : db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -228,10 +228,10 @@ fn test_restore_conflicted_merge() {
     // ... and restore it back again.
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created d955febceac1 conflict
-    Working copy now at: d955febceac1 conflict
-    Parent commit      : aa493daf6659 a
-    Parent commit      : db6a4daf6ee7 b
+    Created d955febc conflict
+    Working copy now at: d955febc conflict
+    Parent commit      : aa493daf a
+    Parent commit      : db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(

--- a/tests/test_restore_command.rs
+++ b/tests/test_restore_command.rs
@@ -43,9 +43,9 @@ fn test_restore() {
     // Restores from parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created ed1678e3 (no description set)
-    Working copy now at: ed1678e3 (no description set)
-    Parent commit      : 1a986a27 (no description set)
+    Created kkmpptxz ed1678e3 (empty) (no description set)
+    Working copy now at: kkmpptxz ed1678e3 (empty) (no description set)
+    Parent commit      : rlvkpnrz 1a986a27 (no description set)
     Added 1 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -59,10 +59,10 @@ fn test_restore() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created e25100af (no description set)
+    Created rlvkpnrz e25100af (empty) (no description set)
     Rebased 1 descendant commits
-    Working copy now at: fd42591e (no description set)
-    Parent commit      : e25100af (no description set)
+    Working copy now at: kkmpptxz fd42591e (conflict) (no description set)
+    Parent commit      : rlvkpnrz e25100af (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
@@ -78,9 +78,9 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 237116e2 (no description set)
-    Working copy now at: 237116e2 (no description set)
-    Parent commit      : 1a986a27 (no description set)
+    Created kkmpptxz 237116e2 (no description set)
+    Working copy now at: kkmpptxz 237116e2 (no description set)
+    Parent commit      : rlvkpnrz 1a986a27 (no description set)
     Added 1 files, modified 0 files, removed 2 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -92,10 +92,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 887f8f96 (no description set)
+    Created rlvkpnrz 887f8f96 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: d2725e6e (no description set)
-    Parent commit      : 887f8f96 (no description set)
+    Working copy now at: kkmpptxz d2725e6e (empty) (no description set)
+    Parent commit      : rlvkpnrz 887f8f96 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -110,10 +110,10 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "--from", "@", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 50c1fe09 (no description set)
+    Created rlvkpnrz 50c1fe09 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: c63aab8e (no description set)
-    Parent commit      : 50c1fe09 (no description set)
+    Working copy now at: kkmpptxz c63aab8e (empty) (no description set)
+    Parent commit      : rlvkpnrz 50c1fe09 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -128,9 +128,9 @@ fn test_restore() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 48f89f52 (no description set)
-    Working copy now at: 48f89f52 (no description set)
-    Parent commit      : 1a986a27 (no description set)
+    Created kkmpptxz 48f89f52 (no description set)
+    Working copy now at: kkmpptxz 48f89f52 (no description set)
+    Parent commit      : rlvkpnrz 1a986a27 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -190,10 +190,10 @@ fn test_restore_conflicted_merge() {
     // ...and restore it back again.
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore", "file"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created 63198ca2 conflict
-    Working copy now at: 63198ca2 conflict
-    Parent commit      : aa493daf a
-    Parent commit      : db6a4daf b
+    Created vruxwmqv 63198ca2 (conflict) (empty) conflict
+    Working copy now at: vruxwmqv 63198ca2 (conflict) (empty) conflict
+    Parent commit      : zsuskuln aa493daf a
+    Parent commit      : royxmykx db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(
@@ -228,10 +228,10 @@ fn test_restore_conflicted_merge() {
     // ... and restore it back again.
     let stdout = test_env.jj_cmd_success(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @r###"
-    Created d955febc conflict
-    Working copy now at: d955febc conflict
-    Parent commit      : aa493daf a
-    Parent commit      : db6a4daf b
+    Created vruxwmqv d955febc (conflict) (empty) conflict
+    Working copy now at: vruxwmqv d955febc (conflict) (empty) conflict
+    Parent commit      : zsuskuln aa493daf a
+    Parent commit      : royxmykx db6a4daf b
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(

--- a/tests/test_revset_output.rs
+++ b/tests/test_revset_output.rs
@@ -256,13 +256,13 @@ fn test_alias() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
 
@@ -385,7 +385,7 @@ fn test_bad_alias_decl() {
     // Invalid declaration should be warned and ignored.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
+    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(stderr, @r###"

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -41,10 +41,10 @@ fn test_split_by_paths() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
-    First part: 5eebce1d (no description set)
-    Second part: 45833353 (no description set)
-    Working copy now at: 45833353 (no description set)
-    Parent commit      : 5eebce1d (no description set)
+    First part: qpvuntsm 5eebce1d (no description set)
+    Second part: kkmpptxz 45833353 (no description set)
+    Working copy now at: kkmpptxz 45833353 (no description set)
+    Parent commit      : qpvuntsm 5eebce1d (no description set)
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
@@ -87,10 +87,10 @@ fn test_split_by_paths() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["split", "-r", "@-", "."]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    First part: 31425b56 (no description set)
-    Second part: af096392 (no description set)
-    Working copy now at: 28d4ec20 (no description set)
-    Parent commit      : af096392 (no description set)
+    First part: qpvuntsm 31425b56 (no description set)
+    Second part: yqosqzyt af096392 (empty) (no description set)
+    Working copy now at: kkmpptxz 28d4ec20 (no description set)
+    Parent commit      : yqosqzyt af096392 (empty) (no description set)
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -113,10 +113,10 @@ fn test_split_by_paths() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    First part: 0647b2cb (no description set)
-    Second part: d5d77af6 (no description set)
-    Working copy now at: 86f228dc (no description set)
-    Parent commit      : d5d77af6 (no description set)
+    First part: qpvuntsm 0647b2cb (empty) (no description set)
+    Second part: kpqxywon d5d77af6 (no description set)
+    Working copy now at: kkmpptxz 86f228dc (no description set)
+    Parent commit      : kpqxywon d5d77af6 (no description set)
     "###);
     insta::assert_snapshot!(stderr, @r###"
     The given paths do not match any file: nonexistent

--- a/tests/test_split_command.rs
+++ b/tests/test_split_command.rs
@@ -41,10 +41,10 @@ fn test_split_by_paths() {
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
-    First part: 5eebce1de3b0 (no description set)
-    Second part: 45833353d94e (no description set)
-    Working copy now at: 45833353d94e (no description set)
-    Parent commit      : 5eebce1de3b0 (no description set)
+    First part: 5eebce1d (no description set)
+    Second part: 45833353 (no description set)
+    Working copy now at: 45833353 (no description set)
+    Parent commit      : 5eebce1d (no description set)
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
@@ -87,10 +87,10 @@ fn test_split_by_paths() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["split", "-r", "@-", "."]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    First part: 31425b568fcf (no description set)
-    Second part: af0963926ac3 (no description set)
-    Working copy now at: 28d4ec20efa9 (no description set)
-    Parent commit      : af0963926ac3 (no description set)
+    First part: 31425b56 (no description set)
+    Second part: af096392 (no description set)
+    Working copy now at: 28d4ec20 (no description set)
+    Parent commit      : af096392 (no description set)
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -113,10 +113,10 @@ fn test_split_by_paths() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    First part: 0647b2cbd0da (no description set)
-    Second part: d5d77af65446 (no description set)
-    Working copy now at: 86f228dc3a50 (no description set)
-    Parent commit      : d5d77af65446 (no description set)
+    First part: 0647b2cb (no description set)
+    Second part: d5d77af6 (no description set)
+    Working copy now at: 86f228dc (no description set)
+    Parent commit      : d5d77af6 (no description set)
     "###);
     insta::assert_snapshot!(stderr, @r###"
     The given paths do not match any file: nonexistent

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -43,8 +43,8 @@ fn test_squash() {
     // Squashes the working copy into the parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b9280a9898cb (no description set)
-    Parent commit      : 6ca29c9d2e7c (no description set)
+    Working copy now at: b9280a98 (no description set)
+    Parent commit      : 6ca29c9d (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b9280a9898cb
@@ -62,8 +62,8 @@ fn test_squash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: e87cf8ebc7e1 (no description set)
-    Parent commit      : 893c93ae2a87 (no description set)
+    Working copy now at: e87cf8eb (no description set)
+    Parent commit      : 893c93ae (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e87cf8ebc7e1 c
@@ -108,8 +108,8 @@ fn test_squash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 959145c11426 (no description set)
-    Parent commit      : 80960125bb96 (no description set)
+    Working copy now at: 959145c1 (no description set)
+    Parent commit      : 80960125 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  959145c11426
@@ -159,8 +159,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: f03d5ce4a973 (no description set)
-    Parent commit      : c9f931cd78af (no description set)
+    Working copy now at: f03d5ce4 (no description set)
+    Parent commit      : c9f931cd (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f03d5ce4a973 c
@@ -178,8 +178,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: e7a40106bee6 (no description set)
-    Parent commit      : 05d951646873 (no description set)
+    Working copy now at: e7a40106 (no description set)
+    Parent commit      : 05d95164 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e7a40106bee6 c
@@ -211,8 +211,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: a911fa1d0627 (no description set)
-    Parent commit      : fb73ad17899f (no description set)
+    Working copy now at: a911fa1d (no description set)
+    Parent commit      : fb73ad17 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a911fa1d0627 c
@@ -243,8 +243,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 5e297967f76c (no description set)
-    Parent commit      : ac2586097a71 (no description set)
+    Working copy now at: 5e297967 (no description set)
+    Parent commit      : ac258609 (no description set)
     "###);
 
     // We get a warning if we pass a positional argument that looks like a revset
@@ -254,8 +254,8 @@ fn test_squash_partial() {
     warning: The argument "b" is being interpreted as a path. To specify a revset, pass -r "b" instead.
     "###);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1c4e5596a511 (no description set)
-    Parent commit      : 16cc94b4efe9 (no description set)
+    Working copy now at: 1c4e5596 (no description set)
+    Parent commit      : 16cc94b4 (no description set)
     "###);
 }
 
@@ -359,8 +359,8 @@ fn test_squash_empty() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: e45abe2cd9a9 (no description set)
-    Parent commit      : 1265289bbbbf parent
+    Working copy now at: e45abe2c (no description set)
+    Parent commit      : 1265289b parent
     "###);
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
     parent

--- a/tests/test_squash_command.rs
+++ b/tests/test_squash_command.rs
@@ -43,8 +43,8 @@ fn test_squash() {
     // Squashes the working copy into the parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: b9280a98 (no description set)
-    Parent commit      : 6ca29c9d (no description set)
+    Working copy now at: vruxwmqv b9280a98 (empty) (no description set)
+    Parent commit      : kkmpptxz 6ca29c9d (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b9280a9898cb
@@ -62,8 +62,8 @@ fn test_squash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: e87cf8eb (no description set)
-    Parent commit      : 893c93ae (no description set)
+    Working copy now at: mzvwutvl e87cf8eb (no description set)
+    Parent commit      : qpvuntsm 893c93ae (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e87cf8ebc7e1 c
@@ -108,8 +108,8 @@ fn test_squash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 959145c1 (no description set)
-    Parent commit      : 80960125 (no description set)
+    Working copy now at: xlzxqlsl 959145c1 (empty) (no description set)
+    Parent commit      : nmzmmopx 80960125 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  959145c11426
@@ -159,8 +159,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: f03d5ce4 (no description set)
-    Parent commit      : c9f931cd (no description set)
+    Working copy now at: mzvwutvl f03d5ce4 (no description set)
+    Parent commit      : qpvuntsm c9f931cd (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f03d5ce4a973 c
@@ -178,8 +178,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: e7a40106 (no description set)
-    Parent commit      : 05d95164 (no description set)
+    Working copy now at: mzvwutvl e7a40106 (no description set)
+    Parent commit      : kkmpptxz 05d95164 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e7a40106bee6 c
@@ -211,8 +211,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: a911fa1d (no description set)
-    Parent commit      : fb73ad17 (no description set)
+    Working copy now at: mzvwutvl a911fa1d (no description set)
+    Parent commit      : kkmpptxz fb73ad17 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a911fa1d0627 c
@@ -243,8 +243,8 @@ fn test_squash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 5e297967 (no description set)
-    Parent commit      : ac258609 (no description set)
+    Working copy now at: mzvwutvl 5e297967 (no description set)
+    Parent commit      : kkmpptxz ac258609 (no description set)
     "###);
 
     // We get a warning if we pass a positional argument that looks like a revset
@@ -254,8 +254,8 @@ fn test_squash_partial() {
     warning: The argument "b" is being interpreted as a path. To specify a revset, pass -r "b" instead.
     "###);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1c4e5596 (no description set)
-    Parent commit      : 16cc94b4 (no description set)
+    Working copy now at: mzvwutvl 1c4e5596 (no description set)
+    Parent commit      : kkmpptxz 16cc94b4 (no description set)
     "###);
 }
 
@@ -359,8 +359,8 @@ fn test_squash_empty() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: e45abe2c (no description set)
-    Parent commit      : 1265289b parent
+    Working copy now at: kkmpptxz e45abe2c (empty) (no description set)
+    Parent commit      : qpvuntsm 1265289b (empty) parent
     "###);
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
     parent

--- a/tests/test_status_command.rs
+++ b/tests/test_status_command.rs
@@ -33,9 +33,9 @@ fn test_status_merge() {
     // to the auto-merged parents)
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
+    The working copy is clean
+    Working copy : mzvwutvl c965365c (empty) (no description set)
     Parent commit: rlvkpnrz 9ae48ddb (empty) left
     Parent commit: zsuskuln 29b991e9 right
-    Working copy : mzvwutvl c965365c (empty) (no description set)
-    The working copy is clean
     "###);
 }

--- a/tests/test_status_command.rs
+++ b/tests/test_status_command.rs
@@ -33,9 +33,9 @@ fn test_status_merge() {
     // to the auto-merged parents)
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 9ae48ddb left
-    Parent commit: 29b991e9 right
-    Working copy : c965365c (no description set)
+    Parent commit: rlvkpnrz 9ae48ddb (empty) left
+    Parent commit: zsuskuln 29b991e9 right
+    Working copy : mzvwutvl c965365c (empty) (no description set)
     The working copy is clean
     "###);
 }

--- a/tests/test_status_command.rs
+++ b/tests/test_status_command.rs
@@ -33,9 +33,9 @@ fn test_status_merge() {
     // to the auto-merged parents)
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
-    Parent commit: 9ae48ddba058 left
-    Parent commit: 29b991e938dd right
-    Working copy : c965365c98d2 (no description set)
+    Parent commit: 9ae48ddb left
+    Parent commit: 29b991e9 right
+    Working copy : c965365c (no description set)
     The working copy is clean
     "###);
 }

--- a/tests/test_undo.rs
+++ b/tests/test_undo.rs
@@ -70,8 +70,8 @@ fn test_git_push_undo() {
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -82,7 +82,7 @@ fn test_git_push_undo() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
+    main: qpvuntsm 8c05de15 (empty) BB
     "###);
 
     // Undo the push
@@ -94,8 +94,8 @@ fn test_git_push_undo() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
@@ -110,10 +110,10 @@ fn test_git_push_undo() {
     // git fetch && jj undo && jj git fetch` would become a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - 0cffb614 AA
-      + 0a3e99f0 CC
-      + 8c05de15 BB
-      @origin (behind by 1 commits): 8c05de15 BB
+      - qpvuntsm 0cffb614 (empty) AA
+      + qpvuntsm 0a3e99f0 (empty) CC
+      + qpvuntsm 8c05de15 (empty) BB
+      @origin (behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
     "###);
 }
 
@@ -141,8 +141,8 @@ fn test_git_push_undo_with_import() {
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -153,7 +153,7 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
+    main: qpvuntsm 8c05de15 (empty) BB
     "###);
 
     // Undo the push
@@ -165,8 +165,8 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
 
     // PROBLEM: inserting this import changes the outcome compared to previous test
@@ -180,7 +180,7 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
+    main: qpvuntsm 8c05de15 (empty) BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
@@ -188,8 +188,8 @@ fn test_git_push_undo_with_import() {
     // There is not a conflict. This seems like a good outcome; undoing `git push`
     // was essentially a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 0a3e99f0 CC
-      @origin (ahead by 1 commits, behind by 1 commits): 8c05de15 BB
+    main: qpvuntsm 0a3e99f0 (empty) CC
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
     "###);
 }
 
@@ -218,8 +218,8 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -230,7 +230,7 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
+    main: qpvuntsm 8c05de15 (empty) BB
     "###);
 
     // Undo the push
@@ -250,8 +250,8 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
@@ -260,11 +260,11 @@ fn test_git_push_undo_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - 0cffb614 AA
-      + 0a3e99f0 CC
-      + 8c05de15 BB
-      @git (behind by 1 commits): 0a3e99f0 CC
-      @origin (behind by 1 commits): 8c05de15 BB
+      - qpvuntsm 0cffb614 (empty) AA
+      + qpvuntsm 0a3e99f0 (empty) CC
+      + qpvuntsm 8c05de15 (empty) BB
+      @git (behind by 1 commits): qpvuntsm 0a3e99f0 (empty) CC
+      @origin (behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
     "###);
 }
 
@@ -284,13 +284,13 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 0cffb614 AA
+    main: qpvuntsm 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "BB"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
+    main: qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -301,15 +301,15 @@ fn test_git_push_undo_repo_only() {
         &["op", "restore", "--what=repo", &pre_push_opid],
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de15 BB
+    main: qpvuntsm 8c05de15 (empty) BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     // This currently gives an identical result to `test_git_push_undo_import`.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 0a3e99f0 CC
-      @origin (ahead by 1 commits, behind by 1 commits): 8c05de15 BB
+    main: qpvuntsm 0a3e99f0 (empty) CC
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
     "###);
 }
 

--- a/tests/test_undo.rs
+++ b/tests/test_undo.rs
@@ -70,8 +70,8 @@ fn test_git_push_undo() {
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -82,7 +82,7 @@ fn test_git_push_undo() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
+    main: 8c05de15 BB
     "###);
 
     // Undo the push
@@ -94,8 +94,8 @@ fn test_git_push_undo() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
@@ -110,10 +110,10 @@ fn test_git_push_undo() {
     // git fetch && jj undo && jj git fetch` would become a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - 0cffb6146141 AA
-      + 0a3e99f08a48 CC
-      + 8c05de152218 BB
-      @origin (behind by 1 commits): 8c05de152218 BB
+      - 0cffb614 AA
+      + 0a3e99f0 CC
+      + 8c05de15 BB
+      @origin (behind by 1 commits): 8c05de15 BB
     "###);
 }
 
@@ -141,8 +141,8 @@ fn test_git_push_undo_with_import() {
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -153,7 +153,7 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
+    main: 8c05de15 BB
     "###);
 
     // Undo the push
@@ -165,8 +165,8 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
 
     // PROBLEM: inserting this import changes the outcome compared to previous test
@@ -180,7 +180,7 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
+    main: 8c05de15 BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
@@ -188,8 +188,8 @@ fn test_git_push_undo_with_import() {
     // There is not a conflict. This seems like a good outcome; undoing `git push`
     // was essentially a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 0a3e99f08a48 CC
-      @origin (ahead by 1 commits, behind by 1 commits): 8c05de152218 BB
+    main: 0a3e99f0 CC
+      @origin (ahead by 1 commits, behind by 1 commits): 8c05de15 BB
     "###);
 }
 
@@ -218,8 +218,8 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -230,7 +230,7 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
+    main: 8c05de15 BB
     "###);
 
     // Undo the push
@@ -250,8 +250,8 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
@@ -260,11 +260,11 @@ fn test_git_push_undo_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - 0cffb6146141 AA
-      + 0a3e99f08a48 CC
-      + 8c05de152218 BB
-      @git (behind by 1 commits): 0a3e99f08a48 CC
-      @origin (behind by 1 commits): 8c05de152218 BB
+      - 0cffb614 AA
+      + 0a3e99f0 CC
+      + 8c05de15 BB
+      @git (behind by 1 commits): 0a3e99f0 CC
+      @origin (behind by 1 commits): 8c05de15 BB
     "###);
 }
 
@@ -284,13 +284,13 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 0cffb6146141 AA
+    main: 0cffb614 AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "BB"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
-      @origin (ahead by 1 commits, behind by 1 commits): 0cffb6146141 AA
+    main: 8c05de15 BB
+      @origin (ahead by 1 commits, behind by 1 commits): 0cffb614 AA
     "###);
     let pre_push_opid = current_operation_id(&test_env, &repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
@@ -301,15 +301,15 @@ fn test_git_push_undo_repo_only() {
         &["op", "restore", "--what=repo", &pre_push_opid],
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 8c05de152218 BB
+    main: 8c05de15 BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_success(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_success(&repo_path, &["git", "fetch"]);
     // This currently gives an identical result to `test_git_push_undo_import`.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: 0a3e99f08a48 CC
-      @origin (ahead by 1 commits, behind by 1 commits): 8c05de152218 BB
+    main: 0a3e99f0 CC
+      @origin (ahead by 1 commits, behind by 1 commits): 8c05de15 BB
     "###);
 }
 

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -43,8 +43,8 @@ fn test_unsquash() {
     // Unsquashes into the working copy from its parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1b10d78f (no description set)
-    Parent commit      : 90aeefd0 (no description set)
+    Working copy now at: mzvwutvl 1b10d78f (no description set)
+    Parent commit      : qpvuntsm 90aeefd0 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1b10d78f6136 c
@@ -61,8 +61,8 @@ fn test_unsquash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 45b8b3dd (no description set)
-    Parent commit      : 9146bcc8 (no description set)
+    Working copy now at: mzvwutvl 45b8b3dd (no description set)
+    Parent commit      : kkmpptxz 9146bcc8 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  45b8b3ddc25a c
@@ -107,9 +107,9 @@ fn test_unsquash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 3217340c merge
-    Parent commit      : 90fe0a96 (no description set)
-    Parent commit      : 5658521e (no description set)
+    Working copy now at: pzsxstzt 3217340c merge
+    Parent commit      : mzvwutvl 90fe0a96 (no description set)
+    Parent commit      : xznxytkn 5658521e (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    3217340cb761
@@ -158,8 +158,8 @@ fn test_unsquash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 37c961d0 (no description set)
-    Parent commit      : 000af220 (no description set)
+    Working copy now at: mzvwutvl 37c961d0 (no description set)
+    Parent commit      : kkmpptxz 000af220 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  37c961d0d1e2 c
@@ -177,8 +177,8 @@ fn test_unsquash_partial() {
     std::fs::write(edit_script, "reset file1").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: a8e8fded (no description set)
-    Parent commit      : 46cc0667 (no description set)
+    Working copy now at: mzvwutvl a8e8fded (no description set)
+    Parent commit      : kkmpptxz 46cc0667 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a8e8fded1021 c

--- a/tests/test_unsquash_command.rs
+++ b/tests/test_unsquash_command.rs
@@ -43,8 +43,8 @@ fn test_unsquash() {
     // Unsquashes into the working copy from its parent by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 1b10d78f6136 (no description set)
-    Parent commit      : 90aeefd03044 (no description set)
+    Working copy now at: 1b10d78f (no description set)
+    Parent commit      : 90aeefd0 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1b10d78f6136 c
@@ -61,8 +61,8 @@ fn test_unsquash() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 45b8b3ddc25a (no description set)
-    Parent commit      : 9146bcc8d996 (no description set)
+    Working copy now at: 45b8b3dd (no description set)
+    Parent commit      : 9146bcc8 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  45b8b3ddc25a c
@@ -107,9 +107,9 @@ fn test_unsquash() {
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: 3217340cb761 merge
-    Parent commit      : 90fe0a96fc90 (no description set)
-    Parent commit      : 5658521e0f8b (no description set)
+    Working copy now at: 3217340c merge
+    Parent commit      : 90fe0a96 (no description set)
+    Parent commit      : 5658521e (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    3217340cb761
@@ -158,8 +158,8 @@ fn test_unsquash_partial() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: 37c961d0d1e2 (no description set)
-    Parent commit      : 000af22057b9 (no description set)
+    Working copy now at: 37c961d0 (no description set)
+    Parent commit      : 000af220 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  37c961d0d1e2 c
@@ -177,8 +177,8 @@ fn test_unsquash_partial() {
     std::fs::write(edit_script, "reset file1").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: a8e8fded1021 (no description set)
-    Parent commit      : 46cc06672a99 (no description set)
+    Working copy now at: a8e8fded (no description set)
+    Parent commit      : 46cc0667 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a8e8fded1021 c

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -31,7 +31,7 @@ fn test_workspaces_add_second_workspace() {
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: e0e6d5672858 (no description set)
+    default: e0e6d567 (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -40,8 +40,8 @@ fn test_workspaces_add_second_workspace() {
     );
     insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
     Created workspace in "../secondary"
-    Working copy now at: 397eac932ad3 (no description set)
-    Parent commit      : 7d308bc9d934 initial
+    Working copy now at: 397eac93 (no description set)
+    Parent commit      : 7d308bc9 initial
     Added 1 files, modified 0 files, removed 0 files
     "###);
 
@@ -65,8 +65,8 @@ fn test_workspaces_add_second_workspace() {
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: e0e6d5672858 (no description set)
-    second: 397eac932ad3 (no description set)
+    default: e0e6d567 (no description set)
+    second: 397eac93 (no description set)
     "###);
 }
 
@@ -100,8 +100,8 @@ fn test_workspaces_conflicting_edits() {
     let stdout = test_env.jj_cmd_success(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: fe8f41ed01d6 (no description set)
-    Parent commit      : c0d4a99ef98a (no description set)
+    Working copy now at: fe8f41ed (no description set)
+    Parent commit      : c0d4a99e (no description set)
     "###);
 
     // The secondary workspace's working-copy commit was updated
@@ -132,7 +132,7 @@ fn test_workspaces_conflicting_edits() {
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    Working copy now at: a1896a17282f (no description set)
+    Working copy now at: a1896a17 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
@@ -185,8 +185,8 @@ fn test_workspaces_updated_by_other() {
     let stdout = test_env.jj_cmd_success(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: fe8f41ed01d6 (no description set)
-    Parent commit      : c0d4a99ef98a (no description set)
+    Working copy now at: fe8f41ed (no description set)
+    Parent commit      : c0d4a99e (no description set)
     "###);
 
     // The secondary workspace's working-copy commit was updated.
@@ -207,7 +207,7 @@ fn test_workspaces_updated_by_other() {
     // It was detected that the working copy is now stale, but clean. So no
     // divergent commit should be created.
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: a1896a17282f (no description set)
+    Working copy now at: a1896a17 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
@@ -298,7 +298,7 @@ fn test_workspaces_forget() {
     // When listing workspaces, only the secondary workspace shows up
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    secondary: feda1c4e5ffe (no description set)
+    secondary: feda1c4e (no description set)
     "###);
 
     // `jj status` tells us that there's no working copy here

--- a/tests/test_workspaces.rs
+++ b/tests/test_workspaces.rs
@@ -31,7 +31,7 @@ fn test_workspaces_add_second_workspace() {
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: e0e6d567 (no description set)
+    default: rlvkpnrz e0e6d567 (empty) (no description set)
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -40,8 +40,8 @@ fn test_workspaces_add_second_workspace() {
     );
     insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
     Created workspace in "../secondary"
-    Working copy now at: 397eac93 (no description set)
-    Parent commit      : 7d308bc9 initial
+    Working copy now at: rzvqmyuk 397eac93 (empty) (no description set)
+    Parent commit      : qpvuntsm 7d308bc9 initial
     Added 1 files, modified 0 files, removed 0 files
     "###);
 
@@ -65,8 +65,8 @@ fn test_workspaces_add_second_workspace() {
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: e0e6d567 (no description set)
-    second: 397eac93 (no description set)
+    default: rlvkpnrz e0e6d567 (empty) (no description set)
+    second: rzvqmyuk 397eac93 (empty) (no description set)
     "###);
 }
 
@@ -100,8 +100,8 @@ fn test_workspaces_conflicting_edits() {
     let stdout = test_env.jj_cmd_success(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: fe8f41ed (no description set)
-    Parent commit      : c0d4a99e (no description set)
+    Working copy now at: mzvwutvl fe8f41ed (empty) (no description set)
+    Parent commit      : qpvuntsm c0d4a99e (no description set)
     "###);
 
     // The secondary workspace's working-copy commit was updated
@@ -132,7 +132,7 @@ fn test_workspaces_conflicting_edits() {
     insta::assert_snapshot!(stdout, @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    Working copy now at: a1896a17 (no description set)
+    Working copy now at: pmmvwywv a1896a17 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
@@ -185,8 +185,8 @@ fn test_workspaces_updated_by_other() {
     let stdout = test_env.jj_cmd_success(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @r###"
     Rebased 1 descendant commits
-    Working copy now at: fe8f41ed (no description set)
-    Parent commit      : c0d4a99e (no description set)
+    Working copy now at: mzvwutvl fe8f41ed (empty) (no description set)
+    Parent commit      : qpvuntsm c0d4a99e (no description set)
     "###);
 
     // The secondary workspace's working-copy commit was updated.
@@ -207,7 +207,7 @@ fn test_workspaces_updated_by_other() {
     // It was detected that the working copy is now stale, but clean. So no
     // divergent commit should be created.
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: a1896a17 (no description set)
+    Working copy now at: pmmvwywv a1896a17 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
@@ -298,7 +298,7 @@ fn test_workspaces_forget() {
     // When listing workspaces, only the secondary workspace shows up
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    secondary: feda1c4e (no description set)
+    secondary: pmmvwywv feda1c4e (empty) (no description set)
     "###);
 
     // `jj status` tells us that there's no working copy here


### PR DESCRIPTION
This extracts the parts of #1845 that seem applicable to all short commit messages (including `jj branch list`, which shouldn't list branches). See commit descriptions for motivations.

The result looks as follows. Empty commit:
![Screenshot 2023-07-29 10 30 11 PM](https://github.com/martinvonz/jj/assets/4123047/cb496f11-63dc-42f3-b3f4-fd9c676dce85)

Conflict resolution commit:
![Screenshot 2023-07-29 10 29 33 PM](https://github.com/martinvonz/jj/assets/4123047/0f818832-c7ae-4b97-bc2b-aff35cd71ed9)

WDYT?

If we go with this, we'd need to adjust the tutorial a bit as well as the screenshots in the README, though we might want to wait for #1845 and maybe until just before we release the next version.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
