### PR TITLE
cargo: make `jj` installable with `cargo binstall`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,3 +84,8 @@ packaging = []
 test-fakes = []
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]
+
+[package.metadata.binstall]
+# The archive name is jj, not jj-cli. Also, `cargo binstall` gets
+# confused by the `v` before versions in archive name.
+pkg-url="{ repo }/releases/download/v{ version }/jj-v{ version }-{ target }.{ archive-format }"


### PR DESCRIPTION
(This is mainly a draft because it is based on #2277)

https://github.com/cargo-bins/cargo-binstall

Note that `jj` will only become installable once the next release
is published to crates.io. For this reason, I am planning to
wait until then before documenting the fact that `jj` can be
installed this way.

At that point, `cargo binstall jj-cli` should be sufficient.

Before then, it's possible to test that this will work by doing

```
cargo binstall jj-cli --force --strategies crate-meta-data \
   --log-level debug  --dry-run --manifest-path cli/Cargo.toml
``` 

Without --dry-run, this should install the 0.9 release if run
on `cli/Cargo.toml` form this commit. (You don't need the rest
of the `jj` repo for this to work, you can just download the
`Cargo.toml` and point `--manifest-path` to it)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
