### PR TITLE
templates: Add more string methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Revsets gained a new function `mine()` that aliases `author(exact:"your_email")`.
 
 * `jj log` timestamp format now accepts `.utc()` to convert a timestamp to UTC.
+ 
+* templates now support additional string methods `.starts_with(x)`, `.ends_with(x)`
+  `.remove_prefix(x)`, `.remove_suffix(x)`, and `.substr(start, end)`.
 
 ### Fixed bugs
 

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -25,8 +25,8 @@ raw_literal = @{ literal_char+ }
 literal = { "\"" ~ (raw_literal | escape)* ~ "\"" }
 
 integer_literal = {
-  ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
-  | "0"
+  "-"? ~ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
+  | "-"? ~ "0"
 }
 
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -633,6 +633,16 @@ fn test_log_shortest_length_parameter() {
     ◉  0
     "###);
     insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(-0)"]), @r###"
+    @  2
+    ◉  0
+    "###);
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(-100)"]), @r###"
+    @  2
+    ◉  0
+    "###);
+    insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id.shortest(100)"]), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◉  0000000000000000000000000000000000000000

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -289,6 +289,8 @@ fn test_templater_list_method() {
     insta::assert_snapshot!(
         render(r#""a\nb\nc".lines().map(|s| "x\ny".lines().map(|t| s ++ t).join(",")).join(";")"#),
         @"ax,ay;bx,by;cx,cy");
+    // Nested string operations
+    insta::assert_snapshot!(render(r#""!a\n!b\nc\nend".remove_suffix("end").lines().map(|s| s.remove_prefix("!"))"#), @"a b c");
 
     // Lambda expression in alias
     insta::assert_snapshot!(render(r#""a\nb\nc".lines().map(identity)"#), @"a b c");
@@ -364,6 +366,36 @@ fn test_templater_string_method() {
 
     insta::assert_snapshot!(render(r#""".lines()"#), @"");
     insta::assert_snapshot!(render(r#""a\nb\nc\n".lines()"#), @"a b c");
+
+    insta::assert_snapshot!(render(r#""".starts_with("")"#), @"true");
+    insta::assert_snapshot!(render(r#""everything".starts_with("")"#), @"true");
+    insta::assert_snapshot!(render(r#""".starts_with("foo")"#), @"false");
+    insta::assert_snapshot!(render(r#""foo".starts_with("foo")"#), @"true");
+    insta::assert_snapshot!(render(r#""foobar".starts_with("foo")"#), @"true");
+    insta::assert_snapshot!(render(r#""foobar".starts_with("bar")"#), @"false");
+
+    insta::assert_snapshot!(render(r#""".ends_with("")"#), @"true");
+    insta::assert_snapshot!(render(r#""everything".ends_with("")"#), @"true");
+    insta::assert_snapshot!(render(r#""".ends_with("foo")"#), @"false");
+    insta::assert_snapshot!(render(r#""foo".ends_with("foo")"#), @"true");
+    insta::assert_snapshot!(render(r#""foobar".ends_with("foo")"#), @"false");
+    insta::assert_snapshot!(render(r#""foobar".ends_with("bar")"#), @"true");
+
+    insta::assert_snapshot!(render(r#""".remove_prefix("wip: ")"#), @"");
+    insta::assert_snapshot!(render(r#""wip: testing".remove_prefix("wip: ")"#), @"testing");
+
+    insta::assert_snapshot!(render(r#""bar@my.example.com".remove_suffix("@other.example.com")"#), @"bar@my.example.com");
+    insta::assert_snapshot!(render(r#""bar@other.example.com".remove_suffix("@other.example.com")"#), @"bar");
+
+    insta::assert_snapshot!(render(r#""foo".substr(0, 0)"#), @"");
+    insta::assert_snapshot!(render(r#""foo".substr(0, 1)"#), @"f");
+    insta::assert_snapshot!(render(r#""foo".substr(0, 99)"#), @"foo");
+    insta::assert_snapshot!(render(r#""abcdef".substr(2, -1)"#), @"cde");
+    insta::assert_snapshot!(render(r#""abcdef".substr(-3, 99)"#), @"def");
+
+    // ranges with end > start are empty
+    insta::assert_snapshot!(render(r#""abcdef".substr(4, 2)"#), @"");
+    insta::assert_snapshot!(render(r#""abcdef".substr(-2, -4)"#), @"");
 }
 
 #[test]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -142,6 +142,11 @@ defined.
 * `.lines() -> List<String>`: Split into lines excluding newline characters.
 * `.upper() -> String`
 * `.lower() -> String`
+* `.starts_with(needle: Template) -> Boolean`
+* `.ends_with(needle: Template) -> Boolean`
+* `.remove_prefix(needle: Template) -> String`: Removes the passed prefix, if present
+* `.remove_suffix(needle: Template) -> String`: Removes the passed suffix, if present
+* `.substr(start: Integer, end: Integer) -> String`: Extract substring. Negative values count from the end.
 
 ### Template type
 


### PR DESCRIPTION
Add starts_with/ends_with/remove_prefix/remove_suffix/substr methods to string when templating.

**Note: This also adds negative numbers to the template grammar**

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
