### PR TITLE
cargo: unify crate dependencies and metadata via workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "gen-protos"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "prost-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,83 @@ cargo-features = []
 resolver = "2"
 members = ["cli", "lib", "lib/testutils", "lib/gen-protos"]
 
+[workspace.dependencies]
+anyhow = "1.0.72"
+assert_cmd = "2.0.8"
+assert_matches = "1.5.0"
+backoff = "0.4.0"
+blake2 = "0.10.6"
+byteorder = "1.4.3"
+bytes = "1.4.0"
+cargo_metadata = "0.17.0"
+clap = { version = "4.3.19", features = ["derive", "deprecated"] }
+clap_complete = "4.3.2"
+clap_mangen = "0.2.10"
+chrono = { version = "0.4.26", default-features = false, features = [
+    "std",
+    "clock",
+] }
+config = { version = "0.13.2", default-features = false, features = ["toml"] }
+criterion = "0.5.1"
+crossterm = { version = "0.26", default-features = false }
+digest = "0.10.7"
+dirs = "5.0.1"
+esl01-renderdag = "0.3.0"
+glob = "0.3.1"
+git2 = "0.17.2"
+hex = "0.4.3"
+itertools = "0.11.0"
+indexmap = "2.0.0"
+libc = { version = "0.2.147" }
+insta = { version = "1.31.0", features = ["filters"] }
+maplit = "1.0.2"
+num_cpus = "1.16.0"
+once_cell = "1.18.0"
+pest = "2.7.2"
+pest_derive = "2.7.2"
+prost = "0.11.9"
+prost-build = "0.11.9"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+rayon = "1.7.0"
+regex = "1.9.1"
+rpassword = "7.2.0"
+rustix = { version = "0.38.6", features = ["fs"] }
+smallvec = { version = "1.11.0", features = [
+    "const_generics",
+    "const_new",
+    "union",
+] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.104"
+slab = "0.4.8"
+strsim = "0.10.0"
+tempfile = "3.7.0"
+test-case = "3.1.0"
+textwrap = "0.16.0"
+thiserror = "1.0.44"
+timeago = { version = "0.4.1", default-features = false }
+toml_edit = { version = "0.19.14", features = ["serde"] }
+tracing = "0.1.37"
+tracing-chrome = "0.7.1"
+tracing-subscriber = { version = "0.3.17", default-features = false, features = [
+    "std",
+    "ansi",
+    "env-filter",
+    "fmt",
+] }
+tokio = { version = "1.29.1" }
+watchman_client = { version = "0.8.0" }
+whoami = "1.4.1"
+version_check = "0.9.4"
+zstd = "0.12.4"
+
+# put all inter-workspace libraries, i.e. those that use 'path = ...' here in
+# their own (alphabetically sorted) block
+
+jj-lib = { path = "lib" }
+testutils = { path = "lib/testutils" }
+
 [profile.release]
 strip = "debuginfo"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,18 @@ cargo-features = []
 resolver = "2"
 members = ["cli", "lib", "lib/testutils", "lib/gen-protos"]
 
+[workspace.package]
+version = "0.8.0"
+license = "Apache-2.0"
+rust-version = "1.71"                                 # NOTE: remember to update CI, contributing.md, changelog.md, and flake.nix
+edition = "2021"
+readme = "README.md"
+homepage = "https://github.com/martinvonz/jj"
+repository = "https://github.com/martinvonz/jj"
+documentation = "https://github.com/martinvonz/jj"
+categories = ["version-control", "development-tools"]
+keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
+
 [workspace.dependencies]
 anyhow = "1.0.72"
 assert_cmd = "2.0.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,18 +1,16 @@
 [package]
 name = "jj-cli"
-version = "0.8.0"
-authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
-edition = "2021"
-rust-version = "1.71"                                        # Remember to update CI, and contributing.md
-license = "Apache-2.0"
-description = "Jujutsu (an experimental VCS)"
-homepage = "https://github.com/martinvonz/jj"
-repository = "https://github.com/martinvonz/jj"
-documentation = "https://docs.rs/jj-cli"
-readme = "README.md"
-keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
-categories = ["command-line-utilities", "development-tools"]
+description = "Jujutsu - an experimental version control system"
 default-run = "jj"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+keywords.workspace = true
 
 [[bin]]
 name = "jj"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "jj-cli"
 version = "0.8.0"
 authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
 edition = "2021"
-rust-version = "1.71"  # Remember to update CI, and contributing.md
+rust-version = "1.71"                                        # Remember to update CI, and contributing.md
 license = "Apache-2.0"
 description = "Jujutsu (an experimental VCS)"
 homepage = "https://github.com/martinvonz/jj"
@@ -27,51 +27,51 @@ name = "fake-diff-editor"
 path = "testing/fake-diff-editor.rs"
 
 [build-dependencies]
-cargo_metadata = "0.17.0"
+cargo_metadata.workspace = true
 
 [dependencies]
-chrono = { version = "0.4.26", default-features = false, features = ["std", "clock"] }
-clap = { version = "4.3.19", features = ["derive", "deprecated"] }
-clap_complete = "4.3.2"
-clap_mangen = "0.2.10"
-config = { version = "0.13.3", default-features = false, features = ["toml"] }
-criterion = {version = "0.5.1", optional = true }
-crossterm = { version = "0.26", default-features = false }
-dirs = "5.0.1"
-esl01-renderdag = "0.3.0"
-git2 = "0.17.2"
-glob = "0.3.1"
-hex = "0.4.3"
-indexmap = "2.0.0"
-itertools = "0.11.0"
-jj-lib = { version = "=0.8.0", path = "../lib", default-features = false }
-maplit = "1.0.2"
-once_cell = "1.18.0"
-pest = "2.7.2"
-pest_derive = "2.7.2"
-regex = "1.9.1"
-rpassword = "7.2.0"
-serde = { version = "1.0", features = ["derive"] }
-slab = "0.4.8"
-tempfile = "3.7.0"
-textwrap = "0.16.0"
-thiserror = "1.0.44"
-timeago = { version = "0.4.1", default-features = false }
-toml_edit = { version = "0.19.14", features = ["serde"] }
-tracing = "0.1.37"
-tracing-chrome = "0.7.1"
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["std", "ansi", "env-filter", "fmt"] }
+chrono.workspace = true
+clap.workspace = true
+clap_complete.workspace = true
+clap_mangen.workspace = true
+config.workspace = true
+criterion = { workspace = true, optional = true }
+crossterm.workspace = true
+dirs.workspace = true
+esl01-renderdag.workspace = true
+git2.workspace = true
+glob.workspace = true
+hex.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+jj-lib.workspace = true
+maplit.workspace = true
+once_cell.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+regex.workspace = true
+rpassword.workspace = true
+serde.workspace = true
+slab.workspace = true
+tempfile.workspace = true
+textwrap.workspace = true
+thiserror.workspace = true
+timeago.workspace = true
+toml_edit.workspace = true
+tracing.workspace = true
+tracing-chrome.workspace = true
+tracing-subscriber.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.147" }
+libc.workspace = true
 
 [dev-dependencies]
