### PR TITLE
git_backend: don't let external callers acquire `Mutex<git2::Repository>`

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -776,7 +776,7 @@ impl WorkspaceCommandHelper {
     pub fn snapshot(&mut self, ui: &mut Ui) -> Result<(), CommandError> {
         if self.may_update_working_copy {
             if self.working_copy_shared_with_git {
-                let git_repo = self.git_backend().unwrap().git_repo_clone();
+                let git_repo = self.git_backend().unwrap().open_git_repo()?;
                 self.import_git_refs_and_head(ui, &git_repo)?;
             }
             self.snapshot_working_copy(ui)?;
@@ -1391,7 +1391,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             }
 
             if self.working_copy_shared_with_git {
-                let git_repo = self.user_repo.git_backend().unwrap().git_repo_clone();
+                let git_repo = self.user_repo.git_backend().unwrap().open_git_repo()?;
                 let failed_branches = git::export_refs(mut_repo, &git_repo)?;
                 print_failed_git_export(ui, &failed_branches)?;
             }
@@ -1458,7 +1458,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             writeln!(ui, "Rebased {num_rebased} descendant commits")?;
         }
         if self.working_copy_shared_with_git {
-            let git_repo = self.git_backend().unwrap().git_repo_clone();
+            let git_repo = self.git_backend().unwrap().open_git_repo()?;
             self.export_head_to_git(mut_repo, &git_repo)?;
             let failed_branches = git::export_refs(mut_repo, &git_repo)?;
             print_failed_git_export(ui, &failed_branches)?;

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -187,7 +187,7 @@ pub struct GitSubmodulePrintGitmodulesArgs {
 fn get_git_repo(store: &Store) -> Result<git2::Repository, CommandError> {
     match store.backend_impl().downcast_ref::<GitBackend>() {
         None => Err(user_error("The repo is not backed by a git repo")),
-        Some(git_backend) => Ok(git_backend.git_repo_clone()),
+        Some(git_backend) => Ok(git_backend.open_git_repo()?),
     }
 }
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1206,7 +1206,7 @@ fn cmd_init(ui: &mut Ui, command: &CommandHelper, args: &InitArgs) -> Result<(),
             .backend_impl()
             .downcast_ref::<GitBackend>()
             .unwrap()
-            .git_repo_clone();
+            .open_git_repo()?;
         let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;
         workspace_command.snapshot(ui)?;
         if workspace_command.working_copy_shared_with_git() {

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -154,7 +154,7 @@ impl GitBackend {
         Ok(GitBackend::new(repo, extra_metadata_store))
     }
 
-    pub fn git_repo(&self) -> MutexGuard<'_, git2::Repository> {
+    fn git_repo(&self) -> MutexGuard<'_, git2::Repository> {
         self.repo.lock().unwrap()
     }
 

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -19,7 +19,7 @@ use std::fmt::{Debug, Error, Formatter};
 use std::fs;
 use std::io::{Cursor, Read};
 use std::ops::Deref;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use git2::Oid;
@@ -161,6 +161,21 @@ impl GitBackend {
     pub fn git_repo_clone(&self) -> git2::Repository {
         let path = self.repo.lock().unwrap().path().to_owned();
         git2::Repository::open(path).unwrap()
+    }
+
+    /// Git configuration for this repository.
+    pub fn git_config(&self) -> Result<git2::Config, git2::Error> {
+        self.git_repo().config()
+    }
+
+    /// Path to the `.git` directory or the repository itself if it's bare.
+    pub fn git_repo_path(&self) -> PathBuf {
+        self.git_repo().path().to_owned()
+    }
+
+    /// Path to the working directory if the repository isn't bare.
+    pub fn git_workdir(&self) -> Option<PathBuf> {
+        self.git_repo().workdir().map(|path| path.to_owned())
     }
 
     fn cached_extra_metadata_table(&self) -> BackendResult<Arc<ReadonlyTable>> {

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -158,9 +158,10 @@ impl GitBackend {
         self.repo.lock().unwrap()
     }
 
-    pub fn git_repo_clone(&self) -> git2::Repository {
-        let path = self.repo.lock().unwrap().path().to_owned();
-        git2::Repository::open(path).unwrap()
+    /// Creates new owned git repository instance.
+    pub fn open_git_repo(&self) -> Result<git2::Repository, git2::Error> {
+        let locked_repo = self.git_repo();
+        git2::Repository::open(locked_repo.path())
     }
 
     /// Git configuration for this repository.

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -79,7 +79,7 @@ fn get_git_backend(repo: &Arc<ReadonlyRepo>) -> &GitBackend {
 }
 
 fn get_git_repo(repo: &Arc<ReadonlyRepo>) -> git2::Repository {
-    get_git_backend(repo).git_repo_clone()
+    get_git_backend(repo).open_git_repo().unwrap()
 }
 
 #[test]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -201,7 +201,8 @@ fn test_resolve_symbol_change_id(readonly: bool) {
         .backend_impl()
         .downcast_ref::<GitBackend>()
         .unwrap()
-        .git_repo_clone();
+        .open_git_repo()
+        .unwrap();
     // Add some commits that will end up having change ids with common prefixes
     let empty_tree_id = git_repo.treebuilder(None).unwrap().write().unwrap();
     let git_author = git2::Signature::new(


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
