### PR TITLE
revset: remove round-trip conversion from heads() evaluation

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -1007,7 +1007,7 @@ impl<'a> CompositeIndex<'a> {
         rev_walk
     }
 
-    fn heads_pos(
+    pub fn heads_pos(
         &self,
         mut candidate_positions: BTreeSet<IndexPosition>,
     ) -> BTreeSet<IndexPosition> {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -846,6 +846,7 @@ fn test_evaluate_expression_heads(use_git: bool) {
     let commit1 = graph_builder.initial_commit();
     let commit2 = graph_builder.commit_with_parents(&[&commit1]);
     let commit3 = graph_builder.commit_with_parents(&[&commit2]);
+    let commit4 = graph_builder.commit_with_parents(&[&commit1]);
 
     // Heads of an empty set is an empty set
     assert_eq!(resolve_commit_ids(mut_repo, "heads(none())"), vec![]);
@@ -879,6 +880,15 @@ fn test_evaluate_expression_heads(use_git: bool) {
             &format!("heads({} | {})", commit1.id().hex(), commit3.id().hex())
         ),
         vec![commit3.id().clone()]
+    );
+
+    // Heads should be sorted in reverse index position order
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("heads({} | {})", commit3.id().hex(), commit4.id().hex())
+        ),
+        vec![commit4.id().clone(), commit3.id().clone()]
     );
 
     // Heads of all commits is the set of visible heads in the repo


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
