### PR TITLE
Fix .gitignore handling of ignored directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed bugs
 
+* Fix issues related to .gitignore handling of untracked directories
+  [#2051](https://github.com/martinvonz/jj/issues/2051).
+
 * `jj config set --user` and `jj config edit --user` can now be used outside of any repository.
 
 * SSH authentication could hang when ssh-agent couldn't be reached

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -796,7 +796,7 @@ impl TreeState {
                 }
 
                 if file_type.is_dir() {
-                    if git_ignore.matches_all_files_in(&path.to_internal_dir_string()) {
+                    if git_ignore.matches(&path.to_internal_dir_string()) {
                         // If the whole directory is ignored, visit only paths we're already
                         // tracking.
                         let tracked_paths = self
@@ -867,7 +867,7 @@ impl TreeState {
                     }
                     let maybe_current_file_state = self.file_states.get(&path);
                     if maybe_current_file_state.is_none()
-                        && git_ignore.matches_file(&path.to_internal_file_string())
+                        && git_ignore.matches(&path.to_internal_file_string())
                     {
                         // If it wasn't already tracked and it matches
                         // the ignored paths, then


### PR DESCRIPTION
This addresses #2051.
 - Ignore .gitignore files from untracked directories
 - Do not allow un-ignoring files within ignored directories
 - Make it more clear how GitIgnoreFile works