### PR TITLE
copy refs/heads to `remote_targets["git"]` to remove special case for `@git` branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   should be noticeably faster on large repos. You may need to create a new
   clone to see the full speedup.
 
+* The `remote_branches()` revset now includes branches exported to the Git
+  repository (so called Git-tracking branches.) Use
+  `remote_branches(remote=exact:"origin")` to query branches of certain remote.
+
 ### New features
 
 ### Fixed bugs

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -403,10 +403,8 @@ fn cmd_branch_list(
         write!(formatter.labeled("branch"), "{name}")?;
         if branch_target.local_target.is_present() {
             print_branch_target(formatter, &branch_target.local_target)?;
-        } else if found_non_git_remote {
-            writeln!(formatter, " (deleted)")?;
         } else {
-            writeln!(formatter, " (forgotten)")?;
+            writeln!(formatter, " (deleted)")?;
         }
 
         for (remote, remote_target) in branch_target.remote_targets.iter() {

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -320,7 +320,7 @@ fn cmd_branch_list(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
-    let mut all_branches = git::build_unified_branches_map(repo.view());
+    let mut all_branches = repo.view().branches().clone(); // TODO: useless clone
     if !args.revisions.is_empty() {
         // Match against local targets only, which is consistent with "jj git push".
         fn local_targets(branch_target: &BranchTarget) -> impl Iterator<Item = &CommitId> {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -24,7 +24,7 @@ use jj_lib::hex_util::to_reverse_hex;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::op_store::{RefTarget, WorkspaceId};
 use jj_lib::repo::Repo;
-use jj_lib::{git, rewrite};
+use jj_lib::rewrite;
 use once_cell::unsync::OnceCell;
 
 use crate::formatter::Formatter;
@@ -358,8 +358,7 @@ impl RefNamesIndex {
 
 fn build_branches_index(repo: &dyn Repo) -> RefNamesIndex {
     let mut index = RefNamesIndex::default();
-    let all_branches = git::build_unified_branches_map(repo.view());
-    for (branch_name, branch_target) in &all_branches {
+    for (branch_name, branch_target) in repo.view().branches() {
         let local_target = &branch_target.local_target;
         let mut unsynced_remote_targets = branch_target
             .remote_targets

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -239,25 +239,13 @@ fn test_branch_forget_export() {
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "forget", "foo"]);
     insta::assert_snapshot!(stdout, @"");
-    // Forgetting a branch does not delete its local-git tracking branch. The
-    // git-tracking branch is kept.
-    // TODO: Actually git-tracking branch is forgotten. Update the branch
-    // resolution code to not shadow the real @git branch.
+    // Forgetting a branch deletes local and remote-tracking branches including
+    // the corresponding git-tracking branch.
     let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    foo (forgotten)
-      @git: rlvkpnrz 65b6b74e (empty) (no description set)
-      (this branch will be deleted from the underlying Git repo on the next `jj git export`)
-    "###);
+    insta::assert_snapshot!(stdout, @"");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r=foo", "--no-graph"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Revision "foo" doesn't exist
-    Hint: Did you mean "foo@git"?
-    "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r=foo@git", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
-    rlvkpnrz test.user@example.com 2001-02-03 04:05:08.000 +07:00 foo@git 65b6b74e
-    (empty) (no description set)
     "###);
 
     // `jj git export` will delete the branch from git. In a colocated repo,

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -39,30 +39,20 @@ fn test_resolution_of_git_tracking_branches() {
     "###);
 
     // Test that we can address both revisions
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &[
-            "log",
-            "-r=main",
-            "-T",
-            r#"commit_id ++ " " ++ description"#,
-            "--no-graph",
-        ],
-    );
-    insta::assert_snapshot!(stdout, @r###"
+    let query = |expr| {
+        let template = r#"commit_id ++ " " ++ description"#;
+        test_env.jj_cmd_success(
+            &repo_path,
+            &["log", "-r", expr, "-T", template, "--no-graph"],
+        )
+    };
+    insta::assert_snapshot!(query("main"), @r###"
     3af370264cdcbba791762f8ef6bc79b456dcbf3b new_message
     "###);
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &[
-            "log",
-            "-r=main@git",
-            "-T",
-            r#"commit_id ++ " " ++ description"#,
-            "--no-graph",
-        ],
-    );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(query("main@git"), @r###"
+    16d541ca40f42baf2dea41aa61a0b5f1cbf1f91b old_message
+    "###);
+    insta::assert_snapshot!(query(r#"remote_branches(exact:"main", exact:"git")"#), @r###"
     16d541ca40f42baf2dea41aa61a0b5f1cbf1f91b old_message
     "###);
 }

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -157,21 +157,13 @@ fn test_git_import_undo() {
     );
     insta::assert_snapshot!(stdout, @r###"
     "###);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a (forgotten)
-      @git: qpvuntsm 230dd059 (empty) (no description set)
-      (this branch will be deleted from the underlying Git repo on the next `jj git export`)
-    "###);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
     // Try "git import" again, which should *not* re-import the branch "a" and be a
     // no-op.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @r###"
     Nothing changed.
     "###);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    a (forgotten)
-      @git: qpvuntsm 230dd059 (empty) (no description set)
-      (this branch will be deleted from the underlying Git repo on the next `jj git export`)
-    "###);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
 
     // We can restore *only* the git refs to make an import re-import the branch
     let stdout = test_env.jj_cmd_success(

--- a/lib/src/protos/op_store.proto
+++ b/lib/src/protos/op_store.proto
@@ -82,6 +82,8 @@ message View {
   // TODO: Delete support for the old format.
   bytes git_head_legacy = 7 [deprecated = true];
   RefTarget git_head = 9;
+  // Whether "@git" branches have been migrated to remote_targets.
+  bool has_git_refs_migrated_to_remote = 10;
 }
 
 message Operation {

--- a/lib/src/protos/op_store.rs
+++ b/lib/src/protos/op_store.rs
@@ -120,6 +120,9 @@ pub struct View {
     pub git_head_legacy: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "9")]
     pub git_head: ::core::option::Option<RefTarget>,
+    /// Whether "@git" branches have been migrated to remote_targets.
+    #[prost(bool, tag = "10")]
+    pub has_git_refs_migrated_to_remote: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 
 use crate::backend::{BackendError, BackendResult, ChangeId, CommitId, ObjectId};
 use crate::commit::Commit;
-use crate::git::{self, get_local_git_tracking_branch};
+use crate::git;
 use crate::hex_util::to_forward_hex;
 use crate::index::{HexPrefix, PrefixResolution};
 use crate::op_store::WorkspaceId;
@@ -2018,7 +2018,6 @@ fn resolve_remote_branch(repo: &dyn Repo, name: &str, remote: &str) -> Option<Ve
     let view = repo.view();
     let target = match (name, remote) {
         ("HEAD", git::REMOTE_NAME_FOR_LOCAL_GIT_REPO) => view.git_head(),
-        (name, git::REMOTE_NAME_FOR_LOCAL_GIT_REPO) => get_local_git_tracking_branch(view, name),
         (name, remote) => view.get_remote_branch(name, remote),
     };
     target
@@ -2028,8 +2027,7 @@ fn resolve_remote_branch(repo: &dyn Repo, name: &str, remote: &str) -> Option<Ve
 
 fn collect_branch_symbols(repo: &dyn Repo, include_synced_remotes: bool) -> Vec<String> {
     let view = repo.view();
-    let all_branches = git::build_unified_branches_map(view);
-    all_branches
+    view.branches()
         .iter()
         .flat_map(|(name, branch_target)| {
             let local_target = &branch_target.local_target;

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -409,8 +409,9 @@ fn test_resolve_symbol_branches() {
         "mirror",
         mut_repo.get_local_branch("local-remote"),
     );
-    mut_repo.set_git_ref_target(
-        "refs/heads/local-remote",
+    mut_repo.set_remote_branch_target(
+        "local-remote",
+        git::REMOTE_NAME_FOR_LOCAL_GIT_REPO,
         mut_repo.get_local_branch("local-remote"),
     );
 
@@ -739,11 +740,7 @@ fn test_resolve_symbol_git_refs() {
         resolve_symbol(mut_repo, "branch").unwrap_err(), @r###"
     NoSuchRevision {
         name: "branch",
-        candidates: [
-            "branch1@git",
-            "branch2@git",
-            "branch@git",
-        ],
+        candidates: [],
     }
     "###);
     // heads/branch does get resolved to the git ref refs/heads/branch


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
