### PR TITLE
docs index.md: explain that the website sidebar may be hidden

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,13 @@
 ## Welcome to `jj`'s documentation website!
 
 <!-- This only applies to the website, not to the GitHub interface -->
-The complete list of the documentation pages available is available in the
-sidebar.
+The complete list of the available documentation pages is located in
+the sidebar on the left of the page. The sidebar may be hidden; if so,
+you can open it either by widening your browser window or by clicking
+on the hamburger menu that appears in this situation.
 
-Additional help is available using the `jj help` command if you have `jj`
-installed.
+Additional help is available using the `jj help` command if you have
+`jj` installed.
 
 You may want to jump to:
 


### PR DESCRIPTION
This happens on mobile browsers or when the browser window is too narrow.
