### PR TITLE
Github release action: release archived HTML of the docs for offline use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,8 @@ jobs:
         asset_name: ${{ env.ASSET }}
         asset_content_type: application/octet-stream
 
-  docs-build-deploy:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  docs-deploy-website-latest-release:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 
@@ -89,7 +86,7 @@ jobs:
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: latest
-      - name: Install dependencies, compile and deploy docs
+      - name: Install dependencies, compile and deploy docs to the "latest release" section of the website
         run: |
           git config user.name jj-docs-bot
           git config user.email jj-docs-bot@users.noreply.github.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,41 @@ jobs:
         asset_name: ${{ env.ASSET }}
         asset_content_type: application/octet-stream
 
+  docs-release-archive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Install packages (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: latest
+      - name: Compile docs and zip them up
+        run: |
+          poetry install
+          poetry run -- mkdocs build --no-directory-urls
+          archive="jj-${{ github.event.release.tag_name }}-docs-html.tar.gz"
+          tar czf "$archive" -C "rendered-docs" .
+          echo "ASSET=$archive" >> $GITHUB_ENV
+      - name: Upload release archive
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream
+
   docs-deploy-website-latest-release:
     runs-on: ubuntu-latest
     permissions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ extra:
   version:
     provider: mike
 plugins:
+    - offline
     - search
     - redirects:
         redirect_maps:


### PR DESCRIPTION
For a demo, see https://github.com/ilyagr/jj/releases/tag/0.8.6-tmpdocs and the [jj-0.8.6-tmpdocs-docs-html.tar.gz](https://github.com/ilyagr/jj/releases/download/0.8.6-tmpdocs/jj-0.8.6-tmpdocs-docs-html.tar.gz) link on that page. "-tmpdocs" is part of the version in this example.

I'm not sure how many people would find this useful, but it seems conceivable and was quite easy to do. Perhaps packagers (from the theoretical future) could package this with the binary.