-anyhow = "1.0.72"
-assert_cmd = "2.0.8"
-assert_matches = "1.5.0"
-insta = { version = "1.31.0", features = ["filters"] }
-test-case = "3.1.0"
-testutils = { path = "../lib/testutils" }
+anyhow.workspace = true
+assert_cmd.workspace = true
+assert_matches.workspace = true
+insta.workspace = true
+test-case.workspace = true
+testutils.workspace = true
 
 [features]
 default = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,57 +18,50 @@ name = "diff_bench"
 harness = false
 
 [build-dependencies]
-version_check = "0.9.4"
+version_check.workspace = true
 
 [dependencies]
-backoff = "0.4.0"
-blake2 = "0.10.6"
-byteorder = "1.4.3"
-bytes = "1.4.0"
-chrono = { version = "0.4.26", default-features = false, features = [
-    "std",
-    "clock",
-] }
-config = { version = "0.13.3", default-features = false, features = ["toml"] }
-digest = "0.10.7"
-git2 = "0.17.2"
-hex = "0.4.3"
-itertools = "0.11.0"
-maplit = "1.0.2"
-once_cell = "1.18.0"
-pest = "2.7.2"
-pest_derive = "2.7.2"
-prost = "0.11.9"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-rayon = "1.7.0"
-regex = "1.9.1"
-serde_json = "1.0.104"
-smallvec = { version = "1.11.0", features = [
-    "const_generics",
-    "const_new",
-    "union",
-] }
-strsim = "0.10.0"
-tempfile = "3.7.0"
-thiserror = "1.0.44"
-tokio = { version = "1.29.1", optional = true }
-tracing = "0.1.37"
-watchman_client = { version = "0.8.0", optional = true }
-whoami = "1.4.1"
-zstd = "0.12.4"
+backoff.workspace = true
+blake2.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+chrono.workspace = true
+config.workspace = true
+digest.workspace = true
+git2.workspace = true
+hex.workspace = true
+itertools.workspace = true
+maplit.workspace = true
+once_cell.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+prost.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+rayon.workspace = true
+regex.workspace = true
+serde_json.workspace = true
+smallvec.workspace = true
+strsim.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, optional = true }
+tracing.workspace = true
+watchman_client = { workspace = true, optional = true }
+whoami.workspace = true
+zstd.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.38.6", features = ["fs"] }
+rustix.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-criterion = "0.5.1"
-esl01-renderdag = "0.3.0"
-insta = "1.31.0"
-num_cpus = "1.16.0"
-test-case = "3.1.0"
-testutils = { path = "testutils" }
+assert_matches.workspace = true
+criterion.workspace = true
+esl01-renderdag.workspace = true
+insta.workspace = true
+num_cpus.workspace = true
+test-case.workspace = true
+testutils.workspace = true
 
 [features]
 default = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "jj-lib"
