### PR TITLE
cli rebase: do not allow `-r --skip-empty`

### DIFF
--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -72,6 +72,19 @@ fn test_rebase_invalid() {
     For more information, try '--help'.
     "###);
 
+    // Both -r and --skip-empty
+    let stderr = test_env.jj_cmd_cli_error(
+        &repo_path,
+        &["rebase", "-r", "a", "-d", "b", "--skip-empty"],
+    );
+    insta::assert_snapshot!(stderr, @r###"
+    error: the argument '--revision <REVISION>' cannot be used with '--skip-empty'
+
+    Usage: jj rebase --destination <DESTINATION> --revision <REVISION>
+
+    For more information, try '--help'.
+    "###);
+
     // Rebase onto self with -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "a"]);
     insta::assert_snapshot!(stderr, @r###"

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -215,7 +215,7 @@ pub fn back_out_commit(
         .write()?)
 }
 
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub enum EmptyBehaviour {
     /// Always keep empty commits
     #[default]
@@ -236,7 +236,7 @@ pub enum EmptyBehaviour {
 // change the RebaseOptions construction in the CLI, and changing the
 // rebase_commit function to actually use the flag, and ensure we don't need to
 // plumb it in.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct RebaseOptions {
     pub empty: EmptyBehaviour,
 }


### PR DESCRIPTION
This follows up on 3967f63 (see that commit's description for more motivation) and @matts1 's e79c8b6.

In a discussion linked below, it was decided that forbidding `-r --skip-empty` entirely is preferable to the mixed behavior introduced in 3967f63.

https://github.com/martinvonz/jj/commit/3967f637dc31abdf8ed8817a377defab70821e37#commitcomment-133539911

# Checklist

If applicable:
- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (README.md, docs/, demos/)
- n/a I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
