### PR TITLE
cli: move `make_branch_term` out of commands/mod.rs

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -17,7 +17,6 @@ use crate::cli_util::{
     parse_string_pattern, user_error, user_error_with_hint, CommandError, CommandHelper,
     RevisionArg,
 };
-use crate::commands::make_branch_term;
 use crate::formatter::Formatter;
 use crate::ui::Ui;
 
@@ -228,6 +227,13 @@ impl fmt::Display for RemoteBranchNamePattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let RemoteBranchNamePattern { branch, remote } = self;
         write!(f, "{branch}@{remote}")
+    }
+}
+
+fn make_branch_term(branch_names: &[impl fmt::Display]) -> String {
+    match branch_names {
+        [branch_name] => format!("branch {}", branch_name),
+        branch_names => format!("branches {}", branch_names.iter().join(", ")),
     }
 }
 

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
 use std::time::Instant;
-use std::{fs, io};
+use std::{fmt, fs, io};
 
 use clap::{ArgGroup, Subcommand};
 use itertools::Itertools;
@@ -33,7 +33,6 @@ use crate::cli_util::{
     resolve_multiple_nonempty_revsets, short_change_hash, short_commit_hash, user_error,
     user_error_with_hint, CommandError, CommandHelper, RevisionArg, WorkspaceCommandHelper,
 };
-use crate::commands::make_branch_term;
 use crate::progress::Progress;
 use crate::ui::Ui;
 
@@ -189,6 +188,13 @@ pub struct GitSubmodulePrintGitmodulesArgs {
     /// Read .gitmodules from the given revision.
     #[arg(long, short = 'r', default_value = "@")]
     revisions: RevisionArg,
+}
+
+fn make_branch_term(branch_names: &[impl fmt::Display]) -> String {
+    match branch_names {
+        [branch_name] => format!("branch {}", branch_name),
+        branch_names => format!("branches {}", branch_names.iter().join(", ")),
+    }
 }
 
 fn get_git_repo(store: &Store) -> Result<git2::Repository, CommandError> {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -55,11 +55,9 @@ mod util;
 mod version;
 mod workspace;
 
-use std::fmt;
 use std::fmt::Debug;
 
 use clap::{Command, CommandFactory, FromArgMatches, Subcommand};
-use itertools::Itertools;
 use tracing::instrument;
 
 use crate::cli_util::{user_error_with_hint, Args, CommandError, CommandHelper};
@@ -145,13 +143,6 @@ enum Commands {
 struct DummyCommandArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
     _args: Vec<String>,
-}
-
-fn make_branch_term(branch_names: &[impl fmt::Display]) -> String {
-    match branch_names {
-        [branch_name] => format!("branch {}", branch_name),
-        branch_names => format!("branches {}", branch_names.iter().join(", ")),
-    }
 }
 
 pub fn default_app() -> Command {


### PR DESCRIPTION
It is now out of place in mod.rs. It is only used in two places, so I copied it in each of them.

Follows up on @AntoineCezar 's work.