### PR TITLE
chore(nix): add 'default' features to list of cargo features

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,6 @@
         jujutsu = ourRustPlatform.buildRustPackage rec {
           pname = "jujutsu";
           version = "unstable-${self.shortRev or "dirty"}";
-          buildNoDefaultFeatures = true;
           buildFeatures = [ "packaging" ];
           cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
           useNextest = true;


### PR DESCRIPTION
Summary: By default, and to be explicit, the local flake turns off default features. But, https://github.com/martinvonz/jj/commit/70f6e0a452230c050e1eb8ccb7f5471b9ec16112 turned off watchman support for the Nix build by accident. Enable default features so this doesn't happen again.

Change-Id: Ib7dd935eceab328fa5b0333b10368377

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
