### PR TITLE
Add optional `depth` parameter to ancestors() revset function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* The `ancestors()` revset function now takes an optional `depth` argument 
+  to limit the depth of the ancestor set. For example, use `jj log -r 
+  'ancestors(@, 5)` to view the last 5 commits.
+
 ### Fixed bugs
 
 ## [0.9.0] - 2023-09-06

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -79,7 +79,9 @@ revsets (expressions) as arguments.
 
 * `parents(x)`: Same as `x-`.
 * `children(x)`: Same as `x+`.
-* `ancestors(x)`: Same as `:x`.
+* `ancestors(x[, depth])`: `ancestors(x)` is the same as `::x`. 
+  `ancestors(x, depth)` returns the ancestors of `x` limited to the given 
+  `depth`.
 * `descendants(x)`: Same as `x::`.
 * `connected(x)`: Same as `x::x`. Useful when `x` includes several commits.
 * `all()`: All visible commits in the repo.

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -524,11 +524,7 @@ impl RevsetExpression {
 
     /// Ancestors of `self`, including `self`.
     pub fn ancestors(self: &Rc<RevsetExpression>) -> Rc<RevsetExpression> {
-        Rc::new(RevsetExpression::Ancestors {
-            heads: self.clone(),
-            generation: GENERATION_RANGE_FULL,
-            is_legacy: false,
-        })
+        self.ancestors_range(GENERATION_RANGE_FULL)
     }
     fn legacy_ancestors(self: &Rc<RevsetExpression>) -> Rc<RevsetExpression> {
         Rc::new(RevsetExpression::Ancestors {
@@ -540,9 +536,17 @@ impl RevsetExpression {
 
     /// Ancestors of `self`, including `self` until `generation` back.
     pub fn ancestors_at(self: &Rc<RevsetExpression>, generation: u64) -> Rc<RevsetExpression> {
+        self.ancestors_range(generation..(generation + 1))
+    }
+
+    /// Ancestors of `self` in the given range.
+    pub fn ancestors_range(
+        self: &Rc<RevsetExpression>,
+        generation_range: Range<u64>,
+    ) -> Rc<RevsetExpression> {
         Rc::new(RevsetExpression::Ancestors {
             heads: self.clone(),
-            generation: generation..(generation + 1),
+            generation: generation_range,
             is_legacy: false,
         })
     }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1205,6 +1205,24 @@ fn test_evaluate_expression_ancestors(use_git: bool) {
             root_commit.id().clone(),
         ]
     );
+
+    // Can find last n ancestors of a commit
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("ancestors({}, 0)", commit2.id().hex())),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("ancestors({}, 1)", commit3.id().hex())),
+        vec![commit3.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("ancestors({}, 3)", commit3.id().hex())),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+        ]
+    );
 }
 
 #[test_case(false ; "local backend")]


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->
Allows `ancestors(rev, n)` in the revset language.
```
⮞ jj log -r 'ancestors(@, 5)'
@  korrtmol sullyj3@gmail.com 2023-09-02 17:37:15.000 +10:00 c9dca8e9
│  (empty) Add test for revset n ancestors
◉  owvqrlnu sullyj3@gmail.com 2023-09-02 17:35:20.000 +10:00 main* HEAD@git 498cd57b
│  Add optional argument n to ancestors() in revset language
◉  yoslkysy sullyj3@gmail.com 2023-09-02 17:09:53.000 +10:00 80456ec4
│  Add generations argument to RevsetExpression::ancestors method
◉  uqwupmro martinvonz@google.com 2023-09-01 16:49:23.000 -07:00 main@upstream e3825495
│  store: don't include cached objects in `Debug` format
◉  ostmnpsu martinvonz@google.com 2023-09-01 16:23:39.000 -07:00 16c897d8
│  conflicts: leverage `Merge::map()` in `materialize_merge_result()`
~
```
See https://github.com/martinvonz/jj/discussions/1984 for some context.

Since I care most about the `git log -n 5` use-case, I chose to implement the simplest option of those discussed, returning the last n changes, including the "descendent" change. 

Support for `ancestors(x, m, n)` can be added later, since it will be backwards compatible. However, if we later went for the `ancestors(x, m..n)` syntax, I believe that would require a breaking change, unless it was allowed to support either a number or a range argument. I'm not familiar enough with the language to know if that's possible.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
