### PR TITLE
cli: re-enable 'watchman' support when 'packaging' is enabled

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -76,6 +76,6 @@ testutils = { workspace = true }
 [features]
 default = ["watchman"]
 bench = ["dep:criterion"]
-packaging = []
+packaging = ["watchman"]
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]


### PR DESCRIPTION
Summary: 70f6e0a enabled watchman by default in the *default* features set, but removed it from the 'packaging' set. But features are not 'additive' by default. When building the Nix flake from this repository, it uses --features packaging, which no longer enables watchman, because it was removed.

The easiest solution is probably just to ensure 'packaging' is always a superset of 'default', but I'm not sure of a way to do this.