### PR TITLE
index: rename readonly index types, move `impl Index` to wrapper type

### DIFF
--- a/lib/src/default_index_store.rs
+++ b/lib/src/default_index_store.rs
@@ -370,7 +370,7 @@ pub enum IndexLoadError {
 // TODO: replace the table by a trie so we don't have to repeat the full commit
 //       ids
 // TODO: add a fanout table like git's commit graph has?
-pub(crate) struct ReadonlyIndexImpl {
+struct ReadonlyIndexImpl {
     parent_file: Option<Arc<ReadonlyIndexImpl>>,
     num_parent_commits: u32,
     name: String,
@@ -447,7 +447,7 @@ impl MutableIndexImpl {
         }
     }
 
-    pub(crate) fn incremental(parent_file: Arc<ReadonlyIndexImpl>) -> Self {
+    fn incremental(parent_file: Arc<ReadonlyIndexImpl>) -> Self {
         let num_parent_commits = parent_file.num_parent_commits + parent_file.num_local_commits;
         let commit_id_length = parent_file.commit_id_length;
         let change_id_length = parent_file.change_id_length;
@@ -1877,7 +1877,7 @@ impl ReadonlyIndexImpl {
         }))
     }
 
-    pub fn as_composite(&self) -> CompositeIndex {
+    fn as_composite(&self) -> CompositeIndex {
         CompositeIndex(self)
     }
 

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -14,7 +14,7 @@
 
 use itertools::Itertools;
 use jj_lib::commit::Commit;
-use jj_lib::default_index_store::ReadonlyIndexWrapper;
+use jj_lib::default_index_store::DefaultReadonlyIndex;
 use jj_lib::default_revset_engine::{evaluate, RevsetImpl};
 use jj_lib::repo::{ReadonlyRepo, Repo as _};
 use jj_lib::revset::ResolvedExpression;
@@ -29,7 +29,7 @@ fn revset_for_commits<'index>(
     let index = repo
         .readonly_index()
         .as_any()
-        .downcast_ref::<ReadonlyIndexWrapper>()
+        .downcast_ref::<DefaultReadonlyIndex>()
         .unwrap()
         .as_composite();
     let expression =

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -18,7 +18,7 @@ use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::commit_builder::CommitBuilder;
 use jj_lib::default_index_store::{
-    CompositeIndex, IndexPosition, MutableIndexImpl, ReadonlyIndexWrapper,
+    CompositeIndex, DefaultReadonlyIndex, IndexPosition, MutableIndexImpl,
 };
 use jj_lib::index::Index as _;
 use jj_lib::repo::{MutableRepo, ReadonlyRepo, Repo};
@@ -446,7 +446,7 @@ fn create_n_commits(
 fn as_readonly_composite(repo: &Arc<ReadonlyRepo>) -> CompositeIndex<'_> {
     repo.readonly_index()
         .as_any()
-        .downcast_ref::<ReadonlyIndexWrapper>()
+        .downcast_ref::<DefaultReadonlyIndex>()
         .unwrap()
         .as_composite()
 }

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -443,26 +443,20 @@ fn create_n_commits(
     tx.commit()
 }
 
-fn as_readonly_wrapper(repo: &Arc<ReadonlyRepo>) -> &ReadonlyIndexWrapper {
+fn as_readonly_composite(repo: &Arc<ReadonlyRepo>) -> CompositeIndex<'_> {
     repo.readonly_index()
         .as_any()
         .downcast_ref::<ReadonlyIndexWrapper>()
         .unwrap()
+        .as_composite()
 }
 
-fn as_readonly_composite(repo: &Arc<ReadonlyRepo>) -> CompositeIndex<'_> {
-    as_readonly_wrapper(repo).as_composite()
-}
-
-fn as_mutable_impl(repo: &MutableRepo) -> &MutableIndexImpl {
+fn as_mutable_composite(repo: &MutableRepo) -> CompositeIndex<'_> {
     repo.mutable_index()
         .as_any()
         .downcast_ref::<MutableIndexImpl>()
         .unwrap()
-}
-
-fn as_mutable_composite(repo: &MutableRepo) -> CompositeIndex<'_> {
-    as_mutable_impl(repo).as_composite()
+        .as_composite()
 }
 
 fn commits_by_level(repo: &Arc<ReadonlyRepo>) -> Vec<u32> {


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
