### PR TITLE
revset: pass all context arguments to `parse()` via an object

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -199,17 +199,11 @@ fn cmd_debug_revset(
     command: &CommandHelper,
     args: &DebugRevsetArgs,
 ) -> Result<(), CommandError> {
-    let user_email = command.settings().user_email();
     let workspace_command = command.workspace_helper(ui)?;
-    let workspace_ctx = workspace_command.revset_context();
+    let workspace_ctx = workspace_command.revset_parse_context();
     let repo = workspace_command.repo().as_ref();
 
-    let expression = revset::parse(
-        &args.revision,
-        workspace_command.revset_aliases_map(),
-        &user_email,
-        Some(&workspace_ctx),
-    )?;
+    let expression = revset::parse(&args.revision, &workspace_ctx)?;
     writeln!(ui, "-- Parsed:")?;
     writeln!(ui, "{expression:#?}")?;
     writeln!(ui)?;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -40,9 +40,7 @@ use jj_lib::merge::Merge;
 use jj_lib::op_store::WorkspaceId;
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::repo_path::RepoPath;
-use jj_lib::revset::{
-    RevsetAliasesMap, RevsetExpression, RevsetFilterPredicate, RevsetIteratorExt,
-};
+use jj_lib::revset::{RevsetExpression, RevsetFilterPredicate, RevsetIteratorExt};
 use jj_lib::revset_graph::{
     ReverseRevsetGraphIterator, RevsetGraphEdgeType, TopoGroupedRevsetGraphIterator,
 };
@@ -1724,13 +1722,7 @@ fn cmd_log(ui: &mut Ui, command: &CommandHelper, args: &LogArgs) -> Result<(), C
                  the working copy commit, pass -r '@' instead."
             )?;
         } else if revset.is_empty()
-            && revset::parse(
-                only_path,
-                &RevsetAliasesMap::new(),
-                &command.settings().user_email(),
-                Some(&workspace_command.revset_context()),
-            )
-            .is_ok()
+            && revset::parse(only_path, &workspace_command.revset_parse_context()).is_ok()
         {
             writeln!(
                 ui.warning(),
@@ -2521,9 +2513,7 @@ from the source will be moved into the parent.
             if matches.value_source("revision").unwrap() == ValueSource::DefaultValue
                 && revset::parse(
                     only_path,
-                    &RevsetAliasesMap::new(),
-                    &command.settings().user_email(),
-                    Some(&tx.base_workspace_helper().revset_context()),
+                    &tx.base_workspace_helper().revset_parse_context(),
                 )
                 .is_ok()
             {


### PR DESCRIPTION

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
