### PR TITLE
docs: restore directory structure of the website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Compile docs and zip them up
         run: |
           poetry install
-          poetry run -- mkdocs build --no-directory-urls
+          poetry run -- mkdocs build -f mkdocs-offline.yml
           archive="jj-${{ github.event.release.tag_name }}-docs-html.tar.gz"
           tar czf "$archive" -C "rendered-docs" .
           echo "ASSET=$archive" >> $GITHUB_ENV

--- a/mkdocs-offline.yml
+++ b/mkdocs-offline.yml
@@ -1,0 +1,10 @@
+# This config is good if you plan to use the rendered docs from
+# your file system. To use, run:
+#      poetry run -- mkdocs -f mkdocs-offline.yml
+INHERIT: 'mkdocs.yml'
+plugins:
+    - offline
+# Turns out the `offline` plugin forces the following
+# option no matter what, and therefore shouldn't be
+# used in the main config file.
+use_directory_urls: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,6 @@ extra:
   version:
     provider: mike
 plugins:
-    - offline
     - search
     - redirects:
         redirect_maps:


### PR DESCRIPTION
The `offline` plugin added to the MkDocs config in commit 772e2b8 ended up changing the directory structure of the website, see the resulting commit 56aec196.

**Before** that commit, the following URLs were valid:

<https://martinvonz.github.io/jj/v0.9.0/revsets>
<https://martinvonz.github.io/jj/v0.9.0/revsets/>

and <https://martinvonz.github.io/jj/v0.9.0/revsets.html> was invalid.

The situation described above should be restored by this commit.

**After** 772e2b8 and before this commit, the following URLs were valid:

<https://martinvonz.github.io/jj/v0.9.0/revsets>
<https://martinvonz.github.io/jj/v0.9.0/revsets.html> and <https://martinvonz.github.io/jj/v0.9.0/revsets/> was invalid.

This commit is likely to break the version switcher between v0.9.0 and newer versions. The breakage would be minimized if this is merged shortly before a release (but with enough time to test it out). Alternatively, I could try to fix up the docs for that version.

We could also consciously decide to leave things as they are now.

The problem was noticed by @hooper, who noticed URLs in their browser history that were no longer valid.

# Checklist

If applicable:
- [ ] Test that this WAI locally
