### PR TITLE
repo_path: split RepoPathComponent into owned and borrowed types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
+ "ref-cast",
  "regex",
  "rustix",
  "serde",
@@ -2378,6 +2379,26 @@ dependencies = [
  "getrandom",
  "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acde58d073e9c79da00f2b5b84eed919c8326832648a5b109b3fce1bb1175280"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ prost-build = "0.11.9"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.8.0"
+ref-cast = "1.0.20"
 regex = "1.10.2"
 rpassword = "7.3.1"
 rustix = { version = "0.38.25", features = ["fs"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -43,6 +43,7 @@ prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
+ref-cast = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 
 use crate::content_hash::ContentHash;
 use crate::merge::Merge;
-use crate::repo_path::{RepoPath, RepoPathComponent};
+use crate::repo_path::{RepoPath, RepoPathComponent, RepoPathComponentBuf};
 
 pub trait ObjectId {
     fn new(value: Vec<u8>) -> Self;
@@ -358,7 +358,7 @@ impl<'a> TreeEntry<'a> {
 }
 
 pub struct TreeEntriesNonRecursiveIterator<'a> {
-    iter: std::collections::btree_map::Iter<'a, RepoPathComponent, TreeValue>,
+    iter: std::collections::btree_map::Iter<'a, RepoPathComponentBuf, TreeValue>,
 }
 
 impl<'a> Iterator for TreeEntriesNonRecursiveIterator<'a> {
@@ -374,7 +374,7 @@ impl<'a> Iterator for TreeEntriesNonRecursiveIterator<'a> {
 content_hash! {
     #[derive(Default, PartialEq, Eq, Debug, Clone)]
     pub struct Tree {
-        entries: BTreeMap<RepoPathComponent, TreeValue>,
+        entries: BTreeMap<RepoPathComponentBuf, TreeValue>,
     }
 }
 
@@ -393,7 +393,7 @@ impl Tree {
         }
     }
 
-    pub fn set(&mut self, name: RepoPathComponent, value: TreeValue) {
+    pub fn set(&mut self, name: RepoPathComponentBuf, value: TreeValue) {
         self.entries.insert(name, value);
     }
 

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -384,7 +384,7 @@ impl Tree {
     }
 
     pub fn names(&self) -> impl Iterator<Item = &RepoPathComponent> {
-        self.entries.keys()
+        self.entries.keys().map(|name| name.as_ref())
     }
 
     pub fn entries(&self) -> TreeEntriesNonRecursiveIterator {
@@ -407,7 +407,7 @@ impl Tree {
                 self.entries.remove(name);
             }
             Some(value) => {
-                self.entries.insert(name.clone(), value);
+                self.entries.insert(name.to_owned(), value);
             }
         }
     }

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -37,7 +37,7 @@ use crate::backend::{
 use crate::file_util::{IoResultExt as _, PathError};
 use crate::lock::FileLock;
 use crate::merge::{Merge, MergeBuilder};
-use crate::repo_path::{RepoPath, RepoPathComponent};
+use crate::repo_path::{RepoPath, RepoPathComponentBuf};
 use crate::settings::UserSettings;
 use crate::stacked_table::{
     MutableTable, ReadonlyTable, TableSegment, TableStore, TableStoreError,
@@ -766,7 +766,7 @@ impl Backend for GitBackend {
                     (name, TreeValue::GitSubmodule(id))
                 }
             };
-            tree.set(RepoPathComponent::from(name), value);
+            tree.set(RepoPathComponentBuf::from(name), value);
         }
         Ok(tree)
     }

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -34,7 +34,7 @@ use crate::backend::{
 use crate::content_hash::blake2b_hash;
 use crate::file_util::persist_content_addressed_temp_file;
 use crate::merge::MergeBuilder;
-use crate::repo_path::{RepoPath, RepoPathComponent};
+use crate::repo_path::{RepoPath, RepoPathComponentBuf};
 
 const COMMIT_ID_LENGTH: usize = 64;
 const CHANGE_ID_LENGTH: usize = 16;
@@ -368,7 +368,7 @@ fn tree_from_proto(proto: crate::protos::local_store::Tree) -> Tree {
     let mut tree = Tree::default();
     for proto_entry in proto.entries {
         let value = tree_value_from_proto(proto_entry.value.unwrap());
-        tree.set(RepoPathComponent::from(proto_entry.name), value);
+        tree.set(RepoPathComponentBuf::from(proto_entry.name), value);
     }
     tree
 }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -783,7 +783,7 @@ impl TreeState {
                 if name == ".jj" || name == ".git" {
                     return Ok(());
                 }
-                let path = dir.join(&RepoPathComponent::from(name));
+                let path = dir.join(RepoPathComponent::new(name));
                 if let Some(file_state) = file_states.get(&path) {
                     if file_state.file_type == FileType::GitSubmodule {
                         return Ok(());

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -30,7 +30,7 @@ use pollster::FutureExt;
 use crate::backend::{BackendError, BackendResult, ConflictId, MergedTreeId, TreeId, TreeValue};
 use crate::matchers::{EverythingMatcher, Matcher};
 use crate::merge::{Merge, MergeBuilder, MergedTreeValue};
-use crate::repo_path::{RepoPath, RepoPathComponent};
+use crate::repo_path::{RepoPath, RepoPathComponent, RepoPathComponentBuf};
 use crate::store::Store;
 use crate::tree::{try_resolve_file_conflict, Tree, TreeMergeError};
 use crate::tree_builder::TreeBuilder;
@@ -268,7 +268,8 @@ impl MergedTree {
         }
     }
 
-    fn sub_tree_recursive(&self, components: &[RepoPathComponent]) -> Option<MergedTree> {
+    // TODO: switch to borrowed &RepoPath type or RepoPathComponents iterator
+    fn sub_tree_recursive(&self, components: &[RepoPathComponentBuf]) -> Option<MergedTree> {
         if let Some((first, tail)) = components.split_first() {
             tail.iter()
                 .try_fold(self.sub_tree(first)?, |tree, name| tree.sub_tree(name))

--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -30,7 +30,7 @@ use crate::backend::{
 use crate::files::MergeResult;
 use crate::matchers::{EverythingMatcher, Matcher};
 use crate::merge::{trivial_merge, Merge, MergedTreeValue};
-use crate::repo_path::{RepoPath, RepoPathComponent};
+use crate::repo_path::{RepoPath, RepoPathComponent, RepoPathComponentBuf};
 use crate::store::Store;
 use crate::{backend, files};
 
@@ -159,7 +159,8 @@ impl Tree {
         self.store.get_tree(subdir, id).unwrap()
     }
 
-    fn sub_tree_recursive(&self, components: &[RepoPathComponent]) -> Option<Tree> {
+    // TODO: switch to borrowed &RepoPath type or RepoPathComponents iterator
+    fn sub_tree_recursive(&self, components: &[RepoPathComponentBuf]) -> Option<Tree> {
         if let Some((first, tail)) = components.split_first() {
             tail.iter()
                 .try_fold(self.sub_tree(first)?, |tree, name| tree.sub_tree(name))

--- a/lib/src/tree_builder.rs
+++ b/lib/src/tree_builder.rs
@@ -82,7 +82,7 @@ impl TreeBuilder {
             let tree = trees_to_write.get_mut(&dir).unwrap();
             match file_override {
                 Override::Replace(value) => {
-                    tree.set(basename.clone(), value);
+                    tree.set(basename.to_owned(), value);
                 }
                 Override::Tombstone => {
                     tree.remove(basename);
@@ -104,7 +104,7 @@ impl TreeBuilder {
                     }
                 } else {
                     let tree = store.write_tree(&dir, tree).unwrap();
-                    parent_tree.set(basename.clone(), TreeValue::Tree(tree.id().clone()));
+                    parent_tree.set(basename.to_owned(), TreeValue::Tree(tree.id().clone()));
                 }
             } else {
                 // We're writing the root tree. Write it even if empty. Return its id.

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -145,7 +145,7 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
                 Merge::normal(TreeValue::Symlink(id))
             }
             Kind::Tree => {
-                let file_path = path.join(&RepoPathComponent::from("file"));
+                let file_path = path.join(RepoPathComponent::new("file"));
                 let id = testutils::write_file(store, &file_path, "normal file contents");
                 let value = TreeValue::File {
                     id,
@@ -348,7 +348,7 @@ fn test_conflicting_changes_on_disk() {
         &[
             (&file_file_path, "committed contents"),
             (
-                &file_dir_path.join(&RepoPathComponent::from("file")),
+                &file_dir_path.join(RepoPathComponent::new("file")),
                 "committed contents",
             ),
             (&dir_file_path, "committed contents"),

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -83,36 +83,36 @@ fn test_same_type() {
 
     // Check that the simple, non-conflicting cases were resolved correctly
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("__a")),
-        side2_tree.value(&RepoPathComponent::from("__a"))
+        merged_tree.value(RepoPathComponent::new("__a")),
+        side2_tree.value(RepoPathComponent::new("__a"))
     );
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("_a_")),
-        side1_tree.value(&RepoPathComponent::from("_a_"))
+        merged_tree.value(RepoPathComponent::new("_a_")),
+        side1_tree.value(RepoPathComponent::new("_a_"))
     );
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("_aa")),
-        side1_tree.value(&RepoPathComponent::from("_aa"))
+        merged_tree.value(RepoPathComponent::new("_aa")),
+        side1_tree.value(RepoPathComponent::new("_aa"))
     );
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("aaa")),
-        side1_tree.value(&RepoPathComponent::from("aaa"))
+        merged_tree.value(RepoPathComponent::new("aaa")),
+        side1_tree.value(RepoPathComponent::new("aaa"))
     );
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("aab")),
-        side2_tree.value(&RepoPathComponent::from("aab"))
+        merged_tree.value(RepoPathComponent::new("aab")),
+        side2_tree.value(RepoPathComponent::new("aab"))
     );
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("aba")),
-        side1_tree.value(&RepoPathComponent::from("aba"))
+        merged_tree.value(RepoPathComponent::new("aba")),
+        side1_tree.value(RepoPathComponent::new("aba"))
     );
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("abb")),
-        side1_tree.value(&RepoPathComponent::from("abb"))
+        merged_tree.value(RepoPathComponent::new("abb")),
+        side1_tree.value(RepoPathComponent::new("abb"))
     );
 
     // Check the conflicting cases
-    let component = &RepoPathComponent::from("_ab");
+    let component = RepoPathComponent::new("_ab");
     match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
@@ -129,7 +129,7 @@ fn test_same_type() {
         }
         _ => panic!("unexpected value"),
     };
-    let component = &RepoPathComponent::from("a_b");
+    let component = RepoPathComponent::new("a_b");
     match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
@@ -146,7 +146,7 @@ fn test_same_type() {
         }
         _ => panic!("unexpected value"),
     };
-    let component = &RepoPathComponent::from("ab_");
+    let component = RepoPathComponent::new("ab_");
     match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
@@ -163,7 +163,7 @@ fn test_same_type() {
         }
         _ => panic!("unexpected value"),
     };
-    let component = &RepoPathComponent::from("abc");
+    let component = RepoPathComponent::new("abc");
     match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
@@ -221,16 +221,16 @@ fn test_executable() {
     let merged_tree = merge_trees(&side1_tree, &base_tree, &side2_tree).unwrap();
 
     // Check that the merged tree has the correct executable bits
-    let norm = base_tree.value(&RepoPathComponent::from("nnn"));
-    let exec = base_tree.value(&RepoPathComponent::from("xxx"));
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("nnn")), norm);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("nnx")), exec);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("nxn")), exec);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("nxx")), exec);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("xnn")), norm);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("xnx")), norm);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("xxn")), norm);
-    assert_eq!(merged_tree.value(&RepoPathComponent::from("xxx")), exec);
+    let norm = base_tree.value(RepoPathComponent::new("nnn"));
+    let exec = base_tree.value(RepoPathComponent::new("xxx"));
+    assert_eq!(merged_tree.value(RepoPathComponent::new("nnn")), norm);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("nnx")), exec);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("nxn")), exec);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("nxx")), exec);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("xnn")), norm);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("xnx")), norm);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("xxn")), norm);
+    assert_eq!(merged_tree.value(RepoPathComponent::new("xxx")), exec);
 }
 
 #[test]
