### PR TITLE
Implement rebase --skip-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commit. For example, `jj new a b --no-edit -m Merge` creates a merge commit
   without affecting the working copy.
 
+* `jj rebase` now takes the flag `--skip-empty`, which doesn't copy over commits
+  that would become empty after a rebase.
+
 ### Fixed bugs
 
 

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -334,7 +334,10 @@ fn rebase_revision(
         );
     }
     // Now, rebase the descendants of the children.
-    rebased_commit_ids.extend(tx.mut_repo().rebase_descendants_return_map(settings)?);
+    rebased_commit_ids.extend(
+        tx.mut_repo()
+            .rebase_descendants_return_map(settings, Default::default())?,
+    );
     let num_rebased_descendants = rebased_commit_ids.len();
 
     // We now update `new_parents` to account for the rebase of all of

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -171,10 +171,33 @@ pub fn back_out_commit(
         .write()?)
 }
 
+#[derive(Clone, Default, PartialEq)]
+pub enum EmptyBehaviour {
+    /// Always keep empty commits
+    #[default]
+    Keep,
+    /// Skips commits that would be empty after the rebase, but that were not
+    /// originally empty.
+    /// Will never skip merge commits with multiple non-empty parents.
+    AbandonNewlyEmpty,
+    /// Skips all empty commits, including ones that were empty before the
+    /// rebase.
+    /// Will never skip merge commits with multiple non-empty parents.
+    AbandonAllEmpty,
+}
+
+/// Controls the configuration of a rebase.
+// If we wanted to add a flag similar to `git rebase --ignore-date`, then this
+// makes it much easier by ensuring that the only changes required are to
+// change the RebaseOptions construction in the CLI, and changing the
+// rebase_commit function to actually use the flag, and ensure we don't need to
+// plumb it in.
+#[derive(Clone, Default)]
+pub struct RebaseOptions {
+    pub empty: EmptyBehaviour,
+}
+
 /// Rebases descendants of a commit onto a new commit (or several).
-// TODO: Should there be an option to drop empty commits (and/or an option to
-// drop empty commits only if they weren't already empty)? Or maybe that
-// shouldn't be this type's job.
 pub struct DescendantRebaser<'settings, 'repo> {
     settings: &'settings UserSettings,
     mut_repo: &'repo mut MutableRepo,


### PR DESCRIPTION
Fixes issue #229. See the issue for discussions.

- Add test helper functions to give full control over the tree.
- Implement plumbing to add RebaseOptions to rebase_commit and DescendentRebaser.
- Implement skipping of empty commits.
- Add a --skip-empty flag to rebase

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
