### PR TITLE
cli templates: include hidden (AKA abandoned) status in short commit template

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -1,7 +1,11 @@
 [templates]
 commit_summary = '''
 separate(" ",
-  format_short_change_id(change_id),
+  label(
+    if(hidden, "hidden"),
+    separate(" ",
+      format_short_change_id(change_id),
+      if(hidden, "hidden"))),
   format_short_commit_id(commit_id),
   separate(commit_summary_separator,
     branches,
@@ -16,7 +20,11 @@ separate(" ",
 
 commit_summary_no_branches = '''
 separate(" ",
-  format_short_change_id(change_id),
+  label(
+    if(hidden, "hidden"),
+    separate(" ",
+      format_short_change_id(change_id),
+      if(hidden, "hidden"))),
   format_short_commit_id(commit_id),
   if(conflict, label("conflict", "(conflict)")),
   if(empty, label("empty", "(empty)")),

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -190,7 +190,7 @@ fn test_double_abandon() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", &commit_id]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Abandoned commit rlvkpnrz 2443ea76 a
+    Abandoned commit rlvkpnrz hidden 2443ea76 a
     Nothing changed.
     "###);
 }

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -918,7 +918,7 @@ fn test_branch_list_filtered_by_revset() {
        next `jj git push`. Use `jj branch forget` to prevent this)
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
 
     let query = |revset| test_env.jj_cmd_success(&local_path, &["branch", "list", "-r", revset]);
