### PR TITLE
sign: Define signing backend API and integrate it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
  "async-trait",
  "config",
  "git2",
+ "hex",
  "itertools 0.11.0",
  "jj-lib",
  "rand",

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -27,7 +27,8 @@ use jj_lib::git_backend::GitBackend;
 use jj_lib::repo::StoreFactories;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::settings::UserSettings;
-use jj_lib::workspace::Workspace;
+use jj_lib::signing::Signer;
+use jj_lib::workspace::{Workspace, WorkspaceInitError};
 
 #[derive(clap::Parser, Clone, Debug)]
 enum CustomCommands {
@@ -59,6 +60,8 @@ fn run_custom_command(
                 command_helper.settings(),
                 wc_path,
                 &|settings, store_path| Ok(Box::new(JitBackend::init(settings, store_path)?)),
+                Signer::from_settings(command_helper.settings())
+                    .map_err(WorkspaceInitError::SignInit)?,
             )?;
             Ok(())
         }

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -28,12 +28,15 @@ use jj_lib::op_store::{OperationId, WorkspaceId};
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::settings::UserSettings;
+use jj_lib::signing::Signer;
 use jj_lib::store::Store;
 use jj_lib::working_copy::{
     CheckoutError, CheckoutStats, LockedWorkingCopy, ResetError, SnapshotError, SnapshotOptions,
     WorkingCopy, WorkingCopyStateError,
 };
-use jj_lib::workspace::{default_working_copy_factories, WorkingCopyInitializer, Workspace};
+use jj_lib::workspace::{
+    default_working_copy_factories, WorkingCopyInitializer, Workspace, WorkspaceInitError,
+};
 
 #[derive(clap::Parser, Clone, Debug)]
 enum CustomCommands {
@@ -58,6 +61,8 @@ fn run_custom_command(
                 command_helper.settings(),
                 wc_path,
                 &backend_initializer,
+                Signer::from_settings(command_helper.settings())
+                    .map_err(WorkspaceInitError::SignInit)?,
                 &ReadonlyRepo::default_op_store_initializer(),
                 &ReadonlyRepo::default_op_heads_store_initializer(),
                 &ReadonlyRepo::default_index_store_initializer(),

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -355,6 +355,31 @@
                     "default": "1MiB"
                 }
             }
+        },
+        "signing": {
+            "type": "object",
+            "description": "Settings for verifying and creating cryptographic commit signatures",
+            "properties": {
+                "backend": {
+                    "type": "string",
+                    "description": "Which backend to use to create commit signatures"
+                },
+                "key": {
+                    "type": "string",
+                    "description": "The key parameter to pass to the signing backend. Overridden by `jj sign` parameter or by the global `--sign-with` option"
+                },
+                "sign-all": {
+                    "type": "boolean",
+                    "description": "Whether to sign all commits by default. Overridden by global `--no-sign` option",
+                    "default": false
+                },
+                "backends": {
+                    "type": "object",
+                    "description": "Tables of options to pass to specific signing backends",
+                    "properties": {},
+                    "additionalProperties": true
+                }
+            }
         }
     }
 }

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 use crate::content_hash::ContentHash;
 use crate::merge::Merge;
 use crate::repo_path::{RepoPath, RepoPathComponent, RepoPathComponentBuf};
+use crate::signing::SignResult;
 
 pub trait ObjectId {
     fn new(value: Vec<u8>) -> Self;
@@ -147,7 +148,7 @@ content_hash! {
     }
 }
 
-pub type SigningFn = Box<dyn FnMut(&[u8]) -> BackendResult<Vec<u8>>>;
+pub type SigningFn = Box<dyn FnMut(&[u8]) -> SignResult<Vec<u8>>>;
 
 /// Identifies a single legacy tree, which may have path-level conflicts, or a
 /// merge of multiple trees, where the individual trees do not have conflicts.

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use crate::backend;
 use crate::backend::{BackendError, ChangeId, CommitId, MergedTreeId, Signature};
 use crate::merged_tree::MergedTree;
+use crate::signing::{SignResult, Verification};
 use crate::store::Store;
 
 #[derive(Clone)]
@@ -145,6 +146,20 @@ impl Commit {
             }
         }
         false
