### PR TITLE
docs: Add information about Change ID scope to glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -41,6 +41,9 @@ A change ID is a unique identifier for a [change](#change). They are typically
 them as a sequence of 12 letters in the k-z range, at the beginning of a line.
 These are actually hexadecimal numbers that use "digits" z-k instead of 0-9a-f.
 
+For the git backend, Change IDs are currently maintained only locally and not
+exchanged via push/fetch operations.
+
 ## Commit
 
 A snapshot of the files in the repository at a given point in time (technically


### PR DESCRIPTION
I was recently tripped up by a question about "where are change ids stored, and in what scope are they valid". Got an answer on Discord, thought I'd add it in the place where I initially searched :)