### PR TITLE
cli tests: Move `current_operation_id` to test_utils

### DIFF
--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -222,6 +222,12 @@ impl TestEnvironment {
         self.env_vars.insert(key.to_string(), val.to_string());
     }
 
+    pub fn current_operation_id(&self, repo_path: &Path) -> String {
+        let id_and_newline =
+            self.jj_cmd_success(repo_path, &["debug", "operation", "--display=id"]);
+        id_and_newline.trim_end().to_owned()
+    }
+
     /// Sets up the fake editor to read an edit script from the returned path
     /// Also sets up the fake editor as a merge tool named "fake-editor"
     pub fn set_up_fake_editor(&mut self) -> PathBuf {

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -50,13 +50,6 @@ fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     test_env.jj_cmd_success(repo_path, &["branch", "list"])
 }
 
-fn current_operation_id(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let mut id = test_env.jj_cmd_success(repo_path, &["debug", "operation", "--display=id"]);
-    let len_trimmed = id.trim_end().len();
-    id.truncate(len_trimmed);
-    id
-}
-
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
     let descr = format!("descr_for_{name}");
     if parents.is_empty() {
@@ -711,7 +704,7 @@ fn test_fetch_undo_what() {
     // Initial state we will try to return to after `op restore`. There are no
     // branches.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-    let base_operation_id = current_operation_id(&test_env, &repo_path);
+    let base_operation_id = test_env.current_operation_id(&repo_path);
 
     // Fetch a branch
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "fetch", "--branch", "b"]);

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -135,7 +135,7 @@ fn test_git_import_undo() {
 
     // Initial state we will return to after `undo`. There are no branches.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-    let base_operation_id = current_operation_id(&test_env, &repo_path);
+    let base_operation_id = test_env.current_operation_id(&repo_path);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
@@ -217,7 +217,7 @@ fn test_git_import_move_export_with_default_undo() {
     // Initial state we will try to return to after `op restore`. There are no
     // branches.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-    let base_operation_id = current_operation_id(&test_env, &repo_path);
+    let base_operation_id = test_env.current_operation_id(&repo_path);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
@@ -265,13 +265,6 @@ fn test_git_import_move_export_with_default_undo() {
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     test_env.jj_cmd_success(repo_path, &["branch", "list"])
-}
-
-fn current_operation_id(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let mut id = test_env.jj_cmd_success(repo_path, &["debug", "operation", "--display=id"]);
-    let len_trimmed = id.trim_end().len();
-    id.truncate(len_trimmed);
-    id
 }
 
 fn get_git_repo_refs(git_repo: &git2::Repository) -> Vec<(String, CommitId)> {

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -73,7 +73,7 @@ fn test_git_push_undo() {
     main: qpvuntsm 8c05de15 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
-    let pre_push_opid = current_operation_id(&test_env, &repo_path);
+    let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
     //                     |         | git    | repo
@@ -144,7 +144,7 @@ fn test_git_push_undo_with_import() {
     main: qpvuntsm 8c05de15 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
-    let pre_push_opid = current_operation_id(&test_env, &repo_path);
+    let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
     //                     |         | git    | repo
@@ -221,7 +221,7 @@ fn test_git_push_undo_colocated() {
     main: qpvuntsm 8c05de15 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
-    let pre_push_opid = current_operation_id(&test_env, &repo_path);
+    let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
     //                     |         | git    | repo
@@ -292,7 +292,7 @@ fn test_git_push_undo_repo_only() {
     main: qpvuntsm 8c05de15 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
-    let pre_push_opid = current_operation_id(&test_env, &repo_path);
+    let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_success(&repo_path, &["git", "push"]);
 
     // Undo the push, but keep both the git_refs and the remote-tracking branches
@@ -311,13 +311,6 @@ fn test_git_push_undo_repo_only() {
     main: qpvuntsm 0a3e99f0 (empty) CC
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
     "###);
-}
-
-fn current_operation_id(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    let mut id = test_env.jj_cmd_success(repo_path, &["debug", "operation", "--display=id"]);
-    let len_trimmed = id.trim_end().len();
-    id.truncate(len_trimmed);
-    id
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {


### PR DESCRIPTION
This is the first commit from https://github.com/martinvonz/jj/pull/2123, which should be
less controversial (even though it is not particularly important either)
