### PR TITLE
merge_tools.toml: add a comment to `meld-3` definition

### DIFF
--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -9,6 +9,7 @@ merge-args = ["$left", "$base", "$right", "-o", "$output", "--auto-merge"]
 
 [merge-tools.meld-3]
 program="meld"
+# If using this as a template, note that `$output` is repeated twice below
 edit-args = ["$left", "$output", "$right", "-o", "$output"]
 
 [merge-tools.vimdiff]


### PR DESCRIPTION
In https://github.com/martinvonz/jj/pull/2665#issuecomment-1837552283, a user used `$base` instead of one of the `$output`s and nothing worked. This seems like a natural mistake to make, the config is confusing.
