### PR TITLE
Fix build when `bstr` is also imported.

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -559,8 +559,7 @@ impl MutableIndexImpl {
             buf.write_u32::<LittleEndian>(pos.0).unwrap();
         }
 
-        buf[parent_overflow_offset..parent_overflow_offset + 4]
-            .as_mut()
+        (&mut buf[parent_overflow_offset..parent_overflow_offset + 4])
             .write_u32::<LittleEndian>(parent_overflow.len() as u32)
             .unwrap();
         for parent_pos in parent_overflow {


### PR DESCRIPTION
Add type annotation to `vec` to avoid the following build error if you additionally import `bstr`:

```
~/jj> cargo test
   Compiling jj-lib v0.8.0 (/home/aspotashev/jj/lib)
warning: unused import: `bstr`
  --> lib/src/default_index_store.rs:30:5
   |
30 | use bstr;
   |     ^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0282]: type annotations needed
   --> lib/src/default_index_store.rs:564:14
    |
564 |             .as_mut()
    |              ^^^^^^
565 |             .write_u32::<LittleEndian>(parent_overflow.len() as u32)
    |              --------- type must be known at this point
    |
help: try using a fully qualified path to specify the expected types
    |
563 |         <[u8] as AsMut<T>>::as_mut(&mut buf[parent_overflow_offset..parent_overflow_offset + 4])
    |         +++++++++++++++++++++++++++++++                                                        ~

For more information about this error, try `rustc --explain E0282`.
warning: `jj-lib` (lib) generated 1 warning
error: could not compile `jj-lib` (lib) due to previous error; 1 warning emitted
```

Reason to support `bstr` being imported: in a Bazel environment where crates are imported with certain features enabled, jj-lib may pull in bstr as part of the following dependency chain:
  jj-lib -> insta -> similar -> bstr.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
