### PR TITLE
external diff-editors: allow 3-pane diff, set up `meld-3`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   external program. For configuration, see [the documentation](docs/config.md).
   [#1886](https://github.com/martinvonz/jj/issues/1886)
 
+* A new experimental diff editor `meld-3` is introduced that sets up Meld to
+  allow you to see both sides of the original diff while editing. This can be
+  used with `jj split`, `jj move -i`, etc.
+
 * `jj log`/`obslog`/`op log` now supports `--limit N` option to show the first
   `N` entries.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1485,16 +1485,7 @@ impl WorkspaceCommandTransaction<'_> {
         matcher: &dyn Matcher,
     ) -> Result<TreeId, CommandError> {
         if interactive {
-            let base_ignores = self.helper.base_ignores();
-            let settings = &self.helper.settings;
-            Ok(crate::merge_tools::edit_diff(
-                ui,
-                left_tree,
-                right_tree,
-                instructions,
-                base_ignores,
-                settings,
-            )?)
+            self.edit_diff(ui, left_tree, right_tree, instructions)
         } else if matcher.visit(&RepoPath::root()) == Visit::AllRecursively {
             // Optimization for a common case
             Ok(right_tree.id().clone())

--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -7,6 +7,10 @@ merge-args = ["$base", "$left", "$right", "-o", "$output", "--auto"]
 edit-args = ["$left", "$right"]
 merge-args = ["$left", "$base", "$right", "-o", "$output", "--auto-merge"]
 
+[merge-tools.meld-3]
+program="meld"
+edit-args = ["$left", "$output", "$right", "-o", "$output"]
+
 [merge-tools.vimdiff]
 program = "vim"
 # `-d` enables diff mode. `-f` makes vim run in foreground even if it starts a GUI.

--- a/cli/testing/fake-diff-editor.rs
+++ b/cli/testing/fake-diff-editor.rs
@@ -28,6 +28,10 @@ struct Args {
 
     /// Path to the "after" directory
     after: PathBuf,
+
+    /// Ignored argument
+    #[arg(long)]
+    _ignore: Vec<String>,
 }
 
 fn files_recursively(dir: &Path) -> HashSet<String> {

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::TestEnvironment;
+use crate::common::{escaped_fake_diff_editor_path, TestEnvironment};
 
 pub mod common;
 
@@ -171,6 +171,122 @@ fn test_diffedit_new_file() {
     R file1
     A file2
     "###);
+}
+
+#[test]
+fn test_diffedit_3pane() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "a\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file2"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file3"), "a\n").unwrap();
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::remove_file(repo_path.join("file1")).unwrap();
+    std::fs::write(repo_path.join("file2"), "b\n").unwrap();
+
+    // 2 configs for a 3-pane setup. In the first, "$right" is passed to what the
+    // fake diff editor considers the "after" state.
+    let config_with_right_as_after = format!(
+        r#"ui.diff-editor=["{}", "$left", "$right", "--ignore=$output"]"#,
+        escaped_fake_diff_editor_path()
+    );
+    let config_with_output_as_after = format!(
+        r#"ui.diff-editor=["{}", "$left", "$output", "--ignore=$right"]"#,
+        escaped_fake_diff_editor_path()
+    );
+    let edit_script = test_env.env_root().join("diff_edit_script");
+    std::fs::write(&edit_script, "").unwrap();
+    test_env.add_env_var("DIFF_EDIT_SCRIPT", edit_script.to_str().unwrap());
+
+    // Nothing happens if we make no changes
+    std::fs::write(
+        &edit_script,
+        "files-before file1 file2\0files-after JJ-INSTRUCTIONS file2",
+    )
+    .unwrap();
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["diffedit", "--config-toml", &config_with_output_as_after],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
+    insta::assert_snapshot!(stdout, @r###"
+    R file1
+    M file2
+    "###);
+    // Nothing happens if we make no changes, `config_with_right_as_after` version
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["diffedit", "--config-toml", &config_with_right_as_after],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
+    insta::assert_snapshot!(stdout, @r###"
+    R file1
+    M file2
+    "###);
+
+    // Can edit changes to individual files
+    std::fs::write(&edit_script, "reset file2").unwrap();
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["diffedit", "--config-toml", &config_with_output_as_after],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Created kkmpptxz 1930da4a (no description set)
+    Working copy now at: kkmpptxz 1930da4a (no description set)
+    Parent commit      : rlvkpnrz 613028a4 (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
+    insta::assert_snapshot!(stdout, @r###"
+    R file1
+    "###);
+
+    // Can write something new to `file1`
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    std::fs::write(&edit_script, "write file1\nnew content").unwrap();
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["diffedit", "--config-toml", &config_with_output_as_after],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Created kkmpptxz ff2907b6 (no description set)
+    Working copy now at: kkmpptxz ff2907b6 (no description set)
+    Parent commit      : rlvkpnrz 613028a4 (no description set)
+    Added 1 files, modified 0 files, removed 0 files
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
+    insta::assert_snapshot!(stdout, @r###"
+    M file1
+    M file2
+    "###);
+
+    // But nothing happens if we modify the right side
+    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    std::fs::write(&edit_script, "write file1\nnew content").unwrap();
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &["diffedit", "--config-toml", &config_with_right_as_after],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
+    insta::assert_snapshot!(stdout, @r###"
+    R file1
+    M file2
+    "###);
+
+    // TODO: test with edit_script of "reset file2". This fails on right side
+    // since the file is readonly.
 }
 
 #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -374,6 +374,20 @@ merge-tools.kdiff3.edit-args = [
     "--merge", "--cs", "CreateBakFiles=0", "$left", "$right"]
 ```
 
+### Experimental 3-pane diff editing
+
+The special `"meld-3"` diff editor sets up Meld to show 3 panes: the sides of
+the diff on the left and right, and an editing pane in the middle. This allow
+you to see both sides of the original diff while editing. If you use
+`ui.diff-editor = "meld-3"`, note that you can still get the 2-pane Meld view
+using `jj diff --tool meld`.
+
+To configure other diff editors, you can include `$output` together with `$left`
+and `$right` in `merge-tools.TOOL.edit-args`. `jj` will replace `$output` with
+the directory where the diff editor will be expected to put the result of the
+user's edits. Initially, the contents of `$output` will be the same as the
+contents of `$right`.
+
 ### Setting up `scm-diff-editor`
 
 `scm-diff-editor` is a terminal-based diff editor that is part of


### PR DESCRIPTION
Implementation for 3-pane diff as discussed in https://github.com/martinvonz/jj/discussions/1905#discussioncomment-6589673. 

To test it out, patch this PR and try

    cargo run -- --config-toml 'ui.diff-editor="meld-3"' diffedit -r @-

If you'd like to try programs other than `meld`, just use a merge tool config that has `$output` in its `edit-args`.

I am also thinking about trying out a conflict resolution interface based on this.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
