### PR TITLE
Allow \0 escape for nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj op log` now supports `--no-graph`.
 
+* Templates now support an additional escape: `\0`. This will output a literal
+  null byte. This may be useful for e.g.
+  `jj log -T 'description ++ "\0"' --no-graph` to output descriptions only, but
+  be able to tell where the boundaries are
+
 ### Fixed bugs
 
 ## [0.9.0] - 2023-09-06

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -19,7 +19,7 @@
 
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
-escape = @{ "\\" ~ ("t" | "r" | "n" | "\"" | "\\") }
+escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
 literal_char = @{ !("\"" | "\\") ~ ANY }
 raw_literal = @{ literal_char+ }
 literal = { "\"" ~ (raw_literal | escape)* ~ "\"" }

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -256,12 +256,13 @@ fn parse_string_literal(pair: Pair<Rule>) -> String {
             Rule::raw_literal => {
                 result.push_str(part.as_str());
             }
-            Rule::escape => match part.as_str().as_bytes()[1] as char {
-                '"' => result.push('"'),
-                '\\' => result.push('\\'),
-                't' => result.push('\t'),
-                'r' => result.push('\r'),
-                'n' => result.push('\n'),
+            Rule::escape => match &part.as_str()[1..] {
+                "\"" => result.push('"'),
+                "\\" => result.push('\\'),
+                "t" => result.push('\t'),
+                "r" => result.push('\r'),
+                "n" => result.push('\n'),
+                "0" => result.push('\0'),
                 char => panic!("invalid escape: \\{char:?}"),
             },
             _ => panic!("unexpected part of string: {part:?}"),
@@ -963,8 +964,8 @@ mod tests {
     fn test_string_literal() {
         // "\<char>" escapes
         assert_eq!(
-            parse_into_kind(r#" "\t\r\n\"\\" "#),
-            Ok(ExpressionKind::String("\t\r\n\"\\".to_owned())),
+            parse_into_kind(r#" "\t\r\n\"\\\0" "#),
+            Ok(ExpressionKind::String("\t\r\n\"\\\0".to_owned())),
         );
 
         // Invalid "\<char>" escape

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -147,6 +147,27 @@ fn test_op_log_no_graph() {
 }
 
 #[test]
+fn test_op_log_no_graph_null_terminated() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "message1"]);
+    test_env.jj_cmd_success(&repo_path, &["commit", "-m", "message2"]);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "op",
+            "log",
+            "--no-graph",
+            "--template",
+            r#"id.short(4) ++ "\0""#,
+        ],
+    );
+    insta::assert_debug_snapshot!(stdout, @r###""c8b0\07277\019b8\0f1c4\0""###);
+}
+
+#[test]
 fn test_op_log_template() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_success(test_env.env_root(), &["init", "repo", "--git"]);

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -279,6 +279,8 @@ fn test_templater_list_method() {
 
     insta::assert_snapshot!(render(r#""".lines().join("|")"#), @"");
     insta::assert_snapshot!(render(r#""a\nb\nc".lines().join("|")"#), @"a|b|c");
+    // Null separator
+    insta::assert_snapshot!(render(r#""a\nb\nc".lines().join("\0")"#), @"a\0b\0c");
     // Keyword as separator
     insta::assert_snapshot!(render(r#""a\nb\nc".lines().join(commit_id.short(2))"#), @"a00b00c");
 


### PR DESCRIPTION
This allows safely getting e.g. multiple descriptions, and knowing where the boundaries are

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
- N/A I have updated the documentation (README.md, docs/, demos/)
- N/A I have updated the config schema (cli/src/config-schema.json)
