### PR TITLE
merge_tools.toml: add VS Code as a default merge tool.

### DIFF
--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -22,3 +22,11 @@ merge-tool-edits-conflict-markers = true
 # the DirDiff Vim plugin for a better experience, see
 # https://gist.github.com/ilyagr/5d6339fb7dac5e7ab06fe1561ec62d45
 edit-args = ["-f", "-d", "$left", "$right"]
+
+[merge-tools.vscode]
+program = "code"
+merge-args = ["--wait", "--merge", "$left", "$right", "$base", "$output"]
+# VS Code reads the output file and behaves better if it's prepopulated with conflict
+# markers. Unfortunately, it does not seem to be able to output conflict markers when
+# the user only resolves some of the conflicts.
+merge-tool-edits-conflict-markers = true

--- a/docs/config.md
+++ b/docs/config.md
@@ -432,13 +432,19 @@ by `jj resolve`. For example:
 
 ```toml
 # Use merge-tools.meld.merge-args
-ui.merge-editor = "meld"  # Or "kdiff3" or "vimdiff"
+ui.merge-editor = "meld"  # Or "vscode" or "kdiff3" or "vimdiff"
 # Specify merge-args inline
 ui.merge-editor = ["meld", "$left", "$base", "$right", "-o", "$output"]
 ```
 
-The "meld", "kdiff3", and "vimdiff" tools can be used out of the box, as long as
-they are installed.
+The "vscode", "meld", "kdiff3", and "vimdiff" tools can be used out of the box,
+as long as they are installed.
+
+Using VS Code as a merge tool works well with VS Code's [Remote
+Development](https://code.visualstudio.com/docs/remote/remote-overview)
+functionality, as long as `jj` is called from VS Code's terminal.
+
+### Setting up a custom merge tool
 
 To use a different tool named `TOOL`, the arguments to pass to the tool MUST be
 specified either inline or in the `merge-tools.TOOL.merge-args` key. As an

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -14,13 +14,14 @@ ui.diff-editor = "meld" # default, requires meld to be installed
 # ui.diff-editor = "vimdiff"
 
 ui.merge-editor = "meld" # default
+# ui.merge-editor = "vscode"
 # ui.merge-editor = "vimdiff"
 # ui.merge-editor = "kdiff3"
 
 # Relative timestamp rendered as "x days/hours/seconds ago"
 template-aliases.'format_timestamp(timestamp)' = 'timestamp.ago()'
 
-# The three merge tools above are pre-configured. For detailed information
+# The four merge tools listed above are pre-configured. For detailed information
 # about how to change the default configuration or how to configure another tool,
 # see documentation in config.md. An example:
 


### PR DESCRIPTION
Thanks to @glencbz for noticing that VS Code works fine now as a merge tool, and thanks to @solson for suggesting
`merge-tool-edits-conflict-markers = true`.


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json) (doesn't seem necessary)
- [ ] I have added tests to cover my changes
