### PR TITLE
install-and-setup.md: `--strategy` -> `--strategies` for `cargo binstall`

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -19,11 +19,11 @@ can install the same binaries of the last `jj` release from GitHub as follows:
 
 ```shell
 # Will put the jj binary for the latest release in ~/.cargo/bin by default
-cargo binstall --strategy crate-meta-data jj-cli
+cargo binstall --strategies crate-meta-data jj-cli
 ```
 
-Without the `--strategy` option, you may get equivalent binaries that should be
-compiled from the same source code.
+Without the `--strategies` option, you may get equivalent binaries that should
+be compiled from the same source code.
 
 
 ### Linux


### PR DESCRIPTION
The instructions in the docs for installing `jj` with `cargo-binstall` used the flag `--strategy` which should be `--strategies` ([source](https://github.com/cargo-bins/cargo-binstall/blob/469fc1783e5caa1b1e1f7e4af57c4ad49834e497/crates/bin/src/args.rs#L155)).  This change just fixes that typo.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
