### PR TITLE
cli: trim the description from editor before using it

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1922,13 +1922,12 @@ fn edit_description(
     // Delete the file only if everything went well.
     // TODO: Tell the user the name of the file we left behind.
     std::fs::remove_file(description_file_path).ok();
-    // Normalize line ending, remove trailing blank lines.
-    let mut description = description
+    // Normalize line ending, remove leading and trailing blank lines.
+    let description = description
         .lines()
         .filter(|line| !line.starts_with("JJ: "))
         .join("\n");
-    description.truncate(description.trim_end_matches('\n').len());
-    Ok(text_util::complete_newline(description))
+    Ok(text_util::complete_newline(description.trim_matches('\n')))
 }
 
 fn edit_sparse(

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -94,10 +94,24 @@ fn test_describe() {
     Nothing changed.
     "###);
 
+    // Multi-line description starting with newlines
+    std::fs::write(&edit_script, "write\n\n\nline1\nline2").unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
+    insta::assert_snapshot!(stdout, @r#"
+    Working copy now at: qpvuntsm 13f903c1 (empty) line1
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    "#);
+    let stdout =
+        test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
+    insta::assert_snapshot!(stdout, @r#"
+    line1
+    line2
+    "#);
+
     // Clear description
     let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", ""]);
     insta::assert_snapshot!(stdout, @r###"
-    Working copy now at: qpvuntsm d6957294 (empty) (no description set)
+    Working copy now at: qpvuntsm 3196270d (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     std::fs::write(&edit_script, "write\n").unwrap();


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
