### PR TITLE
merge_tools: make dirs readonly for external difftool

### DIFF
--- a/cli/src/merge_tools.rs
+++ b/cli/src/merge_tools.rs
@@ -438,6 +438,10 @@ pub fn generate_diff(
 ) -> Result<(), DiffGenerateError> {
     let store = left_tree.store();
     let diff_wc = check_out_trees(store, left_tree, right_tree, matcher)?;
+    set_readonly_recursively(diff_wc.left_working_copy_path())
+        .map_err(ExternalToolError::SetUpDir)?;
+    set_readonly_recursively(diff_wc.right_working_copy_path())
+        .map_err(ExternalToolError::SetUpDir)?;
     // TODO: Add support for tools without directory diff functionality?
     // TODO: Somehow propagate --color to the external command?
     let patterns = diff_wc.to_command_variables();


### PR DESCRIPTION
As far as I understand, the difftool is supposed to be readonly, so let's encourage people to no edit the files being diffed.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
