### PR TITLE
tests: disable parsing of system CA certificates in CLI tests

### DIFF
--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -107,6 +107,14 @@ impl TestEnvironment {
         cmd.env("JJ_TIMESTAMP", timestamp.to_rfc3339());
         cmd.env("JJ_OP_TIMESTAMP", timestamp.to_rfc3339());
 
+        // libgit2 always initializes OpenSSL, and it takes a few tens of milliseconds
+        // to load the system CA certificates in X509_load_cert_crl_file_ex(). As we
+        // don't use HTTPS in our tests, we can disable the cert loading to speed up the
+        // CLI tests. If we migrated to gitoxide, maybe we can remove this hack.
+        if cfg!(unix) {
+            cmd.env("SSL_CERT_FILE", "/dev/null");
+        }
+
         if cfg!(all(windows, target_env = "gnu")) {
             // MinGW executables cannot run without `mingw\bin` in the PATH (which we're
             // clearing above), so we add it again here.

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -16,6 +16,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use itertools::Itertools as _;
 use regex::{Captures, Regex};
 use tempfile::TempDir;
 use testutils;
@@ -106,10 +107,7 @@ impl TestEnvironment {
         cmd.env("JJ_TIMESTAMP", timestamp.to_rfc3339());
         cmd.env("JJ_OP_TIMESTAMP", timestamp.to_rfc3339());
 
-        #[cfg(all(windows, target_env = "gnu"))]
-        {
-            use itertools::Itertools as _;
-
+        if cfg!(all(windows, target_env = "gnu")) {
             // MinGW executables cannot run without `mingw\bin` in the PATH (which we're
             // clearing above), so we add it again here.
             if let Ok(path_var) = std::env::var("PATH").or_else(|_| std::env::var("Path")) {


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
