### PR TITLE
cli: change the default revsets for push to be based on trunk()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Check [revsets.toml](cli/src/config/revsets.toml) and [revsets.md](docs/revset.md)
   to understand how the function can be adapted.
 
+* `jj git push` will now push all branches in the range `(trunk()..@):: & branches()`
+  instead of only branches pointing to `remote_branches()..@`.
+
 ### New features
 
 * The `ancestors()` revset function now takes an optional `depth` argument 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -140,9 +140,7 @@ fn test_git_push_matching_branch_unchanged() {
     insta::assert_snapshot!(stdout, @r###"
     Nothing changed.
     "###);
-    insta::assert_snapshot!(stderr, @r###"
-    No branches point to the specified revisions.
-    "###);
+    insta::assert_snapshot!(stderr, @"");
 }
 
 /// Test that `jj git push` without arguments pushes a branch to the specified
@@ -183,9 +181,7 @@ fn test_git_push_other_remote_has_branch() {
     insta::assert_snapshot!(stdout, @r###"
     Nothing changed.
     "###);
-    insta::assert_snapshot!(stderr, @r###"
-    No branches point to the specified revisions.
-    "###);
+    insta::assert_snapshot!(stderr, @"");
     // But it will still get pushed to another remote
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--remote=other"]);
     insta::assert_snapshot!(stdout, @r###"


### PR DESCRIPTION
As with #2088, I'm not wedded to this, but it seems like a valuable change for my workflow at least and matches [git-branchless submit](https://github.com/arxanas/git-branchless/wiki/Command:-git-submit).

Builds on the trunk alias from #2088. The benefits of this over the previous default in my opinion is:
1. It captures the entire stack range instead of just up to `@`, meaning you can run it from inside a stack; and
2. It's built on `trunk()..@`, so if the trunk branch was accidentally modified, the default push won't include it.

Note: Once `trunk()` is made into a built-in function, we can create a `stack()` function that resolves to `(trunk()..@)::` which should be a bit cleaner than the current approach.