### PR TITLE
revsets.md and glossary.md: correct and clarify "visible commits"

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -109,6 +109,10 @@ anonymous heads (heads without a branch pointing to them) are visible at a
 given [operation](#operation). Note that this is quite different from Git's
 [HEAD](https://git-scm.com/book/en/v2/Git-Internals-Git-References#ref_the_ref).
 
+## Hidden commits, abandoned commits
+
+See [visible commits](#visible-commits).
+
 ## Operation
 
 A snapshot of the [visible commits](#visible-commits) and [branches](#branches)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -175,6 +175,12 @@ Visible commits are the commits you see in `jj log -r 'all()'`. They are the
 commits that are reachable from an anonymous head in the [view](#view).
 Ancestors of a visible commit are implicitly visible.
 
+Intuitively, visible commits are the "latest versions" of a revision with a
+given [change id](#change-id). A commit that's abandoned or
+[rewritten](#rewrite) stops being visible and is labeled as "hidden". Such
+commits are no longer accessible using a change id, but they are still
+accessible by their [commit id](#commit-id).
+
 ## View
 
 A view is a snapshot of branches and their targets, anonymous heads,

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -12,7 +12,7 @@ commits) to such commands.
 
 The words "revisions" and "commits" are used interchangeably in this document.
 
-The commits listed by `jj log` without arguments are called "visible commits".
+Most revsets search only the [visible commits](glossary.md#visible-commits).
 Other commits are only included if you explicitly mention them (e.g. by commit
 ID or a Git ref pointing to them).
 


### PR DESCRIPTION
This is mainly motivated by an outdated sentence in `revsets.md`. Let me know if the other change should be discussed separately.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
