### PR TITLE
config docs: minor fixups

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -416,12 +416,12 @@ this file will be ignored. To suppress the creation of this file, set
 
 Using `ui.diff-editor = "vimdiff"` is possible but not recommended. For a better
 experience, you can follow these [instructions] to configure
-the [`DirDiff` Vim plugin] and/or the [`vimtabdiff` Python script].
+the [DirDiff Vim plugin] and/or the [vimtabdiff Python script].
 
 [instructions]: https://gist.github.com/ilyagr/5d6339fb7dac5e7ab06fe1561ec62d45
 
-[`DirDiff` Vim plugin]: https://github.com/will133/vim-dirdiff
-[`vimtabdiff` Python script]: https://github.com/balki/vimtabdiff
+[DirDiff Vim plugin]: https://github.com/will133/vim-dirdiff
+[vimtabdiff Python script]: https://github.com/balki/vimtabdiff
 
 ## 3-way merge tools for conflict resolution
 
@@ -536,7 +536,7 @@ cargo install --git https://github.com/martinvonz/jj.git --locked --bin jj jj-cl
 
 To configure the Watchman filesystem monitor, set
 `core.fsmonitor = "watchman"`. Ensure that you have [installed the Watchman
-executable on your system](https://facebook.github.io/watchman/docs/install)).
+executable on your system](https://facebook.github.io/watchman/docs/install).
 
 Debugging commands are available under `jj debug watchman`.
 


### PR DESCRIPTION
mkdocs can't seem to handle backticks in link anchors for out-of-text links.
