### PR TITLE
revset: rename literal:"" prefix to exact:""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,11 +82,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   description was empty on the input commit.
 
 * `branches()`/`remote_branches()`/`author()`/`committer()`/`description()`
-  revsets now support literal matching. For example, `branch(literal:main)`
-  selects the branch named "main", but not "maint". `description(literal:"")`
+  revsets now support exact matching. For example, `branch(exact:main)`
+  selects the branch named "main", but not "maint". `description(exact:"")`
   selects commits whose description is empty.
 
-* Revsets gained a new function `mine()` that aliases `author([literal:"your_email"])`.
+* Revsets gained a new function `mine()` that aliases `author(exact:"your_email")`.
 
 ### Fixed bugs
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -142,7 +142,7 @@ revsets (expressions) as arguments.
 Functions that perform string matching support the following pattern syntax.
 
 * `"string"`, `substring:"string"`: Matches strings that contain `string`.
-* `literal:"string"`: Matches strings exactly equal to `string`.
+* `exact:"string"`: Matches strings exactly equal to `string`.
 
 ## Aliases
 

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1717,13 +1717,13 @@ fn test_evaluate_expression_branches(use_git: bool) {
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, "branches(literal:branch1)"),
+        resolve_commit_ids(mut_repo, "branches(exact:branch1)"),
         vec![commit1.id().clone()]
     );
     // Can silently resolve to an empty set if there's no matches
     assert_eq!(resolve_commit_ids(mut_repo, "branches(branch3)"), vec![]);
     assert_eq!(
-        resolve_commit_ids(mut_repo, "branches(literal:ranch1)"),
+        resolve_commit_ids(mut_repo, "branches(exact:ranch1)"),
         vec![]
     );
     // Two branches pointing to the same commit does not result in a duplicate in
@@ -1797,7 +1797,7 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, "remote_branches(literal:branch1)"),
+        resolve_commit_ids(mut_repo, "remote_branches(exact:branch1)"),
         vec![commit1.id().clone()]
     );
     // Can get branches from matching remotes
@@ -1810,7 +1810,7 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, r#"remote_branches("", literal:origin)"#),
+        resolve_commit_ids(mut_repo, r#"remote_branches("", exact:origin)"#),
         vec![commit1.id().clone()]
     );
     // Can get branches with matching names from matching remotes
@@ -1823,10 +1823,7 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
         vec![commit2.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(
-            mut_repo,
-            r#"remote_branches(literal:branch1, literal:origin)"#
-        ),
+        resolve_commit_ids(mut_repo, r#"remote_branches(exact:branch1, exact:origin)"#),
         vec![commit1.id().clone()]
     );
     // Can silently resolve to an empty set if there's no matches
@@ -1843,17 +1840,11 @@ fn test_evaluate_expression_remote_branches(use_git: bool) {
         vec![]
     );
     assert_eq!(
-        resolve_commit_ids(
-            mut_repo,
-            r#"remote_branches(literal:ranch1, literal:origin)"#
-        ),
+        resolve_commit_ids(mut_repo, r#"remote_branches(exact:ranch1, exact:origin)"#),
         vec![]
     );
     assert_eq!(
-        resolve_commit_ids(
-            mut_repo,
-            r#"remote_branches(literal:branch1, literal:orig)"#
-        ),
+        resolve_commit_ids(mut_repo, r#"remote_branches(exact:branch1, exact:orig)"#),
         vec![]
     );
     // Two branches pointing to the same commit does not result in a duplicate in


### PR DESCRIPTION
Per discussion in #2107, I believe "exact" is preferred.

We can also change the default to exact match, but it doesn't always make sense. Exact match would be useful for branches(), but not for description(). We could define default per predicate function, but I'm pretty sure I cannot remember which one is which.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