@@ -411,7 +411,7 @@ fn test_types() {
     let merged_tree = merge_trees(&side1_tree, &base_tree, &side2_tree).unwrap();
 
     // Check the conflicting cases
-    let component = &RepoPathComponent::from("normal_executable_symlink");
+    let component = RepoPathComponent::new("normal_executable_symlink");
     match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
@@ -431,7 +431,7 @@ fn test_types() {
         }
         _ => panic!("unexpected value"),
     };
-    let component = &RepoPathComponent::from("tree_normal_symlink");
+    let component = RepoPathComponent::new("tree_normal_symlink");
     match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
@@ -456,7 +456,7 @@ fn test_simplify_conflict() {
     let repo = &test_repo.repo;
     let store = repo.store();
 
-    let component = &RepoPathComponent::from("file");
+    let component = RepoPathComponent::new("file");
     let path = RepoPath::from_internal_string("file");
     let write_tree = |contents: &str| -> Tree { create_single_tree(repo, &[(&path, contents)]) };
 
@@ -495,7 +495,7 @@ fn test_simplify_conflict() {
     match further_rebased_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
-                .read_conflict(&RepoPath::from_components(vec![component.clone()]), id)
+                .read_conflict(&RepoPath::from_components(vec![component.to_owned()]), id)
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -112,15 +112,15 @@ fn test_same_type() {
     );
 
     // Check the conflicting cases
-    let component = RepoPathComponent::from("_ab");
-    match merged_tree.value(&component).unwrap() {
+    let component = &RepoPathComponent::from("_ab");
+    match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(&RepoPath::from_internal_string("_ab"), id)
                 .unwrap();
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
-                vec![side1_tree.value(&component), side2_tree.value(&component)]
+                vec![side1_tree.value(component), side2_tree.value(component)]
             );
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
@@ -129,53 +129,53 @@ fn test_same_type() {
         }
         _ => panic!("unexpected value"),
     };
-    let component = RepoPathComponent::from("a_b");
-    match merged_tree.value(&component).unwrap() {
+    let component = &RepoPathComponent::from("a_b");
+    match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(&RepoPath::from_internal_string("a_b"), id)
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
-                vec![side2_tree.value(&component), None]
+                vec![side2_tree.value(component), None]
             );
         }
         _ => panic!("unexpected value"),
     };
