### PR TITLE
cli: hide irrelevant information about the root commit in default log templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Default template for `jj log` now does not show irrelevant information
+  (timestamp, empty, message placeholder etc.) about the root commit.
+
 * Commit templates now support the `root` keyword, which is `true` for the root
   commit and `false` for every other commit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Commit templates now support the `root` keyword, which is `true` for the root
+  commit and `false` for every other commit.
+
 * `jj init --git-repo` now works with bare repositories.
 
 * `jj config edit --user` and `jj config set --user` will now pick a default

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -306,6 +306,9 @@ fn build_commit_keyword_opt<'repo>(
             let parent_tree = rewrite::merge_commit_trees(repo, &commit.parents()).unwrap();
             commit.tree_id() == parent_tree.id()
         })),
+        "root" => language.wrap_boolean(wrap_fn(property, move |commit| {
+            commit.id() == repo.store().root_commit_id()
+        })),
         _ => return None,
     };
     Some(property)

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -175,7 +175,8 @@
                         "is_git_head",
                         "divergent",
                         "hidden",
-                        "conflict"
+                        "conflict",
+                        "root"
                     ]
                 }
             },

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -33,6 +33,7 @@
 "conflict" = "red"
 "empty" = "green"
 "separator" = "bright black"
+"root" = {fg = "bright green", bold = true}
 
 "working_copy" = { bold = true }
 "working_copy commit_id" = "bright blue"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -29,50 +29,58 @@ op_log = 'builtin_op_log_compact'
 show = 'builtin_log_detailed'
 
 [template-aliases]
