### PR TITLE
docs: revert to using revset operator `:` instead of `::`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -196,7 +196,7 @@ To get shorter prefixes for certain revisions, set `revsets.short-prefixes`:
 
 ```toml
 # Prioritize the current branch
-revsets.short-prefixes = "(main..@)::"
+revsets.short-prefixes = "(main..@):"
 ```
 
 ### Relative timestamps
@@ -259,7 +259,7 @@ You can define aliases for commands, including their arguments. For example:
 ```toml
 # `jj l` shows commits on the working-copy commit's (anonymous) branch
 # compared to the `main` branch
-aliases.l = ["log", "-r", "(main..@):: | (main..@)-"]
+aliases.l = ["log", "-r", "(main..@): | (main..@)-"]
 ```
 
 ## Editor

--- a/docs/github.md
+++ b/docs/github.md
@@ -148,7 +148,7 @@ remote
 Log all remote branches, which you authored or committed to  
 `jj log -r 'remote_branches() & (committer(your@email.com) | author(your@email.com))'`  
 Log all descendants of the current working copy, which aren't on a remote   
-`jj log -r '::@ & ~remote_branches()'`
+`jj log -r ':@ & ~remote_branches()'`
 
 ## Merge conflicts
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -58,16 +58,16 @@ only symbols.
 * `~x`: Revisions that are not in `x`.
 * `x-`: Parents of `x`.
 * `x+`: Children of `x`.
-* `::x`: Ancestors of `x`, including the commits in `x` itself.
-* `x::`: Descendants of `x`, including the commits in `x` itself.
-* `x::y`: Descendants of `x` that are also ancestors of `y`. Equivalent
-   to `x:: & ::y`. This is what `git log` calls `--ancestry-path x..y`.
-* `:x`, `x:`, and `x:y`: Deprecated synonyms for `::x`, `x::`, and `x::y`. We
-  plan to delete them in jj 0.15+.
+* `:x`: Ancestors of `x`, including the commits in `x` itself.
+* `x:`: Descendants of `x`, including the commits in `x` itself.
+* `x:y`: Descendants of `x` that are also ancestors of `y`. Equivalent
+   to `x: & :y`. This is what `git log` calls `--ancestry-path x..y`.
+* `::x`, `x::`, and `x::y`: New versions of for `:x`, `x:`, and `x:y` to be
+  released in jj 0.9.0. We plan to delete the latter in jj 0.15+.
 * `x..y`: Ancestors of `y` that are not also ancestors of `x`. Equivalent to
-  `::y ~ ::x`. This is what `git log` calls `x..y` (i.e. the same as we call it).
+  `:y ~ :x`. This is what `git log` calls `x..y` (i.e. the same as we call it).
 * `..x`: Ancestors of `x`, including the commits in `x` itself. Equivalent to
-  `::x` and provided for consistency.
+  `:x` and provided for consistency.
 * `x..`: Revisions that are not ancestors of `x`.
 
 You can use parentheses to control evaluation order, such as `(x & y) | z` or
@@ -80,9 +80,9 @@ revsets (expressions) as arguments.
 
 * `parents(x)`: Same as `x-`.
 * `children(x)`: Same as `x+`.
-* `ancestors(x)`: Same as `::x`.
-* `descendants(x)`: Same as `x::`.
-* `connected(x)`: Same as `x::x`. Useful when `x` includes several commits.
+* `ancestors(x)`: Same as `:x`.
+* `descendants(x)`: Same as `x:`.
+* `connected(x)`: Same as `x:x`. Useful when `x` includes several commits.
 * `all()`: All visible commits in the repo.
 * `none()`: No commits. This function is rarely useful; it is provided for
   completeness.
@@ -171,7 +171,7 @@ jj log -r 'remote_branches(remote=origin)..'
 Show all ancestors of the working copy (almost like plain `git log`)
 
 ```
-jj log -r ::@
+jj log -r :@
 ```
 
 Show the initial commits in the repo (the ones Git calls "root commits"):
@@ -191,7 +191,7 @@ those commits:
 
 
 ```
-jj log -r '(remote_branches()..@)::'
+jj log -r '(remote_branches()..@):'
 ```
 
 Show commits authored by "martinvonz" and containing the word "reset" in the

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -159,7 +159,7 @@ called the "root commit". It's the root commit of every repo. The `root` symbol
 in the revset matches it.
 
 There are also operators for getting the parents (`foo-`), children (`foo+`),
-ancestors (`::foo`), descendants (`foo::`), DAG range (`foo::bar`, like
+ancestors (`:foo`), descendants (`foo:`), DAG range (`foo:bar`, like
 `git log --ancestry-path`), range (`foo..bar`, same as Git's). There are also a
 few more functions, such as `heads(<set>)`, which filters out revisions in the
 input set if they're ancestors of other revisions in the set.
@@ -345,7 +345,7 @@ $ jj new -m ABC; printf 'A\nB\nc\n' > file
 Working copy now at: 6f30cd1fb351 ABC
 $ jj new -m ABCD; printf 'A\nB\nC\nD\n' > file
 Working copy now at: a67491542e10 ABCD
-$ jj log -r master::@
+$ jj log -r master:@
 @  mrxqplykzpkw martinvonz@google.com 2023-02-12 19:38:21.000 -08:00 b98c607bf87f
 │  ABCD
 ◉  kwtuwqnmqyqp martinvonz@google.com 2023-02-12 19:38:12.000 -08:00 30aecc0871ea


### PR DESCRIPTION
Since our latest release doesn't support `::`, we shouldn't tell the user to use it.

This commit should be backed out we've released jj 0.9.0.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
