### PR TITLE
revset: exclude `@git` branches from `remote_branches()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* The `remote_branches()` revset no longer includes branches exported to the Git
+  repository (so called Git-tracking branches.)
+
 ### New features
 
 * `jj workspace add` can now take _multiple_ `--revision` arguments, which will
@@ -33,8 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clone to see the full speedup.
 
 * The `remote_branches()` revset now includes branches exported to the Git
-  repository (so called Git-tracking branches.) Use
-  `remote_branches(remote=exact:"origin")` to query branches of certain remote.
+  repository (so called Git-tracking branches.) *This change will be reverted
+  in 0.12.0.*
 
 * Status messages are now printed to stderr.
 

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -53,9 +53,8 @@ fn test_resolution_of_git_tracking_branches() {
     insta::assert_snapshot!(query("main@git"), @r###"
     16d541ca40f42baf2dea41aa61a0b5f1cbf1f91b old_message
     "###);
-    insta::assert_snapshot!(query(r#"remote_branches(exact:"main", exact:"git")"#), @r###"
-    16d541ca40f42baf2dea41aa61a0b5f1cbf1f91b old_message
-    "###);
+    // Can't be selected by remote_branches()
+    insta::assert_snapshot!(query(r#"remote_branches(exact:"main", exact:"git")"#), @"");
 }
 
 #[test]

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -112,6 +112,9 @@ revsets (expressions) as arguments.
   `main@origin` or `main@upstream`. If a branch is in a conflicted state, all
   its possible targets are included.
 
+  While Git-tracking branches can be selected by `<name>@git`, these branches
+  aren't included in `remote_branches()`.
+
 * `tags()`: All tag targets. If a tag is in a conflicted state, all its
   possible targets are included.
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2147,9 +2147,11 @@ fn resolve_commit_ref(
             branch_pattern,
             remote_pattern,
         } => {
+            // TODO: should we allow to select @git branches explicitly?
             let commit_ids = repo
                 .view()
                 .remote_branches_matching(branch_pattern, remote_pattern)
+                .filter(|&((_, remote_name), _)| remote_name != git::REMOTE_NAME_FOR_LOCAL_GIT_REPO)
                 .flat_map(|(_, remote_ref)| remote_ref.target.added_ids())
                 .cloned()
                 .collect();

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1836,12 +1836,19 @@ fn test_evaluate_expression_remote_branches() {
     let commit2 = write_random_commit(mut_repo, &settings);
     let commit3 = write_random_commit(mut_repo, &settings);
     let commit4 = write_random_commit(mut_repo, &settings);
+    let commit_git_remote = write_random_commit(mut_repo, &settings);
 
     // Can get branches when there are none
     assert_eq!(resolve_commit_ids(mut_repo, "remote_branches()"), vec![]);
     // Can get a few branches
     mut_repo.set_remote_branch("branch1", "origin", normal_remote_ref(commit1.id()));
     mut_repo.set_remote_branch("branch2", "private", normal_remote_ref(commit2.id()));
+    // Git-tracking branches aren't included
+    mut_repo.set_remote_branch(
+        "branch",
+        git::REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+        normal_remote_ref(commit_git_remote.id()),
+    );
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_branches()"),
         vec![commit2.id().clone(), commit1.id().clone()]


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
