### PR TITLE
git: split `export_some_refs()` to smaller functions

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -603,7 +603,7 @@ fn update_git_ref(
             } else {
                 // The branch was added in jj but still doesn't exist in git, so add it
                 git_repo
-                    .reference(git_ref_name, new_oid, true, "export from jj")
+                    .reference(git_ref_name, new_oid, false, "export from jj")
                     .map_err(FailedRefExportReason::FailedToSet)?;
             }
         }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -420,7 +420,6 @@ pub enum FailedRefExportReason {
 /// We do not export tags and other refs at the moment, since these aren't
 /// supposed to be modified by JJ. For them, the Git state is considered
 /// authoritative.
-// TODO: Also indicate why we failed to export these branches
 pub fn export_refs(
     mut_repo: &mut MutableRepo,
     git_repo: &git2::Repository,


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
