### PR TITLE
github CI: Retry tests after a 15-min timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,13 @@ jobs:
         toolchain:  1.71
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
-    - name: Test
-      run: cargo test --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
+    - uses: nick-fields/retry@v2
+      name: Test (retries if not done after 15m)
+      with:
+        timeout_minutes: 15
+        max_attempts: 5
+        retry_on: timeout
+        command: cargo test --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
       env:
         RUST_BACKTRACE: 1
 


### PR DESCRIPTION
The Windows tests have been quite flaky lately,
`test_concurrent_read_write_commit` can run for 5+ hours. See e.g.
https://github.com/martinvonz/jj/actions/runs/6964394504/job/18951562247

This is not the most elegant solution, but fixing the test seems
trickier.

Normally, it takes ~3 minutes, but the timeout is 15 just to be safe.

PR #2627 checks that failed tests are not retried.

Example of this working (Windows tests pass after 2 attempts, for
older version of the PR with 30m timeout):
https://github.com/martinvonz/jj/actions/runs/6974955234/job/18981391917#step:5:1510