### PR TITLE
cleanup: don't use debug format to print source errors

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -480,7 +480,7 @@ impl TracingSubscription {
                     .from_env_lossy()
             })
             .map_err(|err| {
-                CommandError::InternalError(format!("failed to enable verbose logging: {err:?}"))
+                CommandError::InternalError(format!("failed to enable verbose logging: {err}"))
             })?;
         tracing::info!("verbose logging enabled");
         Ok(())
@@ -2215,14 +2215,14 @@ pub fn write_config_value_to_file(
             // If config doesn't exist yet, read as empty and we'll write one.
             std::io::ErrorKind::NotFound => Ok("".to_string()),
             _ => Err(user_error(format!(
-                "Failed to read file {path}: {err:?}",
+                "Failed to read file {path}: {err}",
                 path = path.display()
             ))),
         }
     })?;
     let mut doc = toml_edit::Document::from_str(&config_toml).map_err(|err| {
         user_error(format!(
-            "Failed to parse file {path}: {err:?}",
+            "Failed to parse file {path}: {err}",
             path = path.display()
         ))
     })?;
@@ -2264,7 +2264,7 @@ pub fn write_config_value_to_file(
     // Write config back
     std::fs::write(path, doc.to_string()).map_err(|err| {
         user_error(format!(
-            "Failed to write file {path}: {err:?}",
+            "Failed to write file {path}: {err}",
             path = path.display()
         ))
     })

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -36,7 +36,7 @@ pub enum BuiltinToolError {
     },
     #[error("Rendering {item} {id} is unimplemented for the builtin difftool/mergetool")]
     Unimplemented { item: &'static str, id: String },
-    #[error("Backend error: {0:?}")]
+    #[error("Backend error: {0}")]
     BackendError(#[from] jj_lib::backend::BackendError),
 }
 

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -170,13 +170,13 @@ pub enum PaginationChoice {
 fn pagination_setting(config: &config::Config) -> Result<PaginationChoice, CommandError> {
     config
         .get::<PaginationChoice>("ui.paginate")
-        .map_err(|err| CommandError::ConfigError(format!("Invalid `ui.paginate`: {err:?}")))
+        .map_err(|err| CommandError::ConfigError(format!("Invalid `ui.paginate`: {err}")))
 }
 
 fn pager_setting(config: &config::Config) -> Result<CommandNameAndArgs, CommandError> {
     config
         .get::<CommandNameAndArgs>("ui.pager")
-        .map_err(|err| CommandError::ConfigError(format!("Invalid `ui.pager`: {err:?}")))
+        .map_err(|err| CommandError::ConfigError(format!("Invalid `ui.pager`: {err}")))
 }
 
 impl Ui {

--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -251,12 +251,12 @@ impl IndexStore for DefaultIndexStore {
             .downcast::<MutableIndexImpl>()
             .expect("index to merge in must be a MutableIndexImpl");
         let index = index.save_in(self.dir.clone()).map_err(|err| {
-            IndexWriteError::Other(format!("Failed to write commit index file: {err:?}"))
+            IndexWriteError::Other(format!("Failed to write commit index file: {err}"))
         })?;
         self.associate_file_with_operation(&index, op_id)
             .map_err(|err| {
                 IndexWriteError::Other(format!(
-                    "Failed to associate commit index file with a operation {op_id:?}: {err:?}"
+                    "Failed to associate commit index file with a operation {op_id:?}: {err}"
                 ))
             })?;
         Ok(Box::new(ReadonlyIndexWrapper(index)))

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -141,7 +141,7 @@ pub enum SnapshotError {
         max_size: HumanByteSize,
     },
     /// Some other error happened while snapshotting the working copy.
-    #[error("{message}: {err:?}")]
+    #[error("{message}: {err}")]
     Other {
         /// Error message.
         message: String,
@@ -224,7 +224,7 @@ pub enum CheckoutError {
     #[error("Internal backend error: {0}")]
     InternalBackendError(#[from] BackendError),
     /// Some other error happened while checking out the working copy.
-    #[error("{message}: {err:?}")]
+    #[error("{message}: {err}")]
     Other {
         /// Error message.
         message: String,
@@ -248,7 +248,7 @@ pub enum ResetError {
     #[error("Internal error: {0}")]
     InternalBackendError(#[from] BackendError),
     /// Some other error happened while checking out the working copy.
-    #[error("{message}: {err:?}")]
+    #[error("{message}: {err}")]
     Other {
         /// Error message.
         message: String,
@@ -260,7 +260,7 @@ pub enum ResetError {
 
 /// An error while reading the working copy state.
 #[derive(Debug, Error)]
-#[error("{message}: {err:?}")]
+#[error("{message}: {err}")]
 pub struct WorkingCopyStateError {
     /// Error message.
     pub message: String,


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
