### PR TITLE
templater: fix offset of negative substr() index to be char-based

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -378,10 +378,14 @@ fn build_string_method<'a, L: TemplateLanguage<'a>>(
             language.wrap_string(TemplateFunction::new(
                 (self_property, start_idx_property, end_idx_property),
                 |(s, start_idx, end_idx)| {
+                    // TODO: If we add .len() method, we'll expose bytes-based and char-based APIs.
+                    // Having different index units would be confusing, so we might want to change
+                    // .substr() to bytes-based and round up/down towards char or grapheme-cluster
+                    // boundary.
                     let to_idx = |i: i64| -> usize {
                         let magnitude = usize::try_from(i.unsigned_abs()).unwrap_or(usize::MAX);
                         if i < 0 {
-                            s.len().saturating_sub(magnitude)
+                            s.chars().count().saturating_sub(magnitude)
                         } else {
                             magnitude
                         }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -392,6 +392,8 @@ fn test_templater_string_method() {
     insta::assert_snapshot!(render(r#""foo".substr(0, 99)"#), @"foo");
     insta::assert_snapshot!(render(r#""abcdef".substr(2, -1)"#), @"cde");
     insta::assert_snapshot!(render(r#""abcdef".substr(-3, 99)"#), @"def");
+    insta::assert_snapshot!(render(r#""abc💩".substr(2, -1)"#), @"c");
+    insta::assert_snapshot!(render(r#""abc💩".substr(-1, 99)"#), @"💩");
 
     // ranges with end > start are empty
     insta::assert_snapshot!(render(r#""abcdef".substr(4, 2)"#), @"");


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
