### PR TITLE
cli: add `jj op log --no-graph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for the Watchman filesystem monitor is now bundled by default. Set
   `core.fsmonitor = "watchman"` in your repo to enable.
 
+* `jj op log` now supports `--no-graph`.
+
 ### Fixed bugs
 
 ## [0.9.0] - 2023-09-06

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -131,6 +131,22 @@ fn test_op_log_limit() {
 }
 
 #[test]
+fn test_op_log_no_graph() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stdout =
+        test_env.jj_cmd_success(&repo_path, &["op", "log", "--no-graph", "--color=always"]);
+    insta::assert_snapshot!(stdout, @r###"
+    [1m[38;5;12m19b8089fc78b[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
+    [1madd workspace 'default'[0m
+    [38;5;4mf1c462c494be[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
+    initialize repo
+    "###);
+}
+
+#[test]
 fn test_op_log_template() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
Seems useful, and makes it consistent with the `jj log` and `jj obslog`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
