### PR TITLE
commands: destructure `SplitArgs` exhaustively

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3046,14 +3046,15 @@ fn diff_summary_to_description(bytes: &[u8]) -> String {
 
 #[instrument(skip_all)]
 fn cmd_split(ui: &mut Ui, command: &CommandHelper, args: &SplitArgs) -> Result<(), CommandError> {
+    let SplitArgs { revision, paths } = args;
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(revision, ui)?;
     workspace_command.check_rewritable(&commit)?;
-    let matcher = workspace_command.matcher_from_values(&args.paths)?;
+    let matcher = workspace_command.matcher_from_values(paths)?;
     let mut tx =
         workspace_command.start_transaction(&format!("split commit {}", commit.id().hex()));
     let base_tree = merge_commit_trees(tx.repo(), &commit.parents())?;
-    let interactive = args.paths.is_empty();
+    let interactive = paths.is_empty();
     let instructions = format!(
         "\
 You are splitting a commit in two: {}
@@ -3083,7 +3084,7 @@ don't make any changes, then the operation will be aborted.
         writeln!(
             ui.warning(),
             "The given paths do not match any file: {}",
-            args.paths.join(" ")
+            paths.join(" ")
         )?;
     }
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
