### PR TITLE
cli templates: include info on divergent change ids in short commit template

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3191,9 +3191,15 @@ fn cmd_restore(
             .rewrite_commit(command.settings(), &to_commit)
             .set_tree_id(new_tree_id)
             .write()?;
+        // rebase_descendants early; otherwise `new_commit` would always have
+        // a conflicted change id at this point.
+        let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
         write!(ui.stderr(), "Created ")?;
         tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
         writeln!(ui.stderr())?;
+        if num_rebased > 0 {
+            writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
+        }
         tx.finish(ui)?;
     }
     Ok(())
@@ -3248,9 +3254,15 @@ don't make any changes, then the operation will be aborted.",
             .rewrite_commit(command.settings(), &target_commit)
             .set_tree_id(tree_id)
             .write()?;
+        // rebase_descendants early; otherwise `new_commit` would always have
+        // a conflicted change id at this point.
+        let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
         write!(ui.stderr(), "Created ")?;
         tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
         writeln!(ui.stderr())?;
+        if num_rebased > 0 {
+            writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
+        }
         tx.finish(ui)?;
     }
     Ok(())

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -15,9 +15,6 @@
 "divergent rest" = "red"
 "divergent prefix" = {fg = "red", underline=true}
 "hidden prefix" = "default"
-"divergent hidden" = {fg = "default", bold = true}
-"divergent hidden prefix" = {fg = "default", underline = false}
-"divergent hidden rest" = {fg ="bright black", bold = false}
 
 "email" = "yellow"
 "username" = "yellow"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -133,10 +133,16 @@ commit_summary_separator = 'label("separator", " | ")'
   time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp'
 
