### PR TITLE
cli: indicate empty files in default diff format

### DIFF
--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -51,6 +51,7 @@
 "working_copy conflict" = "bright red"
 "working_copy empty" = "bright green"
 "diff header" = "yellow"
+"diff empty" = "cyan"
 "diff file_header" = { bold = true }
 "diff hunk_header" = "cyan"
 "diff removed" = "red"

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -384,7 +384,11 @@ pub fn show_color_words_diff(
                     formatter.labeled("header"),
                     "Added {description} {ui_path}:"
                 )?;
-                show_color_words_diff_hunks(&[], &right_content, formatter)?;
+                if right_content.is_empty() {
+                    writeln!(formatter.labeled("empty"), "    (empty)")?;
+                } else {
+                    show_color_words_diff_hunks(&[], &right_content, formatter)?;
+                }
             }
             tree::Diff::Modified(left_value, right_value) => {
                 let left_content = diff_content(repo, &path, &left_value)?;
@@ -440,7 +444,11 @@ pub fn show_color_words_diff(
                     formatter.labeled("header"),
                     "Removed {description} {ui_path}:"
                 )?;
-                show_color_words_diff_hunks(&left_content, &[], formatter)?;
+                if left_content.is_empty() {
+                    writeln!(formatter.labeled("empty"), "    (empty)")?;
+                } else {
+                    show_color_words_diff_hunks(&left_content, &[], formatter)?;
+                }
             }
         }
     }

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -109,6 +109,28 @@ fn test_diff_basic() {
 }
 
 #[test]
+fn test_diff_empty() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "").unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Added regular file file1:
+        (empty)
+    "###);
+
+    test_env.jj_cmd_success(&repo_path, &["new"]);
+    std::fs::remove_file(repo_path.join("file1")).unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Removed regular file file1:
+        (empty)
+    "###);
+}
+
+#[test]
 fn test_diff_types() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
@@ -400,6 +422,7 @@ fn test_color_words_diff_missing_newline() {
     insta::assert_snapshot!(stdout, @r###"
     === Empty
     Added regular file file1:
+        (empty)
     === Add no newline
     Modified regular file file1:
             1: a


### PR DESCRIPTION
Empty files can be confusing in diff output. For example:


```
Added regular file file1:
Added regular file file2:
        1: foo
```

This commit adds an "(empty)" placeholder instead. Since it's not colored, and doesn't have line numbers, it will hopefully not be mistaken for a file with the contents "(empty)".

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
