### PR TITLE
docs: try to clarify that we want contributors to squash fixup commits

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,8 @@ information on using pull requests.
 
 Unlike many GitHub projects (but like many VCS projects), we care more about the
 contents of commits than about the contents of PRs. We review each commit
-separately, and we don't squash them when the PR is ready.
+separately, and we don't squash-merge the PR (so please manually squash any
+fixup commits before sending for review).
 
 Each commit should ideally do one thing. For example, if you need to refactor a
 function in order to add a new feature cleanly, put the refactoring in one


### PR DESCRIPTION
It's happened a few times that contributors misunderstood the guidelines, so they're clearly not clear enough. Hopefully this clarifies.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
