### PR TITLE
sign: Implement storage for digital commit signatures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             in
             pkgs.lib.all (re: builtins.match re relPath == null) regexes;
         };
- 
+
       rust-version = pkgs.rust-bin.stable."1.71.0".default;
 
       ourRustPlatform = pkgs.makeRustPlatform {
@@ -129,6 +129,9 @@
           cargo-insta
           cargo-nextest
           cargo-watch
+
+          # In case you need to run `cargo run --bin gen-protos`
+          protobuf
 
           # For building the documentation website
           poetry

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -139,6 +139,14 @@ content_hash! {
     }
 }
 
+content_hash! {
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    pub struct SecureSig {
+        pub data: Vec<u8>,
+        pub sig: Vec<u8>,
+    }
+}
+
 /// Identifies a single legacy tree, which may have path-level conflicts, or a
 /// merge of multiple trees, where the individual trees do not have conflicts.
 // TODO(#1624): Delete this type at some point in the future, when we decide to drop
@@ -178,7 +186,7 @@ impl ContentHash for MergedTreeId {
 }
 
 impl MergedTreeId {
-    /// Create a resolved `MergedTreeId` from a single regular tree.  
+    /// Create a resolved `MergedTreeId` from a single regular tree.
     pub fn resolved(tree_id: TreeId) -> Self {
         MergedTreeId::Merge(Merge::resolved(tree_id))
     }
@@ -202,6 +210,7 @@ content_hash! {
         pub description: String,
         pub author: Signature,
         pub committer: Signature,
+        pub secure_sig: Option<SecureSig>,
     }
 }
 
@@ -450,6 +459,7 @@ pub fn make_root_commit(root_change_id: ChangeId, empty_tree_id: TreeId) -> Comm
         description: String::new(),
         author: signature.clone(),
         committer: signature,
+        secure_sig: None,
     }
 }
 

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -48,6 +48,7 @@ impl CommitBuilder<'_> {
             description: String::new(),
             author: signature.clone(),
             committer: signature,
+            secure_sig: None,
         };
         CommitBuilder {
             mut_repo,

--- a/lib/src/protos/local_store.proto
+++ b/lib/src/protos/local_store.proto
@@ -60,6 +60,7 @@ message Commit {
   }
   Signature author = 6;
   Signature committer = 7;
+  optional bytes secure_sig = 9;
 }
 
 message Conflict {

--- a/lib/src/protos/local_store.rs
+++ b/lib/src/protos/local_store.rs
@@ -65,6 +65,8 @@ pub struct Commit {
     pub author: ::core::option::Option<commit::Signature>,
     #[prost(message, optional, tag = "7")]
     pub committer: ::core::option::Option<commit::Signature>,
+    #[prost(bytes = "vec", optional, tag = "9")]
+    pub secure_sig: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// Nested message and enum types in `Commit`.
 pub mod commit {

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -334,6 +334,7 @@ pub fn commit_with_tree(store: &Arc<Store>, tree_id: MergedTreeId) -> Commit {
         description: "description".to_string(),
         author: signature.clone(),
         committer: signature,
+        secure_sig: None,
     };
     store.write_commit(commit).unwrap()
 }


### PR DESCRIPTION
Recognize signature metadata from git commit objects, implement a basic version of that for the native backend.
Extract the signed data (a commit binary repr without the signature) to be verified later.

---
Third time's the charm :)
This change would be undoubtedly needed for any signing implementation, so might push it to main to make the diffs of any future changes smaller - trying to push the smallest atomic changes.

This time I'm planning to make the actual signature creation part of signing happen outside of the backend, which seems like an obvious idea, but I thought it would be easier to do the other way then

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