-version = "0.8.0"
-authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
-edition = "2021"
-rust-version = "1.71"
-license = "Apache-2.0"
-description = "Library for Jujutsu (an experimental VCS)"
-homepage = "https://github.com/martinvonz/jj"
-repository = "https://github.com/martinvonz/jj"
-documentation = "https://docs.rs/jj-lib"
-readme = "../README.md"
+description = "Library for Jujutsu - an experimental version control system"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme.workspace = true
 
 [[bench]]
 name = "diff_bench"

--- a/lib/gen-protos/Cargo.toml
+++ b/lib/gen-protos/Cargo.toml
@@ -6,4 +6,4 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-prost-build = "0.11.9"
+prost-build.workspace = true

--- a/lib/gen-protos/Cargo.toml
+++ b/lib/gen-protos/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "gen-protos"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
+description = "Generate Protocol Buffers definitions for the jj-lib crate"
 publish = false
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 prost-build.workspace = true

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "testutils"
-version = "0.8.0"
-authors = ["Martin von Zweigbergk <martinvonz@google.com>"]
-edition = "2021"
-rust-version = "1.61"
-license = "Apache-2.0"
 description = "Integration test utils for the jj-lib crate"
-homepage = "https://github.com/martinvonz/jj"
-repository = "https://github.com/martinvonz/jj"
-documentation = "https://docs.rs/jj-lib"
-readme = "../..//README.md"
 publish = false
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -15,9 +15,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-config = { version = "0.13.2", default-features = false, features = ["toml"] }
-git2 = "0.17.2"
-itertools = "0.11.0"
-jj-lib = { path = ".." }
-rand = "0.8.5"
-tempfile = "3.7.0"
+config.workspace = true
+git2.workspace = true
+itertools.workspace = true
+jj-lib.workspace = true
+rand.workspace = true
+tempfile.workspace = true


### PR DESCRIPTION
This unifies crate dependencies between `jj-lib` and `jj-cli` under the top level `Cargo.toml` file, and transitions those crates to use `{ workspace = true }` instead to specify versions. All of the versions between the two crates were the same, so this just makes the whole thing less error prone.

The net effect here is that deps should just be added to the top level Cargo file, and using it in a package just specifies `workspace = true` and everything should work out. Note that the top-level Cargo file doesn't support `optional = true`; it only lists crate versions, whether or not a crate dependency is optional must still be specified in that crates' Cargo.toml (not the workspace version.)

As a nice side bonus, we can also now aggregate a lot of the metadata itself inside the top level `Cargo.toml`, so we no longer need to re-specify the license, README, authors info etc between crates. This is a lot nicer and less error prone. We just leave the `name` and `description` fields for each crate on their own.

- Note: there is a `Cargo.lock` change, but it is actually a no-op; I made `gen-protos` inherit the `version` field from the workspace just out of consistency, so the lockfile got its `gen-protos` entry changed too. Totally benign.
- Note: I also added `The Jujutsu Developers` to the authors field, since we seem to be getting more people writing patches now. :)
- Note: `cargo add` does not work to add things to the top-level `workspace.dependencies`, but you can use `cargo add crate -p jj-cli` or whatever to add it to your chosen crate (or update the lockfile for a specific dep) and then modify it manually. Minor nit.
- Dependabot seems to work fine, from what I've seen elsewhere in other repos using `workspace.dependencies`.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
