### PR TITLE
cli: add option to generate textual diff by external command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from a merge revision's parents. This undoes the changes that `jj diff -r`
   would show.
 
+* `jj diff`/`log` now supports `--tool <name>` option to generate diffs by
+  external program. For configuration, see [the documentation](docs/config.md).
+  [#1886](https://github.com/martinvonz/jj/issues/1886)
 
 ### Fixed bugs
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -141,6 +141,21 @@ ui.default-command = "log"
 ui.diff.format = "git"
 ```
 
+### Generating diffs by external command
+
+If `diff --tool <name>` argument is given, the external diff command will be
+called instead of the internal diff function. The command arguments can be
+specified as follows.
+
+```toml
+[merge-tools.<name>]
+# program = "<name>"  # Defaults to the name of the tool if not specified
+diff-args = ["--color=always", "$left", "$right"]
+```
+
+- `$left` and `$right` are replaced with the paths to the left and right
+  directories to diff respectively.
+
 ### Default revisions to log
 
 You can configure the revisions `jj log` without `-r` should show.

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -410,6 +410,10 @@ pub enum TreeStateError {
 }
 
 impl TreeState {
+    pub fn working_copy_path(&self) -> &Path {
+        &self.working_copy_path
+    }
+
     pub fn current_tree_id(&self) -> &TreeId {
         &self.tree_id
     }

--- a/src/cli_util.rs
+++ b/src/cli_util.rs
@@ -72,7 +72,7 @@ use crate::config::{
     new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
 };
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
-use crate::merge_tools::{ConflictResolveError, DiffEditError};
+use crate::merge_tools::{ConflictResolveError, DiffEditError, DiffGenerateError};
 use crate::template_parser::{TemplateAliasesMap, TemplateParseError};
 use crate::templater::Template;
 use crate::ui::{ColorChoice, Ui};
@@ -236,6 +236,12 @@ impl From<ResetError> for CommandError {
 impl From<DiffEditError> for CommandError {
     fn from(err: DiffEditError) -> Self {
         user_error(format!("Failed to edit diff: {err}"))
+    }
+}
+
+impl From<DiffGenerateError> for CommandError {
+    fn from(err: DiffGenerateError) -> Self {
+        user_error(format!("Failed to generate diff: {err}"))
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1445,6 +1445,7 @@ fn cmd_diff(ui: &mut Ui, command: &CommandHelper, args: &DiffArgs) -> Result<(),
         to_tree = commit.tree()
     }
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
+    let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
     ui.request_pager();
     diff_util::show_diff(
         ui.stdout_formatter().as_mut(),
@@ -1452,7 +1453,7 @@ fn cmd_diff(ui: &mut Ui, command: &CommandHelper, args: &DiffArgs) -> Result<(),
         &from_tree,
         &to_tree,
         matcher.as_ref(),
-        &diff_util::diff_formats_for(command.settings(), &args.format),
+        &diff_formats,
     )?;
     Ok(())
 }
@@ -1463,6 +1464,7 @@ fn cmd_show(ui: &mut Ui, command: &CommandHelper, args: &ShowArgs) -> Result<(),
     let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
     let template_string = command.settings().config().get_string("templates.show")?;
     let template = workspace_command.parse_commit_template(&template_string)?;
+    let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
@@ -1472,7 +1474,7 @@ fn cmd_show(ui: &mut Ui, command: &CommandHelper, args: &ShowArgs) -> Result<(),
         &workspace_command,
         &commit,
         &EverythingMatcher,
-        &diff_util::diff_formats_for(command.settings(), &args.format),
+        &diff_formats,
     )?;
     Ok(())
 }
@@ -1609,7 +1611,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
 
     let store = repo.store();
     let diff_formats =
-        diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch);
+        diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch)?;
 
     let template_string = match &args.template {
         Some(value) => value.to_string(),
@@ -1745,7 +1747,7 @@ fn cmd_obslog(ui: &mut Ui, command: &CommandHelper, args: &ObslogArgs) -> Result
     let wc_commit_id = workspace_command.get_wc_commit_id();
 
     let diff_formats =
-        diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch);
+        diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch)?;
 
     let template_string = match &args.template {
         Some(value) => value.to_string(),
@@ -1849,6 +1851,7 @@ fn cmd_interdiff(
 
     let from_tree = rebase_to_dest_parent(&workspace_command, &from, &to)?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
+    let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
     ui.request_pager();
     diff_util::show_diff(
         ui.stdout_formatter().as_mut(),
@@ -1856,7 +1859,7 @@ fn cmd_interdiff(
         &from_tree,
         &to.tree(),
         matcher.as_ref(),
-        &diff_util::diff_formats_for(command.settings(), &args.format),
+        &diff_formats,
     )
 }
 

--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -242,6 +242,12 @@
                     "program": {
                         "type": "string"
                     },
+                    "diff-args": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "edit-args": {
                         "type": "array",
                         "items": {

--- a/src/merge_tools.rs
+++ b/src/merge_tools.rs
@@ -47,7 +47,7 @@ pub enum ExternalToolError {
          must be defined (see docs for details)"
     )]
     MergeArgsNotConfigured { tool_name: String },
-    #[error("Error setting up temporary directory: {0:?}")]
+    #[error("Error setting up temporary directory: {0}")]
     SetUpDir(#[source] std::io::Error),
     // TODO: Remove the "(run with --verbose to see the exact invocation)"
     // from this and other errors. Print it as a hint but only if --verbose is *not* set.
@@ -67,7 +67,7 @@ pub enum ExternalToolError {
     ToolAborted {
         exit_status: std::process::ExitStatus,
     },
-    #[error("I/O error: {0:?}")]
+    #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }
 
@@ -75,9 +75,9 @@ pub enum ExternalToolError {
 pub enum DiffEditError {
     #[error(transparent)]
     ExternalTool(#[from] ExternalToolError),
-    #[error("Failed to write directories to diff: {0:?}")]
+    #[error("Failed to write directories to diff: {0}")]
     Checkout(#[from] CheckoutError),
-    #[error("Failed to snapshot changes: {0:?}")]
+    #[error("Failed to snapshot changes: {0}")]
     Snapshot(#[from] SnapshotError),
     #[error(transparent)]
     Config(#[from] config::ConfigError),
@@ -105,7 +105,7 @@ pub enum ConflictResolveError {
          to see the exact invocation)."
     )]
     EmptyOrUnchanged,
-    #[error("Backend error: {0:?}")]
+    #[error("Backend error: {0}")]
     Backend(#[from] jj_lib::backend::BackendError),
 }
 

--- a/testing/fake-diff-editor.rs
+++ b/testing/fake-diff-editor.rs
@@ -80,6 +80,19 @@ fn main() {
                     exit(1)
                 }
             }
+            ["print", message] => {
+                println!("{message}");
+            }
+            ["print-files-before"] => {
+                for base_name in files_recursively(&args.before).iter().sorted() {
+                    println!("{base_name}");
+                }
+            }
+            ["print-files-after"] => {
+                for base_name in files_recursively(&args.after).iter().sorted() {
+                    println!("{base_name}");
+                }
+            }
             ["rm", file] => {
                 std::fs::remove_file(args.after.join(file)).unwrap();
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -255,7 +255,12 @@ impl TestEnvironment {
         // Simplified TOML escaping, hoping that there are no '"' or control characters
         // in it
         let escaped_diff_editor_path = diff_editor_path.to_str().unwrap().replace('\\', r"\\");
-        self.add_config(&format!(r#"ui.diff-editor = "{escaped_diff_editor_path}""#));
+        self.add_config(&format!(
+            r###"
+            ui.diff-editor = "fake-diff-editor"
+            merge-tools.fake-diff-editor.program = "{escaped_diff_editor_path}"
+            "###
+        ));
         let edit_script = self.env_root().join("diff_edit_script");
         std::fs::write(&edit_script, "").unwrap();
         self.add_env_var("DIFF_EDIT_SCRIPT", edit_script.to_str().unwrap());


### PR DESCRIPTION
#1886

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
