### PR TITLE
test_abandon_command: test we don't create commits that are both direct and indirect descendants

### DIFF
--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -95,6 +95,28 @@ fn test_rebase_branch_with_merge() {
     ◉
     "###);
 
+    // Abandoning `a` would normally result in its descendant merge commit, `e`,
+    // still having two parents. However, since one of those parents (the root
+    // commit) would be the ancestor of another, only one of the parents is kept.
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "a"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Abandoned commit rlvkpnrz 2443ea76 a | a
+    Rebased 2 descendant commits onto parents of abandoned commits
+    Working copy now at: znkkpsqq b0af79c3 e | e
+    Parent commit      : vruxwmqv b7c62f28 d | d
+    Added 0 files, modified 0 files, removed 1 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  e
+    ◉  d
+    ◉  c
+    │ ◉  b
+    ├─╯
+    ◉  a
+    "###);
+
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "descendants(c)"]);
     insta::assert_snapshot!(stdout, @"");
@@ -103,7 +125,7 @@ fn test_rebase_branch_with_merge() {
       znkkpsqq 5557ece3 e | e
       vruxwmqv b7c62f28 d | d
       royxmykx fe2e8e8b c | c
-    Working copy now at: xtnwkqum e7bb0612 (empty) (no description set)
+    Working copy now at: wvuyspvk 3f93e69f (empty) (no description set)
     Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Added 0 files, modified 0 files, removed 3 files
     "###);
@@ -142,7 +164,7 @@ fn test_rebase_branch_with_merge() {
       vruxwmqv b7c62f28 d | d
       zsuskuln 1394f625 b | b
       rlvkpnrz 2443ea76 a | a
-    Working copy now at: xlzxqlsl af874bff (empty) (no description set)
+    Working copy now at: oupztwtk 304ae338 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 a b e?? | (empty) (no description set)
     Added 0 files, modified 0 files, removed 4 files
     "###);

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -97,11 +97,6 @@ fn test_rebase_branch_with_merge() {
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "descendants(c)"]);
-    // TODO(ilyagr): Minor Bug: The branch `e` should be shown next
-    // to the commit with description `e` below. This is because the commits are
-    // printed in the state *after* abandonment. This will be fixed together with
-    // adding (hidden) to the commit template, which causes a more obvious version
-    // of the same problem.
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Abandoned the following commits:


### PR DESCRIPTION
Illustrates #2600, in addition to being IMO a useful test.

This is similar to the following test:

https://github.com/martinvonz/jj/blob/5186066cf5064564466e58096b79fba6b0c0ecfd/cli/tests/test_rebase_command.rs#L264-L269 

from https://github.com/martinvonz/jj/pull/538.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
