### PR TITLE
docs: add mermaid plugin for diagrams

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,11 @@ markdown_extensions:
   - mdx_breakless_lists
   - pymdownx.tabbed:
       alternate_style: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
   - pymdownx.snippets
   - pymdownx.emoji:


### PR DESCRIPTION
The documentation at https://martinvonz.github.io/jj/v0.11.0/technical/architecture/#design-of-the-library-crate includes a Mermaid diagram.

Unfortunately the Mermaid plugin is not enabled in your MkDocs theme. This PR just follows the instructions at https://squidfunk.github.io/mkdocs-material/reference/diagrams/ to enable it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- ~[ ] I have updated `CHANGELOG.md`~
- ~[ ] I have updated the documentation (README.md, docs/, demos/)~
- ~[ ] I have updated the config schema (cli/src/config-schema.json)~
- ~[ ] I have added tests to cover my changes~
