### PR TITLE
docs: create a basic homepage for the docs website

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# Jujutsu—a version control system
+
+## Welcome to `jj`'s documentation website!
+
+<!-- This only applies to the website, not to the GitHub interface -->
+The complete list of the documentation pages available is available in the
+sidebar.
+
+Additional help is available using the `jj help` command if you have `jj`
+installed.
+
+You may want to jump to:
+
+- Documentation for the [latest released version of `jj`](https://martinvonz.github.io/jj/latest).
+- Documentation for the [unreleased version of `jj`](https://martinvonz.github.io/jj/prerelease). This version of the docs corresponds to the `main` branch of the `jj` repo.
+
+## Some useful links
+
+- [GitHub repo for `jj`](https://github.com/martinvonz/jj)
+- Overview of `jj` in the repo's [README](https://github.com/martinvonz/jj?tab=readme-ov-file#jujutsu-vcs)
+- [Installation and Setup](install-and-setup.md)
+- [Tutorial and Birds-Eye View](tutorial.md)
+- [Working with GitHub](github.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,6 @@ plugins:
     - search
     - redirects:
         redirect_maps:
-            'index.md': 'install-and-setup.md'
 
 # Not all of these may be necessary, especially since the material
 # theme substitutes for some of them
@@ -38,6 +37,8 @@ markdown_extensions:
 
 # This lists all the files that become part of the documentation
 nav:
+- 'Home': 'index.md'
+
 - 'Getting started':
       - 'Installation and Setup': 'install-and-setup.md'
       - 'Tutorial and Birds-Eye View': 'tutorial.md'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.8"
 [tool.poetry.dev-dependencies]
 mkdocs = "^1.5.2"
 mkdocs-material = "^9.2.5"
-# Makes `install-and-setup.md` open by default instead of `index.md`.
+# Allows setting up redirects when renaming docs files
 mkdocs-redirects = "^1.2.1"
 # Versioning of documentation
 mike = "^1.1.2"


### PR DESCRIPTION
Before, https://martinvonz.github.io/jj/latest redirected to
https://martinvonz.github.io/jj/latest/install-and-setup.html.

Now, it will direct people to a basic page with a link to
the repo and a few other useful pages.

An additional motivation is the desire to have a homepage to
link to from
https://github.com/martinvonz/jj/pull/2273#discussion_r1331008117.

Better something very basic than nothing.

------------------

I made this in a bit of a rush so that we could merge this before the next release updates the "latest" website section. PTAL, I may have made some mistakes. Also, it's fine if we decide we don't want to merge this.

![image](https://github.com/martinvonz/jj/assets/4123047/f0b7ee22-0137-4bef-b04b-bc8f8eb6562f)
