### PR TITLE
cli: allow to select branches to track/untrack by string pattern

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -496,6 +496,13 @@ fn cmd_branch_track(
             .track_remote_branch(&name.branch, &name.remote);
     }
     tx.finish(ui)?;
+    if names.len() > 1 {
+        writeln!(
+            ui.stderr(),
+            "Started tracking {} remote branches.",
+            names.len()
+        )?;
+    }
     Ok(())
 }
 
@@ -527,6 +534,13 @@ fn cmd_branch_untrack(
             .untrack_remote_branch(&name.branch, &name.remote);
     }
     tx.finish(ui)?;
+    if names.len() > 1 {
+        writeln!(
+            ui.stderr(),
+            "Stopped tracking {} remote branches.",
+            names.len()
+        )?;
+    }
     Ok(())
 }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -720,22 +720,33 @@ fn test_branch_track_untrack_bad_branches() {
 
     // Track already tracked branch
     test_env.jj_cmd_ok(&repo_path, &["branch", "track", "feature1@origin"]);
-    insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["branch", "track", "feature1@origin"]), @r###"
-    Error: Remote branch already tracked: feature1@origin
+    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "track", "feature1@origin"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Remote branch already tracked: feature1@origin
+    Nothing changed.
     "###);
 
     // Untrack non-tracking branch
-    insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["branch", "untrack", "feature2@origin"]), @r###"
-    Error: Remote branch not tracked yet: feature2@origin
+    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "untrack", "feature2@origin"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Remote branch not tracked yet: feature2@origin
+    Nothing changed.
     "###);
 
     // Untrack Git-tracking branch
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
-    insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["branch", "untrack", "main@git"]), @r###"
-    Error: Git-tracking branch cannot be untracked
+    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "untrack", "main@git"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Git-tracking branch cannot be untracked: main@git
+    Nothing changed.
+    "###);
+    insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
+    feature1: omvolwpu 1336caed commit
+      @git: omvolwpu 1336caed commit
+      @origin: omvolwpu 1336caed commit
+    feature2@origin: omvolwpu 1336caed commit
+    main: qpvuntsm 230dd059 (empty) (no description set)
+      @git: qpvuntsm 230dd059 (empty) (no description set)
     "###);
 }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -778,7 +778,9 @@ fn test_branch_track_untrack_patterns() {
 
     // Track by pattern
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "track", "glob:feature?@origin"]);
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Started tracking 2 remote branches.
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: omvolwpu 1336caed commit
       @git: omvolwpu 1336caed commit


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
