### PR TITLE
commands: Add `run`.

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -117,6 +117,9 @@ enum Commands {
     Rebase(RebaseArgs),
     Resolve(ResolveArgs),
     Restore(RestoreArgs),
+    #[command(hide = true)]
+    // TODO: Flesh out.
+    Run(RunArgs),
     Show(ShowArgs),
     #[command(subcommand)]
     Sparse(SparseArgs),
@@ -724,6 +727,29 @@ struct RestoreArgs {
     /// the user might not even realize something went wrong.
     #[arg(long, short, hide = true)]
     revision: Option<RevisionArg>,
+}
+
+/// Run a command across a set of revisions.
+///
+///
+/// All recorded state will be persisted in the `.jj` directory, so occasionally
+/// a `jj run --clean` is needed to clean up disk space.
+///
+/// # Example
+///
+/// # Run pre-commit on your local work
+/// $ jj run 'pre-commit.py .github/pre-commit.yaml' -r (main..@) -j 4
+///
+/// This allows pre-commit integration and other funny stuff.
+#[derive(clap::Args, Clone, Debug)]
+#[command(verbatim_doc_comment)]
+struct RunArgs {
+    /// The command to run across all selected revisions.
+    #[arg(long, short, alias = "x")]
+    command: String,
+    /// The revisions to change.
+    #[arg(long, short, default_value = "@")]
+    revisions: Vec<RevisionArg>,
 }
 
 /// Touch up the content changes in a revision with a diff editor
@@ -3143,6 +3169,11 @@ fn cmd_merge(ui: &mut Ui, command: &CommandHelper, args: &NewArgs) -> Result<(),
     cmd_new(ui, command, args)
 }
 
+// TODO: Move to run.rs
+fn cmd_run(_ui: &mut Ui, _command: &CommandHelper, _args: &RunArgs) -> Result<(), CommandError> {
+    Err(user_error("This is a stub, do not use"))
+}
+
 #[instrument(skip_all)]
 fn cmd_rebase(ui: &mut Ui, command: &CommandHelper, args: &RebaseArgs) -> Result<(), CommandError> {
     if args.allow_large_revsets {
@@ -3732,6 +3763,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Commands::Squash(sub_args) => cmd_squash(ui, command_helper, sub_args),
         Commands::Unsquash(sub_args) => cmd_unsquash(ui, command_helper, sub_args),
         Commands::Restore(sub_args) => cmd_restore(ui, command_helper, sub_args),
+        Commands::Run(sub_args) => cmd_run(ui, command_helper, sub_args),
         Commands::Diffedit(sub_args) => cmd_diffedit(ui, command_helper, sub_args),
         Commands::Split(sub_args) => cmd_split(ui, command_helper, sub_args),
         Commands::Merge(sub_args) => cmd_merge(ui, command_helper, sub_args),


### PR DESCRIPTION
This adds the `run` command as described in the doc. The command is hidden for now, to allow in-tree development. 

The next steps are: 

1. Move it to `run.rs`
2. Find a good backend trait
3. Implement the workers

Initial progress on #1869 and #405

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
