### PR TITLE
misc: drop a few low-hanging unsafes

### DIFF
--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -62,8 +62,8 @@ pub fn cmd_run(ui: &mut Ui, command: &CommandHelper, args: &RunArgs) -> Result<(
 
         // SAFETY:
         // We use a internal constant of 4 threads, if it fails
-        let available = std::thread::available_parallelism()
-            .unwrap_or(unsafe { NonZeroUsize::new_unchecked(4) });
+        let available =
+            std::thread::available_parallelism().unwrap_or(NonZeroUsize::new(4).unwrap());
         available.into()
     };
     Err(user_error("This is a stub, do not use"))

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -839,11 +839,8 @@ impl<'a> CompositeIndex<'a> {
         if pos.0 >= num_parent_commits {
             self.0.segment_entry_by_pos(pos, pos.0 - num_parent_commits)
         } else {
-            let parent_file: &ReadonlyIndexImpl = self.0.segment_parent_file().unwrap().as_ref();
-            // The parent ReadonlyIndex outlives the child
-            let parent_file: &'a ReadonlyIndexImpl = unsafe { std::mem::transmute(parent_file) };
-
-            CompositeIndex(parent_file).entry_by_pos(pos)
+            let parent_file = self.0.segment_parent_file().unwrap();
+            CompositeIndex(&**parent_file).entry_by_pos(pos)
         }
     }
 

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -51,14 +51,8 @@ pub trait TableSegment {
     }
 
     fn get_value<'a>(&'a self, key: &[u8]) -> Option<&'a [u8]> {
-        if let Some(value) = self.segment_get_value(key) {
-            return Some(value);
-        }
-        let parent_file = self.segment_parent_file()?;
-        let parent_file: &ReadonlyTable = parent_file.as_ref();
-        // The parent ReadonlyIndex outlives the child
-        let parent_file: &'a ReadonlyTable = unsafe { std::mem::transmute(parent_file) };
-        parent_file.get_value(key)
+        self.segment_get_value(key)
+            .or_else(|| self.segment_parent_file()?.get_value(key))
     }
 }
 


### PR DESCRIPTION
Remove a couple of unnecessary unsafes:
- The NonZeroUsize is a constant where the unwrap will optimize away anyway and we don't have an unsafe without any good reason there :)
- The other two were simply not needed, lifetimes worked fine, maybe Rust became better since that code was written? NLL? Anyway, they're gone now

---
Was just hacking a bit locally and decided to do a classic unsafe grep :upside_down_face:

Those self-referential iterators could also be refactored I believe (at least with some crate that does that), but it wasn't as low hanging because otherwise you'd have done it instead of transmuting static lifetimes :)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
