### PR TITLE
commands: move resolve and rebase code to separate files

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -37,8 +37,9 @@ mod merge;
 mod r#move;
 mod new;
 mod operation;
+mod resolve;
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::io::{BufRead, Seek, SeekFrom, Write};
 use std::path::Path;
@@ -49,11 +50,11 @@ use clap::parser::ValueSource;
 use clap::{ArgGroup, Command, CommandFactory, FromArgMatches, Subcommand};
 use indexmap::IndexSet;
 use itertools::Itertools;
-use jj_lib::backend::{CommitId, ObjectId, TreeValue};
+use jj_lib::backend::{CommitId, ObjectId};
 use jj_lib::commit::Commit;
 use jj_lib::dag_walk::topo_order_reverse;
 use jj_lib::matchers::EverythingMatcher;
-use jj_lib::merge::{Merge, MergedTreeValue};
+use jj_lib::merge::Merge;
 use jj_lib::merged_tree::{MergedTree, MergedTreeBuilder};
 use jj_lib::op_store::WorkspaceId;
 use jj_lib::repo::{ReadonlyRepo, Repo};
@@ -127,7 +128,7 @@ enum Commands {
     Operation(operation::OperationCommands),
     Prev(PrevArgs),
     Rebase(RebaseArgs),
-    Resolve(ResolveArgs),
+    Resolve(resolve::ResolveArgs),
     Restore(RestoreArgs),
     #[command(hide = true)]
     // TODO: Flesh out.
@@ -337,42 +338,6 @@ struct UnsquashArgs {
     // the default.
     #[arg(long, short)]
     interactive: bool,
-}
-
-/// Resolve a conflicted file with an external merge tool
-///
-/// Only conflicts that can be resolved with a 3-way merge are supported. See
-/// docs for merge tool configuration instructions.
-///
-/// Note that conflicts can also be resolved without using this command. You may
-/// edit the conflict markers in the conflicted file directly with a text
-/// editor.
-//  TODOs:
-//   - `jj resolve --editor` to resolve a conflict in the default text editor. Should work for
-//     conflicts with 3+ adds. Useful to resolve conflicts in a commit other than the current one.
-//   - A way to help split commits with conflicts that are too complicated (more than two sides)
-//     into commits with simpler conflicts. In case of a tree with many merges, we could for example
-//     point to existing commits with simpler conflicts where resolving those conflicts would help
-//     simplify the present one.
-#[derive(clap::Args, Clone, Debug)]
-struct ResolveArgs {
-    #[arg(long, short, default_value = "@")]
-    revision: String,
-    /// Instead of resolving one conflict, list all the conflicts
-    // TODO: Also have a `--summary` option. `--list` currently acts like
-    // `diff --summary`, but should be more verbose.
-    #[arg(long, short)]
-    list: bool,
-    /// Do not print the list of remaining conflicts (if any) after resolving a
-    /// conflict
-    #[arg(long, short, conflicts_with = "list")]
-    quiet: bool,
-    /// Restrict to these paths when searching for a conflict to resolve. We
-    /// will attempt to resolve the first conflict we can find. You can use
-    /// the `--list` argument to find paths to use here.
-    // TODO: Find the conflict we can resolve even if it's not the first one.
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
-    paths: Vec<String>,
 }
 
 /// Restore paths from another revision
@@ -871,7 +836,7 @@ fn cmd_status(
                 formatter.labeled("conflict"),
                 "There are unresolved conflicts at these paths:"
             )?;
-            print_conflicted_paths(&conflicts, formatter, &workspace_command)?
+            resolve::print_conflicted_paths(&conflicts, formatter, &workspace_command)?
         }
 
         formatter.write_str("Working copy : ")?;
@@ -1512,161 +1477,6 @@ aborted.
             .write()?;
     }
     tx.finish(ui)?;
