### PR TITLE
backout of commit e212e10deee96878236c12a565d99abcc18d2fcb

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             in
             pkgs.lib.all (re: builtins.match re relPath == null) regexes;
         };
-
+ 
       rust-version = pkgs.rust-bin.stable."1.71.0".default;
 
       ourRustPlatform = pkgs.makeRustPlatform {
@@ -42,10 +42,6 @@
         cargo = rust-version;
       };
 
-      # NOTE (aseipp): on Linux, go ahead and use mold by default to improve
-      # link times a bit; mostly useful for debug build speed, but will help
-      # over time if we ever get more dependencies, too
-      useMoldLinker = pkgs.stdenv.isLinux;
     in
     {
       packages = {
@@ -132,16 +128,12 @@
           cargo-insta
           cargo-nextest
           cargo-watch
-
-          # Extra, more specific tools follow
-        ] ++ pkgs.lib.optionals useMoldLinker [ mold ];
+        ];
 
         shellHook = ''
           export RUST_BACKTRACE=1
           export ZSTD_SYS_USE_PKG_CONFIG=1
           export LIBSSH2_SYS_USE_PKG_CONFIG=1
-        '' + pkgs.lib.optionalString useMoldLinker ''
-          export RUSTFLAGS="-C link-arg=-fuse-ld=mold $RUSTFLAGS"
         '';
       };
     }));


### PR DESCRIPTION
Summary: mold apparently breaks linking to several external libraries, meaning that the `jj` binary is useless as it can't load e.g. `libgit2.so` -- but somehow I didn't catch it. Backout until a solution can be pinpointed. We can at least give off a sigh of relief knowing that our link times aren't too bad yet.

Change-Id: I6e1851c339ddc72d32c201a44a7ddc49

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
