### PR TITLE
cli: hint for conflicted branches and change ids

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1022,9 +1022,15 @@ impl WorkspaceCommandHelper {
                     .map(|c| self.format_commit_summary(c))
                     .join("\n")
                     + elided.then_some("\n...").unwrap_or_default();
-                let hint = if let RevsetExpression::CommitRef(RevsetCommitRef::Symbol(
-                    branch_name,
-                )) = revset_expression.as_ref()
+                let hint = if commits[0].change_id() == commits[1].change_id() {
+                    // Separate hint if there's commits with same change id
+                    format!(
+                        r#"The revset "{revision_str}" resolved to these revisions:
+{commits_summary}
+Some of these commits have the same change id. Abandon one of them with `jj abandon -r <REVISION>`."#,
+                    )
+                } else if let RevsetExpression::CommitRef(RevsetCommitRef::Symbol(branch_name)) =
+                    revset_expression.as_ref()
                 {
                     // Separate hint if there's a conflicted branch
                     format!(

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1017,14 +1017,14 @@ impl WorkspaceCommandHelper {
                 let mut iter = [commit0, commit1].into_iter().chain(iter);
                 let commits: Vec<_> = iter.by_ref().take(5).try_collect()?;
                 let elided = iter.next().is_some();
+                let commits_summary = commits
+                    .iter()
+                    .map(|c| self.format_commit_summary(c))
+                    .join("\n")
+                    + elided.then_some("\n...").unwrap_or_default();
                 let hint = format!(
-                    r#"The revset "{revision_str}" resolved to these revisions:{eol}{commits}{ellipsis}"#,
-                    eol = "\n",
-                    commits = commits
-                        .iter()
-                        .map(|c| self.format_commit_summary(c))
-                        .join("\n"),
-                    ellipsis = elided.then_some("\n...").unwrap_or_default()
+                    r#"The revset "{revision_str}" resolved to these revisions:
+{commits_summary}"#,
                 );
                 Err(user_error_with_hint(
                     format!(r#"Revset "{revision_str}" resolved to more than one revision"#),


### PR DESCRIPTION
Resolves issue #2192 

The output of the changed hint is:
```
$ jj checkout letters
Error: Revset "letters" resolved to more than one revision
Hint: The revset "letters" resolved to these revisions:
rmyxvrmv f54150b7 letters?? | (conflict) E ammended
pysvtnpy f9e2e044 letters?? | (conflict) E
This error is due to a conflicted branch. To resolve this, try setting to which revision the branch points to with "jj branch set letters --revision <REVISION>"
```
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
