### PR TITLE
templater, revset suggestion: take non-tracking branches unrelated to locals

### DIFF
--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -560,7 +560,7 @@ fn test_branch_track_untrack() {
     main: sptzoqmo 7b33f629 commit 1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1 feature2@origin main 7b33f6295eda
+    ◉  feature1 feature1@origin feature2@origin main 7b33f6295eda
     │ @   230dd059e1b0
     ├─╯
     ◉   000000000000
@@ -586,7 +586,7 @@ fn test_branch_track_untrack() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  feature1@origin feature2@origin main 40dabdaf4abe
-    │ ◉  feature1* 7b33f6295eda
+    │ ◉  feature1 7b33f6295eda
     ├─╯
     │ @   230dd059e1b0
     ├─╯
@@ -619,7 +619,7 @@ fn test_branch_track_untrack() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉  feature1@origin feature2@origin feature3 main 3f0f86fa0e57
-    │ ◉  feature1* 7b33f6295eda
+    │ ◉  feature1 7b33f6295eda
     ├─╯
     │ @   230dd059e1b0
     ├─╯

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2035,7 +2035,9 @@ fn collect_branch_symbols(repo: &dyn Repo, include_synced_remotes: bool) -> Vec<
                 .remote_refs
                 .into_iter()
                 .filter(move |&(_, remote_ref)| {
-                    include_synced_remotes || remote_ref.target != *local_target
+                    include_synced_remotes
+                        || !remote_ref.is_tracking()
+                        || remote_ref.target != *local_target
                 })
                 .map(move |(remote_name, _)| format!("{name}@{remote_name}"));
             local_symbol.into_iter().chain(remote_symbols)


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
