### PR TITLE
github: fix codespell `skip` syntax for directories

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           check_filenames: true
           check_hidden: true
-          skip: target,.jj,*.lock
+          skip: ./target,./.jj,*.lock
           ignore_words_list: crate,nd,nD


### PR DESCRIPTION
Summary: Codespell actually matches local files at the root of the repo with the `./` prefix, so without it the `skip` field won't match. Fix this for `./target` and `./.jj` directories.

Change-Id: Ibeafd7e400ff3bca9187d62241296060