### PR TITLE
docs: prefer new revset operator `::` over deprecated `:`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -231,7 +231,7 @@ To get shorter prefixes for certain revisions, set `revsets.short-prefixes`:
 
 ```toml
 # Prioritize the current branch
-revsets.short-prefixes = "(main..@):"
+revsets.short-prefixes = "(main..@)::"
 ```
 
 ### Relative timestamps
@@ -306,7 +306,7 @@ You can define aliases for commands, including their arguments. For example:
 ```toml
 # `jj l` shows commits on the working-copy commit's (anonymous) branch
 # compared to the `main` branch
-aliases.l = ["log", "-r", "(main..@): | (main..@)-"]
+aliases.l = ["log", "-r", "(main..@):: | (main..@)-"]
 ```
 
 ## Editor

--- a/docs/github.md
+++ b/docs/github.md
@@ -148,7 +148,7 @@ remote
 Log all remote branches, which you authored or committed to
 `jj log -r 'remote_branches() & (mine() | committer(your@email.com))'`
 Log all descendants of the current working copy, which aren't on a remote
-`jj log -r ':@ & ~remote_branches()'`
+`jj log -r '::@ & ~remote_branches()'`
 
 ## Merge conflicts
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -54,17 +54,17 @@ only symbols.
 * `~x`: Revisions that are not in `x`.
 * `x-`: Parents of `x`.
 * `x+`: Children of `x`.
-* `:x`: Ancestors of `x`, including the commits in `x` itself.
-* `x:`: Descendants of `x`, including the commits in `x` itself.
-* `x:y`: Descendants of `x` that are also ancestors of `y`. Equivalent
-   to `x: & :y`. This is what `git log` calls `--ancestry-path x..y`.
-* `::x`, `x::`, and `x::y`: New versions of `:x`, `x:`, and `x:y` released in
-  jj 0.9.0. We plan to delete the latter in jj 0.15+.
+* `::x`: Ancestors of `x`, including the commits in `x` itself.
+* `x::`: Descendants of `x`, including the commits in `x` itself.
+* `x::y`: Descendants of `x` that are also ancestors of `y`. Equivalent
+   to `x:: & ::y`. This is what `git log` calls `--ancestry-path x..y`.
 * `::`: All visible commits in the repo. Equivalent to `all()`.
+* `:x`, `x:`, and `x:y`: Deprecated versions of `::x`, `x::`, and `x::y` We
+  plan to delete them in jj 0.15+.
 * `x..y`: Ancestors of `y` that are not also ancestors of `x`. Equivalent to
-  `:y ~ :x`. This is what `git log` calls `x..y` (i.e. the same as we call it).
+  `::y ~ ::x`. This is what `git log` calls `x..y` (i.e. the same as we call it).
 * `..x`: Ancestors of `x`, including the commits in `x` itself, but excluding
-  the root commit. Equivalent to `:x ~ root()`.
+  the root commit. Equivalent to `::x ~ root()`.
 * `x..`: Revisions that are not ancestors of `x`.
 * `..`: All visible commits in the repo, but excluding the root commit.
   Equivalent to `~root()`.
@@ -80,8 +80,8 @@ revsets (expressions) as arguments.
 * `parents(x)`: Same as `x-`.
 * `children(x)`: Same as `x+`.
 * `ancestors(x)`: Same as `:x`.
-* `descendants(x)`: Same as `x:`.
-* `connected(x)`: Same as `x:x`. Useful when `x` includes several commits.
+* `descendants(x)`: Same as `x::`.
+* `connected(x)`: Same as `x::x`. Useful when `x` includes several commits.
 * `all()`: All visible commits in the repo.
 * `none()`: No commits. This function is rarely useful; it is provided for
   completeness.
@@ -180,7 +180,7 @@ jj log -r 'remote_branches(remote=origin)..'
 Show all ancestors of the working copy (almost like plain `git log`)
 
 ```
-jj log -r :@
+jj log -r ::@
 ```
 
 Show the initial commits in the repo (the ones Git calls "root commits"):
@@ -200,7 +200,7 @@ those commits:
 
 
 ```
-jj log -r '(remote_branches()..@):'
+jj log -r '(remote_branches()..@)::'
 ```
 
 Show commits authored by "martinvonz" and containing the word "reset" in the

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -160,7 +160,7 @@ called the "root commit". It's the root commit of every repo. The `root()`
 function in the revset matches it.
 
 There are also operators for getting the parents (`foo-`), children (`foo+`),
-ancestors (`:foo`), descendants (`foo:`), DAG range (`foo:bar`, like
+ancestors (`::foo`), descendants (`foo::`), DAG range (`foo::bar`, like
 `git log --ancestry-path`), range (`foo..bar`, same as Git's). There are also a
 few more functions, such as `heads(<set>)`, which filters out revisions in the
 input set if they're ancestors of other revisions in the set.
@@ -346,7 +346,7 @@ $ jj new -m ABC; printf 'A\nB\nc\n' > file
 Working copy now at: 6f30cd1fb351 ABC
 $ jj new -m ABCD; printf 'A\nB\nC\nD\n' > file
 Working copy now at: a67491542e10 ABCD
-$ jj log -r master:@
+$ jj log -r master::@
 @  mrxqplykzpkw martinvonz@google.com 2023-02-12 19:38:21.000 -08:00 b98c607bf87f
 │  ABCD
 ◉  kwtuwqnmqyqp martinvonz@google.com 2023-02-12 19:38:12.000 -08:00 30aecc0871ea


### PR DESCRIPTION
Now that we're very close to a release, it should be fine to use the new syntax in our documentation. This effecttively backs out 37436f7344d4.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
