### PR TITLE
nix: include darwin deps inside `devShell`, too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,13 @@
         cargo = rust-version;
       };
 
+      # these are needed in both devShell and buildInputs
+      darwinDeps = with pkgs; lib.optionals stdenv.isDarwin [
+        darwin.apple_sdk.frameworks.Security
+        darwin.apple_sdk.frameworks.SystemConfiguration
+        libiconv
+      ];
+
     in
     {
       packages = {
@@ -68,11 +75,7 @@
           ];
           buildInputs = with pkgs; [
             openssl zstd libgit2 libssh2
-          ] ++ lib.optionals stdenv.isDarwin [
-            darwin.apple_sdk.frameworks.Security
-            darwin.apple_sdk.frameworks.SystemConfiguration
-            libiconv
-          ];
+          ] ++ darwinDeps;
 
           ZSTD_SYS_USE_PKG_CONFIG = "1";
           LIBSSH2_SYS_USE_PKG_CONFIG = "1";
@@ -129,7 +132,7 @@
 
           # For building the documentation website
           poetry
-        ];
+        ] ++ darwinDeps;
 
         shellHook = ''
           export RUST_BACKTRACE=1


### PR DESCRIPTION
Summary: Without `devShell` providing the needed Darwin-specific inputs, `cargo build` does not work inside a `nix develop` or `direnv` environment; libgit2 in particular fails on being able to find the Security framework.

The actual `nix build` invocation however *does* work because we correctly include those dependencies in the package `buildInputs`. So just factor them out, and use them in both places.

Change-Id: I484bf381ca31c29c4c39fb6d184bdd21