### PR TITLE
cli_utils: fix a typo in a comment

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2169,7 +2169,7 @@ pub fn write_config_value_to_file(
     })?;
 
     // Apply config value
-    // Iterpret value as string unless it's another simple scalar type.
+    // Interpret value as string unless it's another simple scalar type.
     // TODO(#531): Infer types based on schema (w/ --type arg to override).
     let item = match toml_edit::Value::from_str(value_str) {
         Ok(value @ toml_edit::Value::Boolean(..))


### PR DESCRIPTION
The codespell GitHub action fails because of the typo. I don't know why it started failing now. The comment is 8 months old and the codespell action hasn't been updated in 5 months.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