-    Ok(())
-}
-
-#[instrument(skip_all)]
-fn cmd_resolve(
-    ui: &mut Ui,
-    command: &CommandHelper,
-    args: &ResolveArgs,
-) -> Result<(), CommandError> {
-    let mut workspace_command = command.workspace_helper(ui)?;
-    let matcher = workspace_command.matcher_from_values(&args.paths)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
-    let tree = commit.tree()?;
-    let conflicts = tree
-        .conflicts()
-        .filter(|path| matcher.matches(&path.0))
-        .collect_vec();
-    if conflicts.is_empty() {
-        return Err(CommandError::CliError(format!(
-            "No conflicts found {}",
-            if args.paths.is_empty() {
-                "at this revision"
-            } else {
-                "at the given path(s)"
-            }
-        )));
-    }
-    if args.list {
-        return print_conflicted_paths(
-            &conflicts,
-            ui.stdout_formatter().as_mut(),
-            &workspace_command,
-        );
-    };
-
-    let (repo_path, _) = conflicts.get(0).unwrap();
-    workspace_command.check_rewritable([&commit])?;
-    let mut tx = workspace_command.start_transaction(&format!(
-        "Resolve conflicts in commit {}",
-        commit.id().hex()
-    ));
-    let new_tree_id = tx.run_mergetool(ui, &tree, repo_path)?;
-    let new_commit = tx
-        .mut_repo()
-        .rewrite_commit(command.settings(), &commit)
-        .set_tree_id(new_tree_id)
-        .write()?;
-    tx.finish(ui)?;
-
-    if !args.quiet {
-        let new_tree = new_commit.tree()?;
-        let new_conflicts = new_tree.conflicts().collect_vec();
-        if !new_conflicts.is_empty() {
-            writeln!(
-                ui.stderr(),
-                "After this operation, some files at this revision still have conflicts:"
-            )?;
-            print_conflicted_paths(
-                &new_conflicts,
-                ui.stderr_formatter().as_mut(),
-                &workspace_command,
-            )?;
-        }
-    };
-    Ok(())
-}
-
-#[instrument(skip_all)]
-fn print_conflicted_paths(
-    conflicts: &[(RepoPath, MergedTreeValue)],
-    formatter: &mut dyn Formatter,
-    workspace_command: &WorkspaceCommandHelper,
-) -> Result<(), CommandError> {
-    let formatted_paths = conflicts
-        .iter()
-        .map(|(path, _conflict)| workspace_command.format_file_path(path))
-        .collect_vec();
-    let max_path_len = formatted_paths.iter().map(|p| p.len()).max().unwrap_or(0);
-    let formatted_paths = formatted_paths
-        .into_iter()
-        .map(|p| format!("{:width$}", p, width = max_path_len.min(32) + 3));
-
-    for ((_, conflict), formatted_path) in std::iter::zip(conflicts.iter(), formatted_paths) {
-        let sides = conflict.num_sides();
-        let n_adds = conflict.adds().iter().flatten().count();
-        let deletions = sides - n_adds;
-
-        let mut seen_objects = BTreeMap::new(); // Sort for consistency and easier testing
-        if deletions > 0 {
-            seen_objects.insert(
-                format!(
-                    // Starting with a number sorts this first
-                    "{deletions} deletion{}",
-                    if deletions > 1 { "s" } else { "" }
-                ),
-                "normal", // Deletions don't interfere with `jj resolve` or diff display
-            );
-        }
-        // TODO: We might decide it's OK for `jj resolve` to ignore special files in the
-        // `removes` of a conflict (see e.g. https://github.com/martinvonz/jj/pull/978). In
-        // that case, `conflict.removes` should be removed below.
-        for term in itertools::chain(conflict.removes().iter(), conflict.adds().iter()).flatten() {
-            seen_objects.insert(
-                match term {
-                    TreeValue::File {
-                        executable: false, ..
-                    } => continue,
-                    TreeValue::File {
-                        executable: true, ..
-                    } => "an executable",
-                    TreeValue::Symlink(_) => "a symlink",
-                    TreeValue::Tree(_) => "a directory",
-                    TreeValue::GitSubmodule(_) => "a git submodule",
-                    TreeValue::Conflict(_) => "another conflict (you found a bug!)",
-                }
-                .to_string(),
-                "difficult",
-            );
-        }
-
-        write!(formatter, "{formatted_path} ",)?;
-        formatter.with_label("conflict_description", |formatter| {
-            let print_pair = |formatter: &mut dyn Formatter, (text, label): &(String, &str)| {
-                formatter.with_label(label, |fmt| fmt.write_str(text))
-            };
-            print_pair(
-                formatter,
-                &(
-                    format!("{sides}-sided"),
-                    if sides > 2 { "difficult" } else { "normal" },
-                ),
-            )?;
-            formatter.write_str(" conflict")?;
-
-            if !seen_objects.is_empty() {
-                formatter.write_str(" including ")?;
-                let seen_objects = seen_objects.into_iter().collect_vec();
-                match &seen_objects[..] {
-                    [] => unreachable!(),
-                    [only] => print_pair(formatter, only)?,
-                    [first, middle @ .., last] => {
-                        print_pair(formatter, first)?;
-                        for pair in middle {
-                            formatter.write_str(", ")?;
-                            print_pair(formatter, pair)?;
-                        }
-                        formatter.write_str(" and ")?;
-                        print_pair(formatter, last)?;
-                    }
-                };
-            }
-            Ok(())
-        })?;
-        writeln!(formatter)?;
-    }
     Ok(())
 }
 
