### PR TITLE
cli: add short form `-c` for `jj git push --change`

### DIFF
--- a/src/commands/git.rs
+++ b/src/commands/git.rs
@@ -147,7 +147,7 @@ pub struct GitPushArgs {
     revisions: Vec<RevisionArg>,
     /// Push this commit by creating a branch based on its change ID (can be
     /// repeated)
-    #[arg(long)]
+    #[arg(long, short)]
     change: Vec<RevisionArg>,
     /// Only display what will change on the remote
     #[arg(long)]


### PR DESCRIPTION
I use `--change` a lot and somehow still didn't think to add a short form until @ilyagr (?) mentioned it somewhere recently.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
