### PR TITLE
cli: include hint when push is not fast-forward

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -975,6 +975,11 @@ fn cmd_git_push(
     })
     .map_err(|err| match err {
         GitPushError::InternalGitError(err) => map_git_error(err),
+        GitPushError::NotFastForward => user_error_with_hint(
+            "The push conflicts with changes made on the remote (it is not fast-forwardable).",
+            "Try fetching from the remote, then make the branch point to where you want it to be, \
+             and push again.",
+        ),
         _ => user_error(err.to_string()),
     })?;
     git::import_refs(tx.mut_repo(), &git_repo, &command.settings().git_settings())?;


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
