### PR TITLE
index: make the default log revset (or `heads(tags())`) evaluation faster

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -912,20 +912,16 @@ impl<'a> CompositeIndex<'a> {
 
         let mut result = BTreeSet::new();
         while !(items1.is_empty() || items2.is_empty()) {
-            #[allow(unstable_name_collisions)]
             let entry1 = items1.last().unwrap();
-            #[allow(unstable_name_collisions)]
             let entry2 = items2.last().unwrap();
             match entry1.cmp(entry2) {
                 Ordering::Greater => {
-                    #[allow(unstable_name_collisions)]
                     let entry1 = items1.pop_last().unwrap();
                     for parent_entry in entry1.0.parents() {
                         items1.insert(IndexEntryByGeneration(parent_entry));
                     }
                 }
                 Ordering::Less => {
-                    #[allow(unstable_name_collisions)]
                     let entry2 = items2.pop_last().unwrap();
                     for parent_entry in entry2.0.parents() {
                         items2.insert(IndexEntryByGeneration(parent_entry));
@@ -933,9 +929,7 @@ impl<'a> CompositeIndex<'a> {
                 }
                 Ordering::Equal => {
                     result.insert(entry1.0.pos);
-                    #[allow(unstable_name_collisions)]
                     items1.pop_last();
-                    #[allow(unstable_name_collisions)]
                     items2.pop_last();
                 }
             }

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -911,9 +911,7 @@ impl<'a> CompositeIndex<'a> {
             .collect();
 
         let mut result = BTreeSet::new();
-        while !(items1.is_empty() || items2.is_empty()) {
-            let entry1 = items1.last().unwrap();
-            let entry2 = items2.last().unwrap();
+        while let (Some(entry1), Some(entry2)) = (items1.last(), items2.last()) {
             match entry1.cmp(entry2) {
                 Ordering::Greater => {
                     let entry1 = items1.pop_last().unwrap();


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
