### PR TITLE
Update init_with_factories to initialize a workspace with a workspace_id other than "default"

### DIFF
--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -167,6 +167,7 @@ impl Workspace {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn init_with_factories(
         user_settings: &UserSettings,
         workspace_root: &Path,
@@ -175,6 +176,7 @@ impl Workspace {
         op_heads_store_factory: impl FnOnce(&Path) -> Box<dyn OpHeadsStore>,
         index_store_factory: impl FnOnce(&Path) -> Box<dyn IndexStore>,
         submodule_store_factory: impl FnOnce(&Path) -> Box<dyn SubmoduleStore>,
+        workspace_id: WorkspaceId,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let jj_dir = create_jj_dir(workspace_root)?;
         (|| {
@@ -193,13 +195,8 @@ impl Workspace {
                 RepoInitError::Backend(err) => WorkspaceInitError::Backend(err),
                 RepoInitError::Path(err) => WorkspaceInitError::Path(err),
             })?;
-            let (working_copy, repo) = init_working_copy(
-                user_settings,
-                &repo,
-                workspace_root,
-                &jj_dir,
-                WorkspaceId::default(),
-            )?;
+            let (working_copy, repo) =
+                init_working_copy(user_settings, &repo, workspace_root, &jj_dir, workspace_id)?;
             let repo_loader = repo.loader();
             let workspace = Workspace::new(workspace_root, working_copy, repo_loader)?;
             Ok((workspace, repo))
@@ -223,6 +220,7 @@ impl Workspace {
             ReadonlyRepo::default_op_heads_store_factory(),
             ReadonlyRepo::default_index_store_factory(),
             ReadonlyRepo::default_submodule_store_factory(),
+            WorkspaceId::default(),
         )
     }
 


### PR DESCRIPTION
This change allows a custom jj binary to initialize a workspace with a workspace_id other than "default".

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
