### PR TITLE
RFC: implement a hacky `git submodule clone`

### DIFF
--- a/lib/src/default_submodule_store.rs
+++ b/lib/src/default_submodule_store.rs
@@ -47,4 +47,13 @@ impl SubmoduleStore for DefaultSubmoduleStore {
     fn name(&self) -> &str {
         DefaultSubmoduleStore::name()
     }
+
+    fn get_submodule_path(&self, submodule: &str) -> PathBuf {
+        PathBuf::new()
+            .join(self.path.clone())
+            // FIXME hackily sanitze "/" in the path. It's likely that we'll
+            // need to do reverse lookups (e.g. from 'sanitized' to the 'real'
+            // name), so this probably won't do in the long run.
+            .join(submodule.to_string().replace("/", "__"))
+    }
 }

--- a/lib/src/submodule_store.rs
+++ b/lib/src/submodule_store.rs
@@ -15,7 +15,17 @@
 #![allow(missing_docs)]
 
 use std::fmt::Debug;
+use std::path::PathBuf;
 
 pub trait SubmoduleStore: Send + Sync + Debug {
     fn name(&self) -> &str;
+    // FIXME This is a quick hack to experiment with git clone. Now we just pass
+    // the path to the high level git clone machinery, but in the long run,
+    // we're more likely to move git clone machinery into the SubmoduleStore
+    // implementation and replace this function with something like
+    // clone_submodule().
+    //
+    // Given the name of a submodule, return the path that it should be cloned
+    // to (for consumption by the `jj git clone` machinery).
+    fn get_submodule_path(&self, submodule: &str) -> PathBuf;
 }


### PR DESCRIPTION
Implement an RFC-quality command to clone a given submodule. I'm publishing this a) to share what sorts of hackery I've been playing around with b) to make this publicly cloneable because I'm going to lose access to my work laptop soon.

Things marked with FIXME are shortcuts I took in the name of speed, but I think they can and should be fixed before merging. You can largely ignore these.

Things marked with TODO are outstanding questions that I need help on, namely:

- During the clone, I use a transaction to get a handle to a MutableRepo, but AFAICT the point of the transaction is to be able to group together ref updates in the operation log, and we aren't updating any refs. Making `jj git submodule clone` undoable is probably going to be very difficult and I don't think we need to aim for that any time soon, so does it make to use a transaction here?

- I initialize the submodule repo with Workspace::init_internal_git(), which is the most convenient thing I could find, but has the unwanted side effect of creating a workspace (submodules shouldn't need workspaces). Is there a way to init a repo without a workspace? If not, should we invest time creating one? Might this break implicit assumptions that there is always a workspace?

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
