### PR TITLE
revset: add support for explicit substring:"..." prefix

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -141,8 +141,8 @@ revsets (expressions) as arguments.
 
 Functions that perform string matching support the following pattern syntax.
 
-* `"substring"`: Matches strings that contain `substring`.
-* `literal:"string"`:  Matches strings exactly equal to `string`.
+* `"string"`, `substring:"string"`: Matches strings that contain `string`.
+* `literal:"string"`: Matches strings exactly equal to `string`.
 
 ## Aliases
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1324,7 +1324,7 @@ fn parse_function_argument_to_string_pattern(
             };
             match kind.as_ref() {
                 "literal" => StringPattern::Literal(needle.clone()),
-                // TODO: maybe add explicit kind for substring match?
+                "substring" => StringPattern::Substring(needle.clone()),
                 _ => {
                     // TODO: error span can be narrowed to the lhs node
                     return Err(make_error(format!(
@@ -2696,6 +2696,12 @@ mod tests {
         assert_eq!(
             parse(r#"branches(literal:"foo")"#),
             Ok(RevsetExpression::branches(StringPattern::Literal(
+                "foo".to_owned()
+            )))
+        );
+        assert_eq!(
+            parse(r#"branches(substring:"foo")"#),
+            Ok(RevsetExpression::branches(StringPattern::Substring(
                 "foo".to_owned()
             )))
         );


### PR DESCRIPTION
git-branchless calls it a substring, so let's do the same.

FWIW, I copied literal:_ from Mercurial, but it's exact:_ in git-branchless. I have no idea which one is preferred. Since this feature isn't released, we can freely change it if exact:_ makes more sense.

https://github.com/arxanas/git-branchless/wiki/Reference:-Revsets#patterns

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [x] I have added tests to cover my changes
