### PR TITLE
git: add method to import commits, promote them to tree-conflict format

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -225,12 +225,14 @@ pub fn import_some_refs(
         changed_git_refs.values().map(|(_, new_target)| new_target),
     )
     .flat_map(|target| target.added_ids());
-    let heads_imported = git_backend.import_head_commits(head_ids).is_ok();
+    let heads_imported = git_backend
+        .import_head_commits(head_ids, store.use_tree_conflict_format())
+        .is_ok();
     let mut head_commits = Vec::new();
     let get_commit = |id| {
         // If bulk-import failed, try again to find bad head or ref.
         if !heads_imported {
-            git_backend.import_head_commits([id])?;
+            git_backend.import_head_commits([id], store.use_tree_conflict_format())?;
         }
         store.get_commit(id)
     };

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1855,7 +1855,10 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
     )
     .unwrap();
     get_git_backend(&jj_repo)
-        .import_head_commits(&[jj_id(&initial_git_commit)])
+        .import_head_commits(
+            &[jj_id(&initial_git_commit)],
+            jj_repo.store().use_tree_conflict_format(),
+        )
         .unwrap();
     let mut tx = jj_repo.start_transaction(settings, "test");
     let new_commit = create_random_commit(tx.mut_repo(), settings)
@@ -2289,7 +2292,10 @@ fn test_concurrent_read_write_commit() {
                     pending_commit_ids = pending_commit_ids
                         .into_iter()
                         .filter_map(|commit_id| {
-                            match git_backend.import_head_commits([&commit_id]) {
+                            match git_backend.import_head_commits(
+                                [&commit_id],
+                                repo.store().use_tree_conflict_format(),
+                            ) {
                                 Ok(()) => {
                                     // update index as git::import_refs() would do
                                     let commit = repo.store().get_commit(&commit_id).unwrap();


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
