### PR TITLE
cli tests: Replace undo with op restore (pt 1)

### DIFF
--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -42,6 +42,7 @@ fn test_rebase_branch_with_merge() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["a", "d"]);
     // Test the setup
+    let base_operation_id = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
@@ -76,7 +77,7 @@ fn test_rebase_branch_with_merge() {
     ◉
     "###);
 
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon"] /* abandons `e` */);
     insta::assert_snapshot!(stdout, @r###"
@@ -96,7 +97,7 @@ fn test_rebase_branch_with_merge() {
     ◉
     "###);
 
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
     // TODO(ilyagr): Minor Bug: The branch `e` should be shown next
@@ -122,7 +123,7 @@ fn test_rebase_branch_with_merge() {
     "###);
 
     // Test abandoning the same commit twice directly
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -139,7 +140,7 @@ fn test_rebase_branch_with_merge() {
     "###);
 
     // Test abandoning the same commit twice indirectly
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d::", "a::"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -42,6 +42,7 @@ fn test_rebase_branch_with_merge() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["a", "d"]);
     // Test the setup
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
@@ -54,11 +55,12 @@ fn test_rebase_branch_with_merge() {
     ◉
     "###);
 
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned commit vruxwmqv b7c62f28 d
     Rebased 1 descendant commits onto parents of abandoned commits
-    Working copy now at: znkkpsqq 11a2e10e e | e
+    Working copy now at: znkkpsqq e44dc3ad e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : royxmykx fe2e8e8b c d | c
     Added 0 files, modified 0 files, removed 1 files
@@ -75,10 +77,11 @@ fn test_rebase_branch_with_merge() {
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon"] /* abandons `e` */);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned commit znkkpsqq 5557ece3 e
-    Working copy now at: nkmrtpmo 6b527513 (empty) (no description set)
+    Working copy now at: rupkowyz fb48f04f (empty) (no description set)
     Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Added 0 files, modified 0 files, removed 3 files
     "###);
@@ -94,6 +97,7 @@ fn test_rebase_branch_with_merge() {
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "descendants(c)"]);
     // TODO(ilyagr): Minor Bug: The branch `e` should be shown next
     // to the commit with description `e` below. This is because the commits are
@@ -105,7 +109,7 @@ fn test_rebase_branch_with_merge() {
       znkkpsqq 5557ece3 e
       vruxwmqv b7c62f28 d
       royxmykx fe2e8e8b c
-    Working copy now at: xtnwkqum e7bb0612 (empty) (no description set)
+    Working copy now at: lulsmzln d8eb25e2 (empty) (no description set)
     Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Added 0 files, modified 0 files, removed 3 files
     "###);
@@ -119,6 +123,7 @@ fn test_rebase_branch_with_merge() {
 
     // Test abandoning the same commit twice directly
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned commit zsuskuln 1394f625 b
@@ -135,6 +140,7 @@ fn test_rebase_branch_with_merge() {
 
     // Test abandoning the same commit twice indirectly
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["abandon", "d::", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
     Abandoned the following commits:
@@ -142,7 +148,7 @@ fn test_rebase_branch_with_merge() {
       vruxwmqv b7c62f28 d
       zsuskuln 1394f625 b
       rlvkpnrz 2443ea76 a
-    Working copy now at: xlzxqlsl af874bff (empty) (no description set)
+    Working copy now at: lyntwxtv da15b14e (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 a b e?? | (empty) (no description set)
     Added 0 files, modified 0 files, removed 4 files
     "###);

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -40,6 +40,7 @@ fn test_duplicate() {
     create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     // Test the setup
+    let base_operation_id = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    17a00fc21654   c
@@ -71,7 +72,7 @@ fn test_duplicate() {
     ◉  000000000000
     "###);
 
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]), @"");
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @r###"
@@ -100,7 +101,7 @@ fn test_duplicate_many() {
     create_commit(&test_env, &repo_path, "c", &["a"]);
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["b", "d"]);
-
+    let base_operation_id = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -136,7 +137,7 @@ fn test_duplicate_many() {
     "###);
 
     // Try specifying the same commit twice directly
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -156,7 +157,7 @@ fn test_duplicate_many() {
     "###);
 
     // Try specifying the same commit twice indirectly
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -181,7 +182,7 @@ fn test_duplicate_many() {
     ◉  000000000000
     "###);
 
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     // Reminder of the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -218,7 +219,7 @@ fn test_duplicate_many() {
     "###);
 
     // Check for BUG -- makes too many 'a'-s, etc.
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -261,6 +262,7 @@ fn test_undo_after_duplicate() {
     ◉  000000000000
     "###);
 
+    let base_operation_id = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -273,7 +275,7 @@ fn test_undo_after_duplicate() {
     ◉  000000000000
     "###);
 
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]), @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
     ◉  000000000000

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -40,6 +40,7 @@ fn test_duplicate() {
     create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     // Test the setup
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    17a00fc21654   c
     ├─╮
@@ -54,12 +55,13 @@ fn test_duplicate() {
     Error: Cannot rewrite the root commit
     "###);
 
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as znkkpsqq 2f6dc5a1 a
+    Duplicated 2443ea76b0b1 as snltkkzs fc15166f a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  2f6dc5a1ffc2   a
+    ◉  fc15166fed23   a
     │ @    17a00fc21654   c
     │ ├─╮
     │ │ ◉  d370aee184ba   b
@@ -70,12 +72,13 @@ fn test_duplicate() {
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["undo"]), @"");
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 17a00fc21654 as wqnwkozp 1dd099ea c
+    Duplicated 17a00fc21654 as rupkowyz fe5b2a8f c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    1dd099ea963c   c
+    ◉    fe5b2a8fbc39   c
     ├─╮
     │ │ @  17a00fc21654   c
     ╭─┬─╯
@@ -97,6 +100,8 @@ fn test_duplicate_many() {
     create_commit(&test_env, &repo_path, "c", &["a"]);
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["b", "d"]);
+
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
@@ -109,15 +114,16 @@ fn test_duplicate_many() {
     ◉  000000000000
     "###);
 
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as wqnwkozp 3b74d969 b
-    Duplicated 921dde6e55c0 as mouksmqu 8348ddce e
+    Duplicated 1394f625cbbd as snltkkzs 528b626f b
+    Duplicated 921dde6e55c0 as vwpvxnxt 6f523f94 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    8348ddcec733   e
+    ◉    6f523f94081b   e
     ├─╮
-    ◉ │  3b74d9691015   b
+    ◉ │  528b626f3460   b
     │ │ @  921dde6e55c0   e
     │ ╭─┤
     │ ◉ │  ebd06dba20ec   d
@@ -131,12 +137,13 @@ fn test_duplicate_many() {
 
     // Try specifying the same commit twice directly
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b", "b"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b
+    Duplicated 1394f625cbbd as rupkowyz a674a5ee b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  0276d3d7c24d   b
+    ◉  a674a5ee9a9f   b
     │ @    921dde6e55c0   e
     │ ├─╮
     │ │ ◉  ebd06dba20ec   d
@@ -150,17 +157,18 @@ fn test_duplicate_many() {
 
     // Try specifying the same commit twice indirectly
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 1394f625cbbd as xtnwkqum fa167d18 b
-    Duplicated ebd06dba20ec as pqrnrkux 2181781b d
-    Duplicated 921dde6e55c0 as ztxkyksq 0f7430f2 e
+    Duplicated 1394f625cbbd as lulsmzln 451f6198 b
+    Duplicated ebd06dba20ec as pnsnxuxl 4b8937cf d
+    Duplicated 921dde6e55c0 as xlvlvppo 47cf3da3 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    0f7430f2727a   e
+    ◉    47cf3da3a0e2   e
     ├─╮
-    │ ◉  2181781b4f81   d
-    ◉ │  fa167d18a83a   b
+    │ ◉  4b8937cf8736   d
+    ◉ │  451f619834bf   b
     │ │ @    921dde6e55c0   e
     │ │ ├─╮
     │ │ │ ◉  ebd06dba20ec   d
@@ -174,6 +182,7 @@ fn test_duplicate_many() {
     "###);
 
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     // Reminder of the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
@@ -187,14 +196,14 @@ fn test_duplicate_many() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as nlrtlrxv c6f7f8c4 a
-    Duplicated ebd06dba20ec as plymsszl d94e4c55 d
-    Duplicated 921dde6e55c0 as urrlptpw 9bd4389f e
+    Duplicated 2443ea76b0b1 as zxlqlsry fc054cc3 a
+    Duplicated ebd06dba20ec as tkmsxyoo 506910c9 d
+    Duplicated 921dde6e55c0 as sntoynvw 3a94bbb4 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    9bd4389f5d47   e
+    ◉    3a94bbb4d36b   e
     ├─╮
-    │ ◉  d94e4c55a68b   d
+    │ ◉  506910c99bdb   d
     │ │ @  921dde6e55c0   e
     ╭───┤
     │ │ ◉  ebd06dba20ec   d
@@ -203,29 +212,30 @@ fn test_duplicate_many() {
     ◉ │  1394f625cbbd   b
     ├─╯
     ◉  2443ea76b0b1   a
-    │ ◉  c6f7f8c4512e   a
+    │ ◉  fc054cc36761   a
     ├─╯
     ◉  000000000000
     "###);
 
     // Check for BUG -- makes too many 'a'-s, etc.
     test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a::"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as uuuvxpvw 0fe67a05 a
-    Duplicated 1394f625cbbd as nmpuuozl e13ac0ad b
-    Duplicated c0cb3a0b73e7 as kzpokyyw df53fa58 c
-    Duplicated ebd06dba20ec as yxrlprzz 2f2442db d
-    Duplicated 921dde6e55c0 as mvkzkxrl ee8fe64e e
+    Duplicated 2443ea76b0b1 as lyntwxtv 38574b0a a
+    Duplicated 1394f625cbbd as pympstqw edc5436d b
+    Duplicated c0cb3a0b73e7 as zyzynvxr 0ee42c3f c
+    Duplicated ebd06dba20ec as tknxwlno 0be0769b d
+    Duplicated 921dde6e55c0 as yqtrmkok 9d48ed7d e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    ee8fe64ed254   e
+    ◉    9d48ed7d40b0   e
     ├─╮
-    │ ◉  2f2442db08eb   d
-    │ ◉  df53fa589286   c
-    ◉ │  e13ac0adabdf   b
+    │ ◉  0be0769bcabe   d
+    │ ◉  0ee42c3fc967   c
+    ◉ │  edc5436dbeec   b
     ├─╯
-    ◉  0fe67a05989e   a
+    ◉  38574b0af5eb   a
     │ @    921dde6e55c0   e
     │ ├─╮
     │ │ ◉  ebd06dba20ec   d
@@ -251,12 +261,13 @@ fn test_undo_after_duplicate() {
     ◉  000000000000
     "###);
 
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @r###"
-    Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a
+    Duplicated 2443ea76b0b1 as vorwnozm e22f2d74 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  f5cefcbb65a4   a
+    ◉  e22f2d74a67d   a
     │ @  2443ea76b0b1   a
     ├─╯
     ◉  000000000000

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -354,6 +354,7 @@ fn test_git_colocated_squash_undo() {
     git2::Repository::init(&repo_path).unwrap();
     test_env.jj_cmd_success(&repo_path, &["init", "--git-repo=."]);
     test_env.jj_cmd_success(&repo_path, &["ci", "-m=A"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo 8f71e3b6a3be
@@ -361,10 +362,11 @@ fn test_git_colocated_squash_undo() {
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  zsuskulnrvyr f0c12b0396d9
-    ◉  qpvuntsmwlqt 2f376ea1478c A master HEAD@git
+    @  snltkkzswkpz 6b61bdd29f7d
+    ◉  qpvuntsmwlqt d61bed40569c A master HEAD@git
     ◉  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_success(&repo_path, &["undo"]);

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -362,6 +362,7 @@ fn test_git_colocated_squash_undo() {
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 
+    let pre_squash_opid = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     test_env.jj_cmd_success(&repo_path, &["squash"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
@@ -369,7 +370,7 @@ fn test_git_colocated_squash_undo() {
     ◉  qpvuntsmwlqt d61bed40569c A master HEAD@git
     ◉  zzzzzzzzzzzz 000000000000
     "###);
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &pre_squash_opid]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -637,6 +637,7 @@ fn test_git_fetch_undo() {
     ◉  ff36dc55760e descr_for_trunk1 master trunk1
     ◉  000000000000
     "###);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
 
     // Fetch 2 branches
     let stdout = test_env.jj_cmd_success(
@@ -660,6 +661,7 @@ fn test_git_fetch_undo() {
     ◉  000000000000
     "###);
     // Now try to fetch just one branch
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -637,6 +637,8 @@ fn test_git_fetch_undo() {
     ◉  ff36dc55760e descr_for_trunk1 master trunk1
     ◉  000000000000
     "###);
+
+    let base_operation_id = test_env.current_operation_id(&target_jj_repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
 
     // Fetch 2 branches
@@ -654,7 +656,7 @@ fn test_git_fetch_undo() {
     ├─╯
     ◉  000000000000
     "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["undo"]), @"");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["op", "restore", &base_operation_id]), @"");
     // The undo works as expected
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -94,6 +94,7 @@ fn test_git_export_undo() {
     let git_repo = git2::Repository::open(repo_path.join(".jj/repo/store/git")).unwrap();
 
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "a"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
     "###);

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -94,6 +94,7 @@ fn test_git_export_undo() {
     let git_repo = git2::Repository::open(repo_path.join(".jj/repo/store/git")).unwrap();
 
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "a"]);
+    let base_operation_id = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
@@ -101,7 +102,7 @@ fn test_git_export_undo() {
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "export"]), @"");
 
     // "git export" can't be undone.
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "undo"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]), @r###"
     "###);
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
     [

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -32,6 +32,8 @@ fn test_interdiff_basic() {
     test_env.jj_cmd_success(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file2"), "foo\nbar\n").unwrap();
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "right"]);
+
+    let base_operation_id = test_env.current_operation_id(&repo_path);
     test_env.advance_test_rng_seed_to_multiple_of(200_000);
 
     // implicit --to
@@ -54,7 +56,7 @@ fn test_interdiff_basic() {
        1    1: foo
             2: bar
     "###);
-    test_env.jj_cmd_success(&repo_path, &["undo"]);
+    test_env.jj_cmd_success(&repo_path, &["op", "restore", &base_operation_id]);
 
     // formats specifiers
     test_env.advance_test_rng_seed_to_multiple_of(200_000);

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -32,6 +32,7 @@ fn test_interdiff_basic() {
     test_env.jj_cmd_success(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file2"), "foo\nbar\n").unwrap();
     test_env.jj_cmd_success(&repo_path, &["branch", "create", "right"]);
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
 
     // implicit --to
     let stdout = test_env.jj_cmd_success(&repo_path, &["interdiff", "--from", "left"]);
@@ -42,6 +43,7 @@ fn test_interdiff_basic() {
     "###);
 
     // explicit --to
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     test_env.jj_cmd_success(&repo_path, &["checkout", "@-"]);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -55,6 +57,7 @@ fn test_interdiff_basic() {
     test_env.jj_cmd_success(&repo_path, &["undo"]);
 
     // formats specifiers
+    test_env.advance_test_rng_seed_to_multiple_of(200_000);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "-s"],


### PR DESCRIPTION
This is a test refactor. I intend to do this to all the tests, but I didn't have time today, so let's discuss the method and merge the portion I have done to avoid merge conflicts. 

This will be done to the remaining tests in a separate PR.

# Checklist

If applicable:
- [x] I have added tests to cover my changes
