### PR TITLE
cli: hide non-tracking remote branches by default, `--all` to show all remotes/locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [automatic local branch creation](docs/config.md#automatic-local-branch-creation)
   for details.
 
+* Non-tracking remote branches aren't listed by default. Use `jj branch list
+  --all` to show all local and remote branches.
+
 * It's not allowed to push branches if non-tracking remote branches of the same
   name exist.
 

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -65,9 +65,10 @@ pub struct BranchDeleteArgs {
 /// List branches and their targets
 ///
 /// By default, a tracking remote branch will be included only if its target is
-/// different from the local target. For a conflicted branch (both local and
-/// remote), old target revisions are preceded by a "-" and new target revisions
-/// are preceded by a "+".
+/// different from the local target. A non-tracking remote branch won't be
+/// listed. For a conflicted branch (both local and remote), old target
+/// revisions are preceded by a "-" and new target revisions are preceded by a
+/// "+".
 ///
 /// For information about branches, see
 /// https://github.com/martinvonz/jj/blob/main/docs/branches.md.
@@ -573,10 +574,11 @@ fn cmd_branch_list(
             }
         }
 
-        // TODO: hide non-tracking remotes by default?
-        for &(remote, remote_ref) in &untracked_remote_refs {
-            write!(formatter.labeled("branch"), "{name}@{remote}")?;
-            print_branch_target(formatter, &remote_ref.target)?;
+        if args.all {
+            for &(remote, remote_ref) in &untracked_remote_refs {
+                write!(formatter.labeled("branch"), "{name}@{remote}")?;
+                print_branch_target(formatter, &remote_ref.target)?;
+            }
         }
     }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -756,7 +756,8 @@ fn test_branch_list() {
         &["branch", "set", "--allow-backwards", "remote-unsync"],
     );
 
-    // Synchronized tracking remotes aren't listed by default
+    // Synchronized tracking remotes and non-tracking remotes aren't listed by
+    // default
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&local_path, &["branch", "list"]), @r###"
     local-only: wqnwkozp 4e887f78 (empty) local-only
@@ -767,7 +768,6 @@ fn test_branch_list() {
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
     remote-unsync: wqnwkozp 4e887f78 (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    remote-untrack@origin: vmortlor 71a16b05 (empty) remote-untrack
     "###);
 
     insta::assert_snapshot!(

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -228,9 +228,14 @@ fn test_git_clone_colocate() {
     "###);
 
     // The old default branch "master" shouldn't exist.
-    let stdout = test_env.jj_cmd_success(&test_env.env_root().join("clone"), &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(
+        &test_env.env_root().join("clone"),
+        &["branch", "list", "--all"],
+    );
     insta::assert_snapshot!(stdout, @r###"
     main: mzyxwzks 9f01a0e0 message
+      @git: mzyxwzks 9f01a0e0 message
+      @origin: mzyxwzks 9f01a0e0 message
     "###);
 
     // Subsequent fetch should just work even if the source path was relative

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -377,9 +377,10 @@ fn test_git_colocated_branch_forget() {
     ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
     ◉  0000000000000000000000000000000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
+      @git: rlvkpnrz 65b6b74e (empty) (no description set)
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["branch", "forget", "foo"]);
@@ -387,7 +388,7 @@ fn test_git_colocated_branch_forget() {
     insta::assert_snapshot!(stderr, @"");
     // A forgotten branch is deleted in the git repo. For a detailed demo explaining
     // this, see `test_branch_forget_export` in `test_branch_command.rs`.
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @"");
 }
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -52,7 +52,7 @@ fn add_git_remote(test_env: &TestEnvironment, repo_path: &Path, remote: &str) {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
 }
 
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
@@ -83,6 +83,7 @@ fn test_git_fetch_default_remote() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin: oputwtnw ffecd2d6 message
+      @origin: oputwtnw ffecd2d6 message
     "###);
 }
 
@@ -100,6 +101,7 @@ fn test_git_fetch_single_remote() {
         .stderr("Fetching from the only existing remote: rem1\n");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -116,6 +118,7 @@ fn test_git_fetch_single_remote_all_remotes_flag() {
         .success();
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -129,6 +132,7 @@ fn test_git_fetch_single_remote_from_arg() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -143,6 +147,7 @@ fn test_git_fetch_single_remote_from_config() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     "###);
 }
 
@@ -160,7 +165,9 @@ fn test_git_fetch_multiple_remotes() {
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
+      @rem2: yszkquru 2497a8a0 message
     "###);
 }
 
@@ -175,7 +182,9 @@ fn test_git_fetch_all_remotes() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--all-remotes"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
+      @rem2: yszkquru 2497a8a0 message
     "###);
 }
 
@@ -191,7 +200,9 @@ fn test_git_fetch_multiple_remotes_from_config() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
+      @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
+      @rem2: yszkquru 2497a8a0 message
     "###);
 }
 
@@ -248,7 +259,7 @@ fn test_git_fetch_from_remote_named_git() {
     "###);
 
     // Implicit import shouldn't fail because of the remote ref.
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
 
@@ -261,9 +272,11 @@ fn test_git_fetch_from_remote_named_git() {
 
     // The remote can be renamed, and the ref can be imported.
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     git: mrylzrtu 76fc7466 message
+      @bar: mrylzrtu 76fc7466 message
+      @git: mrylzrtu 76fc7466 message
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Done importing changes from the underlying Git repo.
@@ -279,6 +292,7 @@ fn test_git_fetch_prune_before_updating_tips() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin: oputwtnw ffecd2d6 message
+      @origin: oputwtnw ffecd2d6 message
     "###);
 
     // Remove origin branch in git repo and create origin/subname
@@ -292,6 +306,7 @@ fn test_git_fetch_prune_before_updating_tips() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     origin/subname: oputwtnw ffecd2d6 message
+      @origin: oputwtnw ffecd2d6 message
     "###);
 }
 
@@ -337,6 +352,7 @@ fn test_git_fetch_conflicting_branches_colocated() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "rem1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     rem1: zsuskuln f652c321 (empty) (no description set)
+      @git: zsuskuln f652c321 (empty) (no description set)
     "###);
 
     test_env.jj_cmd_ok(
@@ -424,9 +440,13 @@ fn test_git_fetch_all() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: nknoxmzm 359a9a02 descr_for_a1
+      @origin: nknoxmzm 359a9a02 descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
+      @origin: qkvnknrk decaa396 descr_for_a2
     b: vpupmnsl c7d4bdcb descr_for_b
+      @origin: vpupmnsl c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
+      @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b
@@ -474,10 +494,13 @@ fn test_git_fetch_all() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: nknoxmzm 359a9a02 descr_for_a1
+      @origin: nknoxmzm 359a9a02 descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
+      @origin: qkvnknrk decaa396 descr_for_a2
     b: vpupmnsl 061eddbb new_descr_for_b_to_create_conflict
       @origin (ahead by 1 commits, behind by 1 commits): vpupmnsl c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
+      @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
@@ -486,14 +509,18 @@ fn test_git_fetch_all() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: quxllqov 0424f6df descr_for_a1
+      @origin: quxllqov 0424f6df descr_for_a1
     a2: osusxwst 91e46b4b descr_for_a2
+      @origin: osusxwst 91e46b4b descr_for_a2
     b (conflicted):
       - vpupmnsl c7d4bdcb descr_for_b
       + vpupmnsl 061eddbb new_descr_for_b_to_create_conflict
       + vktnwlsu babc4922 descr_for_b
       @origin (behind by 1 commits): vktnwlsu babc4922 descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
+      @origin: zowqyktl ff36dc55 descr_for_trunk1
     trunk2: umznmzko 8f1f14fb descr_for_trunk2
+      @origin: umznmzko 8f1f14fb descr_for_trunk2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  babc49226c14 descr_for_b b?? b@origin
@@ -568,6 +595,7 @@ fn test_git_fetch_some_of_many_branches() {
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     b: vpupmnsl c7d4bdcb descr_for_b
+      @origin: vpupmnsl c7d4bdcb descr_for_b
     "###);
     // ...then fetch two others with a glob.
     let (stdout, stderr) =
@@ -662,7 +690,9 @@ fn test_git_fetch_some_of_many_branches() {
     // We left a2 where it was before, let's see how `jj branch list` sees this.
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: kmuktwqx 6f4e1c4d descr_for_a1
+      @origin: kmuktwqx 6f4e1c4d descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
+      @origin: qkvnknrk decaa396 descr_for_a2
     b (conflicted):
       - vpupmnsl c7d4bdcb descr_for_b
       + vpupmnsl 2be688d8 new_descr_for_b_to_create_conflict
@@ -695,7 +725,9 @@ fn test_git_fetch_some_of_many_branches() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: kmuktwqx 6f4e1c4d descr_for_a1
+      @origin: kmuktwqx 6f4e1c4d descr_for_a1
     a2: xwxurvnt 010977d6 descr_for_a2
+      @origin: xwxurvnt 010977d6 descr_for_a2
     b (conflicted):
       - vpupmnsl c7d4bdcb descr_for_b
       + vpupmnsl 2be688d8 new_descr_for_b_to_create_conflict
@@ -822,6 +854,7 @@ fn test_fetch_undo_what() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b: vpupmnsl c7d4bdcb descr_for_b
+      @origin: vpupmnsl c7d4bdcb descr_for_b
     "###);
 
     // We can undo the change in the repo without moving the remote-tracking branch
@@ -1143,6 +1176,7 @@ fn test_git_fetch_remote_only_branch() {
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message
+      @origin: mzyxwzks 9f01a0e0 message
     "###);
 
     git_repo
@@ -1167,6 +1201,7 @@ fn test_git_fetch_remote_only_branch() {
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message
+      @origin: mzyxwzks 9f01a0e0 message
     feature2@origin: mzyxwzks 9f01a0e0 message
     "###);
 }

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -152,6 +152,7 @@ fn test_git_import_undo() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
+      @git: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     // "git import" can be undone by default.
@@ -165,6 +166,7 @@ fn test_git_import_undo() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
+      @git: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 }
 
@@ -193,6 +195,7 @@ fn test_git_import_move_export_with_default_undo() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
+      @git: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 
     // Move branch "a" and export to git repo
@@ -207,6 +210,7 @@ fn test_git_import_move_export_with_default_undo() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: yqosqzyt 096dc80d (empty) (no description set)
+      @git: yqosqzyt 096dc80d (empty) (no description set)
     "###);
 
     // "git import" can be undone with the default `restore` behavior, as shown in
@@ -237,11 +241,12 @@ fn test_git_import_move_export_with_default_undo() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: yqosqzyt 096dc80d (empty) (no description set)
+      @git: yqosqzyt 096dc80d (empty) (no description set)
     "###);
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
 }
 
 fn get_git_repo_refs(git_repo: &git2::Repository) -> Vec<(String, CommitId)> {

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -73,7 +73,7 @@ fn test_git_push_current_branch() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "my-branch"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
       @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
@@ -97,12 +97,14 @@ fn test_git_push_current_branch() {
       Move branch branch2 from 8476341eb395 to 10ee3363b259
       Add branch my-branch to 10ee3363b259
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
       @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
     branch2: yostqsxw 10ee3363 (empty) foo
+      @origin: yostqsxw 10ee3363 (empty) foo
     my-branch: yostqsxw 10ee3363 (empty) foo
+      @origin: yostqsxw 10ee3363 (empty) foo
     "###);
 }
 
@@ -247,10 +249,12 @@ fn test_git_push_locally_created_and_rewritten() {
     // Rewrite it and push again, which would fail if the pushed branch weren't
     // set to "tracking"
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-mlocal 2"]);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 45a3aa29 (empty) description 1
+      @origin: lzmmnrxq 45a3aa29 (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
+      @origin: rlzusymt 8476341e (empty) description 2
     my: vruxwmqv bde1d2e4 (empty) local 2
       @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv fcc99992 (empty) local 1
     "###);
@@ -272,7 +276,7 @@ fn test_git_push_multiple() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "my-branch"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1 (deleted)
       @origin: lzmmnrxq 45a3aa29 (empty) description 1
@@ -333,10 +337,12 @@ fn test_git_push_multiple() {
       Force branch branch2 from 8476341eb395 to 15dcdaa4f12f
       Add branch my-branch to 15dcdaa4f12f
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch2: yqosqzyt 15dcdaa4 (empty) foo
+      @origin: yqosqzyt 15dcdaa4 (empty) foo
     my-branch: yqosqzyt 15dcdaa4 (empty) foo
+      @origin: yqosqzyt 15dcdaa4 (empty) foo
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -666,8 +672,10 @@ fn test_git_push_conflicting_branches() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()", "-m=description 3"]);
     test_env.jj_cmd_ok(&workspace_root, &["branch", "set", "branch2"]);
     test_env.jj_cmd_ok(&workspace_root, &["git", "fetch"]);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["branch", "list"]), @r###"
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]), @r###"
     branch1: lzmmnrxq 45a3aa29 (empty) description 1
+      @origin: lzmmnrxq 45a3aa29 (empty) description 1
     branch2 (conflicted):
       + yostqsxw 8e670e2d (empty) description 3
       + rlzusymt 8476341e (empty) description 2

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -84,6 +84,7 @@ fn test_git_push_undo() {
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @origin: qpvuntsm 8c05de15 (empty) BB
     "###);
 
     // Undo the push
@@ -156,6 +157,7 @@ fn test_git_push_undo_with_import() {
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @origin: qpvuntsm 8c05de15 (empty) BB
     "###);
 
     // Undo the push
@@ -183,6 +185,7 @@ fn test_git_push_undo_with_import() {
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @origin: qpvuntsm 8c05de15 (empty) BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -222,6 +225,7 @@ fn test_git_push_undo_colocated() {
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @git: qpvuntsm 8c05de15 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
@@ -234,6 +238,8 @@ fn test_git_push_undo_colocated() {
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @git: qpvuntsm 8c05de15 (empty) BB
+      @origin: qpvuntsm 8c05de15 (empty) BB
     "###);
 
     // Undo the push
@@ -254,6 +260,7 @@ fn test_git_push_undo_colocated() {
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @git: qpvuntsm 8c05de15 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
@@ -289,6 +296,7 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 0cffb614 (empty) AA
+      @origin: qpvuntsm 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
@@ -306,6 +314,7 @@ fn test_git_push_undo_repo_only() {
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
+      @origin: qpvuntsm 8c05de15 (empty) BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -318,5 +327,5 @@ fn test_git_push_undo_repo_only() {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
 }


### PR DESCRIPTION
#1136

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
