### PR TITLE
readme: Add Discord badge to the top of document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![](https://img.shields.io/github/v/release/martinvonz/jj)
 ![](https://img.shields.io/github/release-date/martinvonz/jj)
 ![](https://img.shields.io/crates/v/jj-cli)
+[![Discord](https://img.shields.io/discord/968932220549103686.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/dkmfj3aGQN)
 <br/>
 ![](https://github.com/martinvonz/jj/workflows/build/badge.svg)
 ![](https://img.shields.io/codefactor/grade/github/martinvonz/jj/main)


### PR DESCRIPTION
A coworker was having trouble finding a link to the jj Discord community. Add it to the top of the document, alongside the other badges, so it's easier to find.
