### PR TITLE
formatter: reset colors on early drop

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -946,6 +946,7 @@ mod tests {
             let mut output = Vec::new();
             let mut formatter = ColorFormatter::new(&mut output, self.color_rules.clone().into());
             template.format(&(), &mut formatter).unwrap();
+            drop(formatter);
             String::from_utf8(output).unwrap()
         }
     }

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -275,6 +275,7 @@ mod tests {
         let mut output = Vec::new();
         let mut formatter = ColorFormatter::for_config(&mut output, &config).unwrap();
         write(&mut formatter).unwrap();
+        drop(formatter);
         String::from_utf8(output).unwrap()
     }
 


### PR DESCRIPTION
If we create a `ColorFormatter`, add some labels to it, print something using the configured style, and then return early because of an error, we would leave the terminal in a bad state. I think many shells reset color codes after a command returns, but let's still do our best.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
