### PR TITLE
git: prevent accidental push to non-tracking remote, mark pushed branches as tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [automatic local branch creation](docs/config.md#automatic-local-branch-creation)
   for details.
 
+* Pushing deleted/moved branches no longer abandons the local commits referenced
+  by the remote branches.
+
 ### New features
 
 * `jj workspace add` now takes a `--revision` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [automatic local branch creation](docs/config.md#automatic-local-branch-creation)
   for details.
 
+* It's not allowed to push branches if non-tracking remote branches of the same
+  name exist.
+
 * Pushing deleted/moved branches no longer abandons the local commits referenced
   by the remote branches.
 

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -732,9 +732,9 @@ fn cmd_git_push(
             }
             let targets = TrackingRefPair {
                 local_target: repo.view().get_local_branch(branch_name),
-                remote_target: &repo.view().get_remote_branch(branch_name, &remote).target,
+                remote_ref: repo.view().get_remote_branch(branch_name, &remote),
             };
-            if targets.local_target.is_absent() && targets.remote_target.is_absent() {
+            if targets.local_target.is_absent() && targets.remote_ref.is_absent() {
                 return Err(user_error(format!("Branch {branch_name} doesn't exist")));
             }
             match classify_branch_update(branch_name, &remote, targets) {
@@ -786,11 +786,7 @@ fn cmd_git_push(
                 .set_local_branch_target(&branch_name, RefTarget::normal(commit.id().clone()));
             let targets = TrackingRefPair {
                 local_target: tx.repo().view().get_local_branch(&branch_name),
-                remote_target: &tx
-                    .repo()
-                    .view()
-                    .get_remote_branch(&branch_name, &remote)
-                    .target,
+                remote_ref: tx.repo().view().get_remote_branch(&branch_name, &remote),
             };
             match classify_branch_update(&branch_name, &remote, targets) {
                 Ok(Some(update)) => branch_updates.push((branch_name.clone(), update)),

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -734,11 +734,11 @@ fn cmd_git_push(
                 local_target: repo.view().get_local_branch(branch_name),
                 remote_ref: repo.view().get_remote_branch(branch_name, &remote),
             };
-            if targets.local_target.is_absent() && targets.remote_ref.is_absent() {
-                return Err(user_error(format!("Branch {branch_name} doesn't exist")));
-            }
             match classify_branch_update(branch_name, &remote, targets) {
                 Ok(Some(update)) => branch_updates.push((branch_name.clone(), update)),
+                Ok(None) if targets.local_target.is_absent() => {
+                    return Err(user_error(format!("Branch {branch_name} doesn't exist")));
+                }
                 Ok(None) => writeln!(
                     ui.stderr(),
                     "Branch {branch_name}@{remote} already matches {branch_name}",

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -1018,6 +1018,9 @@ fn classify_branch_update(
         BranchPushAction::RemoteConflicted => {
             Err(format!("Branch {branch_name}@{remote_name} is conflicted"))
         }
+        BranchPushAction::RemoteUntracked => Err(format!(
+            "Non-tracking remote branch {branch_name}@{remote_name} exists"
+        )),
         BranchPushAction::Update(update) => Ok(Some(update)),
     }
 }

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -977,7 +977,7 @@ fn cmd_git_push(
         force_pushed_branches,
     };
     with_remote_callbacks(ui, |cb| {
-        git::push_branches(&git_repo, &remote, &targets, cb)
+        git::push_branches(tx.mut_repo(), &git_repo, &remote, &targets, cb)
     })
     .map_err(|err| match err {
         GitPushError::InternalGitError(err) => map_git_error(err),
@@ -988,9 +988,6 @@ fn cmd_git_push(
         ),
         _ => user_error(err.to_string()),
     })?;
-    // TODO: mark pushed remote branches as tracking
-    let stats = git::import_refs(tx.mut_repo(), &git_repo, &command.settings().git_settings())?;
-    print_git_import_stats(ui, &stats)?;
     tx.finish(ui)?;
     Ok(())
 }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -741,8 +741,8 @@ fn test_git_push_moved_forward_untracked() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "untrack", "branch1@origin"]);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
-    Branch changes to push to origin:
-      Add branch branch1 to a25f24af0d0e
+    Non-tracking remote branch branch1@origin exists
+    Nothing changed.
     "###);
 }
 
@@ -756,12 +756,10 @@ fn test_git_push_moved_sideways_untracked() {
         &["branch", "set", "--allow-backwards", "branch1"],
     );
     test_env.jj_cmd_ok(&workspace_root, &["branch", "untrack", "branch1@origin"]);
-    let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
+    let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
-    Branch changes to push to origin:
-      Add branch branch1 to cfbae7608334
-    Error: The push conflicts with changes made on the remote (it is not fast-forwardable).
-    Hint: Try fetching from the remote, then make the branch point to where you want it to be, and push again.
+    Non-tracking remote branch branch1@origin exists
+    Nothing changed.
     "###);
 }
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -684,6 +684,7 @@ fn test_git_push_conflicting_branches() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch branch2 is conflicted
+    Hint: Run `jj branch list` to inspect, and use `jj branch set` to fix it up.
     Nothing changed.
     "###);
 
@@ -691,6 +692,7 @@ fn test_git_push_conflicting_branches() {
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--branch", "branch2"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Branch branch2 is conflicted
+    Hint: Run `jj branch list` to inspect, and use `jj branch set` to fix it up.
     "###);
 
     // --all shouldn't be blocked by conflicting branch
@@ -699,6 +701,7 @@ fn test_git_push_conflicting_branches() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch branch2 is conflicted
+    Hint: Run `jj branch list` to inspect, and use `jj branch set` to fix it up.
     Branch changes to push to origin:
       Move branch branch1 from 45a3aa29e907 to fd1d63e031ea
     "###);
@@ -709,6 +712,7 @@ fn test_git_push_conflicting_branches() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch branch2 is conflicted
+    Hint: Run `jj branch list` to inspect, and use `jj branch set` to fix it up.
     Branch changes to push to origin:
       Move branch branch1 from fd1d63e031ea to 8263cf992d33
     "###);
@@ -742,6 +746,7 @@ fn test_git_push_moved_forward_untracked() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
     Non-tracking remote branch branch1@origin exists
+    Hint: Run `jj branch track branch1@origin` to import the remote branch.
     Nothing changed.
     "###);
 }
@@ -759,6 +764,7 @@ fn test_git_push_moved_sideways_untracked() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
     Non-tracking remote branch branch1@origin exists
+    Hint: Run `jj branch track branch1@origin` to import the remote branch.
     Nothing changed.
     "###);
 }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -300,12 +300,21 @@ fn test_git_push_multiple() {
       Delete branch branch1 from 45a3aa29e907
       Force branch branch2 from 8476341eb395 to 15dcdaa4f12f
       Add branch my-branch to 15dcdaa4f12f
-    Abandoned 2 commits that are no longer reachable.
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     branch2: yqosqzyt 15dcdaa4 (empty) foo
     my-branch: yqosqzyt 15dcdaa4 (empty) foo
+    "###);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  yqosqzyt test.user@example.com 2001-02-03 04:05:17.000 +07:00 branch2 my-branch 15dcdaa4
+    │  (empty) foo
+    │ ◉  rlzusymt test.user@example.com 2001-02-03 04:05:10.000 +07:00 8476341e
+    ├─╯  (empty) description 2
+    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 45a3aa29
+    ├─╯  (empty) description 1
+    ◉  zzzzzzzz root() 00000000
     "###);
 }
 
@@ -588,7 +597,16 @@ fn test_git_push_deleted() {
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
       Delete branch branch1 from 45a3aa29e907
-    Abandoned 1 commits that are no longer reachable.
+    "###);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
+    insta::assert_snapshot!(stdout, @r###"
+    ◉  rlzusymt test.user@example.com 2001-02-03 04:05:10.000 +07:00 branch2 8476341e
+    │  (empty) description 2
+    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 45a3aa29
+    ├─╯  (empty) description 1
+    │ @  yqosqzyt test.user@example.com 2001-02-03 04:05:13.000 +07:00 5b36783c
+    ├─╯  (empty) (no description set)
+    ◉  zzzzzzzz root() 00000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::assert_snapshot!(stdout, @"");

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -663,3 +663,23 @@ fn test_git_push_conflicting_branches() {
       Move branch branch1 from fd1d63e031ea to 8263cf992d33
     "###);
 }
+
+#[test]
+fn test_git_push_to_remote_named_git() {
+    let (test_env, workspace_root) = set_up();
+    let git_repo = {
+        let mut git_repo_path = workspace_root.clone();
+        git_repo_path.extend([".jj", "repo", "store", "git"]);
+        git2::Repository::open(&git_repo_path).unwrap()
+    };
+    git_repo.remote_rename("origin", "git").unwrap();
+
+    let stderr =
+        test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all", "--remote=git"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Branch changes to push to git:
+      Add branch branch1 to 45a3aa29e907
+      Add branch branch2 to 8476341eb395
+    Error: Git remote named 'git' is reserved for local Git repository
+    "###);
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -519,11 +519,6 @@ jj branch delete gh-pages
 jj branch untrack gh-pages@upstream
 ```
 
-Note that this setting may make it easier to accidentally delete remote
-branches. Since the local branch isn't created, the remote branch will be
-deleted if you push the branch with `jj git push --branch` or `jj git push
---all`.
-
 ### Prefix for generated branches on push
 
 `jj git push --change` generates branch names with a prefix of "push-" by

--- a/docs/design/tracking-branches.md
+++ b/docs/design/tracking-branches.md
@@ -197,8 +197,7 @@ In particular, a merge of local and remote targets is
      * ~`tags`~ (not implemented, but should be the same as `branches`)
   2. Pushes diff to the remote Git repo (as well as remote tracking branches
      in the backing Git repo.)
-  3. Sets `remotes[remote].branches[name].state = tracking`
-  4. Import changes only for `remotes[remote].branches[glob]`
+  3. Updates `remotes[remote]` and `git_refs` reflecting the push.
 
 * `jj git export`
   1. Copies local `branches`/`tags` back to `remotes["git"]`.
@@ -288,25 +287,22 @@ Note: desired behavior of `jj branch forget` is to
 
 * Pushing new branch, remote doesn't exist
   1. Pushes `[local, absent] - [absent]` -> `local`
-  2. Sets `remotes[remote].branches[name].state = tracking`
-  3. `import_refs()` merges `[local, local] - [absent]` -> `local` (noop)
+  2. Sets `remotes[remote].branches[name].target = local`, `.state = tracking`
 * Pushing new branch, untracked remote exists
   1. Pushes `[local, remote] - [absent]`
      * Fails if `local` moved backwards or sideways
-  2. Sets `remotes[remote].branches[name].state = tracking`
-  3. `import_refs()` merges `[local, local] - [remote]` -> `local` (noop)
+  2. Sets `remotes[remote].branches[name].target = local`, `.state = tracking`
 * Pushing existing branch to tracking remote
   1. Pushes `[local, remote] - [remote]` -> `local`
      * Fails if `local` moved backwards or sideways, and if `remote` is out of
        sync
-  2. `import_refs()` merges `[local, local] - [remote]` -> `local` (noop)
+  2. Sets `remotes[remote].branches[name].target = local`
 * Pushing existing branch to untracked remote
   * Same as "new branch"
 * Pushing deleted branch to tracking remote
   1. Pushes `[absent, remote] - [remote]` -> `absent`
      * TODO: Fails if `remote` is out of sync?
-  2. `import_refs()` merges `[absent, absent] - [remote]` -> `absent`
-  3. Removes `remotes[remote].branches[name]` (`target` becomes `absent`)
+  2. Removes `remotes[remote].branches[name]` (`target` becomes `absent`)
 * Pushing deleted branch to untracked remote
   * Noop since `[absent, remote] - [absent]` -> `remote`
   * Perhaps, UI will report error

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1064,6 +1064,11 @@ pub fn fetch(
 pub enum GitPushError {
     #[error("No git remote named '{0}'")]
     NoSuchRemote(String),
+    #[error(
+        "Git remote named '{name}' is reserved for local Git repository",
+        name = REMOTE_NAME_FOR_LOCAL_GIT_REPO
+    )]
+    RemoteReservedForLocalGitRepo,
     #[error("Push is not fast-forwardable")]
     NotFastForward,
     #[error("Remote rejected the update of some refs (do you have permission to push to {0:?}?)")]
@@ -1167,6 +1172,9 @@ fn push_refs(
     refspecs: &[String],
     callbacks: RemoteCallbacks<'_>,
 ) -> Result<(), GitPushError> {
+    if remote_name == REMOTE_NAME_FOR_LOCAL_GIT_REPO {
+        return Err(GitPushError::RemoteReservedForLocalGitRepo);
+    }
     let mut remote = git_repo.find_remote(remote_name).map_err(|err| {
         if is_remote_not_found_err(&err) {
             GitPushError::NoSuchRemote(remote_name.to_string())

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -604,7 +604,7 @@ fn copy_exportable_local_branches_to_remote_view(
         .filter_map(|(branch, targets)| {
             // TODO: filter out untracked branches (if we add support for untracked @git
             // branches)
-            let old_target = targets.remote_target;
+            let old_target = &targets.remote_ref.target;
             let new_target = targets.local_target;
             (!new_target.has_conflict() && old_target != new_target).then_some((branch, new_target))
         })

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -83,6 +83,11 @@ impl RefTarget {
         &TARGET
     }
 
+    /// Creates non-conflicting target that optionally points to a commit.
+    pub fn resolved(maybe_id: Option<CommitId>) -> Self {
+        Self::from_merge(Merge::resolved(maybe_id))
+    }
+
     /// Creates non-conflicting target pointing to a commit.
     pub fn normal(id: CommitId) -> Self {
         Self::from_merge(Merge::normal(id))


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
