### PR TITLE
gc: implement basic GC for Git backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj rebase` now takes the flag `--skip-empty`, which doesn't copy over commits
   that would become empty after a rebase.
 
+* There is a new `jj util gc` command for cleaning up the repository storage.
+  For now, it simply runs `git gc` on the backing Git repo (when using the Git
+  backend).
+
 ### Fixed bugs
 
 * Fixed another file conflict resolution issue where `jj status` would disagree

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -170,4 +170,8 @@ impl Backend for JitBackend {
     ) -> BackendResult<(CommitId, Commit)> {
         self.inner.write_commit(contents, sign_with)
     }
+
+    fn gc(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.inner.gc()
+    }
 }

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -130,8 +130,8 @@ repos may require you to deal with more involved Jujutsu and Git concepts.
 
 * In co-located repos with a very large number of branches or other refs, `jj`
   commands can get noticeably slower because of the automatic `jj git import`
-  executed on each command. This can be mitigated by occasionally running `git
-  pack-refs --all` to speed up the import.
+  executed on each command. This can be mitigated by occasionally running `jj util
+  gc` to speed up the import (that command includes packing the Git refs).
 
 * Git tools will have trouble with revisions that contain conflicted files. While
   `jj` renders these files with conflict markers in the working copy, they are

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -533,4 +533,8 @@ pub trait Backend: Send + Sync + Debug {
         contents: Commit,
         sign_with: Option<&mut SigningFn>,
     ) -> BackendResult<(CommitId, Commit)>;
+
+    /// Perform garbage collection.
+    // TODO: pass in the set of commits to keep here
+    fn gc(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -297,6 +297,10 @@ impl Backend for LocalBackend {
             .map_err(to_other_err)?;
         Ok((id, commit))
     }
+
+    fn gc(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
 }
 
 pub fn commit_to_proto(commit: &Commit) -> crate::protos::local_store::Commit {

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -265,4 +265,8 @@ impl Store {
     pub fn tree_builder(self: &Arc<Self>, base_tree_id: TreeId) -> TreeBuilder {
         TreeBuilder::new(self.clone(), base_tree_id)
     }
+
+    pub fn gc(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.backend.gc()
+    }
 }

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -292,4 +292,8 @@ impl Backend for TestBackend {
             .insert(id.clone(), contents.clone());
         Ok((id, contents))
     }
+
+    fn gc(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
This adds an initial `jj util gc` command, which simply calls `git gc` when using the Git backend. That should already be useful in non-colocated repos because it's not obvious how to GC (repack) such repos. In my own jj repo, it shrunk `.jj/repo/store/` from 2.4 GiB to 780 MiB, and `jj log --ignore-working-copy` was sped up from 157 ms to 86 ms.

I haven't added any tests because the functionality depends on having `git` binary on the PATH, which we don't yet depend on anywhere else. I think we'll still be able to test much of the future parts of garbage collection without a `git` binary because the interesting parts are about manipulating the Git repo before calling `git gc` on it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
