### PR TITLE
cli: don't call a safe function 'unsafe'

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -845,7 +845,7 @@ impl WorkspaceCommandHelper {
         self.workspace.working_copy()
     }
 
-    pub fn unsafe_start_working_copy_mutation(
+    pub fn unchecked_start_working_copy_mutation(
         &mut self,
     ) -> Result<(LockedWorkingCopy, Commit), CommandError> {
         self.check_working_copy_writable()?;
@@ -863,7 +863,7 @@ impl WorkspaceCommandHelper {
     pub fn start_working_copy_mutation(
         &mut self,
     ) -> Result<(LockedWorkingCopy, Commit), CommandError> {
-        let (locked_working_copy, wc_commit) = self.unsafe_start_working_copy_mutation()?;
+        let (locked_working_copy, wc_commit) = self.unchecked_start_working_copy_mutation()?;
         if wc_commit.tree_id() != locked_working_copy.old_tree_id() {
             return Err(user_error("Concurrent working copy operation. Try again."));
         }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3616,7 +3616,7 @@ fn cmd_workspace_update_stale(
 
     let repo = workspace_command.repo().clone();
     let (mut locked_wc, desired_wc_commit) =
-        workspace_command.unsafe_start_working_copy_mutation()?;
+        workspace_command.unchecked_start_working_copy_mutation()?;
     match check_stale_working_copy(&locked_wc, &desired_wc_commit, &repo) {
         Ok(_) => {
             locked_wc.discard();


### PR DESCRIPTION
I don't have context for what was "unsafe" about this function to begin with, so thoughts on better names welcome.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
