### PR TITLE
revset: do not lookup unimported tags or remote branches by unqualified name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rename` to rename the existing remote.
   [#1690](https://github.com/martinvonz/jj/issues/1690)
 
+* Revset expression like `origin/main` will no longer resolve to a
+  remote-tracking branch. Use `main@origin` instead.
+
 ### New features
 
 * Default template for `jj log` now does not show irrelevant information

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1899,9 +1899,7 @@ fn filter_map_values_by_key_pattern<'a: 'b, 'b, V>(
 
 fn resolve_git_ref(repo: &dyn Repo, symbol: &str) -> Option<Vec<CommitId>> {
     let view = repo.view();
-    // TODO: We should remove `refs/remotes` from this list once we have a better
-    // way to address local git repo's remote-tracking branches.
-    for git_ref_prefix in &["", "refs/", "refs/tags/", "refs/remotes/"] {
+    for git_ref_prefix in &["", "refs/"] {
         let target = view.get_git_ref(&(git_ref_prefix.to_string() + symbol));
         if target.is_present() {
             return Some(target.added_ids().cloned().collect());


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
