### PR TITLE
use `ancestors(x, depth)` in tests and default revset

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -354,9 +354,8 @@ struct StatusArgs {}
 /// Show commit history
 #[derive(clap::Args, Clone, Debug)]
 struct LogArgs {
-    /// Which revisions to show. Defaults to the `revsets.log` setting,
-    /// or `@ | (remote_branches() | tags()).. | ((remote_branches() |
-    /// tags())..)-` if it is not set.
+    /// Which revisions to show. Defaults to the `revsets.log` setting, or
+    /// `@ | ancestors((remote_branches() | tags()).., 2)` if it is not set.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
     /// Show commits modifying the given paths

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -294,7 +294,7 @@
                 "log": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",
-                    "default": "@ | (remote_branches() | tags()).. | ((remote_branches() | tags())..)-"
+                    "default": "@ | ancestors((remote_branches() | tags()).., 2)"
                 },
                 "short-prefixes": {
                     "type": "string",

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -4685,20 +4685,8 @@ mod tests {
         "###);
 
         // Ancestors of empty generation range should be empty.
-        // TODO: rewrite these tests if we added syntax for arbitrary generation
-        // ancestors
-        let empty_generation_ancestors = |heads| {
-            Rc::new(RevsetExpression::Ancestors {
-                heads,
-                generation: GENERATION_RANGE_EMPTY,
-                is_legacy: false,
-            })
-        };
         insta::assert_debug_snapshot!(
-            optimize(empty_generation_ancestors(
-                RevsetExpression::symbol("foo".to_owned()).ancestors()
-            )),
-            @r###"
+            optimize(parse("ancestors(ancestors(foo), 0)").unwrap()), @r###"
         Ancestors {
             heads: CommitRef(
                 Symbol(
@@ -4711,10 +4699,7 @@ mod tests {
         "###
         );
         insta::assert_debug_snapshot!(
-            optimize(
-                empty_generation_ancestors(RevsetExpression::symbol("foo".to_owned())).ancestors()
-            ),
-            @r###"
+            optimize(parse("ancestors(ancestors(foo, 0))").unwrap()), @r###"
         Ancestors {
             heads: CommitRef(
                 Symbol(

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -159,10 +159,7 @@ impl UserSettings {
             // For compatibility with old config files (<0.8.0)
             self.config
                 .get_string("ui.default-revset")
-                .unwrap_or_else(|_| {
-                    "@ | (remote_branches() | tags()).. | ((remote_branches() | tags())..)-"
-                        .to_string()
-                })
+                .unwrap_or_else(|_| "@ | ancestors((remote_branches() | tags()).., 2)".to_string())
         })
     }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
