### PR TITLE
cli: print commits abandoned by git::import_refs() or fetch()

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -838,6 +838,7 @@ impl WorkspaceCommandHelper {
                 self.finish_transaction(ui, tx)?;
             }
         }
+        writeln!(ui, "Done importing changes from the underlying Git repo.")?;
         Ok(())
     }
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -371,6 +371,7 @@ fn test_log_git_head() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
+    Done importing changes from the underlying Git repo.
     @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
     ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;5mmaster[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -160,6 +160,7 @@ fn test_git_colocated_rebase_on_import() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     Abandoned the following commits:
       rlvkpnrz 45fbe1af master | modify a file
+    Done importing changes from the underlying Git repo.
     @  7f96185cfbe36341d0f9a86ebfaeab67a5922c7e
     ◉  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master HEAD@git add a file
     ◉  0000000000000000000000000000000000000000
@@ -212,6 +213,7 @@ fn test_git_colocated_branches() {
       kkmpptxz 35605592 master | (empty) bar
     Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
+    Done importing changes from the underlying Git repo.
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
     │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
@@ -347,6 +349,7 @@ fn test_git_colocated_external_checkout() {
     // The old working-copy commit gets abandoned, but the whole branch should not
     // be abandoned. (#1042)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    Done importing changes from the underlying Git repo.
     @  0521ce3b8c4e29aab79f3c750e2845dcbc4c3874
     ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master HEAD@git A
     │ ◉  66f4d1806ae41bd604f69155dece64062a0056cf B
@@ -364,6 +367,7 @@ fn test_git_colocated_squash_undo() {
     test_env.jj_cmd_success(&repo_path, &["ci", "-m=A"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
+    Done importing changes from the underlying Git repo.
     @  rlvkpnrzqnoo 8f71e3b6a3be
     ◉  qpvuntsmwlqt a86754f975f9 A master HEAD@git
     ◉  zzzzzzzzzzzz 000000000000

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -158,6 +158,8 @@ fn test_git_colocated_rebase_on_import() {
     git_repo.branch("master", &commit1, true).unwrap();
     git_repo.set_head("refs/heads/master").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    Abandoned the following commits:
+      rlvkpnrz 45fbe1af master | modify a file
     @  7f96185cfbe36341d0f9a86ebfaeab67a5922c7e
     ◉  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master HEAD@git add a file
     ◉  0000000000000000000000000000000000000000
@@ -206,6 +208,8 @@ fn test_git_colocated_branches() {
         )
         .unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    Abandoned the following commits:
+      kkmpptxz 35605592 master | (empty) bar
     Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
@@ -294,7 +298,11 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     // Move branch C sideways
     test_env.jj_cmd_success(&origin_path, &["describe", "C_to_move", "-m", "moved C"]);
     let stdout = test_env.jj_cmd_success(&clone_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stdout, @r###"
+    Abandoned the following commits:
+      vnotlzrn 8d4e006f C_to_move | (empty) original C
+      wvpolxwl 929e298a B_to_delete | (empty) B_to_delete
+    "###);
     // "original C" and "B_to_delete" are abandoned, as the corresponding branches
     // were deleted or moved on the remote (#864)
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -262,6 +262,7 @@ fn test_git_fetch_from_remote_named_git() {
     test_env.jj_cmd_success(&repo_path, &["git", "remote", "rename", "git", "bar"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
+    Done importing changes from the underlying Git repo.
     git: mrylzrtu 76fc7466 message
     "###);
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -474,7 +474,11 @@ fn test_git_fetch_all() {
     master: zowqyktl ff36dc55 descr_for_trunk1
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
     "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @"");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch"]), @r###"
+    Abandoned the following commits:
+      qkvnknrk decaa396 a2 | descr_for_a2
+      nknoxmzm 359a9a02 a1 | descr_for_a1
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: quxllqov 0424f6df descr_for_a1
     a2: osusxwst 91e46b4b descr_for_a2
@@ -625,7 +629,10 @@ fn test_git_fetch_some_of_many_branches() {
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "b", "--branch", "a1"],
     );
-    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stdout, @r###"
+    Abandoned the following commits:
+      nknoxmzm 359a9a02 a1 | descr_for_a1
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  13ac032802f1 descr_for_b b?? b@origin
     │ ◉  6f4e1c4dfe29 descr_for_a1 a1
@@ -657,7 +664,10 @@ fn test_git_fetch_some_of_many_branches() {
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "b", "--branch", "a*"],
     );
-    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stdout, @r###"
+    Abandoned the following commits:
+      qkvnknrk decaa396 a2 | descr_for_a2
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  010977d69c5b descr_for_a2 a2
     │ ◉  13ac032802f1 descr_for_b b?? b@origin
@@ -979,7 +989,10 @@ fn test_git_fetch_removed_branch() {
 
     // Fetch branches a2 from origin, and check that it has been removed locally
     let stdout = test_env.jj_cmd_success(&target_jj_repo_path, &["git", "fetch", "--branch", "a2"]);
-    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stdout, @r###"
+    Abandoned the following commits:
+      qkvnknrk decaa396 a2 | descr_for_a2
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b
     │ ◉  359a9a02457d descr_for_a1 a1
@@ -1046,7 +1059,10 @@ fn test_git_fetch_removed_parent_branch() {
             "git", "fetch", "--branch", "master", "--branch", "trunk1", "--branch", "a1",
         ],
     );
-    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stdout, @r###"
+    Abandoned the following commits:
+      nknoxmzm 359a9a02 a1 | descr_for_a1
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b
     │ ◉  decaa3966c83 descr_for_a2 a2

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -295,6 +295,9 @@ fn test_git_push_multiple() {
       Delete branch branch1 from 45a3aa29e907
       Force branch branch2 from 8476341eb395 to 15dcdaa4f12f
       Add branch my-branch to 15dcdaa4f12f
+    Abandoned the following commits:
+      rlzusymt 8476341e branch2@origin | (empty) description 2
+      lzmmnrxq 45a3aa29 branch1@origin | (empty) description 1
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -571,6 +574,8 @@ fn test_git_push_deleted() {
     insta::assert_snapshot!(stdout, @r###"
     Branch changes to push to origin:
       Delete branch branch1 from 45a3aa29e907
+    Abandoned the following commits:
+      lzmmnrxq 45a3aa29 branch1@origin | (empty) description 1
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["git", "push", "--deleted"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_git_submodule.rs
+++ b/cli/tests/test_git_submodule.rs
@@ -50,9 +50,12 @@ fn test_gitsubmodule_print_gitmodules() {
         &["git", "submodule", "print-gitmodules", "-r", "@-"],
     );
     insta::assert_snapshot!(stdout, @r###"
-	name:old
-	url:https://github.com/old/old.git
-	path:old
+    Done importing changes from the underlying Git repo.
+    name:old
+    url:https://github.com/old/old.git
+    path:old
+
+
     "###);
 
     let stdout =

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -164,6 +164,7 @@ fn test_init_git_colocated() {
     init_git_repo(&workspace_root, false);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @r###"
+    Done importing changes from the underlying Git repo.
     Initialized repo in "."
     "###);
 
@@ -211,6 +212,7 @@ fn test_init_git_colocated_gitlink() {
     assert!(workspace_root.join(".git").is_file());
     let stdout = test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @r###"
+    Done importing changes from the underlying Git repo.
     Initialized repo in "."
     "###);
 
@@ -244,6 +246,7 @@ fn test_init_git_colocated_symlink_directory() {
     std::os::unix::fs::symlink(git_repo_path.join(".git"), workspace_root.join(".git")).unwrap();
     let stdout = test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @r###"
+    Done importing changes from the underlying Git repo.
     Initialized repo in "."
     "###);
 
@@ -282,6 +285,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     std::os::unix::fs::symlink(git_workdir_path.join(".git"), workspace_root.join(".git")).unwrap();
     let stdout = test_env.jj_cmd_success(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @r###"
+    Done importing changes from the underlying Git repo.
     Initialized repo in "."
     "###);
 


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
