### PR TITLE
cli trunk() revset: fix docs and add `upstream` remote support

### DIFF
--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -7,6 +7,9 @@ latest(
   remote_branches(exact:"main", exact:"origin") | 
   remote_branches(exact:"master", exact:"origin") | 
   remote_branches(exact:"trunk", exact:"origin") |
+  remote_branches(exact:"main", exact:"upstream") |
+  remote_branches(exact:"master", exact:"upstream") |
+  remote_branches(exact:"trunk", exact:"upstream") |
   root()
 )
 '''

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -167,8 +167,9 @@ See [revsets.toml](https://github.com/martinvonz/jj/blob/main/cli/src/config/rev
 for a comprehensive list.
 
 * `trunk()`: Resolves to the head commit for the trunk branch of the `origin`
-  remote. The branches `main`, `master`, and `trunk` are tried in order.
-  If none of the branches exist, it evaluates to `root()`.
+  remote. The branches `main`, `master`, and `trunk` are tried. If more than one
+  potential trunk commit exists, the newest one is chosen. If none of the
+  branches exist, the revset evaluates to `root()`.
 
   You can [override](./config.md) this as appropriate. If you do, make sure it
   always resolves to exactly one commit. For example:

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -166,10 +166,10 @@ are defined as aliases in order to allow you to overwrite them as needed.
 See [revsets.toml](https://github.com/martinvonz/jj/blob/main/cli/src/config/revsets.toml)
 for a comprehensive list.
 
-* `trunk()`: Resolves to the head commit for the trunk branch of the `origin`
-  remote. The branches `main`, `master`, and `trunk` are tried. If more than one
-  potential trunk commit exists, the newest one is chosen. If none of the
-  branches exist, the revset evaluates to `root()`.
+* `trunk()`: Resolves to the head commit for the trunk branch of the remote
+  named `origin` or `upstream`. The branches `main`, `master`, and `trunk` are
+  tried. If more than one potential trunk commit exists, the newest one is
+  chosen. If none of the branches exist, the revset evaluates to `root()`.
 
   You can [override](./config.md) this as appropriate. If you do, make sure it
   always resolves to exactly one commit. For example:


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
