### PR TITLE
cli: allow interactive `squash` and `move` with `paths`

### DIFF
--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -47,7 +47,7 @@ pub(crate) struct MoveArgs {
     #[arg(long, short)]
     interactive: bool,
     /// Move only changes to these paths (instead of all paths)
-    #[arg(conflicts_with = "interactive", value_hint = clap::ValueHint::AnyPath)]
+    #[arg(value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
 }
 

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -43,7 +43,7 @@ pub(crate) struct SquashArgs {
     #[arg(long, short)]
     interactive: bool,
     /// Move only changes to these paths (instead of all paths)
-    #[arg(conflicts_with = "interactive", value_hint = clap::ValueHint::AnyPath)]
+    #[arg(value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
 }
 


### PR DESCRIPTION
I think `conflicts_with = "interactive"` is an artifact and it's now implemented.