@@ -931,7 +931,7 @@ fn test_branch_list_filtered_by_revset() {
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
 
     // Exclude remote-only branches. "remote-rewrite@origin" is included since
@@ -940,13 +940,13 @@ fn test_branch_list_filtered_by_revset() {
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
 
     // Select branches by name.
     insta::assert_snapshot!(query("branches(remote-rewrite)"), @r###"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn 3e9a5af6 (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
 
     // Can't select deleted branch.

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -498,7 +498,7 @@ fn test_git_fetch_all() {
     a2: qkvnknrk decaa396 descr_for_a2
       @origin: qkvnknrk decaa396 descr_for_a2
     b: vpupmnsl 061eddbb new_descr_for_b_to_create_conflict
-      @origin (ahead by 1 commits, behind by 1 commits): vpupmnsl c7d4bdcb descr_for_b
+      @origin (ahead by 1 commits, behind by 1 commits): vpupmnsl hidden c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
@@ -513,7 +513,7 @@ fn test_git_fetch_all() {
     a2: osusxwst 91e46b4b descr_for_a2
       @origin: osusxwst 91e46b4b descr_for_a2
     b (conflicted):
-      - vpupmnsl c7d4bdcb descr_for_b
+      - vpupmnsl hidden c7d4bdcb descr_for_b
       + vpupmnsl 061eddbb new_descr_for_b_to_create_conflict
       + vktnwlsu babc4922 descr_for_b
       @origin (behind by 1 commits): vktnwlsu babc4922 descr_for_b
@@ -703,7 +703,7 @@ fn test_git_fetch_some_of_many_branches() {
     a2: qkvnknrk decaa396 descr_for_a2
       @origin: qkvnknrk decaa396 descr_for_a2
     b (conflicted):
-      - vpupmnsl c7d4bdcb descr_for_b
+      - vpupmnsl hidden c7d4bdcb descr_for_b
       + vpupmnsl 6ebd41dc new_descr_for_b_to_create_conflict
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
@@ -738,7 +738,7 @@ fn test_git_fetch_some_of_many_branches() {
     a2: qrmzolkr 31c7d94b descr_for_a2
       @origin: qrmzolkr 31c7d94b descr_for_a2
     b (conflicted):
-      - vpupmnsl c7d4bdcb descr_for_b
+      - vpupmnsl hidden c7d4bdcb descr_for_b
       + vpupmnsl 6ebd41dc new_descr_for_b_to_create_conflict
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
@@ -875,7 +875,7 @@ fn test_fetch_undo_what() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b (deleted)
-      @origin: vpupmnsl c7d4bdcb descr_for_b
+      @origin: vpupmnsl hidden c7d4bdcb descr_for_b
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     "###);
@@ -885,7 +885,7 @@ fn test_fetch_undo_what() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "c", "newbranch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b (deleted)
-      @origin: vpupmnsl c7d4bdcb descr_for_b
+      @origin: vpupmnsl hidden c7d4bdcb descr_for_b
       (this branch will be *deleted permanently* on the remote on the
        next `jj git push`. Use `jj branch forget` to prevent this)
     newbranch: qpvuntsm 230dd059 (empty) (no description set)

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -36,7 +36,7 @@ fn test_resolution_of_git_tracking_branches() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-r", "main", "-m", "new_message"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 3af37026 (empty) new_message
-      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm 16d541ca (empty) old_message
+      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 16d541ca (empty) old_message
     "###);
 
     // Test that we can address both revisions

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -76,7 +76,7 @@ fn test_git_push_current_branch() {
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
+      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq hidden 45a3aa29 (empty) description 1
     branch2: yostqsxw 10ee3363 (empty) foo
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
     my-branch: yostqsxw 10ee3363 (empty) foo
@@ -100,7 +100,7 @@ fn test_git_push_current_branch() {
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
+      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq hidden 45a3aa29 (empty) description 1
     branch2: yostqsxw 10ee3363 (empty) foo
       @origin: yostqsxw 10ee3363 (empty) foo
     my-branch: yostqsxw 10ee3363 (empty) foo
@@ -256,7 +256,7 @@ fn test_git_push_locally_created_and_rewritten() {
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     my: vruxwmqv bde1d2e4 (empty) local 2
-      @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv fcc99992 (empty) local 1
+      @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv hidden fcc99992 (empty) local 1
     "###);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -72,7 +72,7 @@ fn test_git_push_undo() {
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -97,7 +97,7 @@ fn test_git_push_undo() {
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -112,7 +112,7 @@ fn test_git_push_undo() {
     // git fetch && jj undo && jj git fetch` would become a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm 0cffb614 (empty) AA
+      - qpvuntsm hidden 0cffb614 (empty) AA
       + qpvuntsm 0a3e99f0 (empty) CC
       + qpvuntsm 8c05de15 (empty) BB
       @origin (behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
@@ -145,7 +145,7 @@ fn test_git_push_undo_with_import() {
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -170,7 +170,7 @@ fn test_git_push_undo_with_import() {
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
 
     // PROBLEM: inserting this import changes the outcome compared to previous test
@@ -194,7 +194,7 @@ fn test_git_push_undo_with_import() {
     // was essentially a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 0a3e99f0 (empty) CC
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 8c05de15 (empty) BB
     "###);
 }
 
@@ -226,7 +226,7 @@ fn test_git_push_undo_colocated() {
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
       @git: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -261,7 +261,7 @@ fn test_git_push_undo_colocated() {
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
       @git: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -270,7 +270,7 @@ fn test_git_push_undo_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm 0cffb614 (empty) AA
+      - qpvuntsm hidden 0cffb614 (empty) AA
       + qpvuntsm 0a3e99f0 (empty) CC
       + qpvuntsm 8c05de15 (empty) BB
       @git (behind by 1 commits): qpvuntsm 0a3e99f0 (empty) CC
@@ -302,7 +302,7 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 0cffb614 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -322,7 +322,7 @@ fn test_git_push_undo_repo_only() {
     // This currently gives an identical result to `test_git_push_undo_import`.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 0a3e99f0 (empty) CC
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 8c05de15 (empty) BB
     "###);
 }
 


### PR DESCRIPTION
This is mainly relevant for `jj abandon` and `jj branch list`. https://github.com/martinvonz/jj/issues/2411

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
