### PR TITLE
Base default log template on `immutable_heads()`

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -213,8 +213,8 @@ fn cmd_debug_revset(
     writeln!(ui, "{expression:#?}")?;
     writeln!(ui)?;
 
-    let expression =
-        expression.resolve_user_expression(repo, &workspace_command.revset_symbol_resolver())?;
+    let symbol_resolver = workspace_command.revset_symbol_resolver()?;
+    let expression = expression.resolve_user_expression(repo, &symbol_resolver)?;
     writeln!(ui, "-- Resolved:")?;
     writeln!(ui, "{expression:#?}")?;
     writeln!(ui)?;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -355,7 +355,8 @@ struct StatusArgs {}
 #[derive(clap::Args, Clone, Debug)]
 struct LogArgs {
     /// Which revisions to show. Defaults to the `revsets.log` setting, or
-    /// `@ | ancestors((remote_branches() | tags()).., 2)` if it is not set.
+    /// `@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())` if
+    /// it is not set.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
     /// Show commits modifying the given paths

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -294,7 +294,7 @@
                 "log": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",
-                    "default": "@ | ancestors((remote_branches() | tags()).., 2)"
+                    "default": "@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())"
                 },
                 "short-prefixes": {
                     "type": "string",

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -165,8 +165,7 @@ fn test_branch_delete_glob() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1 foo-3 foo-4 6fbf398c2d59
-    │
-    ~
+    ◉   000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "delete", "--glob", "foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -174,8 +173,7 @@ fn test_branch_delete_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1@origin foo-3@origin foo-4 6fbf398c2d59
-    │
-    ~
+    ◉   000000000000
     "###);
 
     // We get an error if none of the globs match live branches. Unlike `jj branch
@@ -196,8 +194,7 @@ fn test_branch_delete_glob() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1@origin foo-3@origin foo-4@origin 6fbf398c2d59
-    │
-    ~
+    ◉   000000000000
     "###);
 
     // The deleted branches are still there

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -459,6 +459,26 @@ fn test_log_shortest_accessors() {
 }
 
 #[test]
+fn test_log_bad_short_prefixes() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    // Error on bad config of short prefixes
+    test_env.add_config(r#"revsets.short-prefixes = "!nval!d""#);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["status"]);
+    insta::assert_snapshot!(stderr,
+        @r###"
+    Config error: Invalid `revsets.short-prefixes`:  --> 1:1
+      |
+    1 | !nval!d
+      | ^---
+      |
+      = expected <expression>
+    For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
+    "###);
+}
+
+#[test]
 fn test_log_prefix_highlight_styled() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -67,7 +67,9 @@ fn test_templater_branches() {
     let template = r#"commit_id.short() ++ " " ++ branches"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  b1bb3766d584 branch3??
+    ◉  fed794e2ba44 branch3?? branch3@origin
+    │ ◉  b1bb3766d584 branch3??
+    ├─╯
     │ ◉  21c33875443e branch1*
     ├─╯
     │ @  a5b4d15489cc branch2* new-branch

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -159,7 +159,9 @@ impl UserSettings {
             // For compatibility with old config files (<0.8.0)
             self.config
                 .get_string("ui.default-revset")
-                .unwrap_or_else(|_| "@ | ancestors((remote_branches() | tags()).., 2)".to_string())
+                .unwrap_or_else(|_| {
+                    "@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())".to_string()
+                })
         })
     }
 


### PR DESCRIPTION
One important bit that remains is to teach the templater a `immutable` (or `mutable`) keyword. That's a bit more complicated because we'll probably need to give revsets a caching iterator so we can quickly check if the `immutable()` revset contains a particular commit without eagerly evaluating it (and without searching from the heads every time).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
