### PR TITLE
fix: run 'cargo test' under 'nix flake check' with a non-debug profile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,8 +94,6 @@
         program = "${self.packages.${system}.jujutsu}/bin/jj";
       };
       checks.jujutsu = self.packages.${system}.jujutsu.overrideAttrs ({ ... }: {
-        cargoBuildType = "debug";
-        cargoCheckType = "debug";
         preCheck = ''
           export RUST_BACKTRACE=1
         '';


### PR DESCRIPTION
Summary: The Nix CI has been failing recently due to (what I assume is) disk space issues. But only the `flake check` step is failing. Right now, `nix flake check` runs the Cargo tests with the debug profile to help get more debug info, which is even heftier in terms of debug info than the normal 'test' profile. For reference, a single build of 'cargo test' in a clean working copy results in a 15 gigabyte `target/` directory.

Turn off the debug profile for `nix flake check`, which should hopefully stem the bleeding a bit. I believe the 'test' profile should still have enough symbols for backtraces, so panics should still be useful.

Change-Id: Idde10ac15847a1ad1e6f4e48a2497eca

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
