### PR TITLE
workspace: add '--revision' argument to 'workspace add'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* `jj workspace add` now takes a `--revision` argument.
+
 ### Fixed bugs
 
 * Updating the working copy to a commit where a file that's currently ignored


### PR DESCRIPTION
Summary: Workspaces are most useful to test different versions (commits) of the tree within the same repository, but in many cases you want to check out a specific commit within a workspace.

Make that trivial with a `--revision` option which will be used as the basis for the new workspace. If no `-r` option is given, then the previous behavior applies: the workspace is created with a working copy commit created on top of the current working copy commit's parent.

Change-Id: I23549efe29bc23fb9f75437b6023c237

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
