### PR TITLE
git: migrate import_refs() to diffing git_refs and known remote refs

### DIFF
--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -143,8 +143,9 @@ fn test_git_import_undo() {
     a: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
-    // If we don't restore the git_refs, undoing the import removes the local branch
-    // but makes a following import a no-op.
+    // Even if we don't restore the git_refs, "git import" can re-import the
+    // local branch "a".
+    // TODO: This will be the default "op restore" mode.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -158,23 +159,6 @@ fn test_git_import_undo() {
     insta::assert_snapshot!(stdout, @r###"
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-    // Try "git import" again, which should *not* re-import the branch "a" and be a
-    // no-op.
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @r###"
-    Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-
-    // We can restore *only* the git refs to make an import re-import the branch
-    let stdout = test_env.jj_cmd_success(
-        &repo_path,
-        &["op", "restore", &base_operation_id, "--what=git-tracking"],
-    );
-    insta::assert_snapshot!(stdout, @r###"
-    "###);
-    // The git-tracking branch disappears.
-    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @"");
-    // Try "git import" again, which should again re-import the branch "a".
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["git", "import"]), @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -193,9 +193,6 @@ pub fn import_some_refs(
         old_git_head.is_present().then(RefTarget::absent)
     };
     let changed_remote_refs = diff_refs_to_import(mut_repo.view(), git_repo, git_ref_filter)?;
-    if changed_remote_refs.keys().any(is_reserved_git_remote_ref) {
-        return Err(GitImportError::RemoteReservedForLocalGitRepo);
-    }
 
     // Import new heads
     let store = mut_repo.store();
@@ -340,6 +337,9 @@ fn diff_refs_to_import(
         };
         if !git_ref_filter(&ref_name) {
             continue;
+        }
+        if is_reserved_git_remote_ref(&ref_name) {
+            return Err(GitImportError::RemoteReservedForLocalGitRepo);
         }
         let old_target = known_remote_refs.get(&ref_name).copied().flatten();
         let Some(id) = resolve_git_ref_to_commit_id(&git_ref, old_target) else {


### PR DESCRIPTION
Implements the "import" side described in the following diagram.
https://github.com/martinvonz/jj/blob/7f4fe22a987e33cb2d2ef5976080f6f9a1da7024/docs/design/tracking-branches.md#importexport-data-flow

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
