### PR TITLE
cli: add "--limit N" option to log-like commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   external program. For configuration, see [the documentation](docs/config.md).
   [#1886](https://github.com/martinvonz/jj/issues/1886)
 
+* `jj log`/`obslog`/`op log` now supports `--limit N` option to show the first
+  `N` entries.
+
 ### Fixed bugs
 
 * SSH authentication could hang when ssh-agent couldn't be reached

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -26,6 +26,9 @@ pub enum OperationCommands {
 /// Show the operation log
 #[derive(clap::Args, Clone, Debug)]
 pub struct OperationLogArgs {
+    /// Limit number of operations to show
+    #[arg(long, short)]
+    limit: Option<usize>,
     /// Render each operation using the given template
     ///
     /// For the syntax, see https://github.com/martinvonz/jj/blob/main/docs/templates.md
@@ -119,7 +122,7 @@ fn cmd_op_log(
     let formatter = formatter.as_mut();
     let mut graph = get_graphlog(command.settings(), formatter.raw());
     let default_node_symbol = graph.default_node_symbol().to_owned();
-    for op in operation::walk_ancestors(&head_op) {
+    for op in operation::walk_ancestors(&head_op).take(args.limit.unwrap_or(usize::MAX)) {
         let mut edges = vec![];
         for parent in op.parents() {
             edges.push(Edge::direct(parent.id().clone()));

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -80,6 +80,15 @@ fn test_obslog_with_or_without_diff() {
        (empty) my description
     "###);
 
+    // Test `--limit`
+    let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--limit=2"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
+    │  my description
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 af536e5a conflict
+    │  my description
+    "###);
+
     // Test `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -119,6 +119,18 @@ fn test_op_log() {
 }
 
 #[test]
+fn test_op_log_limit() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription", "--limit=1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  add workspace 'default'
+    "###);
+}
+
+#[test]
 fn test_op_log_template() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
Copied from Mercurial. This isn't a revset predicate since our revset is conceptually unordered.


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
