### PR TITLE
docs: document script to colocate a jj-only repo

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -153,6 +153,26 @@ repos may require you to deal with more involved Jujutsu and Git concepts.
   report any new ones you find, or if any of the known bugs are less minor than
   they appear.
 
+### Converting a repo into a co-located repo
+
+A Jujutsu repo backed by a Git repo has a full Git repo inside, so it is
+technically possible (though not officially supported) to convert it into a
+co-located repo like so:
+
+```bash
+# Move the Git repo
+mv .jj/repo/store/git .git
+# Tell jj where to find it
+echo -n '../../../.git' > .jj/repo/store/git_target
+# Ignore the .jj directory in Git
+echo /.jj/ > .git/info/exclude
+# Make the Git repository non-bare and set HEAD
+git config --unset core.bare
+jj st
+```
+
+We may officially support this in the future. If you try this, we would
+appreciate feedback and bug reports.
 
 ## Branches
 


### PR DESCRIPTION
https://github.com/martinvonz/jj/discussions/2230 indicates a lot of interest in this, so we'd probably want to support this officially at some point. Until then, document a script that has worked well-enough for some of us.

Hi! It's me, non-Googler @chooglen. Why did I choose to separate my GitHub accounts in the first place? I don't really know.


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