+    }
+
+    /// A quick way to just check if a signature is present.
+    pub fn is_signed(&self) -> bool {
+        self.data.secure_sig.is_some()
+    }
+
+    /// A slow (but cached) way to get the full verification.
+    pub fn verification(&self) -> SignResult<Option<Verification>> {
+        self.data
+            .secure_sig
+            .as_ref()
+            .map(|sig| self.store.signer().verify(&self.id, &sig.data, &sig.sig))
+            .transpose()
     }
 }
 

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -967,7 +967,10 @@ impl Backend for GitBackend {
                 let mut data = Vec::with_capacity(512);
                 commit.write_to(&mut data).unwrap();
 
-                let sig = sign(&data)?;
+                let sig = sign(&data).map_err(|err| BackendError::WriteObject {
+                    object_type: "commit",
+                    source: Box::new(err),
+                })?;
                 commit
                     .extra_headers
                     .push(("gpgsig".into(), sig.clone().into()));

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -58,6 +58,7 @@ pub mod revset;
 pub mod revset_graph;
 pub mod rewrite;
 pub mod settings;
+pub mod signing;
 pub mod simple_op_heads_store;
 pub mod simple_op_store;
 pub mod stacked_table;

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -281,7 +281,7 @@ impl Backend for LocalBackend {
         let mut proto = commit_to_proto(&commit);
         if let Some(mut sign) = sign_with {
             let data = proto.encode_to_vec();
-            let sig = sign(&data)?;
+            let sig = sign(&data).map_err(to_other_err)?;
             proto.secure_sig = Some(sig.clone());
             commit.secure_sig = Some(SecureSig { data, sig });
         }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -119,8 +119,6 @@ pub enum RepoInitError {
     Backend(#[from] BackendInitError),
     #[error(transparent)]
     Path(#[from] PathError),
-    #[error(transparent)]
-    SignInit(#[from] SignInitError),
 }
 
 impl ReadonlyRepo {
@@ -143,10 +141,12 @@ impl ReadonlyRepo {
         &|_settings, store_path| Box::new(DefaultSubmoduleStore::init(store_path))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn init(
         user_settings: &UserSettings,
         repo_path: &Path,
         backend_initializer: &BackendInitializer,
+        signer: Signer,
         op_store_initializer: &OpStoreInitializer,
         op_heads_store_initializer: &OpHeadsStoreInitializer,
         index_store_initializer: &IndexStoreInitializer,
@@ -159,7 +159,6 @@ impl ReadonlyRepo {
         let backend = backend_initializer(user_settings, &store_path)?;
         let backend_path = store_path.join("type");
         fs::write(&backend_path, backend.name()).context(&backend_path)?;
-        let signer = Signer::from_settings(user_settings)?;
         let store = Store::new(backend, signer, user_settings.use_tree_conflict_format());
         let repo_settings = user_settings.with_repo(&repo_path).unwrap();
 

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -1,0 +1,249 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic APIs to work with cryptographic signatures created and verified by
+//! various backends.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::RwLock;
+
+use thiserror::Error;
+
+use crate::backend::CommitId;
+use crate::settings::UserSettings;
+
+/// A status of the signature, part of the [Verification] type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigStatus {
+    /// Valid signature that matches the data.
+    Good,
+    /// Valid signature that could not be verified (e.g. due to an unknown key).
+    Unknown,
+    /// Valid signature that does not match the signed data.
+    Bad,
+}
+
+/// The result of a signature verification.
+/// Key and display are optional additional info that backends can or can not
+/// provide to add additional information for the templater to potentially show.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Verification {
+    /// The status of the signature.
+    pub status: SigStatus,
+    /// The key id representation, if available. For GPG, this will be the key
+    /// fingerprint.
+    pub key: Option<String>,
+    /// A display string, if available. For GPG, this will be formatted primary
+    /// user ID.
+    pub display: Option<String>,
+}
+
+impl Verification {
+    /// A shortcut to create an `Unknown` verification with no additional
+    /// metadata.
+    pub fn unknown() -> Self {
+        Self {
+            status: SigStatus::Unknown,
+            key: None,
+            display: None,
+        }
+    }
+}
+
+/// The backend for signing and verifying cryptographic signatures.
+///
+/// This allows using different signers, such as GPG or SSH, or different
+/// versions of them.
+pub trait SigningBackend: Debug + Send + Sync {
+    /// Name of the backend, used in the config and for display.
+    fn name(&self) -> &str;
+
+    /// Check if the signature can be read and verified by this backend.
+    ///
+    /// Should check the signature format, usually just looks at the prefix.
+    fn can_read(&self, signature: &[u8]) -> bool;
+
+    /// Create a signature for arbitrary data.
+    ///
+    /// The `key` parameter is what `jj sign` receives as key argument, or what
+    /// is configured in the `signing.key` config.
+    fn sign(&self, data: &[u8], key: Option<&str>) -> SignResult<Vec<u8>>;
+
+    /// Verify a signature. Should be reflexive with `sign`:
+    /// ```rust,ignore
+    /// verify(data, sign(data)?)?.status == SigStatus::Good
+    /// ```
+    fn verify(&self, data: &[u8], signature: &[u8]) -> SignResult<Verification>;
+}
+
+/// An error type for the signing/verifying operations
+#[derive(Debug, Error)]
+pub enum SignError {
+    /// The verification failed because the signature *format* was invalid.
+    #[error("Invalid signature")]
+    InvalidSignatureFormat,
+    /// A generic error from the backend impl.
+    #[error("Signing error: {0}")]
+    Backend(Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// A result type for the signing/verifying operations
+pub type SignResult<T> = Result<T, SignError>;
+
+/// An error type for the signing backend initialization.
+#[derive(Debug, Error)]
+pub enum SignInitError {
+    /// If the backend name specified in the config is not known.
+    #[error("Unknown signing backend configured: {0}")]
+    UnknownBackend(String),
+    /// A generic error from the backend impl.
+    #[error("Failed to initialize signing: {0}")]
+    Backend(Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// A enum that describes if a created/rewritten commit should be signed or not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SignBehavior {
+    /// Drop existing signatures.
+    /// This is what jj did before signing support or does now when a signing
+    /// backend is not configured.
+    #[default]
+    Drop,
+    /// Only sign commits that were authored by self and already signed,
+    /// "preserving" the signature across rewrites.
+    /// This is what jj does when a signing backend is configured.
+    Keep,
+    /// Sign/re-sign commits that were authored by self and drop them for
+    /// others. This is what jj does when configured to always sign.
+    Own,
+    /// Always sign commits, regardless of who authored or signed them before.
+    /// This is what jj does on `jj sign -f`.
+    Force,
+}
+
+/// Wraps low-level signing backends and adds caching, similar to `Store`.
+#[derive(Debug, Default)]
+pub struct Signer {
+    /// The backend that is used for signing commits.
+    /// Optional because signing might not be configured.
+    main_backend: Option<Box<dyn SigningBackend>>,
+    /// All known backends without the main one - used for verification.
+    /// Main backend is also used for verification, but it's not in this list
+    /// for ownership reasons.
+    backends: Vec<Box<dyn SigningBackend>>,
+    cache: RwLock<HashMap<CommitId, Verification>>,
+}
+
+impl Signer {
+    /// Creates a signer based on user settings. Uses all known backends, and
+    /// chooses one of them to be used for signing depending on the config.
+    pub fn from_settings(settings: &UserSettings) -> Result<Self, SignInitError> {
+        let mut backends: Vec<Box<dyn SigningBackend>> = vec![
+            // Box::new(GpgBackend::from_settings(settings)?),
+            // Box::new(SshBackend::from_settings(settings)?),
+            // Box::new(X509Backend::from_settings(settings)?),
+        ];
+
+        let main_backend = settings
+            .signing_backend()
+            .map(|backend| {
+                backends
+                    .iter()
+                    .position(|b| b.name() == backend)
+                    .map(|i| backends.remove(i))
+                    .ok_or(SignInitError::UnknownBackend(backend))
+            })
+            .transpose()?;
+
+        Ok(Self::new(main_backend, backends))
+    }
+
+    /// Creates a signer with the given backends.
+    pub fn new(
+        main_backend: Option<Box<dyn SigningBackend>>,
+        other_backends: Vec<Box<dyn SigningBackend>>,
+    ) -> Self {
+        Self {
+            main_backend,
+            backends: other_backends,
+            cache: Default::default(),
+        }
+    }
+
+    /// Checks if the signer can sign, i.e. if a main backend is configured.
+    pub fn can_sign(&self) -> bool {
+        self.main_backend.is_some()
+    }
+
+    /// This is just a pass-through to the main backend that unconditionally
+    /// creates a signature.
+    pub fn sign(&self, data: &[u8], key: Option<&str>) -> SignResult<Vec<u8>> {
+        self.main_backend
+            .as_ref()
+            .expect("tried to sign without checking can_sign first")
+            .sign(data, key)
+    }
+
+    /// Looks for backend that can verify the signature and returns the result
+    /// of its verification.
+    pub fn verify(
+        &self,
+        commit_id: &CommitId,
+        data: &[u8],
+        signature: &[u8],
+    ) -> SignResult<Verification> {
+        let cached = self.cache.read().unwrap().get(commit_id).cloned();
+        if let Some(check) = cached {
+            return Ok(check);
+        }
+
+        let verification = self
+            .main_backend
+            .iter()
+            .chain(self.backends.iter())
+            .filter(|b| b.can_read(signature))
+            // skip unknown and invalid sigs to allow other backends that can read to try
+            // for example, we might have gpg and sq, both of which could read a PGP signature
+            .find_map(|backend| match backend.verify(data, signature) {
+                Ok(check) if check.status == SigStatus::Unknown => None,
+                Err(SignError::InvalidSignatureFormat) => None,
+                e => Some(e),
+            })
+            .transpose()?;
+
+        if let Some(verification) = verification {
+            // a key might get imported before next call?.
+            // realistically this is unlikely, but technically
+            // it's correct to not cache unknowns here
+            if verification.status != SigStatus::Unknown {
+                self.cache
+                    .write()
+                    .unwrap()
+                    .insert(commit_id.clone(), verification.clone());
+            }
+            Ok(verification)
+        } else {
+            // now here it's correct to cache unknowns, as we don't
+            // have a backend that knows how to handle this signature
+            //
+            // not sure about how much of an optimization this is
+            self.cache
+                .write()
+                .unwrap()
+                .insert(commit_id.clone(), Verification::unknown());
+            Ok(Verification::unknown())
+        }
+    }
+}

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -36,6 +36,7 @@ use crate::repo::{
     StoreFactories, StoreLoadError, SubmoduleStoreInitializer,
 };
 use crate::settings::UserSettings;
+use crate::signing::SignInitError;
 use crate::store::Store;
 use crate::working_copy::{
     CheckoutError, CheckoutStats, LockedWorkingCopy, WorkingCopy, WorkingCopyStateError,
@@ -55,6 +56,8 @@ pub enum WorkspaceInitError {
     Path(#[from] PathError),
     #[error(transparent)]
     Backend(#[from] BackendInitError),
+    #[error(transparent)]
+    SignInit(#[from] SignInitError),
 }
 
 #[derive(Error, Debug)]
@@ -249,6 +252,7 @@ impl Workspace {
             .map_err(|repo_init_err| match repo_init_err {
                 RepoInitError::Backend(err) => WorkspaceInitError::Backend(err),
                 RepoInitError::Path(err) => WorkspaceInitError::Path(err),
+                RepoInitError::SignInit(err) => WorkspaceInitError::SignInit(err),
             })?;
             let (working_copy, repo) = init_working_copy(
                 user_settings,

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -35,6 +35,7 @@ use jj_lib::op_store::{BranchTarget, RefTarget, RemoteRef, RemoteRefState};
 use jj_lib::refs::BranchPushUpdate;
 use jj_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
 use jj_lib::settings::{GitSettings, UserSettings};
+use jj_lib::signing::Signer;
 use jj_lib::str_util::StringPattern;
 use jj_lib::workspace::Workspace;
 use maplit::{btreemap, hashset};
@@ -1125,6 +1126,7 @@ impl GitRepoData {
                     &git_repo_dir,
                 )?))
             },
+            Signer::from_settings(&settings).unwrap(),
             ReadonlyRepo::default_op_store_initializer(),
             ReadonlyRepo::default_op_heads_store_initializer(),
             ReadonlyRepo::default_index_store_initializer(),
@@ -1990,6 +1992,7 @@ fn test_init() {
                 &git_repo_dir,
             )?))
         },
+        Signer::from_settings(&settings).unwrap(),
         ReadonlyRepo::default_op_store_initializer(),
         ReadonlyRepo::default_op_heads_store_initializer(),
         ReadonlyRepo::default_index_store_initializer(),
@@ -2315,6 +2318,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
                 &clone_repo_dir,
             )?))
         },
+        Signer::from_settings(settings).unwrap(),
         ReadonlyRepo::default_op_store_initializer(),
         ReadonlyRepo::default_op_heads_store_initializer(),
         ReadonlyRepo::default_index_store_initializer(),

--- a/lib/tests/test_signing.rs
+++ b/lib/tests/test_signing.rs
@@ -1,0 +1,171 @@
+use jj_lib::backend::{MillisSinceEpoch, Signature, Timestamp};
+use jj_lib::repo::Repo;
+use jj_lib::settings::UserSettings;
+use jj_lib::signing::{SigStatus, SignBehavior, Signer, Verification};
+use test_case::test_case;
+use testutils::test_signing_backend::TestSigningBackend;
+use testutils::{create_random_commit, write_random_commit, TestRepoBackend, TestWorkspace};
+
+fn user_settings(sign_all: bool) -> UserSettings {
+    let config = testutils::base_config()
+        .add_source(config::File::from_str(
+            &format!(
+                r#"
+                signing.key = "impeccable"
+                signing.sign-all = {sign_all}
+                "#
+            ),
+            config::FileFormat::Toml,
+        ))
+        .build()
+        .unwrap();
+    UserSettings::from_config(config)
+}
+
+fn someone_else() -> Signature {
+    Signature {
+        name: "Someone Else".to_string(),
+        email: "someone-else@example.com".to_string(),
+        timestamp: Timestamp {
+            timestamp: MillisSinceEpoch(0),
+            tz_offset: 0,
+        },
+    }
+}
+
+fn good_verification() -> Option<Verification> {
+    Some(Verification {
+        status: SigStatus::Good,
+        key: Some("impeccable".to_owned()),
+        display: None,
+    })
+}
+
+#[test_case(TestRepoBackend::Local ; "local backend")]
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn manual(backend: TestRepoBackend) {
+    let settings = user_settings(true);
+
+    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
+
+    let repo = &test_workspace.repo;
+
+    let settings = settings.clone();
+    let repo = repo.clone();
+    let mut tx = repo.start_transaction(&settings, "test");
+    let commit1 = create_random_commit(tx.mut_repo(), &settings)
+        .set_sign_behavior(SignBehavior::Own)
+        .write()
+        .unwrap();
+    let commit2 = create_random_commit(tx.mut_repo(), &settings)
+        .set_sign_behavior(SignBehavior::Own)
+        .set_author(someone_else())
+        .write()
+        .unwrap();
+    tx.commit();
+
+    let commit1 = repo.store().get_commit(commit1.id()).unwrap();
+    assert_eq!(commit1.verification().unwrap(), good_verification());
+
+    let commit2 = repo.store().get_commit(commit2.id()).unwrap();
+    assert_eq!(commit2.verification().unwrap(), None);
+}
+
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn keep_on_rewrite(backend: TestRepoBackend) {
+    let settings = user_settings(true);
+
+    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
+
+    let repo = &test_workspace.repo;
+
+    let settings = settings.clone();
+    let repo = repo.clone();
+    let mut tx = repo.start_transaction(&settings, "test");
+    let commit = create_random_commit(tx.mut_repo(), &settings)
+        .set_sign_behavior(SignBehavior::Own)
+        .write()
+        .unwrap();
+    tx.commit();
+
+    let mut tx = repo.start_transaction(&settings, "test");
+    let mut_repo = tx.mut_repo();
+    let rewritten = mut_repo.rewrite_commit(&settings, &commit).write().unwrap();
+
+    let commit = repo.store().get_commit(rewritten.id()).unwrap();
+    assert_eq!(commit.verification().unwrap(), good_verification());
+}
+
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn manual_drop_on_rewrite(backend: TestRepoBackend) {
+    let settings = user_settings(true);
+
+    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
+
+    let repo = &test_workspace.repo;
+
+    let settings = settings.clone();
+    let repo = repo.clone();
+    let mut tx = repo.start_transaction(&settings, "test");
+    let commit = create_random_commit(tx.mut_repo(), &settings)
+        .set_sign_behavior(SignBehavior::Own)
+        .write()
+        .unwrap();
+    tx.commit();
+
+    let mut tx = repo.start_transaction(&settings, "test");
+    let mut_repo = tx.mut_repo();
+    let rewritten = mut_repo
+        .rewrite_commit(&settings, &commit)
+        .set_sign_behavior(SignBehavior::Drop)
+        .write()
+        .unwrap();
+
+    let commit = repo.store().get_commit(rewritten.id()).unwrap();
+    assert_eq!(commit.verification().unwrap(), None);
+}
+
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn forced(backend: TestRepoBackend) {
+    let settings = user_settings(true);
+
+    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
+
+    let repo = &test_workspace.repo;
+
+    let settings = settings.clone();
+    let repo = repo.clone();
+    let mut tx = repo.start_transaction(&settings, "test");
+    let commit = create_random_commit(tx.mut_repo(), &settings)
+        .set_sign_behavior(SignBehavior::Force)
+        .set_author(someone_else())
+        .write()
+        .unwrap();
+    tx.commit();
+
+    let commit = repo.store().get_commit(commit.id()).unwrap();
+    assert_eq!(commit.verification().unwrap(), good_verification());
+}
+
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn configured(backend: TestRepoBackend) {
+    let settings = user_settings(true);
+
+    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
+
+    let repo = &test_workspace.repo;
+
+    let settings = settings.clone();
+    let repo = repo.clone();
+    let mut tx = repo.start_transaction(&settings, "test");
+    let commit = write_random_commit(tx.mut_repo(), &settings);
+    tx.commit();
+
+    let commit = repo.store().get_commit(commit.id()).unwrap();
+    assert_eq!(commit.verification().unwrap(), good_verification());
+}

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -18,6 +18,7 @@ readme = { workspace = true }
 async-trait = { workspace = true }
 config = { workspace = true }
 git2 = { workspace = true }
+hex = { workspace = true }
 itertools = { workspace = true }
 jj-lib = { workspace = true }
 rand = { workspace = true }

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -336,7 +336,7 @@ pub fn commit_with_tree(store: &Arc<Store>, tree_id: MergedTreeId) -> Commit {
         committer: signature,
         secure_sig: None,
     };
-    store.write_commit(commit).unwrap()
+    store.write_commit(commit, None).unwrap()
 }
 
 pub fn dump_tree(store: &Arc<Store>, tree_id: &MergedTreeId) -> String {

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -282,7 +282,7 @@ impl Backend for TestBackend {
 
         if let Some(sign) = &mut sign_with {
             let data = format!("{contents:?}").into_bytes();
-            let sig = sign(&data)?;
+            let sig = sign(&data).map_err(|err| BackendError::Other(Box::new(err)))?;
             contents.secure_sig = Some(SecureSig { data, sig });
         }
 

--- a/lib/testutils/src/test_signing_backend.rs
+++ b/lib/testutils/src/test_signing_backend.rs
@@ -1,0 +1,54 @@
+use hex::ToHex;
+use jj_lib::content_hash::blake2b_hash;
+use jj_lib::signing::{SigStatus, SignError, SignResult, SigningBackend, Verification};
+
+#[derive(Debug)]
+pub struct TestSigningBackend;
+
+const PREFIX: &str = "--- JJ-TEST-SIGNATURE ---\nKEY: ";
+
+impl SigningBackend for TestSigningBackend {
+    fn name(&self) -> &str {
+        "test"
+    }
+
+    fn can_read(&self, signature: &[u8]) -> bool {
+        signature.starts_with(PREFIX.as_bytes())
+    }
+
+    fn sign(&self, data: &[u8], key: Option<&str>) -> SignResult<Vec<u8>> {
+        let key = key.unwrap_or_default();
+        let mut body = Vec::with_capacity(data.len() + key.len());
+        body.extend_from_slice(key.as_bytes());
+        body.extend_from_slice(data);
+
+        let hash: String = blake2b_hash(&body).encode_hex();
+
+        Ok(format!("{PREFIX}{key}\n{hash}").into_bytes())
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> SignResult<Verification> {
+        let Some(key) = signature
+            .strip_prefix(PREFIX.as_bytes())
+            .and_then(|s| s.splitn(2, |&b| b == b'\n').next())
+        else {
+            return Err(SignError::InvalidSignatureFormat);
+        };
+        let key = (!key.is_empty()).then_some(std::str::from_utf8(key).unwrap().to_owned());
+
+        let sig = self.sign(data, key.as_deref())?;
+        if sig == signature {
+            Ok(Verification {
+                status: SigStatus::Good,
+                key,
+                display: None,
+            })
+        } else {
+            Ok(Verification {
+                status: SigStatus::Bad,
+                key,
+                display: None,
+            })
+        }
+    }
+}


### PR DESCRIPTION
~~Relatively small piece, just adding `signing.rs` stuff, which is to be amended depending on future cli work (and actual signing backend impls), and integrate it with store initialization~~

Basically implemented all of the abstract signing backend management, only things left are the actual impls and the user-facing cli/templater/hints.

Self-review tells me this is small and digestable enough, but I was always wrong about that :)

But writing this felt like all the lego pieces clicking into places, it seems nice

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
