### PR TITLE
git-compatibility.md: adjust instructions to convert to colocated repo to match 872265a22

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -170,7 +170,7 @@ mv .jj/repo/store/git .git
 # Tell jj where to find it
 echo -n '../../../.git' > .jj/repo/store/git_target
 # Ignore the .jj directory in Git
-echo /.jj/ > .git/info/exclude
+echo '/*' > .jj/.gitignore
 # Make the Git repository non-bare and set HEAD
 git config --unset core.bare
 jj st


### PR DESCRIPTION
Please double-check that this actually matches the behavior of 872265a22.
