### PR TITLE
git: on import_refs(), don't abandon ancestors of newly fetched refs

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -302,7 +302,10 @@ pub fn import_some_refs(
         };
         return Ok(stats);
     }
-    let pinned_heads = itertools::chain(
+    let pinned_heads = itertools::chain!(
+        changed_remote_refs
+            .values()
+            .flat_map(|(_, new_target)| new_target.added_ids()),
         pinned_commit_ids(mut_repo.view()),
         iter::once(mut_repo.store().root_commit_id()),
     )


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
