### PR TITLE
docs/config.toml: update the default diff editor

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -10,7 +10,8 @@ ui.color = "auto" # the default
 ui.editor = "pico" # the default on Unix
 # ui.editor = "vim"
 
-ui.diff-editor = "meld" # default, requires meld to be installed
+ui.diff-editor = ":builtin" # default, internal TUI tool
+# ui.diff-editor = "meld"
 # ui.diff-editor = "vimdiff"
 
 ui.merge-editor = "meld" # default


### PR DESCRIPTION
It's been changed to `:builtin` some time ago.

I'm actually not sure if this file has much use anymore. Perhaps we should put it inside `config.md` or get rid of it.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
