### PR TITLE
Allow customizing comment leader in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * templates now support additional string methods `.starts_with(x)`, `.ends_with(x)`
   `.remove_prefix(x)`, `.remove_suffix(x)`, and `.substr(start, end)`.
 
+* The comment marker in editor prompts (e.g. `jj describe`) can now be customized
+  using the `ui.editor-comment-prefix` config option. The default remains `JJ: `.
+
 ### Fixed bugs
 
 * Fix issues related to .gitignore handling of untracked directories

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -124,6 +124,11 @@
                     "type": "string",
                     "description": "Editor to use for commands that involve editing text"
                 },
+                "editor-comment-prefix": {
+                    "type": "string",
+                    "description": "Prefix that marks lines in editor prompts as comments",
+                    "default": "JJ: "
+                },
                 "diff-editor": {
                     "type": "string",
                     "description": "Editor tool to use for editing diffs",

--- a/cli/tests/test_comment_prefix.rs
+++ b/cli/tests/test_comment_prefix.rs
@@ -1,0 +1,83 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test]
+fn test_describe() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let edit_script = test_env.set_up_fake_editor();
+
+    // Set an initial description using `-m` flag
+    let stdout = test_env.jj_cmd_success(&repo_path, &["describe", "-m", "description from CLI"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy now at: qpvuntsm cf3e8673 (empty) description from CLI
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    "###);
+
+    // Check that comment lines are commented and previous description is present
+    // uncommented
+    std::fs::write(&edit_script, "dump editor0").unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+    description from CLI
+
+    JJ: Lines starting with "JJ: " (like this one) will be removed.
+    "###);
+
+    // Set a custom comment prefix
+    // https://github.com/rust-lang/rust-clippy/issues/11068
+    #[allow(clippy::needless_raw_string_hashes)]
+    test_env.add_config(r##"ui.editor-comment-prefix = "#""##);
+
+    // Check that the custom prefix is being used
+    std::fs::write(&edit_script, "dump editor0").unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+    description from CLI
+
+    # Lines starting with "#" (like this one) will be removed.
+    "###);
+
+    // Set an empty prefix
+    #[allow(clippy::needless_raw_string_hashes)]
+    // https://github.com/rust-lang/rust-clippy/issues/11068
+    test_env.add_config(r##"ui.editor-comment-prefix = """##);
+
+    // Check that we fall back to the default
+    std::fs::write(&edit_script, "dump editor0").unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["describe"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Nothing changed.
+    "###);
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+    description from CLI
+
+    JJ: Lines starting with "JJ: " (like this one) will be removed.
+    "###);
+}

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -205,6 +205,14 @@ impl UserSettings {
             e @ Err(_) => e,
         }
     }
+
+    pub fn comment_prefix(&self) -> String {
+        self.config
+            .get_string("ui.editor-comment-prefix")
+            .ok()
+            .filter(|p| !p.is_empty())
+            .unwrap_or_else(|| "JJ: ".to_owned())
+    }
 }
 
 /// This Rng uses interior mutability to allow generating random values using an


### PR DESCRIPTION
This allows setting `ui.editor-comment-prefix` to change the hard-coded `JJ: ` prefix. Empty prefixes are not allowed, and for prefixes without a trailing space, one is added when printing comment lines.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
