### PR TITLE
Fix `new --after` ignoring immutable commits + update hint for root commit being immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Conflicts in executable files can now be resolved just like conflicts in
   non-executable files ([#1279](https://github.com/martinvonz/jj/issues/1279)).
 
+* `jj new --insert-before` and `--insert-after` now respect immutable revisions
+  ([#2468](https://github.com/martinvonz/jj/pull/2468)).
+
 ## [0.10.0] - 2023-10-04
 
 ### Breaking changes

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1268,10 +1268,19 @@ Set which revision the branch points to with `jj branch set {branch_name} -r <RE
         let revset = self.evaluate_revset(to_rewrite_revset.intersection(&immutable_revset))?;
         if let Some(commit) = revset.iter().commits(self.repo().store()).next() {
             let commit = commit?;
-            return Err(user_error_with_hint(
-                format!("Commit {} is immutable", short_commit_hash(commit.id()),),
-                "Configure the set of immutable commits via `revset-aliases.immutable_heads()`.",
-            ));
+            let error = if commit.id() == self.repo().store().root_commit_id() {
+                user_error(format!(
+                    "The root commit {} is immutable",
+                    short_commit_hash(commit.id()),
+                ))
+            } else {
+                user_error_with_hint(
+                    format!("Commit {} is immutable", short_commit_hash(commit.id()),),
+                    "Configure the set of immutable commits via \
+                     `revset-aliases.immutable_heads()`.",
+                )
+            };
+            return Err(error);
         }
 
         Ok(())

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -56,8 +56,7 @@ fn test_rewrite_immutable_generic() {
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "root()"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 000000000000 is immutable
-    Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
+    Error: The root commit 000000000000 is immutable
     "###);
     // Error if we redefine immutable_heads() with an argument
     // TODO: This error comes from the built-in definition of

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -154,6 +154,18 @@ fn test_rewrite_immutable_commands() {
     Error: Commit 16ca9d800b08 is immutable
     Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
+    // new --insert-before
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "--insert-before", "main"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Commit 16ca9d800b08 is immutable
+    Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
+    "###);
+    // new --insert-after parent_of_main
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "--insert-after", "description(b)"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Commit 16ca9d800b08 is immutable
+    Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
+    "###);
     // rebase -s
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s=main", "-d=@"]);
     insta::assert_snapshot!(stderr, @r###"

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -400,8 +400,7 @@ fn test_new_insert_before_root() {
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["new", "--insert-before", "-m", "G", "root()"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 000000000000 is immutable
-    Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
+    Error: The root commit 000000000000 is immutable
     "###);
 }
 

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -400,7 +400,8 @@ fn test_new_insert_before_root() {
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["new", "--insert-before", "-m", "G", "root()"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Cannot insert a commit before the root commit
+    Error: Commit 000000000000 is immutable
+    Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
 }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
