### PR TITLE
templater: fast-path `empty` and `conflict` to not read trees

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -905,7 +905,7 @@ fn cmd_git_push(
         {
             reasons.push("it has no author and/or committer set");
         }
-        if commit.tree()?.has_conflict() {
+        if commit.has_conflict()? {
             reasons.push("it has conflicts");
         }
         if !reasons.is_empty() {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -299,10 +299,13 @@ fn build_commit_keyword_opt<'repo>(
             let maybe_entries = repo.resolve_change_id(commit.change_id());
             maybe_entries.map_or(true, |entries| !entries.contains(commit.id()))
         })),
-        "conflict" => language.wrap_boolean(wrap_fn(property, |commit| {
-            commit.tree().unwrap().has_conflict()
-        })),
+        "conflict" => {
+            language.wrap_boolean(wrap_fn(property, |commit| commit.has_conflict().unwrap()))
+        }
         "empty" => language.wrap_boolean(wrap_fn(property, |commit| {
+            if let [parent] = &commit.parents()[..] {
+                return parent.tree_id() == commit.tree_id();
+            }
             let parent_tree = rewrite::merge_commit_trees(repo, &commit.parents()).unwrap();
             *commit.tree_id() == parent_tree.id()
         })),

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -108,6 +108,14 @@ impl Commit {
         &self.data.root_tree
     }
 
+    pub fn has_conflict(&self) -> Result<bool, BackendError> {
+        if let MergedTreeId::Merge(tree_ids) = self.tree_id() {
+            Ok(!tree_ids.is_resolved())
+        } else {
+            Ok(self.tree()?.has_conflict())
+        }
+    }
+
     pub fn change_id(&self) -> &ChangeId {
         &self.data.change_id
     }

--- a/lib/src/default_revset_engine.rs
+++ b/lib/src/default_revset_engine.rs
@@ -869,7 +869,7 @@ fn build_predicate_fn<'index>(
         }
         RevsetFilterPredicate::HasConflict => pure_predicate_fn(move |entry| {
             let commit = store.get_commit(&entry.commit_id()).unwrap();
-            commit.tree().unwrap().has_conflict()
+            commit.has_conflict().unwrap()
         }),
     }
 }


### PR DESCRIPTION

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