-    let component = RepoPathComponent::from("ab_");
-    match merged_tree.value(&component).unwrap() {
+    let component = &RepoPathComponent::from("ab_");
+    match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(&RepoPath::from_internal_string("ab_"), id)
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
-                vec![side1_tree.value(&component), None]
+                vec![side1_tree.value(component), None]
             );
         }
         _ => panic!("unexpected value"),
     };
-    let component = RepoPathComponent::from("abc");
-    match merged_tree.value(&component).unwrap() {
+    let component = &RepoPathComponent::from("abc");
+    match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(&RepoPath::from_internal_string("abc"), id)
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
-                vec![side1_tree.value(&component), side2_tree.value(&component)]
+                vec![side1_tree.value(component), side2_tree.value(component)]
             );
         }
         _ => panic!("unexpected value"),
@@ -411,8 +411,8 @@ fn test_types() {
     let merged_tree = merge_trees(&side1_tree, &base_tree, &side2_tree).unwrap();
 
     // Check the conflicting cases
-    let component = RepoPathComponent::from("normal_executable_symlink");
-    match merged_tree.value(&component).unwrap() {
+    let component = &RepoPathComponent::from("normal_executable_symlink");
+    match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(
@@ -422,28 +422,28 @@ fn test_types() {
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
-                vec![side1_tree.value(&component), side2_tree.value(&component)]
+                vec![side1_tree.value(component), side2_tree.value(component)]
             );
         }
         _ => panic!("unexpected value"),
     };
-    let component = RepoPathComponent::from("tree_normal_symlink");
-    match merged_tree.value(&component).unwrap() {
+    let component = &RepoPathComponent::from("tree_normal_symlink");
+    match merged_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(&RepoPath::from_internal_string("tree_normal_symlink"), id)
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
-                vec![side1_tree.value(&component), side2_tree.value(&component)]
+                vec![side1_tree.value(component), side2_tree.value(component)]
             );
         }
         _ => panic!("unexpected value"),
