### PR TITLE
cli: respect `ui.default-description` in split as well

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -328,7 +328,7 @@ fn cmd_git_fetch(
     let mut workspace_command = command.workspace_helper(ui)?;
     let git_repo = get_git_repo(workspace_command.repo().store())?;
     let remotes = if args.remotes.is_empty() {
-        get_default_fetch_remotes(ui, command, &git_repo)?
+        get_default_fetch_remotes(ui, command.settings(), &git_repo)?
     } else {
         args.remotes.clone()
     };
@@ -369,14 +369,13 @@ const DEFAULT_REMOTE: &str = "origin";
 
 fn get_default_fetch_remotes(
     ui: &Ui,
-    command: &CommandHelper,
+    settings: &UserSettings,
     git_repo: &git2::Repository,
 ) -> Result<Vec<String>, CommandError> {
     const KEY: &str = "git.fetch";
-    let config = command.settings().config();
-    if let Ok(remotes) = config.get(KEY) {
+    if let Ok(remotes) = settings.config().get(KEY) {
         Ok(remotes)
-    } else if let Some(remote) = config.get_string(KEY).optional()? {
+    } else if let Some(remote) = settings.config().get_string(KEY).optional()? {
         Ok(vec![remote])
     } else if let Some(remote) = get_single_remote(git_repo)? {
         // if nothing was explicitly configured, try to guess
@@ -672,7 +671,7 @@ fn cmd_git_push(
     let remote = if let Some(name) = &args.remote {
         name.clone()
     } else {
-        get_default_push_remote(ui, command, &git_repo)?
+        get_default_push_remote(ui, command.settings(), &git_repo)?
     };
 
     let repo = workspace_command.repo().clone();
@@ -989,11 +988,10 @@ fn cmd_git_push(
 
 fn get_default_push_remote(
     ui: &Ui,
-    command: &CommandHelper,
+    settings: &UserSettings,
     git_repo: &git2::Repository,
 ) -> Result<String, CommandError> {
-    let config = command.settings().config();
-    if let Some(remote) = config.get_string("git.push").optional()? {
+    if let Some(remote) = settings.config().get_string("git.push").optional()? {
         Ok(remote)
     } else if let Some(remote) = get_single_remote(git_repo)? {
         // similar to get_default_fetch_remotes

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2989,10 +2989,7 @@ fn description_template_for_commit(
         &[DiffFormat::Summary],
     )?;
     let description = if commit.description().is_empty() {
-        settings
-            .config()
-            .get_string("ui.default-description")
-            .unwrap_or("".to_owned())
+        settings.default_description()
     } else {
         commit.description().to_owned()
     };
@@ -3023,10 +3020,7 @@ fn description_template_for_cmd_split(
         &[DiffFormat::Summary],
     )?;
     let description = if overall_commit_description.is_empty() {
-        settings
-            .config()
-            .get_string("ui.default-description")
-            .unwrap_or("".to_owned())
+        settings.default_description()
     } else {
         overall_commit_description.to_owned()
     };

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -146,6 +146,12 @@ impl UserSettings {
             .unwrap_or_else(|_| "push-".to_string())
     }
 
+    pub fn default_description(&self) -> String {
+        self.config()
+            .get_string("ui.default-description")
+            .unwrap_or_default()
+    }
+
     pub fn default_revset(&self) -> String {
         self.config.get_string("revsets.log").unwrap_or_else(|_| {
             // For compatibility with old config files (<0.8.0)


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