@@ -2507,7 +2317,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Commands::Merge(sub_args) => merge::cmd_merge(ui, command_helper, sub_args),
         Commands::Rebase(sub_args) => cmd_rebase(ui, command_helper, sub_args),
         Commands::Backout(sub_args) => backout::cmd_backout(ui, command_helper, sub_args),
-        Commands::Resolve(sub_args) => cmd_resolve(ui, command_helper, sub_args),
+        Commands::Resolve(sub_args) => resolve::cmd_resolve(ui, command_helper, sub_args),
         Commands::Branch(sub_args) => branch::cmd_branch(ui, command_helper, sub_args),
         Commands::Undo(sub_args) => operation::cmd_op_undo(ui, command_helper, sub_args),
         Commands::Operation(sub_args) => operation::cmd_operation(ui, command_helper, sub_args),

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -25,7 +25,7 @@ use tracing::instrument;
 use crate::cli_util::{
     self, short_commit_hash, user_error, CommandError, CommandHelper, RevisionArg,
 };
-use crate::commands::resolve_destination_revs;
+use crate::commands::rebase::resolve_destination_revs;
 use crate::ui::Ui;
 
 /// Create a new, empty change and edit it in the working copy

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -1,0 +1,366 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use clap::ArgGroup;
+use indexmap::IndexSet;
+use itertools::Itertools;
+use jj_lib::backend::{CommitId, ObjectId};
+use jj_lib::commit::Commit;
+use jj_lib::repo::{ReadonlyRepo, Repo};
+use jj_lib::revset::{RevsetExpression, RevsetIteratorExt};
+use jj_lib::rewrite::rebase_commit;
+use jj_lib::settings::UserSettings;
+use tracing::instrument;
+
+use crate::cli_util::{
+    resolve_multiple_nonempty_revsets_default_single, short_commit_hash, user_error, CommandError,
+    CommandHelper, RevisionArg, WorkspaceCommandHelper,
+};
+use crate::ui::Ui;
+
+/// Move revisions to different parent(s)
+///
+/// There are three different ways of specifying which revisions to rebase:
+/// `-b` to rebase a whole branch, `-s` to rebase a revision and its
+/// descendants, and `-r` to rebase a single commit. If none of them is
+/// specified, it defaults to `-b @`.
+///
+/// With `-s`, the command rebases the specified revision and its descendants
+/// onto the destination. For example, `jj rebase -s M -d O` would transform
+/// your history like this (letters followed by an apostrophe are post-rebase
+/// versions):
+///
+/// O           N'
+/// |           |
+/// | N         M'
+/// | |         |
+/// | M         O
+/// | |    =>   |
+/// | | L       | L
+/// | |/        | |
+/// | K         | K
+/// |/          |/
+/// J           J
+///
+/// With `-b`, the command rebases the whole "branch" containing the specified
+/// revision. A "branch" is the set of commits that includes:
+///
+/// * the specified revision and ancestors that are not also ancestors of the
+///   destination
+/// * all descendants of those commits
+///
+/// In other words, `jj rebase -b X -d Y` rebases commits in the revset
+/// `(Y..X)::` (which is equivalent to `jj rebase -s 'roots(Y..X)' -d Y` for a
+/// single root). For example, either `jj rebase -b L -d O` or `jj rebase -b M
+/// -d O` would transform your history like this (because `L` and `M` are on the
+/// same "branch", relative to the destination):
+///
+/// O           N'
+/// |           |
+/// | N         M'
+/// | |         |
+/// | M         | L'
+/// | |    =>   |/
+/// | | L       K'
+/// | |/        |
+/// | K         O
+/// |/          |
+/// J           J
+///
+/// With `-r`, the command rebases only the specified revision onto the
+/// destination. Any "hole" left behind will be filled by rebasing descendants
+/// onto the specified revision's parent(s). For example, `jj rebase -r K -d M`
+/// would transform your history like this:
+///
+/// M          K'
+/// |          |
+/// | L        M
+/// | |   =>   |
+/// | K        | L'
+/// |/         |/
+/// J          J
+///
+/// Note that you can create a merge commit by repeating the `-d` argument.
+/// For example, if you realize that commit L actually depends on commit M in
+/// order to work (in addition to its current parent K), you can run `jj rebase
+/// -s L -d K -d M`:
+///
+/// M          L'
+/// |          |\
+/// | L        M |
+/// | |   =>   | |
+/// | K        | K
+/// |/         |/
+/// J          J
+#[derive(clap::Args, Clone, Debug)]
+#[command(verbatim_doc_comment)]
+#[command(group(ArgGroup::new("to_rebase").args(&["branch", "source", "revision"])))]
+pub(crate) struct RebaseArgs {
+    /// Rebase the whole branch relative to destination's ancestors (can be
+    /// repeated)
+    ///
+    /// `jj rebase -b=br -d=dst` is equivalent to `jj rebase '-s=roots(dst..br)'
+    /// -d=dst`.
+    ///
+    /// If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
+    #[arg(long, short)]
+    branch: Vec<RevisionArg>,
+
+    /// Rebase specified revision(s) together their tree of descendants (can be
+    /// repeated)
+    ///
+    /// Each specified revision will become a direct child of the destination
+    /// revision(s), even if some of the source revisions are descendants
+    /// of others.
+    ///
+    /// If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
+    #[arg(long, short)]
+    source: Vec<RevisionArg>,
+    /// Rebase only this revision, rebasing descendants onto this revision's
+    /// parent(s)
+    ///
+    /// If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
+    #[arg(long, short)]
+    revision: Option<RevisionArg>,
+    /// The revision(s) to rebase onto (can be repeated to create a merge
+    /// commit)
+    #[arg(long, short, required = true)]
+    destination: Vec<RevisionArg>,
+    /// Deprecated. Please prefix the revset with `all:` instead.
+    #[arg(long, short = 'L', hide = true)]
+    allow_large_revsets: bool,
+}
+
+#[instrument(skip_all)]
+pub(crate) fn cmd_rebase(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &RebaseArgs,
+) -> Result<(), CommandError> {
+    if args.allow_large_revsets {
+        return Err(user_error(
+            "--allow-large-revsets has been deprecated.
+Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets -d x -d y`.",
+        ));
+    }
+    let mut workspace_command = command.workspace_helper(ui)?;
+    let new_parents = resolve_destination_revs(&workspace_command, ui, &args.destination)?
+        .into_iter()
+        .collect_vec();
+    if let Some(rev_str) = &args.revision {
+        rebase_revision(
+            ui,
+            command.settings(),
+            &mut workspace_command,
+            &new_parents,
+            rev_str,
+        )?;
+    } else if !args.source.is_empty() {
+        let source_commits =
+            resolve_multiple_nonempty_revsets_default_single(&workspace_command, ui, &args.source)?;
+        rebase_descendants(
+            ui,
+            command.settings(),
+            &mut workspace_command,
+            &new_parents,
+            &source_commits,
+        )?;
+    } else {
+        let branch_commits = if args.branch.is_empty() {
+            IndexSet::from([workspace_command.resolve_single_rev("@", ui)?])
+        } else {
+            resolve_multiple_nonempty_revsets_default_single(&workspace_command, ui, &args.branch)?
+        };
+        rebase_branch(
+            ui,
+            command.settings(),
+            &mut workspace_command,
+            &new_parents,
+            &branch_commits,
+        )?;
+    }
+    Ok(())
+}
+
+fn rebase_branch(
+    ui: &mut Ui,
+    settings: &UserSettings,
+    workspace_command: &mut WorkspaceCommandHelper,
+    new_parents: &[Commit],
+    branch_commits: &IndexSet<Commit>,
+) -> Result<(), CommandError> {
+    let parent_ids = new_parents
+        .iter()
+        .map(|commit| commit.id().clone())
+        .collect_vec();
+    let branch_commit_ids = branch_commits
+        .iter()
+        .map(|commit| commit.id().clone())
+        .collect_vec();
+    let roots_expression = RevsetExpression::commits(parent_ids)
+        .range(&RevsetExpression::commits(branch_commit_ids))
+        .roots();
+    let root_commits: IndexSet<_> = roots_expression
+        .resolve(workspace_command.repo().as_ref())
+        .unwrap()
+        .evaluate(workspace_command.repo().as_ref())
+        .unwrap()
+        .iter()
+        .commits(workspace_command.repo().store())
+        .try_collect()?;
+    rebase_descendants(ui, settings, workspace_command, new_parents, &root_commits)
+}
+
+fn rebase_descendants(
+    ui: &mut Ui,
+    settings: &UserSettings,
+    workspace_command: &mut WorkspaceCommandHelper,
+    new_parents: &[Commit],
+    old_commits: &IndexSet<Commit>,
+) -> Result<(), CommandError> {
+    workspace_command.check_rewritable(old_commits)?;
+    for old_commit in old_commits.iter() {
+        check_rebase_destinations(workspace_command.repo(), new_parents, old_commit)?;
+    }
+    let tx_message = if old_commits.len() == 1 {
+        format!(
+            "rebase commit {} and descendants",
+            old_commits.first().unwrap().id().hex()
+        )
+    } else {
+        format!("rebase {} commits and their descendants", old_commits.len())
+    };
+    let mut tx = workspace_command.start_transaction(&tx_message);
+    // `rebase_descendants` takes care of sorting in reverse topological order, so
+    // no need to do it here.
+    for old_commit in old_commits {
+        rebase_commit(settings, tx.mut_repo(), old_commit, new_parents)?;
+    }
+    let num_rebased = old_commits.len() + tx.mut_repo().rebase_descendants(settings)?;
+    writeln!(ui.stderr(), "Rebased {num_rebased} commits")?;
+    tx.finish(ui)?;
+    Ok(())
+}
+
+fn rebase_revision(
+    ui: &mut Ui,
+    settings: &UserSettings,
+    workspace_command: &mut WorkspaceCommandHelper,
+    new_parents: &[Commit],
+    rev_str: &str,
+) -> Result<(), CommandError> {
+    let old_commit = workspace_command.resolve_single_rev(rev_str, ui)?;
+    workspace_command.check_rewritable([&old_commit])?;
+    check_rebase_destinations(workspace_command.repo(), new_parents, &old_commit)?;
+    let children_expression = RevsetExpression::commit(old_commit.id().clone()).children();
+    let child_commits: Vec<_> = children_expression
+        .resolve(workspace_command.repo().as_ref())
+        .unwrap()
+        .evaluate(workspace_command.repo().as_ref())
+        .unwrap()
+        .iter()
+        .commits(workspace_command.repo().store())
+        .try_collect()?;
+
+    let mut tx =
+        workspace_command.start_transaction(&format!("rebase commit {}", old_commit.id().hex()));
+    rebase_commit(settings, tx.mut_repo(), &old_commit, new_parents)?;
+    // Manually rebase children because we don't want to rebase them onto the
+    // rewritten commit. (But we still want to record the commit as rewritten so
+    // branches and the working copy get updated to the rewritten commit.)
+    let mut num_rebased_descendants = 0;
+    for child_commit in &child_commits {
+        let new_child_parent_ids: Vec<CommitId> = child_commit
+            .parents()
+            .iter()
+            .flat_map(|c| {
+                if c == &old_commit {
+                    old_commit
+                        .parents()
+                        .iter()
+                        .map(|c| c.id().clone())
+                        .collect()
+                } else {
+                    [c.id().clone()].to_vec()
+                }
+            })
+            .collect();
+
+        // Some of the new parents may be ancestors of others as in
+        // `test_rebase_single_revision`.
+        let new_child_parents_expression = RevsetExpression::commits(new_child_parent_ids.clone())
+            .minus(
+                &RevsetExpression::commits(new_child_parent_ids.clone())
+                    .parents()
+                    .ancestors(),
+            );
+        let new_child_parents: Vec<Commit> = new_child_parents_expression
+            .resolve(tx.base_repo().as_ref())
+            .unwrap()
+            .evaluate(tx.base_repo().as_ref())
+            .unwrap()
+            .iter()
+            .commits(tx.base_repo().store())
+            .try_collect()?;
+
+        rebase_commit(settings, tx.mut_repo(), child_commit, &new_child_parents)?;
+        num_rebased_descendants += 1;
+    }
+    num_rebased_descendants += tx.mut_repo().rebase_descendants(settings)?;
+    if num_rebased_descendants > 0 {
+        writeln!(
+            ui.stderr(),
+            "Also rebased {num_rebased_descendants} descendant commits onto parent of rebased \
+             commit"
+        )?;
+    }
+    tx.finish(ui)?;
+    Ok(())
+}
+
+fn check_rebase_destinations(
+    repo: &Arc<ReadonlyRepo>,
+    new_parents: &[Commit],
+    commit: &Commit,
+) -> Result<(), CommandError> {
+    for parent in new_parents {
+        if repo.index().is_ancestor(commit.id(), parent.id()) {
+            return Err(user_error(format!(
+                "Cannot rebase {} onto descendant {}",
+                short_commit_hash(commit.id()),
+                short_commit_hash(parent.id())
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Resolves revsets into revisions to rebase onto. These revisions don't have
+/// to be rewriteable.
+pub(crate) fn resolve_destination_revs(
+    workspace_command: &WorkspaceCommandHelper,
+    ui: &mut Ui,
+    revisions: &[RevisionArg],
+) -> Result<IndexSet<Commit>, CommandError> {
+    let commits =
+        resolve_multiple_nonempty_revsets_default_single(workspace_command, ui, revisions)?;
+    let root_commit_id = workspace_command.repo().store().root_commit_id();
+    if commits.len() >= 2 && commits.iter().any(|c| c.id() == root_commit_id) {
+        Err(user_error("Cannot merge with root revision"))
+    } else {
+        Ok(commits)
+    }
+}

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -1,0 +1,217 @@
+// Copyright 2020 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use itertools::Itertools;
+use jj_lib::backend::{ObjectId, TreeValue};
+use jj_lib::merge::MergedTreeValue;
+use jj_lib::repo_path::RepoPath;
+use tracing::instrument;
+
+use crate::cli_util::{CommandError, CommandHelper, WorkspaceCommandHelper};
+use crate::formatter::Formatter;
+use crate::ui::Ui;
+
+/// Resolve a conflicted file with an external merge tool
+///
+/// Only conflicts that can be resolved with a 3-way merge are supported. See
+/// docs for merge tool configuration instructions.
+///
+/// Note that conflicts can also be resolved without using this command. You may
+/// edit the conflict markers in the conflicted file directly with a text
+/// editor.
+//  TODOs:
+//   - `jj resolve --editor` to resolve a conflict in the default text editor. Should work for
+//     conflicts with 3+ adds. Useful to resolve conflicts in a commit other than the current one.
+//   - A way to help split commits with conflicts that are too complicated (more than two sides)
+//     into commits with simpler conflicts. In case of a tree with many merges, we could for example
+//     point to existing commits with simpler conflicts where resolving those conflicts would help
+//     simplify the present one.
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct ResolveArgs {
+    #[arg(long, short, default_value = "@")]
+    revision: String,
+    /// Instead of resolving one conflict, list all the conflicts
+    // TODO: Also have a `--summary` option. `--list` currently acts like
+    // `diff --summary`, but should be more verbose.
+    #[arg(long, short)]
+    list: bool,
+    /// Do not print the list of remaining conflicts (if any) after resolving a
+    /// conflict
+    #[arg(long, short, conflicts_with = "list")]
+    quiet: bool,
+    /// Restrict to these paths when searching for a conflict to resolve. We
+    /// will attempt to resolve the first conflict we can find. You can use
+    /// the `--list` argument to find paths to use here.
+    // TODO: Find the conflict we can resolve even if it's not the first one.
+    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    paths: Vec<String>,
+}
+
+#[instrument(skip_all)]
+pub(crate) fn cmd_resolve(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &ResolveArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+    let matcher = workspace_command.matcher_from_values(&args.paths)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let tree = commit.tree()?;
+    let conflicts = tree
+        .conflicts()
+        .filter(|path| matcher.matches(&path.0))
+        .collect_vec();
+    if conflicts.is_empty() {
+        return Err(CommandError::CliError(format!(
+            "No conflicts found {}",
+            if args.paths.is_empty() {
+                "at this revision"
+            } else {
+                "at the given path(s)"
+            }
+        )));
+    }
+    if args.list {
+        return print_conflicted_paths(
+            &conflicts,
+            ui.stdout_formatter().as_mut(),
+            &workspace_command,
+        );
+    };
+
+    let (repo_path, _) = conflicts.get(0).unwrap();
+    workspace_command.check_rewritable([&commit])?;
+    let mut tx = workspace_command.start_transaction(&format!(
+        "Resolve conflicts in commit {}",
+        commit.id().hex()
+    ));
+    let new_tree_id = tx.run_mergetool(ui, &tree, repo_path)?;
+    let new_commit = tx
+        .mut_repo()
+        .rewrite_commit(command.settings(), &commit)
+        .set_tree_id(new_tree_id)
+        .write()?;
+    tx.finish(ui)?;
+
+    if !args.quiet {
+        let new_tree = new_commit.tree()?;
+        let new_conflicts = new_tree.conflicts().collect_vec();
+        if !new_conflicts.is_empty() {
+            writeln!(
+                ui.stderr(),
+                "After this operation, some files at this revision still have conflicts:"
+            )?;
+            print_conflicted_paths(
+                &new_conflicts,
+                ui.stderr_formatter().as_mut(),
+                &workspace_command,
+            )?;
+        }
+    };
+    Ok(())
+}
+
+#[instrument(skip_all)]
+pub(crate) fn print_conflicted_paths(
+    conflicts: &[(RepoPath, MergedTreeValue)],
+    formatter: &mut dyn Formatter,
+    workspace_command: &WorkspaceCommandHelper,
+) -> Result<(), CommandError> {
+    let formatted_paths = conflicts
+        .iter()
+        .map(|(path, _conflict)| workspace_command.format_file_path(path))
+        .collect_vec();
+    let max_path_len = formatted_paths.iter().map(|p| p.len()).max().unwrap_or(0);
+    let formatted_paths = formatted_paths
+        .into_iter()
+        .map(|p| format!("{:width$}", p, width = max_path_len.min(32) + 3));
+
+    for ((_, conflict), formatted_path) in std::iter::zip(conflicts.iter(), formatted_paths) {
+        let sides = conflict.num_sides();
+        let n_adds = conflict.adds().iter().flatten().count();
+        let deletions = sides - n_adds;
+
+        let mut seen_objects = BTreeMap::new(); // Sort for consistency and easier testing
+        if deletions > 0 {
+            seen_objects.insert(
+                format!(
+                    // Starting with a number sorts this first
+                    "{deletions} deletion{}",
+                    if deletions > 1 { "s" } else { "" }
+                ),
+                "normal", // Deletions don't interfere with `jj resolve` or diff display
+            );
+        }
+        // TODO: We might decide it's OK for `jj resolve` to ignore special files in the
+        // `removes` of a conflict (see e.g. https://github.com/martinvonz/jj/pull/978). In
+        // that case, `conflict.removes` should be removed below.
+        for term in itertools::chain(conflict.removes().iter(), conflict.adds().iter()).flatten() {
+            seen_objects.insert(
+                match term {
+                    TreeValue::File {
+                        executable: false, ..
+                    } => continue,
+                    TreeValue::File {
+                        executable: true, ..
+                    } => "an executable",
+                    TreeValue::Symlink(_) => "a symlink",
+                    TreeValue::Tree(_) => "a directory",
+                    TreeValue::GitSubmodule(_) => "a git submodule",
+                    TreeValue::Conflict(_) => "another conflict (you found a bug!)",
+                }
+                .to_string(),
+                "difficult",
+            );
+        }
+
+        write!(formatter, "{formatted_path} ",)?;
+        formatter.with_label("conflict_description", |formatter| {
+            let print_pair = |formatter: &mut dyn Formatter, (text, label): &(String, &str)| {
+                formatter.with_label(label, |fmt| fmt.write_str(text))
+            };
+            print_pair(
+                formatter,
+                &(
+                    format!("{sides}-sided"),
+                    if sides > 2 { "difficult" } else { "normal" },
+                ),
+            )?;
+            formatter.write_str(" conflict")?;
+
+            if !seen_objects.is_empty() {
+                formatter.write_str(" including ")?;
+                let seen_objects = seen_objects.into_iter().collect_vec();
+                match &seen_objects[..] {
+                    [] => unreachable!(),
+                    [only] => print_pair(formatter, only)?,
+                    [first, middle @ .., last] => {
+                        print_pair(formatter, first)?;
+                        for pair in middle {
+                            formatter.write_str(", ")?;
+                            print_pair(formatter, pair)?;
+                        }
+                        formatter.write_str(" and ")?;
+                        print_pair(formatter, last)?;
+                    }
+                };
+            }
+            Ok(())
+        })?;
+        writeln!(formatter)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
The print_conflicted_paths function could belong either to `resolve.rs` or `status.rs`; I put it into the former for now.

#2452 now depends on this (we can also merge this as part of that PR).

Cc #2465, #2457