@@ -456,7 +456,7 @@ fn test_simplify_conflict() {
     let repo = &test_repo.repo;
     let store = repo.store();
 
-    let component = RepoPathComponent::from("file");
+    let component = &RepoPathComponent::from("file");
     let path = RepoPath::from_internal_string("file");
     let write_tree = |contents: &str| -> Tree { create_single_tree(repo, &[(&path, contents)]) };
 
@@ -468,7 +468,7 @@ fn test_simplify_conflict() {
     // Rebase the branch tree to the first upstream tree
     let rebased1_tree = merge_trees(&branch_tree, &base_tree, &upstream1_tree).unwrap();
     // Make sure we have a conflict (testing the test setup)
-    match rebased1_tree.value(&component).unwrap() {
+    match rebased1_tree.value(component).unwrap() {
         TreeValue::Conflict(_) => {
             // expected
         }
@@ -479,33 +479,33 @@ fn test_simplify_conflict() {
     // both directions.
     let rebased_back_tree = merge_trees(&rebased1_tree, &upstream1_tree, &base_tree).unwrap();
     assert_eq!(
-        rebased_back_tree.value(&component),
-        branch_tree.value(&component)
+        rebased_back_tree.value(component),
+        branch_tree.value(component)
     );
     let rebased_back_tree = merge_trees(&base_tree, &upstream1_tree, &rebased1_tree).unwrap();
     assert_eq!(
-        rebased_back_tree.value(&component),
-        branch_tree.value(&component)
+        rebased_back_tree.value(component),
+        branch_tree.value(component)
     );
 
     // Rebase the rebased tree further upstream. The conflict should be simplified
     // to not mention the contents from the first rebase.
     let further_rebased_tree =
         merge_trees(&rebased1_tree, &upstream1_tree, &upstream2_tree).unwrap();
-    match further_rebased_tree.value(&component).unwrap() {
+    match further_rebased_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store
                 .read_conflict(&RepoPath::from_components(vec![component.clone()]), id)
                 .unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
                 vec![
-                    branch_tree.value(&component),
-                    upstream2_tree.value(&component),
+                    branch_tree.value(component),
+                    upstream2_tree.value(component),
                 ]
             );
         }
@@ -513,18 +513,18 @@ fn test_simplify_conflict() {
     };
     let further_rebased_tree =
         merge_trees(&upstream2_tree, &upstream1_tree, &rebased1_tree).unwrap();
-    match further_rebased_tree.value(&component).unwrap() {
+    match further_rebased_tree.value(component).unwrap() {
         TreeValue::Conflict(id) => {
             let conflict = store.read_conflict(&path, id).unwrap();
             assert_eq!(
                 conflict.removes().map(|v| v.as_ref()).collect_vec(),
-                vec![base_tree.value(&component)]
+                vec![base_tree.value(component)]
             );
             assert_eq!(
                 conflict.adds().map(|v| v.as_ref()).collect_vec(),
                 vec![
-                    upstream2_tree.value(&component),
-                    branch_tree.value(&component)
+                    upstream2_tree.value(component),
+                    branch_tree.value(component)
                 ]
             );
         }

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -123,10 +123,10 @@ fn test_from_legacy_tree() {
     tree_builder.set(file5_path.clone(), TreeValue::Conflict(file5_conflict_id));
 
     // dir1: directory without conflicts
-    let dir1_basename = &RepoPathComponent::from("dir1");
+    let dir1_basename = RepoPathComponent::new("dir1");
     let dir1_filename = RepoPath::root()
         .join(dir1_basename)
-        .join(&RepoPathComponent::from("file"));
+        .join(RepoPathComponent::new("file"));
     let dir1_filename_id = write_file(store.as_ref(), &dir1_filename, "file5_v2");
     tree_builder.set(dir1_filename.clone(), file_value(&dir1_filename_id));
 
@@ -135,7 +135,7 @@ fn test_from_legacy_tree() {
 
     let merged_tree = MergedTree::from_legacy_tree(tree.clone()).unwrap();
     assert_eq!(
-        merged_tree.value(&RepoPathComponent::from("missing")),
+        merged_tree.value(RepoPathComponent::new("missing")),
         MergedTreeVal::Resolved(None)
     );
     // file1: regular file without conflicts
@@ -373,11 +373,11 @@ fn test_resolve_success() {
     let trivial_file_path = RepoPath::from_internal_string("trivial-file");
     let trivial_hunk_path = RepoPath::from_internal_string("trivial-hunk");
     let both_added_dir_path = RepoPath::from_internal_string("added-dir");
-    let both_added_dir_file1_path = both_added_dir_path.join(&RepoPathComponent::from("file1"));
-    let both_added_dir_file2_path = both_added_dir_path.join(&RepoPathComponent::from("file2"));
+    let both_added_dir_file1_path = both_added_dir_path.join(RepoPathComponent::new("file1"));
+    let both_added_dir_file2_path = both_added_dir_path.join(RepoPathComponent::new("file2"));
     let emptied_dir_path = RepoPath::from_internal_string("to-become-empty");
-    let emptied_dir_file1_path = emptied_dir_path.join(&RepoPathComponent::from("file1"));
-    let emptied_dir_file2_path = emptied_dir_path.join(&RepoPathComponent::from("file2"));
+    let emptied_dir_file1_path = emptied_dir_path.join(RepoPathComponent::new("file1"));
+    let emptied_dir_file2_path = emptied_dir_path.join(RepoPathComponent::new("file2"));
     let base1 = create_single_tree(
         repo,
         &[
@@ -503,7 +503,7 @@ fn test_conflict_iterator() {
             (&dir_file_path, "base"),
             // no added_dir_path
             (
-                &modify_delete_dir_path.join(&RepoPathComponent::from("base")),
+                &modify_delete_dir_path.join(RepoPathComponent::new("base")),
                 "base",
             ),
         ],
@@ -520,11 +520,11 @@ fn test_conflict_iterator() {
             (&different_add_path, "side1"),
             (&dir_file_path, "side1"),
             (
-                &added_dir_path.join(&RepoPathComponent::from("side1")),
+                &added_dir_path.join(RepoPathComponent::new("side1")),
                 "side1",
             ),
             (
-                &modify_delete_dir_path.join(&RepoPathComponent::from("side1")),
+                &modify_delete_dir_path.join(RepoPathComponent::new("side1")),
                 "side1",
             ),
         ],
@@ -539,9 +539,9 @@ fn test_conflict_iterator() {
             // no modify_delete_path
             (&same_add_path, "same"),
             (&different_add_path, "side2"),
-            (&dir_file_path.join(&RepoPathComponent::from("dir")), "new"),
+            (&dir_file_path.join(RepoPathComponent::new("dir")), "new"),
             (
-                &added_dir_path.join(&RepoPathComponent::from("side2")),
+                &added_dir_path.join(RepoPathComponent::new("side2")),
                 "side2",
             ),
             // no modify_delete_dir_path
@@ -859,7 +859,7 @@ fn test_diff_dir_file() {
     let path4 = RepoPath::from_internal_string("path4");
     let path5 = RepoPath::from_internal_string("path5");
     let path6 = RepoPath::from_internal_string("path6");
-    let file = &RepoPathComponent::from("file");
+    let file = RepoPathComponent::new("file");
     let left_base = create_single_tree(
         repo,
         &[

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -123,9 +123,9 @@ fn test_from_legacy_tree() {
     tree_builder.set(file5_path.clone(), TreeValue::Conflict(file5_conflict_id));
 
     // dir1: directory without conflicts
-    let dir1_basename = RepoPathComponent::from("dir1");
+    let dir1_basename = &RepoPathComponent::from("dir1");
     let dir1_filename = RepoPath::root()
-        .join(&dir1_basename)
+        .join(dir1_basename)
         .join(&RepoPathComponent::from("file"));
     let dir1_filename_id = write_file(store.as_ref(), &dir1_filename, "file5_v2");
     tree_builder.set(dir1_filename.clone(), file_value(&dir1_filename_id));
@@ -195,8 +195,8 @@ fn test_from_legacy_tree() {
     );
     // file6: directory without conflicts
     assert_eq!(
-        merged_tree.value(&dir1_basename),
-        MergedTreeVal::Resolved(tree.value(&dir1_basename))
+        merged_tree.value(dir1_basename),
+        MergedTreeVal::Resolved(tree.value(dir1_basename))
     );
 
     // Also test that MergedTreeBuilder can create the same tree by starting from an
@@ -859,7 +859,7 @@ fn test_diff_dir_file() {
     let path4 = RepoPath::from_internal_string("path4");
     let path5 = RepoPath::from_internal_string("path5");
     let path6 = RepoPath::from_internal_string("path6");
-    let file = RepoPathComponent::from("file");
+    let file = &RepoPathComponent::from("file");
     let left_base = create_single_tree(
         repo,
         &[
@@ -867,8 +867,8 @@ fn test_diff_dir_file() {
             (&path2, "left"),
             (&path3, "left"),
             (&path4, "left-base"),
-            (&path5.join(&file), "left"),
-            (&path6.join(&file), "left"),
+            (&path5.join(file), "left"),
+            (&path6.join(file), "left"),
         ],
     );
     let left_side1 = create_single_tree(
@@ -878,8 +878,8 @@ fn test_diff_dir_file() {
             (&path2, "left"),
             (&path3, "left"),
             (&path4, "left-side1"),
-            (&path5.join(&file), "left"),
-            (&path6.join(&file), "left"),
+            (&path5.join(file), "left"),
+            (&path6.join(file), "left"),
         ],
     );
     let left_side2 = create_single_tree(
@@ -889,17 +889,17 @@ fn test_diff_dir_file() {
             (&path2, "left"),
             (&path3, "left"),
             (&path4, "left-side2"),
-            (&path5.join(&file), "left"),
-            (&path6.join(&file), "left"),
+            (&path5.join(file), "left"),
+            (&path6.join(file), "left"),
         ],
     );
     let right_base = create_single_tree(
         repo,
         &[
-            (&path1.join(&file), "right"),
+            (&path1.join(file), "right"),
             // path2 absent
             // path3 absent
-            (&path4.join(&file), "right-base"),
+            (&path4.join(file), "right-base"),
             // path5 is absent
             // path6 is absent
         ],
@@ -907,10 +907,10 @@ fn test_diff_dir_file() {
     let right_side1 = create_single_tree(
         repo,
         &[
-            (&path1.join(&file), "right"),
-            (&path2.join(&file), "right"),
-            (&path3.join(&file), "right-side1"),
-            (&path4.join(&file), "right-side1"),
+            (&path1.join(file), "right"),
+            (&path2.join(file), "right"),
+            (&path3.join(file), "right-side1"),
+            (&path4.join(file), "right-side1"),
             (&path5, "right-side1"),
             (&path6, "right"),
         ],
@@ -918,12 +918,12 @@ fn test_diff_dir_file() {
     let right_side2 = create_single_tree(
         repo,
         &[
-            (&path1.join(&file), "right"),
-            (&path2.join(&file), "right"),
+            (&path1.join(file), "right"),
+            (&path2.join(file), "right"),
             (&path3, "right-side2"),
-            (&path4.join(&file), "right-side2"),
+            (&path4.join(file), "right-side2"),
             (&path5, "right-side2"),
-            (&path6.join(&file), "right"),
+            (&path6.join(file), "right"),
         ],
     );
     let left_merged = MergedTree::new(Merge::from_removes_adds(
@@ -948,8 +948,8 @@ fn test_diff_dir_file() {
                 (left_merged.path_value(&path1), Merge::absent()),
             ),
             (
-                path1.join(&file),
-                (Merge::absent(), right_merged.path_value(&path1.join(&file))),
+                path1.join(file),
+                (Merge::absent(), right_merged.path_value(&path1.join(file))),
             ),
             // path2: file1 -> directory1+(directory2-absent)
             (
@@ -957,8 +957,8 @@ fn test_diff_dir_file() {
                 (left_merged.path_value(&path2), Merge::absent()),
             ),
             (
-                path2.join(&file),
-                (Merge::absent(), right_merged.path_value(&path2.join(&file))),
+                path2.join(file),
+                (Merge::absent(), right_merged.path_value(&path2.join(file))),
             ),
             // path3: file1 -> directory1+(file1-absent)
             (
@@ -974,13 +974,13 @@ fn test_diff_dir_file() {
                 (left_merged.path_value(&path4), Merge::absent()),
             ),
             (
-                path4.join(&file),
-                (Merge::absent(), right_merged.path_value(&path4.join(&file))),
+                path4.join(file),
+                (Merge::absent(), right_merged.path_value(&path4.join(file))),
             ),
             // path5: directory1 -> file1+(file2-absent)
             (
-                path5.join(&file),
-                (left_merged.path_value(&path5.join(&file)), Merge::absent()),
+                path5.join(file),
+                (left_merged.path_value(&path5.join(file)), Merge::absent()),
             ),
             (
                 path5.clone(),
@@ -988,8 +988,8 @@ fn test_diff_dir_file() {
             ),
             // path6: directory1 -> file1+(directory1-absent)
             (
-                path6.join(&file),
-                (left_merged.path_value(&path6.join(&file)), Merge::absent()),
+                path6.join(file),
+                (left_merged.path_value(&path6.join(file)), Merge::absent()),
             ),
             (
                 path6.clone(),
@@ -1009,8 +1009,8 @@ fn test_diff_dir_file() {
         let expected_diff = vec![
             // path1: file1 -> directory1
             (
-                path1.join(&file),
-                (right_merged.path_value(&path1.join(&file)), Merge::absent()),
+                path1.join(file),
+                (right_merged.path_value(&path1.join(file)), Merge::absent()),
             ),
             (
                 path1.clone(),
@@ -1018,8 +1018,8 @@ fn test_diff_dir_file() {
             ),
             // path2: file1 -> directory1+(directory2-absent)
             (
-                path2.join(&file),
-                (right_merged.path_value(&path2.join(&file)), Merge::absent()),
+                path2.join(file),
+                (right_merged.path_value(&path2.join(file)), Merge::absent()),
             ),
             (
                 path2.clone(),
@@ -1035,8 +1035,8 @@ fn test_diff_dir_file() {
             ),
             // path4: file1+(file2-file3) -> directory1+(directory2-directory3)
             (
-                path4.join(&file),
-                (right_merged.path_value(&path4.join(&file)), Merge::absent()),
+                path4.join(file),
+                (right_merged.path_value(&path4.join(file)), Merge::absent()),
             ),
             (
                 path4.clone(),
@@ -1048,8 +1048,8 @@ fn test_diff_dir_file() {
                 (right_merged.path_value(&path5), Merge::absent()),
             ),
             (
-                path5.join(&file),
-                (Merge::absent(), left_merged.path_value(&path5.join(&file))),
+                path5.join(file),
+                (Merge::absent(), left_merged.path_value(&path5.join(file))),
             ),
             // path6: directory1 -> file1+(directory1-absent)
             (
@@ -1057,8 +1057,8 @@ fn test_diff_dir_file() {
                 (right_merged.path_value(&path6), Merge::absent()),
             ),
             (
-                path6.join(&file),
-                (Merge::absent(), left_merged.path_value(&path6.join(&file))),
+                path6.join(file),
+                (Merge::absent(), left_merged.path_value(&path6.join(file))),
             ),
         ];
         assert_eq!(actual_diff, expected_diff);
@@ -1085,7 +1085,7 @@ fn test_diff_dir_file() {
 
     // Diff while filtering by `path1/file` (file1 -> directory1) as a file
     {
-        let matcher = FilesMatcher::new(&[path1.join(&file)]);
+        let matcher = FilesMatcher::new(&[path1.join(file)]);
         let actual_diff = left_merged
             .diff(&right_merged, &matcher)
             .map(|(path, diff)| (path, diff.unwrap()))
@@ -1093,8 +1093,8 @@ fn test_diff_dir_file() {
         let expected_diff = vec![
             // path1: file1 -> directory1
             (
-                path1.join(&file),
-                (Merge::absent(), right_merged.path_value(&path1.join(&file))),
+                path1.join(file),
+                (Merge::absent(), right_merged.path_value(&path1.join(file))),
             ),
         ];
         assert_eq!(actual_diff, expected_diff);
@@ -1114,8 +1114,8 @@ fn test_diff_dir_file() {
                 (left_merged.path_value(&path1), Merge::absent()),
             ),
             (
-                path1.join(&file),
-                (Merge::absent(), right_merged.path_value(&path1.join(&file))),
+                path1.join(file),
+                (Merge::absent(), right_merged.path_value(&path1.join(file))),
             ),
         ];
         assert_eq!(actual_diff, expected_diff);


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
