### PR TITLE
cli `new`: add `--no-edit` flag, allow repeating some flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   usual behavior where commits that became unreachable in the Git repo are
   abandoned ([#2504](https://github.com/martinvonz/jj/pull/2504)).
 
+* `jj new` gained a `--no-edit` option to prevent editing the newly created
+  commit. For example, `jj new a b --no-edit -m Merge` creates a merge commit
+  without affecting the working copy.
+
 ### Fixed bugs
 
 

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -27,7 +27,10 @@ use crate::cli_util::{
 };
 use crate::ui::Ui;
 
-/// Create a new, empty change and edit it in the working copy
+/// Create a new, empty change and (by default) edit it in the working copy
+///
+/// By default, `jj` will edit the new change, making the working copy represent
+/// the new commit. This can be avoided with `--no-edit`.
 ///
 /// Note that you can create a merge commit by specifying multiple revisions as
 /// argument. For example, `jj new main @` will create a new commit with the
@@ -50,6 +53,12 @@ pub(crate) struct NewArgs {
     /// Deprecated. Please prefix the revset with `all:` instead.
     #[arg(long, short = 'L', hide = true)]
     allow_large_revsets: bool,
+    /// Do not edit the newly created change
+    #[arg(long, conflicts_with = "_edit")]
+    no_edit: bool,
+    /// No-op flag to pair with --no-edit
+    #[arg(long, hide = true)]
+    _edit: bool,
     /// Insert the new change between the target commit(s) and their children
     //
     // Repeating this flag is allowed, but has no effect.
@@ -193,7 +202,9 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
     if num_rebased > 0 {
         writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
     }
-    tx.edit(&new_commit).unwrap();
+    if !args.no_edit {
+        tx.edit(&new_commit).unwrap();
+    }
     tx.finish(ui)?;
     Ok(())
 }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -42,7 +42,7 @@ pub(crate) struct NewArgs {
     #[arg(default_value = "@")]
     pub(crate) revisions: Vec<RevisionArg>,
     /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true)]
+    #[arg(short = 'r', hide = true, overrides_with = "unused_revision")]
     unused_revision: bool,
     /// The change description to use
     #[arg(long = "message", short, value_name = "MESSAGE")]
@@ -51,10 +51,24 @@ pub(crate) struct NewArgs {
     #[arg(long, short = 'L', hide = true)]
     allow_large_revsets: bool,
     /// Insert the new change between the target commit(s) and their children
-    #[arg(long, short = 'A', visible_alias = "after")]
+    //
+    // Repeating this flag is allowed, but has no effect.
+    #[arg(
+        long,
+        short = 'A',
+        visible_alias = "after",
+        overrides_with = "insert_after"
+    )]
     insert_after: bool,
     /// Insert the new change between the target commit(s) and their parents
-    #[arg(long, short = 'B', visible_alias = "before")]
+    //
+    // Repeating this flag is allowed, but has no effect.
+    #[arg(
+        long,
+        short = 'B',
+        visible_alias = "before",
+        overrides_with = "insert_before"
+    )]
     insert_before: bool,
 }
 

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -199,11 +199,16 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
         }
     }
     num_rebased += tx.mut_repo().rebase_descendants(command.settings())?;
+    if args.no_edit {
+        write!(ui.stderr(), "Created new commit ")?;
+        tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
+        writeln!(ui.stderr())?;
+    } else {
+        tx.edit(&new_commit).unwrap();
+        // The description of the new commit will be printed by tx.finish()
+    }
     if num_rebased > 0 {
         writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
-    }
-    if !args.no_edit {
-        tx.edit(&new_commit).unwrap();
     }
     tx.finish(ui)?;
     Ok(())

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -95,10 +95,10 @@ fn test_new_merge() {
     // Same test with `--no-edit`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "main", "@", "--no-edit"]);
-    // TODO(ilyagr): In this situation, `new` should probably report the identity of
-    // the newly created commit.
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Created new commit znkkpsqq 200ed1a1 (empty) (no description set)
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    200ed1a14c8acf09783dafefe5bebf2ff58f12fd
     ├─╮


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
