### PR TITLE
Allow repeated `-m` options for multi-paragraph descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added the `ui.paginate` option to enable/disable pager usage in commands
 
+* `jj checkout`/`jj describe`/`jj commit`/`jj new`/`jj squash` can take repeated
+  `-m/--message` arguments. Each passed message will be combined into paragraphs
+  (separated by a blank line)
+
 ### Fixed bugs
 
 * SSH authentication could hang when ssh-agent couldn't be reached

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2292,35 +2292,17 @@ pub struct EarlyArgs {
     pub config_toml: Vec<String>,
 }
 
-/// `-m/--message` argument which should be terminated with `\n`.
+/// Create a description from a list of paragraphs.
 ///
 /// Based on the Git CLI behavior. See `opt_parse_m()` and `cleanup_mode` in
 /// `git/builtin/commit.c`.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DescriptionArg(String);
-
-impl DescriptionArg {
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl From<String> for DescriptionArg {
-    fn from(s: String) -> Self {
-        DescriptionArg(text_util::complete_newline(s))
-    }
-}
-
-impl From<&DescriptionArg> for String {
-    fn from(arg: &DescriptionArg) -> Self {
-        arg.0.to_owned()
-    }
-}
-
-impl AsRef<str> for DescriptionArg {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
+pub fn join_message_paragraphs(paragraphs: &[String]) -> String {
+    // Ensure each paragraph ends with a newline, then add another newline between
+    // paragraphs.
+    paragraphs
+        .iter()
+        .map(|p| text_util::complete_newline(p.as_str()))
+        .join("\n")
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Emulates git's behavior:
https://www.git-scm.com/docs/git-commit#Documentation/git-commit.txt--mltmsggt

Fixes #1931 

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
  _I didn't find anywhere obvious where this should be added_
- [ ] I have updated the config schema (src/config-schema.json)
  _I don't believe this is needed as there are no configuration changes_
- [x] I have added tests to cover my changes
