### PR TITLE
sign: Implement generic commit signing on the backend

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -21,7 +21,7 @@ use jj_cli::cli_util::{CliRunner, CommandError, CommandHelper};
 use jj_cli::ui::Ui;
 use jj_lib::backend::{
     Backend, BackendInitError, BackendLoadError, BackendResult, ChangeId, Commit, CommitId,
-    Conflict, ConflictId, FileId, SymlinkId, Tree, TreeId,
+    Conflict, ConflictId, FileId, SigningFn, SymlinkId, Tree, TreeId,
 };
 use jj_lib::git_backend::GitBackend;
 use jj_lib::repo::StoreFactories;
@@ -160,7 +160,11 @@ impl Backend for JitBackend {
         self.inner.read_commit(id).await
     }
 
-    fn write_commit(&self, contents: Commit) -> BackendResult<(CommitId, Commit)> {
-        self.inner.write_commit(contents)
+    fn write_commit(
+        &self,
+        contents: Commit,
+        sign_with: Option<SigningFn>,
+    ) -> BackendResult<(CommitId, Commit)> {
+        self.inner.write_commit(contents, sign_with)
     }
 }

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -126,7 +126,7 @@ impl Store {
 
     pub fn write_commit(self: &Arc<Self>, commit: backend::Commit) -> BackendResult<Commit> {
         assert!(!commit.parents.is_empty());
-        let (commit_id, commit) = self.backend.write_commit(commit)?;
+        let (commit_id, commit) = self.backend.write_commit(commit, None)?;
         let data = Arc::new(commit);
         {
             let mut write_locked_cache = self.commit_cache.write().unwrap();


### PR DESCRIPTION
I feel like this is the least convoluted way of doing it, after all.

Continuing to move small atomic pieces into main :)

Yeah just noticed that because I moved the `write_commit` to `write_commit_impl` it's hard to see the diff.. I've already described the gist of it in discord a few days ago

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
