### PR TITLE
docs/tutorial.md: in the rebase example, use commit descriptions rather than change ids

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -163,7 +163,10 @@ There are also operators for getting the parents (`foo-`), children (`foo+`),
 ancestors (`::foo`), descendants (`foo::`), DAG range (`foo::bar`, like
 `git log --ancestry-path`), range (`foo..bar`, same as Git's). There are also a
 few more functions, such as `heads(<set>)`, which filters out revisions in the
-input set if they're ancestors of other revisions in the set.
+input set if they're ancestors of other revisions in the set, and
+`description(foo)`, the commits whose description (commit message) contains `foo`.
+
+See [revsets](revsets.md) for the full documentation on revsets.
 
 ## Conflicts
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -160,11 +160,10 @@ called the "root commit". It's the root commit of every repo. The `root()`
 function in the revset matches it.
 
 There are also operators for getting the parents (`foo-`), children (`foo+`),
-ancestors (`::foo`), descendants (`foo::`), DAG range (`foo::bar`, like
-`git log --ancestry-path`), range (`foo..bar`, same as Git's). There are also a
-few more functions, such as `heads(<set>)`, which filters out revisions in the
-input set if they're ancestors of other revisions in the set, and
-`description(foo)`, the commits whose description (commit message) contains `foo`.
+ancestors (`::foo`), descendants (`foo::`), DAG range (`foo::bar`, like `git log
+--ancestry-path`), range (`foo..bar`, same as Git's). There are also a few more
+functions, such as `description(foo)` which refers to all commits whose
+description (commit message) contains `foo`.
 
 See [revsets](revsets.md) for the full documentation on revsets.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -199,10 +199,14 @@ $ jj log
 ~
 ```
 
-We now have a few commits, where A, B1, and B2 modify the same file, while C
-modifies a different file. Let's now rebase B2 directly onto A:
+We now have a few commits, where A, B1, and B2 modify the same file,
+while C modifies a different file. Let's now rebase B2 directly onto
+A. Instead of using the change ID of each commit, which may differ on
+your machine, we select each commit using its description (commit
+message).
+
 ```shell
-$ jj rebase -s puqltuttrvzp -d nuvyytnqlquo
+$ jj rebase -s 'description(B2)' -d 'description(A)'
 Rebased 2 commits
 Working copy now at: 1978b53430cd C
 Added 0 files, modified 1 files, removed 0 files


### PR DESCRIPTION
The tutorial currently says:

> Let's now rebase B2 directly onto A:
>
>     $ jj rebase -s puqltuttrvzp -d nuvyytnqlquo

I find it fairly confusing for the following reasons:

- The change ids are different on my machine, so it is difficult for me to tell which of puqltuttrvzp or nuvyytnqlquo correspond to A or B2. I have to scroll above in the tutorial to locate this information again, and I don't want to have to do this.

- You haven't explained the meaning of `-s` and `-d` yet, so I cannot guess from those either.

Instead I propose to select the commits from their commit message / description:

    $ jj rebase -s 'description(B2)' -d 'description(A)'

This is a tad verbose but much clearer. As a reader of the tutorial I appreciate clarity. (I just added both `descr(x)` and `msg(x)` as shorter alises of `description(x)` to my config file, but obviously the tutorial cannot rely on those.)


### Extra comments

1. I added a mention of `description(x)` earlier in the tutoriel when revsets are described.

2. In that part I added a link to the full documentation page on revsets. Having this link would have helped me when I decided that I wanted to name the commit by its commit message, but did not know how to.

2bis. I also tried `jj help revsets`, by analogy with `git help revisions`, but this does not work.

3. Using `--source` and `--destination` in the `rebase` line would have made my life easier, as I would not have had to guess the meaning of `-s` and `-d`. Have you considered using full names in the tutorial for each new option, and then the short name on followup uses? Should I consider a PR doing this?

