### PR TITLE
workspace: `workspace forget` multiple names at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj workspace add` now takes a `--revision` argument.
 
+* `jj workspace forget` can now forget multiple workspaces at once.
+
 ### Fixed bugs
 
 * Updating the working copy to a commit where a file that's currently ignored


### PR DESCRIPTION
Summary: This allows `workspace forget` to forget multiple workspaces in a single action; it now behaves more consistently with other verbs like `abandon` which can take multiple revisions at one time.

There's some hoop-jumping involved to ensure the oplog transaction description looks nice, but as they say: small conveniences cost a lot.

Change-Id: Id91da269f87b145010c870b7dc043748

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
