### PR TITLE
merge_tools: use `left_file_mode` in `make_diff_files`

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -350,7 +350,7 @@ pub fn make_diff_files(
         files.push(scm_record::File {
             old_path: None,
             path: Cow::Owned(changed_path.to_fs_path(Path::new(""))),
-            file_mode: Some(right_file_mode),
+            file_mode: Some(left_file_mode),
             sections,
         });
     }
@@ -654,7 +654,7 @@ mod tests {
                 path: "added",
                 file_mode: Some(
                     FileMode(
-                        33188,
+                        0,
                     ),
                 ),
                 sections: [


### PR DESCRIPTION
The `scm-record` library comments say that the `file_mode` is:
> The Unix file mode of the file (before any changes), if available.

This reverts commit ffd6884 and fixes #2591 and #2548.

Note: The `0` file mode in `added` file doesn't concern use because AFAIK jj only reads the executable bit.