### PR TITLE
configs: add the ability to disable paging altogether via `ui.paginate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj log`/`obslog`/`op log` now supports `--limit N` option to show the first
   `N` entries.
 
+* Added the `ui.paginate` option to enable/disable pager usage in commands
+
 ### Fixed bugs
 
 * SSH authentication could hang when ssh-agent couldn't be reached

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2488,7 +2488,7 @@ fn handle_early_args(
         args.config_toml.push(format!(r#"ui.color="{choice}""#));
     }
     if args.no_pager.unwrap_or_default() {
-        ui.set_pagination(crate::ui::PaginationChoice::No);
+        ui.set_pagination(crate::ui::PaginationChoice::Never);
     }
     if !args.config_toml.is_empty() {
         layered_configs.parse_config_args(&args.config_toml)?;

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -55,6 +55,15 @@
                     ],
                     "default": "auto"
                 },
+                "paginate": {
+                    "type": "string",
+                    "description": "Whether or not to use a pager",
+                    "enum": [
+                        "never",
+                        "auto"
+                    ],
+                     "default": "auto"
+                },
                 "pager": {
                     "type": "string",
                     "description": "Pager to use for displaying command output",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -5,5 +5,6 @@
 # Placeholder: added by user
 
 [ui]
+paginate = "auto"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false

--- a/docs/config.md
+++ b/docs/config.md
@@ -267,6 +267,15 @@ a `$`):
 
 `less -FRX` is the default pager in the absence of any other setting.
 
+Additionally, paging behavior can be toggled via `ui.paginate` like so:
+
+```toml
+# Enable pagination for commands that support it (default) 
+ui.paginate = "auto"
+# Disable all pagination, equivalent to using --no-pager
+ui.paginate = "never"
+```
+
 ### Processing contents to be paged
 
 If you'd like to pass the output through a formatter e.g.


### PR DESCRIPTION
This was a bit of a chance for me to play with `jj` a bit, so feel free to ignore 😄 

I was basically frustrated with having to pass in `--no-pager` constantly and stumbled upon this [PR](https://github.com/martinvonz/jj/pull/672) where I saw that a `ui.paginate` option was considered and [removed](https://github.com/martinvonz/jj/pull/672#discussion_r1035311775). I felt like adding it back might be a tiny, but helpful change for others like me.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
