### PR TITLE
cli: support multiple `--revision` arguments to `workspace add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* `jj workspace add` can now take _multiple_ `--revision` arguments, which will
+  create a new workspace with its working-copy commit on top of all the parents,
+  as if you had run `jj new r1 r2 r3 ...`.
+
 ### Fixed bugs
 
 

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -25,7 +25,6 @@ use tracing::instrument;
 use crate::cli_util::{
     self, short_commit_hash, user_error, CommandError, CommandHelper, RevisionArg,
 };
-use crate::commands::rebase::resolve_destination_revs;
 use crate::ui::Ui;
 
 /// Create a new, empty change and edit it in the working copy
@@ -76,7 +75,7 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
         !args.revisions.is_empty(),
         "expected a non-empty list from clap"
     );
-    let target_commits = resolve_destination_revs(&workspace_command, ui, &args.revisions)?
+    let target_commits = cli_util::resolve_all_revs(&workspace_command, ui, &args.revisions)?
         .into_iter()
         .collect_vec();
     let target_ids = target_commits.iter().map(|c| c.id().clone()).collect_vec();

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -27,7 +27,7 @@ use jj_lib::workspace::{default_working_copy_initializer, Workspace};
 use tracing::instrument;
 
 use crate::cli_util::{
-    check_stale_working_copy, print_checkout_stats, user_error, CommandError, CommandHelper,
+    self, check_stale_working_copy, print_checkout_stats, user_error, CommandError, CommandHelper,
     RevisionArg, WorkspaceCommandHelper,
 };
 use crate::ui::Ui;
@@ -192,13 +192,9 @@ fn cmd_workspace_add(
             vec![tx.repo().store().root_commit()]
         }
     } else {
-        crate::commands::rebase::resolve_destination_revs(
-            &old_workspace_command,
-            ui,
-            &args.revision,
-        )?
-        .into_iter()
-        .collect_vec()
+        cli_util::resolve_all_revs(&old_workspace_command, ui, &args.revision)?
+            .into_iter()
+            .collect_vec()
     };
 
     let tree = merge_commit_trees(tx.repo(), &parents)?;

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -164,6 +164,72 @@ fn test_workspaces_add_workspace_at_revision() {
     "###);
 }
 
+/// Test multiple `-r` flags to `workspace add` to create a workspace
+/// working-copy commit with multiple parents.
+#[test]
+fn test_workspaces_add_workspace_multiple_revisions() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "--git", "main"]);
+    let main_path = test_env.env_root().join("main");
+
+    std::fs::write(main_path.join("file-1"), "contents").unwrap();
+    test_env.jj_cmd_ok(&main_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_ok(&main_path, &["new", "-r", "root()"]);
+
+    std::fs::write(main_path.join("file-2"), "contents").unwrap();
+    test_env.jj_cmd_ok(&main_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_ok(&main_path, &["new", "-r", "root()"]);
+
+    std::fs::write(main_path.join("file-3"), "contents").unwrap();
+    test_env.jj_cmd_ok(&main_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_ok(&main_path, &["new", "-r", "root()"]);
+
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    @  5b36783cd11c4607a329c5e8c2fd9097c9ce2add
+    │ ◉  23881f07b53ce1ea936ca8842e344dea9c3356e5
+    ├─╯
+    │ ◉  1f6a15f0af2a985703864347f5fdf27a82fc3d73
+    ├─╯
+    │ ◉  e7d7dbb91c5a543ea680711093e689916d5f31df
+    ├─╯
+    ◉  0000000000000000000000000000000000000000
+    "###);
+
+    let (_, stderr) = test_env.jj_cmd_ok(
+        &main_path,
+        &[
+            "workspace",
+            "add",
+            "--name=merge",
+            "../merged",
+            "-r=238",
+            "-r=1f6",
+            "-r=e7d",
+        ],
+    );
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    Created workspace in "../merged"
+    Working copy now at: wmwvqwsz fa8fdc28 (empty) (no description set)
+    Parent commit      : mzvwutvl 23881f07 third
+    Parent commit      : kkmpptxz 1f6a15f0 second
+    Parent commit      : qpvuntsm e7d7dbb9 first
+    Added 3 files, modified 0 files, removed 0 files
+    "###);
+
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    ◉      fa8fdc28af12d3c96b1e0ed062f5a8f9a99818f0 merge@
+    ├─┬─╮
+    │ │ ◉  e7d7dbb91c5a543ea680711093e689916d5f31df
+    │ ◉ │  1f6a15f0af2a985703864347f5fdf27a82fc3d73
+    │ ├─╯
+    ◉ │  23881f07b53ce1ea936ca8842e344dea9c3356e5
+    ├─╯
+    │ @  5b36783cd11c4607a329c5e8c2fd9097c9ce2add default@
+    ├─╯
+    ◉  0000000000000000000000000000000000000000
+    "###);
+}
+
 /// Test making changes to the working copy in a workspace as it gets rewritten
 /// from another workspace
 #[test]


### PR DESCRIPTION
Summary: A natural extension of the existing support, as suggested by Scott Olson. Closes #2496.

Change-Id: I91c9c8c377ad67ccde7945ed41af6c79

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
