### PR TITLE
Do not allow `jj init --git` in existing Git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj branch set` no longer creates a new branch. Use `jj branch create`
   instead.
+  
+* `jj init --git` in an existing Git repository now errors and exits rather than
+  creating a second Git store.
 
 ### New features
 

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -418,16 +418,14 @@ fn test_init_git_external_but_git_dir_exists() {
 }
 
 #[test]
-fn test_init_git_internal_but_could_be_colocated() {
+fn test_init_git_internal_must_be_colocated() {
     let test_env = TestEnvironment::default();
     let workspace_root = test_env.env_root().join("repo");
     init_git_repo(&workspace_root, false);
 
-    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["init", "--git"]);
-    insta::assert_snapshot!(stdout, @"");
+    let stderr = test_env.jj_cmd_failure(&workspace_root, &["init", "--git"]);
     insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "."
-    Empty repo created.
+    Error: Did not create a jj repo because there is an existing Git repo in this directory.
     Hint: To create a repo backed by the existing Git repo, run `jj init --git-repo=.` instead.
     "###);
 }


### PR DESCRIPTION
Allowing `jj init --git` in an existing Git repo creates a second Git store in `.jj/repo/store/git`, totally disconnected from the existing Git store. This will only produce extremely confusing bugs for users, since any operations they make in Git will *not* be reflected in the jj repo.

Note: this is a tweak to the behavior as originally implemented in #687.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- N/A: ~~I have updated the documentation (README.md, docs/, demos/)~~
- N/A: ~~I have updated the config schema (cli/src/config-schema.json)~~
- [x] I have added tests to cover my changes
