### PR TITLE
cli: hide non-tracking remote branches by default, add option to list…

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -65,9 +65,12 @@ pub struct BranchDeleteArgs {
 /// List branches and their targets
 ///
 /// A tracking remote branch will be included only if its target is different
-/// from the local target. For a conflicted branch (both local and remote), old
-/// target revisions are preceded by a "-" and new target revisions are preceded
-/// by a "+". For information about branches, see
+/// from the local target. A non-tracking remote branch won't be listed by
+/// default. For a conflicted branch (both local and remote), old target
+/// revisions are preceded by a "-" and new target revisions are preceded by a
+/// "+".
+///
+/// For information about branches, see
 /// https://github.com/martinvonz/jj/blob/main/docs/branches.md.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BranchListArgs {
@@ -77,6 +80,10 @@ pub struct BranchListArgs {
     /// wouldn't have a local target.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
+
+    /// Whether to list non-tracking remote branches
+    #[arg(long)]
+    include_untracked: bool,
 }
 
 /// Forget everything about a branch, including its local and remote
@@ -565,10 +572,11 @@ fn cmd_branch_list(
             }
         }
 
-        // TODO: hide non-tracking remotes by default?
-        for &(remote, remote_ref) in &untracked_remote_refs {
-            write!(formatter.labeled("branch"), "{name}@{remote}")?;
-            print_branch_target(formatter, &remote_ref.target)?;
+        if args.include_untracked {
+            for &(remote, remote_ref) in &untracked_remote_refs {
+                write!(formatter.labeled("branch"), "{name}@{remote}")?;
+                print_branch_target(formatter, &remote_ref.target)?;
+            }
         }
     }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -625,6 +625,14 @@ fn test_branch_track_untrack() {
     ├─╯
     ◉   000000000000
     "###);
+
+    // Non-tracking branches aren't listed by default.
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list"]);
+    insta::assert_snapshot!(stdout, @r###"
+    feature1: sptzoqmo 7b33f629 commit 1
+    feature3: wwnpyzpo 3f0f86fa commit 3
+    main: wwnpyzpo 3f0f86fa commit 3
+    "###);
 }
 
 #[test]
@@ -808,5 +816,5 @@ fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--include-untracked"])
 }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -228,7 +228,10 @@ fn test_git_clone_colocate() {
     "###);
 
     // The old default branch "master" shouldn't exist.
-    let stdout = test_env.jj_cmd_success(&test_env.env_root().join("clone"), &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(
+        &test_env.env_root().join("clone"),
+        &["branch", "list", "--include-untracked"],
+    );
     insta::assert_snapshot!(stdout, @r###"
     main: mzyxwzks 9f01a0e0 message
     "###);

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -377,7 +377,8 @@ fn test_git_colocated_branch_forget() {
     ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
     ◉  0000000000000000000000000000000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout =
+        test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--include-untracked"]);
     insta::assert_snapshot!(stdout, @r###"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
     "###);
@@ -387,7 +388,8 @@ fn test_git_colocated_branch_forget() {
     insta::assert_snapshot!(stderr, @"");
     // A forgotten branch is deleted in the git repo. For a detailed demo explaining
     // this, see `test_branch_forget_export` in `test_branch_command.rs`.
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout =
+        test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--include-untracked"]);
     insta::assert_snapshot!(stdout, @"");
 }
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -52,7 +52,7 @@ fn add_git_remote(test_env: &TestEnvironment, repo_path: &Path, remote: &str) {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--include-untracked"])
 }
 
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
@@ -248,7 +248,8 @@ fn test_git_fetch_from_remote_named_git() {
     "###);
 
     // Implicit import shouldn't fail because of the remote ref.
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list"]);
+    let (stdout, stderr) =
+        test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--include-untracked"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
 
@@ -261,7 +262,8 @@ fn test_git_fetch_from_remote_named_git() {
 
     // The remote can be renamed, and the ref can be imported.
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list"]);
+    let (stdout, stderr) =
+        test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--include-untracked"]);
     insta::assert_snapshot!(stdout, @r###"
     git: mrylzrtu 76fc7466 message
     "###);

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -241,7 +241,7 @@ fn test_git_import_move_export_with_default_undo() {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--include-untracked"])
 }
 
 fn get_git_repo_refs(git_repo: &git2::Repository) -> Vec<(String, CommitId)> {

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -247,7 +247,8 @@ fn test_git_push_locally_created_and_rewritten() {
     // Rewrite it and push again, which would fail if the pushed branch weren't
     // set to "tracking"
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-mlocal 2"]);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout =
+        test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--include-untracked"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 45a3aa29 (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -318,5 +318,5 @@ fn test_git_push_undo_repo_only() {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--include-untracked"])
 }


### PR DESCRIPTION
#1136

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