-'builtin_log_oneline' = '''label(if(current_working_copy, "working_copy"),
-  concat(
-    separate(" ",
-      label(
-        separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
-        separate(" ",
-          format_short_change_id(change_id) ++ if(divergent, "??"),
-          if(hidden, "hidden"))),
-      author.username(),
-      format_timestamp(committer.timestamp()),
-      branches,
-      tags,
-      working_copies,
-      git_head,
-      format_short_commit_id(commit_id),
-      if(conflict, label("conflict", "conflict")),
-      if(empty, label("empty", "(empty)")),
-      if(description, description.first_line(), description_placeholder),
-    ) ++ "\n",
-  ),
+'builtin_log_oneline' = '''
+if(root,
+  builtin_log_root(change_id, commit_id),
+  label(if(current_working_copy, "working_copy"),
+    concat(
+      separate(" ",
+        label(
+          separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
+          separate(" ",
+            format_short_change_id(change_id) ++ if(divergent, "??"),
+            if(hidden, "hidden"))),
+        author.username(),
+        format_timestamp(committer.timestamp()),
+        branches,
+        tags,
+        working_copies,
+        git_head,
+        format_short_commit_id(commit_id),
+        if(conflict, label("conflict", "conflict")),
+        if(empty, label("empty", "(empty)")),
+        if(description, description.first_line(), description_placeholder),
+      ) ++ "\n",
+    ),
+  )
 )
 '''
-'builtin_log_compact' = '''label(if(current_working_copy, "working_copy"),
-  concat(
-    separate(" ",
-      label(
-        separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
-        separate(" ",
-          format_short_change_id(change_id) ++ if(divergent, "??"),
-          if(hidden, "hidden"))),
-      format_short_signature(author),
-      format_timestamp(committer.timestamp()),
-      branches,
-      tags,
-      working_copies,
-      git_head,
-      format_short_commit_id(commit_id),
-      if(conflict, label("conflict", "conflict")),
-    ) ++ "\n",
-    separate(" ",
-      if(empty, label("empty", "(empty)")),
-      if(description, description.first_line(), description_placeholder),
-    ) ++ "\n",
-  ),
+'builtin_log_compact' = '''
+if(root,
+  builtin_log_root(change_id, commit_id),
+  label(if(current_working_copy, "working_copy"),
+    concat(
+      separate(" ",
+        label(
+          separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
+          separate(" ",
+            format_short_change_id(change_id) ++ if(divergent, "??"),
+            if(hidden, "hidden"))),
+        format_short_signature(author),
+        format_timestamp(committer.timestamp()),
+        branches,
+        tags,
+        working_copies,
+        git_head,
+        format_short_commit_id(commit_id),
+        if(conflict, label("conflict", "conflict")),
+      ) ++ "\n",
+      separate(" ",
+        if(empty, label("empty", "(empty)")),
+        if(description, description.first_line(), description_placeholder),
+      ) ++ "\n",
+    ),
+  )
 )
 '''
 builtin_log_comfortable = 'builtin_log_compact ++ "\n"'
@@ -103,6 +111,15 @@ label(if(current_operation, "current_operation"),
 )
 '''
 builtin_op_log_comfortable = 'builtin_op_log_compact ++ "\n"'
+
+'builtin_log_root(change_id, commit_id)' = '''
+separate(" ",
+  format_short_change_id(change_id),
+  label("root", "root"),
+  format_short_commit_id(commit_id),
+  branches
+)
+'''
 
 'description_placeholder' = 'label("description", "(no description set)")'
 'commit_summary_separator' = 'label("separator", " | ")'

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -137,8 +137,7 @@ fn test_alias_cannot_override_builtin() {
     // Alias should be ignored
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 }
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -128,8 +128,7 @@ fn test_log_default() {
     │  (empty) description 1
     ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264
     │  add a file
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     // Color
@@ -139,8 +138,7 @@ fn test_log_default() {
     │  [1m[38;5;10m(empty)[39m description 1[0m
     ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     │  add a file
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-       [38;5;2m(empty)[39m (no description set)
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [1m[38;5;10mroot[0m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     // Color without graph
@@ -150,8 +148,7 @@ fn test_log_default() {
     [1m[38;5;10m(empty)[39m description 1[0m
     [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     add a file
-    [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    [38;5;2m(empty)[39m (no description set)
+    [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [1m[38;5;10mroot[0m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 }
 
@@ -164,23 +161,20 @@ fn test_log_builtin_templates() {
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
     @  qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059 (empty) (no description set)
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000 (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
     │
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
-
+    ◉  zzzzzzzz root 00000000
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r###"
@@ -214,8 +208,7 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
     │  description 1
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     // Create divergence
@@ -230,8 +223,7 @@ fn test_log_obslog_divergence() {
     │  description 2
     │ @  qpvuntsm?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
     ├─╯  description 1
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     // Color
@@ -241,8 +233,7 @@ fn test_log_obslog_divergence() {
     │  description 2
     │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     ├─╯  [1mdescription 1[0m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-       [38;5;2m(empty)[39m (no description set)
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [1m[38;5;10mroot[0m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     // Obslog and hidden divergent
@@ -283,8 +274,7 @@ fn test_log_git_head() {
     │  [1minitial[0m
     ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m (no description set)
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;6m1970-01-01 00:00:00.000 +00:00[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-       [38;5;2m(empty)[39m (no description set)
+    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [1m[38;5;10mroot[0m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 }
 
@@ -309,8 +299,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  Q_pvun test.user@example.com 2001-02-03 04:05:08.000 +07:00 6_9542
     │  (empty) first
-    ◉  Z_zzzz 1970-01-01 00:00:00.000 +00:00 0_0000
-       (empty) (no description set)
+    ◉  Z_zzzz root 0_0000
     "###);
 
     // Customize only the change id
@@ -328,7 +317,6 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  QPVUNTSM test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
     │  (empty) first
-    ◉  ZZZZZZZZ 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  ZZZZZZZZ root 00000000
     "###);
 }

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -649,8 +649,7 @@ fn test_diff_external_tool() {
     │  --
     │  file1
     │  file2
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
        --
     "###);
 

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -321,8 +321,7 @@ fn test_init_git_external_but_git_dir_exists() {
     // The local ".git" repository is unrelated, so no commits should be imported
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     // Check that Git HEAD is not set because this isn't a colocated repo

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -49,8 +49,7 @@ fn test_log_legacy_range_operator() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     The `:` revset operator is deprecated. Please switch to `::`.
@@ -59,8 +58,7 @@ fn test_log_legacy_range_operator() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     The `:` revset operator is deprecated. Please switch to `::`.

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -256,14 +256,12 @@ fn test_alias() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root & syntax-error"]);
@@ -385,8 +383,7 @@ fn test_bad_alias_decl() {
     // Invalid declaration should be warned and ignored.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz 1970-01-01 00:00:00.000 +00:00 00000000
-       (empty) (no description set)
+    ◉  zzzzzzzz root 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Failed to load "revset-aliases."bad"":  --> 1:1

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -34,6 +34,7 @@ The following keywords can be used in `jj log`/`jj obslog` templates.
 * `hidden: Boolean`: True if the commit is not visible (a.k.a. abandoned).
 * `conflict: Boolean`: True if the commit contains merge conflicts.
 * `empty: Boolean`: True if the commit modifies no files.
+* `root: Boolean`: True if the commit is the root commit.
 
 ### Operation keywords
 


### PR DESCRIPTION
The default template makes root look like this now:
![image](https://github.com/martinvonz/jj/assets/33968278/910884bf-b037-40de-95b9-6c4101b64734)


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
