### PR TITLE
rust: bump MSRV to 1.76.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8
       with:
-        toolchain:  1.71
+        toolchain:  1.76
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
     - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* The minimum supported Rust version (MSRV) is now 1.76.0.
+
 ### New features
 
 * Templates now support logical operators: `||`, `&&`, `!`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/testutils", "lib/gen-protos"]
 [workspace.package]
 version = "0.14.0"
 license = "Apache-2.0"
-rust-version = "1.71"                                 # NOTE: remember to update CI, contributing.md, changelog.md, and flake.nix
+rust-version = "1.76"                                 # NOTE: remember to update CI, contributing.md, changelog.md, and flake.nix
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/martinvonz/jj"

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -198,7 +198,6 @@ fn test_git_clone_colocate() {
             .symbolic_target()
     );
     // ".jj" directory should be ignored at Git side.
-    #[allow(unknown_lints)] // Needed for clippy <=1.71
     #[allow(clippy::format_collect)]
     let git_statuses: String = jj_git_repo
         .statuses(None)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -122,7 +122,7 @@ jj config set --repo "revset-aliases.immutable_heads()" "main@origin | gh-pages@
 One-time setup:
 
     rustup toolchain add nightly  # wanted for 'rustfmt'
-    rustup toolchain add 1.71     # also specified in Cargo.toml
+    rustup toolchain add 1.76     # also specified in Cargo.toml
     cargo install cargo-insta
     cargo install cargo-watch
     cargo install cargo-nextest
@@ -131,7 +131,7 @@ During development (adapt according to your preference):
 
     cargo watch --ignore '.jj/**' -s \
       'cargo clippy --workspace --all-targets \
-       && cargo +1.71 check --workspace --all-targets'
+       && cargo +1.76 check --workspace --all-targets'
     cargo +nightly fmt # Occasionally
     cargo nextest run --workspace # Occasionally
     cargo insta test --workspace --test-runner nextest # Occasionally
@@ -160,7 +160,7 @@ These are listed roughly in order of decreasing importance.
 3. Your code will be rejected if it cannot be compiled with the minimal
    supported version of Rust ("MSRV"). Currently, `jj` follows a rather
    casual MSRV policy: "The current `rustc` stable version, minus one."
-   As of this writing, that version is **1.71.0**.
+   As of this writing, that version is **1.76.0**.
 
 4. Your code needs to pass `cargo clippy`. You can also
    use `cargo +nightly clippy` if you wish to see more warnings.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705466837,
-        "narHash": "sha256-iYVxjZqKd9Si4wuf5GO9aNKxqAn9P3bNN38vflIooHY=",
+        "lastModified": 1707451808,
+        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "757637581797f148c50977b6127147c5d298f9e9",
+        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705457855,
-        "narHash": "sha256-5cCHQtP/PEHK1YNTQyZN9v8ehpLTjc723ZSKAP3Tva8=",
+        "lastModified": 1707444620,
+        "narHash": "sha256-P8kRkiJLFttN+hbAOlm11wPxUrQZqKle+QtVCqFiGXY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a854609265af0e9f48c92e497679edf8fab9e690",
+        "rev": "78503e9199010a4df714f29a4f9c00eb2ccae071",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             pkgs.lib.all (re: builtins.match re relPath == null) regexes;
         };
 
-      rust-version = pkgs.rust-bin.stable."1.71.0".default;
+      rust-version = pkgs.rust-bin.stable."1.76.0".default;
 
       ourRustPlatform = pkgs.makeRustPlatform {
         rustc = rust-version;

--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -167,7 +167,7 @@ impl<'revset, 'index> RevsetGraphIterator<'revset, 'index> {
         index_entry: &IndexEntry<'index>,
     ) -> &[IndexGraphEdge] {
         let position = index_entry.position();
-        // `if let Some(edges) = ...` doesn't pass lifetime check as of Rust 1.71.0
+        // `if let Some(edges) = ...` doesn't pass lifetime check as of Rust 1.76.0
         if self.edges.contains_key(&position) {
             return self.edges.get(&position).unwrap();
         }

--- a/lib/src/tree_builder.rs
+++ b/lib/src/tree_builder.rs
@@ -129,7 +129,7 @@ impl TreeBuilder {
             store: &Arc<Store>,
             dir: &RepoPath,
         ) -> &'a Tree {
-            // `if let Some(tree) = ...` doesn't pass lifetime check as of Rust 1.69.0
+            // `if let Some(tree) = ...` doesn't pass lifetime check as of Rust 1.76.0
             if tree_cache.contains_key(dir) {
                 return tree_cache.get(dir).unwrap();
             }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Remove when MSRV passes 1.72
-// https://github.com/frondeus/test-case/issues/126#issuecomment-1635916592
-#![allow(clippy::items_after_test_module)]
-
 use std::fs::OpenOptions;
 use std::io::Write;
 #[cfg(unix)]

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// this was supposed to be fixed in 1.71.0, but barely missed the cut.
-// can be released after we bump MSRV to 1.72.0, see:
-// https://github.com/frondeus/test-case/issues/126#issuecomment-1635916592
-#![allow(clippy::items_after_test_module)]
-
 use std::path::Path;
 
 use assert_matches::assert_matches;


### PR DESCRIPTION
Summary: I was testing 1.72.0, but in order to see if some clippy bugs had been fixed, I bumped it to 1.73.0. The bugs weren't fixed; but I guess we can just bump things here, anyway.

Change-Id: I038346d8a821f83f62cbf122a79c8f30


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
