### PR TITLE
nix: merge (now redundant) flake check with normal build

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -10,12 +10,7 @@ permissions: read-all
 
 jobs:
   nix:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest ]
-        mode: [ "flake check", "build" ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     name: nix-build
     timeout-minutes: 20
     steps:
@@ -24,4 +19,4 @@ jobs:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@07ebb8d2749aa2fac2baae7d1cfa011e4acfd8d1
       - uses: DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
-      - run: nix ${{ matrix.mode }} --print-build-logs --show-trace
+      - run: nix build --print-build-logs --show-trace

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
         jujutsu = ourRustPlatform.buildRustPackage rec {
           pname = "jujutsu";
           version = "unstable-${self.shortRev or "dirty"}";
+
           buildFeatures = [ "packaging" ];
           cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
           useNextest = true;
@@ -57,9 +58,8 @@
             "^flake\\.lock$"
             "^target/"
           ];
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-          };
+
+          cargoLock.lockFile = ./Cargo.lock;
           nativeBuildInputs = with pkgs; [
             gzip
             installShellFiles
@@ -72,11 +72,14 @@
             darwin.apple_sdk.frameworks.Security
             darwin.apple_sdk.frameworks.SystemConfiguration
             libiconv
-            ];
+          ];
+
           ZSTD_SYS_USE_PKG_CONFIG = "1";
           LIBSSH2_SYS_USE_PKG_CONFIG = "1";
           NIX_JJ_GIT_HASH = self.rev or "";
           CARGO_INCREMENTAL = "0";
+
+          preCheck = "export RUST_BACKTRACE=1";
           postInstall = ''
             $out/bin/jj util mangen > ./jj.1
             installManPage ./jj.1
@@ -93,11 +96,6 @@
         type = "app";
         program = "${self.packages.${system}.jujutsu}/bin/jj";
       };
-      checks.jujutsu = self.packages.${system}.jujutsu.overrideAttrs ({ ... }: {
-        preCheck = ''
-          export RUST_BACKTRACE=1
-        '';
-      });
       formatter = pkgs.nixpkgs-fmt;
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [


### PR DESCRIPTION
Summary: Since 066032b6e69 was merged, the `nix flake check` build no longer overrides the 'cargo test' profile explicitly, to save disk space. The CI seems to be in a better spot. This will stem the tide for a while hopefully.

However, with that change in place, the `nix flake check` build was essentially a redundant, nearly-identical copy of a normal `nix build` with no differentiating features, except: `RUST_BACKTRACE` is set to 1.

Delete all this code, and remove it from the CI matrix, and instead just export `RUST_BACKTRACE` on the `checkPhase` of the normal `nix build` instead, which is functionally equivalent.

Also does some minor, no-functional-change touchups to `flake.nix` while I was there (whitespace, etc.)

Change-Id: I87336b16e2a0b973343ecbde8ffd7b8f

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
