### PR TITLE
Add `build-essential` to install instructions

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -17,11 +17,11 @@ options below.
 
 #### Build using `cargo`
 
-First make sure that you have the `libssl-dev`, `openssl`, and `pkg-config`
-packages installed by running something like this:
+First make sure that you have the `libssl-dev`, `openssl`, `pkg-config`, and
+`build-essential` packages installed by running something like this:
 
 ```shell
-sudo apt-get install libssl-dev openssl pkg-config
+sudo apt-get install libssl-dev openssl pkg-config build-essential
 ```
 
 Now run either:


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Ran into issues when trying to run the `cargo install` step from a relatively new OS installation:

```
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)
```

Turns out I had not yet installed the `build-essential` package. After that it works.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
