### PR TITLE
conflicts: remove redundant `num_removes` argument from `parse_confli…

### DIFF
--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -299,7 +299,7 @@ line 5 right
 
     // The first add should always be from the left side
     insta::assert_debug_snapshot!(
-        parse_conflict(materialized.as_bytes(), conflict.removes().len(), conflict.adds().len()),
+        parse_conflict(materialized.as_bytes(), conflict.adds().len()),
         @r###"
     Some(
         [
@@ -436,7 +436,6 @@ line 3
 line 4
 line 5
 ",
-            1,
             2
         ),
         None
@@ -459,7 +458,6 @@ right
 >>>>>>>
 line 5
 ",
-            1,
             2
         ),
         @r###"
@@ -513,7 +511,6 @@ right
 >>>>>>>
 line 5
 ",
-            2,
             3
         ),
         @r###"
@@ -564,7 +561,6 @@ right
 >>>>>>>
 line 5
 ",
-            2,
             3
         ),
         None
@@ -587,7 +583,6 @@ right
 >>>>>>>
 line 5
 ",
-            1,
             2
         ),
         None
@@ -611,7 +606,6 @@ right
 >>>>>>>
 line 5
 ",
-            1,
             2
         ),
         None


### PR DESCRIPTION
…ct()`

Merges always have exactly one more "adds" than "removes" these days.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
