### PR TITLE
cargo: stop `cargo install` from installing `fake-editor` & co.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "indexmap 2.0.0",
  "insta",
  "itertools 0.11.0",
+ "jj-cli",
  "jj-lib",
  "libc",
  "maplit",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,10 +19,12 @@ path = "src/main.rs"
 [[bin]]
 name = "fake-editor"
 path = "testing/fake-editor.rs"
+required-features = ["test-fakes"]
 
 [[bin]]
 name = "fake-diff-editor"
 path = "testing/fake-diff-editor.rs"
+required-features = ["test-fakes"]
 
 [build-dependencies]
 cargo_metadata = { workspace = true }
@@ -72,10 +74,13 @@ assert_matches = { workspace = true }
 insta = { workspace = true }
 test-case = { workspace = true }
 testutils = { workspace = true }
+# https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987
+jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 
 [features]
 default = ["watchman"]
 bench = ["dep:criterion"]
 packaging = []
+test-fakes = []
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]


### PR DESCRIPTION
Among other things, this prevented `jj` from working with `cargo binstall`.

The trick is taken from
https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987.

We could now also remove `--bin jj` from the installation commands in `install-and-setup.md`, but I'm not sure we should. That argument makes it clear that the binary is `jj`, not `jj-cli`.

Fixes #216.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
