### PR TITLE
view: refactor/remove some branch API for ease of migrating to per-remote data structure

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -295,10 +295,8 @@ fn cmd_branch_forget(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let view = workspace_command.repo().view();
-    for branch_name in args.names.iter() {
-        if view.get_branch(branch_name).is_none() {
-            return Err(user_error(format!("No such branch: {branch_name}")));
-        }
+    if let Some(branch_name) = args.names.iter().find(|name| !view.has_branch(name)) {
+        return Err(user_error(format!("No such branch: {branch_name}")));
     }
     let globbed_names = find_globs(view, &args.glob, true)?;
     let names: BTreeSet<String> = args.names.iter().cloned().chain(globbed_names).collect();

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -841,12 +841,7 @@ pub fn remove_remote(
 }
 
 fn remove_remote_refs(mut_repo: &mut MutableRepo, remote_name: &str) {
-    let mut branches_to_delete = vec![];
-    for (branch, target) in mut_repo.view().branches() {
-        if target.remote_targets.contains_key(remote_name) {
-            branches_to_delete.push(branch.clone());
-        }
-    }
+    mut_repo.remove_remote(remote_name);
     let prefix = format!("refs/remotes/{remote_name}/");
     let git_refs_to_delete = mut_repo
         .view()
@@ -855,9 +850,6 @@ fn remove_remote_refs(mut_repo: &mut MutableRepo, remote_name: &str) {
         .filter(|&r| r.starts_with(&prefix))
         .cloned()
         .collect_vec();
-    for branch in branches_to_delete {
-        mut_repo.set_remote_branch_target(&branch, remote_name, RefTarget::absent());
-    }
     for git_ref in git_refs_to_delete {
         mut_repo.set_git_ref_target(&git_ref, RefTarget::absent());
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1007,6 +1007,10 @@ impl MutableRepo {
             .set_remote_branch_target(name, remote_name, target);
     }
 
+    pub fn remove_remote(&mut self, remote_name: &str) {
+        self.view_mut().remove_remote(remote_name);
+    }
+
     pub fn rename_remote(&mut self, old: &str, new: &str) {
         self.view_mut().rename_remote(old, new);
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -983,10 +983,6 @@ impl MutableRepo {
         self.view.with_ref(|v| v.get_branch(name).cloned())
     }
 
-    pub fn set_branch(&mut self, name: String, target: BranchTarget) {
-        self.view_mut().set_branch(name, target);
-    }
-
     pub fn remove_branch(&mut self, name: &str) {
         self.view_mut().remove_branch(name);
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -979,6 +979,12 @@ impl MutableRepo {
         self.view.mark_dirty();
     }
 
+    /// Returns true if any local or remote branch of the given `name` exists.
+    #[must_use]
+    pub fn has_branch(&self, name: &str) -> bool {
+        self.view.with_ref(|v| v.has_branch(name))
+    }
+
     pub fn get_branch(&self, name: &str) -> Option<BranchTarget> {
         self.view.with_ref(|v| v.get_branch(name).cloned())
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -42,7 +42,7 @@ use crate::git_backend::GitBackend;
 use crate::index::{HexPrefix, Index, IndexStore, MutableIndex, PrefixResolution, ReadonlyIndex};
 use crate::local_backend::LocalBackend;
 use crate::op_heads_store::{self, OpHeadResolutionError, OpHeadsStore};
-use crate::op_store::{BranchTarget, OpStore, OpStoreError, OperationId, RefTarget, WorkspaceId};
+use crate::op_store::{OpStore, OpStoreError, OperationId, RefTarget, WorkspaceId};
 use crate::operation::Operation;
 use crate::refs::{diff_named_refs, merge_ref_targets};
 use crate::revset::{self, ChangeIdIndex, Revset, RevsetExpression};
@@ -983,10 +983,6 @@ impl MutableRepo {
     #[must_use]
     pub fn has_branch(&self, name: &str) -> bool {
         self.view.with_ref(|v| v.has_branch(name))
-    }
-
-    pub fn get_branch(&self, name: &str) -> Option<BranchTarget> {
-        self.view.with_ref(|v| v.get_branch(name).cloned())
     }
 
     pub fn remove_branch(&mut self, name: &str) {

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -154,10 +154,6 @@ impl View {
         self.data.branches.contains_key(name)
     }
 
-    pub fn get_branch(&self, name: &str) -> Option<&BranchTarget> {
-        self.data.branches.get(name)
-    }
-
     pub fn remove_branch(&mut self, name: &str) {
         self.data.branches.remove(name);
     }

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -272,6 +272,18 @@ impl View {
             })
     }
 
+    pub fn remove_remote(&mut self, remote_name: &str) {
+        let mut branches_to_delete = vec![];
+        for (branch, target) in &self.data.branches {
+            if target.remote_targets.contains_key(remote_name) {
+                branches_to_delete.push(branch.clone());
+            }
+        }
+        for branch in branches_to_delete {
+            self.remove_remote_branch(&branch, remote_name);
+        }
+    }
+
     pub fn rename_remote(&mut self, old: &str, new: &str) {
         for branch in self.data.branches.values_mut() {
             let target = branch.remote_targets.remove(old).flatten();

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -148,6 +148,12 @@ impl View {
         }
     }
 
+    /// Returns true if any local or remote branch of the given `name` exists.
+    #[must_use]
+    pub fn has_branch(&self, name: &str) -> bool {
+        self.data.branches.contains_key(name)
+    }
+
     pub fn get_branch(&self, name: &str) -> Option<&BranchTarget> {
         self.data.branches.get(name)
     }

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -152,10 +152,6 @@ impl View {
         self.data.branches.get(name)
     }
 
-    pub fn set_branch(&mut self, name: String, target: BranchTarget) {
-        self.data.branches.insert(name, target);
-    }
-
     pub fn remove_branch(&mut self, name: &str) {
         self.data.branches.remove(name);
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -476,7 +476,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
             },
         }),
     );
-    view.get_branch("main").unwrap(); // branch #3 of 3
+    assert!(view.has_branch("main")); // branch #3 of 3
 
     // Simulate fetching from a remote where feature-remote-only and
     // feature-remote-and-local branches were deleted. This leads to the
@@ -492,8 +492,8 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
     let view = repo.view();
     // The local branches were indeed deleted
     assert_eq!(view.branches().len(), 2);
-    assert!(view.get_branch("main").is_some());
-    assert!(view.get_branch("feature-remote-only").is_none());
+    assert!(view.has_branch("main"));
+    assert!(!view.has_branch("feature-remote-only"));
     assert_eq!(
         view.get_branch("feature-remote-and-local"),
         Some(&BranchTarget {
@@ -574,7 +574,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
             },
         }),
     );
-    view.get_branch("main").unwrap(); // branch #3 of 3
+    assert!(view.has_branch("main")); // branch #3 of 3
 
     // Simulate fetching from a remote where feature-remote-only and
     // feature-remote-and-local branches were moved. This leads to the
@@ -619,7 +619,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
             },
         }),
     );
-    view.get_branch("main").unwrap(); // branch #3 of 3
+    assert!(view.has_branch("main")); // branch #3 of 3
     let expected_heads = hashset! {
             jj_id(&commit_main),
             jj_id(&new_commit_remote_and_local),
@@ -844,9 +844,9 @@ fn test_import_some_refs() {
         view.get_branch("feature4"),
         Some(expected_feature4_branch).as_ref()
     );
-    assert_eq!(view.get_branch("main"), None,);
+    assert!(!view.has_branch("main"));
     assert!(!view.heads().contains(&jj_id(&commit_main)));
-    assert_eq!(view.get_branch("ignored"), None,);
+    assert!(!view.has_branch("ignored"));
     assert!(!view.heads().contains(&jj_id(&commit_ign)));
 
     // Delete branch feature1, feature3 and feature4 in git repository and import
@@ -1900,7 +1900,7 @@ fn test_fetch_prune_deleted_ref() {
     )
     .unwrap();
     // Test the setup
-    assert!(tx.mut_repo().get_branch("main").is_some());
+    assert!(tx.mut_repo().has_branch("main"));
 
     test_data
         .origin_repo
@@ -1919,7 +1919,7 @@ fn test_fetch_prune_deleted_ref() {
     )
     .unwrap();
     assert_eq!(stats.import_stats.abandoned_commits, vec![jj_id(&commit)]);
-    assert!(tx.mut_repo().get_branch("main").is_none());
+    assert!(!tx.mut_repo().has_branch("main"));
 }
 
 #[test]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -26,7 +26,7 @@ use jj_lib::commit::Commit;
 use jj_lib::git;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::index::{HexPrefix, PrefixResolution};
-use jj_lib::op_store::{BranchTarget, RefTarget, WorkspaceId};
+use jj_lib::op_store::{RefTarget, WorkspaceId};
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::revset::{
@@ -2869,13 +2869,7 @@ fn test_no_such_revision_suggestion() {
     let commit = write_random_commit(mut_repo, &settings);
 
     for branch_name in ["foo", "bar", "baz"] {
-        mut_repo.set_branch(
-            branch_name.to_string(),
-            BranchTarget {
-                local_target: RefTarget::normal(commit.id().clone()),
-                remote_targets: Default::default(),
-            },
-        );
+        mut_repo.set_local_branch_target(branch_name, RefTarget::normal(commit.id().clone()));
     }
 
     assert_matches!(resolve_symbol(mut_repo, "bar"), Ok(_));


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
