### PR TITLE
Fix docs for diff --stat

### DIFF
--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -43,7 +43,7 @@ pub struct DiffFormatArgs {
     /// For each path, show only whether it was modified, added, or removed
     #[arg(long, short)]
     pub summary: bool,
-    // Show a histogram of the changes
+    /// Show a histogram of the changes
     #[arg(long)]
     pub stat: bool,
     /// For each path, show only its type before and after


### PR DESCRIPTION
I just noticed that the comment on the `--stat` option was `//` instead of `///` so it wasn't showing in the output of `-h` or `help`. This fixes it.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
