### PR TITLE
revset: add function mine()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj split` will now leave the description empty on the second part if the
   description was empty on the input commit.
 
+* Revsets gained a new function `mine()` that aliases `author([your_email])`.
+
 ### Fixed bugs
 
 * `jj config set --user` and `jj config edit --user` can now be used outside of any repository.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1053,6 +1053,7 @@ impl WorkspaceCommandHelper {
         let expression = revset::parse(
             revision_str,
             &self.revset_aliases_map,
+            &self.settings.user_email(),
             Some(&self.revset_context()),
         )?;
         if let Some(ui) = ui {

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -199,6 +199,7 @@ fn cmd_debug_revset(
     command: &CommandHelper,
     args: &DebugRevsetArgs,
 ) -> Result<(), CommandError> {
+    let user_email = command.settings().user_email();
     let workspace_command = command.workspace_helper(ui)?;
     let workspace_ctx = workspace_command.revset_context();
     let repo = workspace_command.repo().as_ref();
@@ -206,6 +207,7 @@ fn cmd_debug_revset(
     let expression = revset::parse(
         &args.revision,
         workspace_command.revset_aliases_map(),
+        &user_email,
         Some(&workspace_ctx),
     )?;
     writeln!(ui, "-- Parsed:")?;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1723,7 +1723,13 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
                  the working copy commit, pass -r '@' instead."
             )?;
         } else if revset.is_empty()
-            && revset::parse(only_path, &RevsetAliasesMap::new(), None).is_ok()
+            && revset::parse(
+                only_path,
+                &RevsetAliasesMap::new(),
+                &command.settings().user_email(),
+                None,
+            )
+            .is_ok()
         {
             writeln!(
                 ui.warning(),
@@ -2512,7 +2518,13 @@ from the source will be moved into the parent.
         if let [only_path] = &args.paths[..] {
             let (_, matches) = command.matches().subcommand().unwrap();
             if matches.value_source("revision").unwrap() == ValueSource::DefaultValue
-                && revset::parse(only_path, &RevsetAliasesMap::new(), None).is_ok()
+                && revset::parse(
+                    only_path,
+                    &RevsetAliasesMap::new(),
+                    &command.settings().user_email(),
+                    None,
+                )
+                .is_ok()
             {
                 writeln!(
                     ui.warning(),

--- a/docs/github.md
+++ b/docs/github.md
@@ -51,8 +51,8 @@ $ # Do some more work.
 $ jj commit -m "Update tutorial"
 $ jj branch create doc-update
 $ # Move the previous revision to doc-update.
-$ jj branch set doc-update -r @- 
-$ jj git push 
+$ jj branch set doc-update -r @-
+$ jj git push
 ```
 
 ## Working in a Jujutsu repository
@@ -63,7 +63,7 @@ able to create a branch for a revision.
 
 ```shell script
 $ # Do your work
-$ jj commit 
+$ jj commit
 $ # Jujutsu automatically creates a branch
 $ jj git push --change $revision
 ```
@@ -101,11 +101,11 @@ something like this:
 
 ```shell script
 $ # Create a new commit on top of the second-to-last commit in `your-feature`,
-$ # as reviews requested a fix there. 
-$ jj new your-feature- 
+$ # as reviews requested a fix there.
+$ jj new your-feature-
 $ # Address the comments by updating the code
 $ # Review the changes
-$ jj diff 
+$ jj diff
 $ # Squash the changes into the parent commit
 $ jj squash
 $ # Push the updated branch to the remote. Jujutsu automatically makes it a force push
@@ -140,14 +140,14 @@ commands like `gh issue list` normally.
 ## Useful Revsets
 
 Log all revisions across all local branches, which aren't on the main branch nor
-on any remote    
-`jj log -r 'branches() & ~(main | remote_branches())'`  
+on any remote
+`jj log -r 'branches() & ~(main | remote_branches())'`
 Log all revisions which you authored, across all branches which aren't on any
-remote  
-`jj log -r 'author(your@email.com) & branches() & ~remote_branches()'`  
-Log all remote branches, which you authored or committed to  
-`jj log -r 'remote_branches() & (committer(your@email.com) | author(your@email.com))'`  
-Log all descendants of the current working copy, which aren't on a remote   
+remote
+`jj log -r 'mine() & branches() & ~remote_branches()'`
+Log all remote branches, which you authored or committed to
+`jj log -r 'remote_branches() & (mine() | committer(your@email.com))'`
+Log all descendants of the current working copy, which aren't on a remote
 `jj log -r ':@ & ~remote_branches()'`
 
 ## Merge conflicts

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -122,6 +122,8 @@ revsets (expressions) as arguments.
   description.
 * `author(needle)`: Commits with the given string in the author's name or
   email.
+* `mine()`: Commits where the author's email matches the email of the current
+  user.
 * `committer(needle)`: Commits with the given string in the committer's
   name or email.
 * `empty()`: Commits modifying no files. This also includes `merges()` without


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

`mine()` is an alias for `author([user.name])` per the specification given in #1976, although I wonder if it should instead act like `author([user.name]) | author([user.email])`.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
