### PR TITLE
cli: in colocated repo, don't restore view.git_head on undo

### DIFF
--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -178,11 +178,14 @@ fn view_with_desired_portions_restored(
     } else {
         current_view.clone()
     };
-    new_view.git_refs = if what.contains(&UndoWhatToRestore::GitTracking) {
-        view_being_restored.git_refs.clone()
+
+    let git_source_view = if what.contains(&UndoWhatToRestore::GitTracking) {
+        view_being_restored
     } else {
-        current_view.git_refs.clone()
+        current_view
     };
+    new_view.git_refs = git_source_view.git_refs.clone();
+    new_view.git_head = git_source_view.git_head.clone();
 
     if what.contains(&UndoWhatToRestore::RemoteTracking) == what.contains(&UndoWhatToRestore::Repo)
     {


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
