### PR TITLE
cli: change ui.default-revset to be based on trunk()

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -355,7 +355,7 @@ struct StatusArgs {}
 #[derive(clap::Args, Clone, Debug)]
 struct LogArgs {
     /// Which revisions to show. Defaults to the `revsets.log` setting, or
-    /// `@ | ancestors((remote_branches() | tags()).., 2)` if it is not set.
+    /// `(trunk()..@):: | (trunk()..@)-` if it is not set.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
     /// Show commits modifying the given paths

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -159,7 +159,7 @@ impl UserSettings {
             // For compatibility with old config files (<0.8.0)
             self.config
                 .get_string("ui.default-revset")
-                .unwrap_or_else(|_| "@ | ancestors((remote_branches() | tags()).., 2)".to_string())
+                .unwrap_or_else(|_| "(trunk()..@):: | (trunk()..@)-".to_string())
         })
     }
 


### PR DESCRIPTION
As with https://github.com/martinvonz/jj/pull/2088, I'm not wedded to this, but it seems like a valuable change for my workflow at least and matches [git-branchless sl](https://github.com/arxanas/git-branchless/wiki/Command:-git-smartlog).

Still a work in progress, requires updating tests which use raw `jj log`. Most likely I'll throw in a PR before this one to change them all to use `jj log -rall()` for robustness if the default needs to be changed in the future.