### PR TITLE
cli: generate commit template after selecting changes

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -48,8 +48,6 @@ pub(crate) fn cmd_commit(
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
     let commit = workspace_command.repo().store().get_commit(commit_id)?;
-    let template =
-        description_template_for_commit(ui, command.settings(), &workspace_command, &commit)?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     let mut tx = workspace_command.start_transaction(&format!("commit {}", commit.id().hex()));
     let base_tree = merge_commit_trees(tx.repo(), &commit.parents())?;
@@ -79,6 +77,16 @@ new working-copy commit.
             args.paths.join(" ")
         )?;
     }
+
+    let template = description_template_for_commit(
+        ui,
+        command.settings(),
+        tx.base_workspace_helper(),
+        "",
+        commit.description(),
+        &base_tree,
+        &middle_tree,
+    )?;
 
     let description = if !args.message_paragraphs.is_empty() {
         join_message_paragraphs(&args.message_paragraphs)

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -18,7 +18,7 @@ use jj_lib::backend::ObjectId;
 use tracing::instrument;
 
 use crate::cli_util::{join_message_paragraphs, CommandError, CommandHelper, RevisionArg};
-use crate::description_util::{description_template_for_commit, edit_description};
+use crate::description_util::{description_template_for_describe, edit_description};
 use crate::ui::Ui;
 
 /// Update the change description or other metadata
@@ -71,7 +71,7 @@ pub(crate) fn cmd_describe(
         commit.description().to_owned()
     } else {
         let template =
-            description_template_for_commit(ui, command.settings(), &workspace_command, &commit)?;
+            description_template_for_describe(ui, command.settings(), &workspace_command, &commit)?;
         edit_description(workspace_command.repo(), &template, command.settings())?
     };
     if description == *commit.description() && !args.reset_author {


### PR DESCRIPTION
Renamed `description_template_for_commit` to
`description_template_for_describe` since it's only used in `cmd_describe`.

Renamed `description_template_for_cmd_split` to
`description_template_for_commit` and modified to accomodate empty `intro` argument.

Fixes #2439.

Feel free to request any changes.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
