### PR TITLE
clippy and rust-analyzer: get rid of warnings

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -19,7 +19,7 @@ use std::io::Write as _;
 use clap::Subcommand;
 use jj_lib::backend::ObjectId;
 use jj_lib::default_index_store::{DefaultIndexStore, ReadonlyIndexWrapper};
-use jj_lib::local_working_copy::{LocalWorkingCopy, LockedLocalWorkingCopy};
+use jj_lib::local_working_copy::LocalWorkingCopy;
 use jj_lib::revset;
 use jj_lib::working_copy::WorkingCopy;
 
@@ -276,6 +276,8 @@ fn cmd_debug_watchman(
     command: &CommandHelper,
     subcommand: &DebugWatchmanSubcommand,
 ) -> Result<(), CommandError> {
+    use jj_lib::local_working_copy::LockedLocalWorkingCopy;
+
     let mut workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo().clone();
     match subcommand {

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -93,7 +93,7 @@ pub(crate) fn cmd_resolve(
         );
     };
 
-    let (repo_path, _) = conflicts.get(0).unwrap();
+    let (repo_path, _) = conflicts.first().unwrap();
     workspace_command.check_rewritable([&commit])?;
     let mut tx = workspace_command.start_transaction(&format!(
         "Resolve conflicts in commit {}",

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -85,7 +85,7 @@ fn test_commit_with_default_description() {
     std::fs::write(workspace_path.join("file1"), "foo\n").unwrap();
     std::fs::write(workspace_path.join("file2"), "bar\n").unwrap();
     let edit_script = test_env.set_up_fake_editor();
-    std::fs::write(&edit_script, ["dump editor"].join("\0")).unwrap();
+    std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r#"

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -259,7 +259,7 @@ fn test_describe_default_description() {
     std::fs::write(workspace_path.join("file1"), "foo\n").unwrap();
     std::fs::write(workspace_path.join("file2"), "bar\n").unwrap();
     let edit_script = test_env.set_up_fake_editor();
-    std::fs::write(&edit_script, ["dump editor"].join("\0")).unwrap();
+    std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"


### PR DESCRIPTION
Also removes a separate warning. I'm not sure why VS Code (and `rust-analyzer`) shows that one to me; running `cargo clippy` does not.