+# We have "hidden" override "divergent", since a hidden revision does not cause
+# change id conflicts and is not affected by such conflicts; you have to use the
+# commit id to refer to a hidden revision regardless.
 builtin_change_id_with_hidden_and_divergent_info = '''
-label(
-  separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
-  separate(" ",
-    format_short_change_id(change_id) ++ if(divergent, "??"),
-    if(hidden, "hidden")))
+if(hidden,
+  label("hidden", 
+    format_short_change_id(change_id) ++ " hidden"
+  ),
+  label(if(divergent, "divergent"),
+    format_short_change_id(change_id) ++ if(divergent,"??")
+  )
+)
 '''

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -43,11 +43,7 @@ if(root,
   label(if(current_working_copy, "working_copy"),
     concat(
       separate(" ",
-        label(
-          separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
-          separate(" ",
-            format_short_change_id(change_id) ++ if(divergent, "??"),
-            if(hidden, "hidden"))),
+        builtin_change_id_with_hidden_and_divergent_info,
         if(author.email(), author.username(), email_placeholder),
         format_timestamp(committer.timestamp()),
         branches,
@@ -69,11 +65,7 @@ if(root,
   label(if(current_working_copy, "working_copy"),
     concat(
       separate(" ",
-        label(
-          separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
-          separate(" ",
-            format_short_change_id(change_id) ++ if(divergent, "??"),
-            if(hidden, "hidden"))),
+        builtin_change_id_with_hidden_and_divergent_info,
         format_short_signature(author),
         format_timestamp(committer.timestamp()),
         branches,
@@ -148,3 +140,11 @@ commit_summary_separator = 'label("separator", " | ")'
 'format_time_range(time_range)' = '''
   time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp'
+
+builtin_change_id_with_hidden_and_divergent_info = '''
+label(
+  separate(" ", if(divergent, "divergent"), if(hidden, "hidden")),
+  separate(" ",
+    format_short_change_id(change_id) ++ if(divergent, "??"),
+    if(hidden, "hidden")))
+'''

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -1,11 +1,7 @@
 [templates]
 commit_summary = '''
 separate(" ",
-  label(
-    if(hidden, "hidden"),
-    separate(" ",
-      format_short_change_id(change_id),
-      if(hidden, "hidden"))),
+  builtin_change_id_with_hidden_and_divergent_info,
   format_short_commit_id(commit_id),
   separate(commit_summary_separator,
     branches,
@@ -20,11 +16,7 @@ separate(" ",
 
 commit_summary_no_branches = '''
 separate(" ",
-  label(
-    if(hidden, "hidden"),
-    separate(" ",
-      format_short_change_id(change_id),
-      if(hidden, "hidden"))),
+  builtin_change_id_with_hidden_and_divergent_info,
   format_short_commit_id(commit_id),
   if(conflict, label("conflict", "(conflict)")),
   if(empty, label("empty", "(empty)")),

--- a/cli/tests/test_checkout.rs
+++ b/cli/tests/test_checkout.rs
@@ -152,8 +152,8 @@ fn test_checkout_conflicting_change_ids() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "qpvuntsm" resolved to more than one revision
     Hint: The revset "qpvuntsm" resolved to these revisions:
-    qpvuntsm d2ae6806 (empty) two
-    qpvuntsm a9330854 (empty) one
+    qpvuntsm?? d2ae6806 (empty) two
+    qpvuntsm?? a9330854 (empty) one
     Some of these commits have the same change id. Abandon one of them with `jj abandon -r <REVISION>`.
     "###);
 }

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -344,9 +344,9 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
     │  description 1
-    ◉  qpvuntsm?? hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 3b68ce25
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 3b68ce25
     │  (no description set)
-    ◉  qpvuntsm?? hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
        (empty) (no description set)
     "###);
 
@@ -355,9 +355,9 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     │  [1mdescription 1[0m
-    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsm[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
+    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
     │  [38;5;3m(no description set)[39m
-    ◉  [1m[24m[39mq[0m[38;5;8mpvuntsm[1m[39m?? hidden[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     "###);
 }

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -192,7 +192,7 @@ fn test_restore_conflicted_merge() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "file"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created vruxwmqv b2c9c888 (conflict) (empty) conflict
+    Created vruxwmqv b2c9c888 conflict | (conflict) (empty) conflict
     Working copy now at: vruxwmqv b2c9c888 conflict | (conflict) (empty) conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
@@ -231,7 +231,7 @@ fn test_restore_conflicted_merge() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created vruxwmqv 4fc10820 (conflict) (empty) conflict
+    Created vruxwmqv 4fc10820 conflict | (conflict) (empty) conflict
     Working copy now at: vruxwmqv 4fc10820 conflict | (conflict) (empty) conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -112,10 +112,10 @@ fn test_git_push_undo() {
     // git fetch && jj undo && jj git fetch` would become a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm hidden 0cffb614 (empty) AA
-      + qpvuntsm 0a3e99f0 (empty) CC
-      + qpvuntsm 8c05de15 (empty) BB
-      @origin (behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
+      - qpvuntsm?? hidden 0cffb614 (empty) AA
+      + qpvuntsm?? 0a3e99f0 (empty) CC
+      + qpvuntsm?? 8c05de15 (empty) BB
+      @origin (behind by 1 commits): qpvuntsm?? 8c05de15 (empty) BB
     "###);
 }
 
@@ -270,11 +270,11 @@ fn test_git_push_undo_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm hidden 0cffb614 (empty) AA
-      + qpvuntsm 0a3e99f0 (empty) CC
-      + qpvuntsm 8c05de15 (empty) BB
-      @git (behind by 1 commits): qpvuntsm 0a3e99f0 (empty) CC
-      @origin (behind by 1 commits): qpvuntsm 8c05de15 (empty) BB
+      - qpvuntsm?? hidden 0cffb614 (empty) AA
+      + qpvuntsm?? 0a3e99f0 (empty) CC
+      + qpvuntsm?? 8c05de15 (empty) BB
+      @git (behind by 1 commits): qpvuntsm?? 0a3e99f0 (empty) CC
+      @origin (behind by 1 commits): qpvuntsm?? 8c05de15 (empty) BB
     "###);
 }
 

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -112,7 +112,7 @@ fn test_git_push_undo() {
     // git fetch && jj undo && jj git fetch` would become a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm?? hidden 0cffb614 (empty) AA
+      - qpvuntsm hidden 0cffb614 (empty) AA
       + qpvuntsm?? 0a3e99f0 (empty) CC
       + qpvuntsm?? 8c05de15 (empty) BB
       @origin (behind by 1 commits): qpvuntsm?? 8c05de15 (empty) BB
@@ -270,7 +270,7 @@ fn test_git_push_undo_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm?? hidden 0cffb614 (empty) AA
+      - qpvuntsm hidden 0cffb614 (empty) AA
       + qpvuntsm?? 0a3e99f0 (empty) CC
       + qpvuntsm?? 8c05de15 (empty) BB
       @git (behind by 1 commits): qpvuntsm?? 0a3e99f0 (empty) CC

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -193,7 +193,7 @@ fn test_workspaces_conflicting_edits() {
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    Working copy now at: pmmvwywv a1896a17 (empty) (no description set)
+    Working copy now at: pmmvwywv?? a1896a17 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),


### PR DESCRIPTION
Fixes https://github.com/martinvonz/jj/issues/2411.

Includes a few related changes. In particular, one of the test changes made me think
that "hidden" should override "divergent" in the commit template (this change can be
split into a separate commit or abandoned if it's controversial).

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
