### PR TITLE
git: migrate export_refs() to gix::Repository

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1386,8 +1386,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             }
 
             if self.working_copy_shared_with_git {
-                let git_repo = self.user_repo.git_backend().unwrap().open_git_repo()?;
-                let failed_branches = git::export_refs(mut_repo, &git_repo)?;
+                let failed_branches = git::export_refs(mut_repo)?;
                 print_failed_git_export(ui, &failed_branches)?;
             }
 
@@ -1462,7 +1461,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             if let Some(wc_commit) = &maybe_new_wc_commit {
                 git::reset_head(tx.mut_repo(), &git_repo, wc_commit)?;
             }
-            let failed_branches = git::export_refs(tx.mut_repo(), &git_repo)?;
+            let failed_branches = git::export_refs(tx.mut_repo())?;
             print_failed_git_export(ui, &failed_branches)?;
         }
         self.user_repo = ReadonlyUserRepo::new(tx.commit());

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -1101,10 +1101,8 @@ fn cmd_git_export(
     _args: &GitExportArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let repo = workspace_command.repo();
-    let git_repo = get_git_repo(repo.store())?;
     let mut tx = workspace_command.start_transaction("export git refs");
-    let failed_branches = git::export_refs(tx.mut_repo(), &git_repo)?;
+    let failed_branches = git::export_refs(tx.mut_repo())?;
     tx.finish(ui)?;
     print_failed_git_export(ui, &failed_branches)?;
     Ok(())

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -517,7 +517,7 @@ fn pinned_commit_ids(view: &View) -> impl Iterator<Item = &CommitId> {
     .flat_map(|target| target.added_ids())
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum GitExportError {
     #[error("Git error: {0}")]
     InternalGitError(#[from] git2::Error),

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -526,14 +526,14 @@ pub enum GitExportError {
 }
 
 /// A ref we failed to export to Git, along with the reason it failed.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct FailedRefExport {
     pub name: RefName,
     pub reason: FailedRefExportReason,
 }
 
 /// The reason we failed to export a ref to Git.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum FailedRefExportReason {
     /// The name is not allowed in Git.
     InvalidGitName,

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1284,7 +1284,7 @@ fn test_export_refs_no_detach() {
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
 
     // Do an initial export to make sure `main` is considered
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         RefTarget::normal(jj_id(&commit1))
@@ -1314,14 +1314,14 @@ fn test_export_refs_branch_changed() {
     let mut_repo = tx.mut_repo();
     git::import_refs(mut_repo, &git_settings).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
 
     let new_commit = create_random_commit(mut_repo, &test_data.settings)
         .set_parents(vec![jj_id(&commit)])
         .write()
         .unwrap();
     mut_repo.set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         RefTarget::normal(new_commit.id().clone())
@@ -1353,14 +1353,14 @@ fn test_export_refs_current_branch_changed() {
     let mut_repo = tx.mut_repo();
     git::import_refs(mut_repo, &git_settings).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
 
     let new_commit = create_random_commit(mut_repo, &test_data.settings)
         .set_parents(vec![jj_id(&commit1)])
         .write()
         .unwrap();
     mut_repo.set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         RefTarget::normal(new_commit.id().clone())
@@ -1390,11 +1390,11 @@ fn test_export_refs_unborn_git_branch() {
     let mut_repo = tx.mut_repo();
     git::import_refs(mut_repo, &git_settings).unwrap();
     mut_repo.rebase_descendants(&test_data.settings).unwrap();
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
 
     let new_commit = write_random_commit(mut_repo, &test_data.settings);
     mut_repo.set_local_branch_target("main", RefTarget::normal(new_commit.id().clone()));
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         RefTarget::normal(new_commit.id().clone())
@@ -1444,7 +1444,7 @@ fn test_export_import_sequence() {
     mut_repo.set_local_branch_target("main", RefTarget::normal(commit_b.id().clone()));
 
     // Export the branch to git
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main"),
         RefTarget::normal(commit_b.id().clone())
@@ -1500,7 +1500,7 @@ fn test_import_export_non_tracking_branch() {
     );
 
     // Export the branch to git
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(mut_repo.get_git_ref("refs/heads/main"), RefTarget::absent());
 
     // Reimport with auto-local-branch on. Local branch shouldn't be created for
@@ -1572,7 +1572,7 @@ fn test_export_conflicts() {
     let commit_c = write_random_commit(mut_repo, &test_data.settings);
     mut_repo.set_local_branch_target("main", RefTarget::normal(commit_a.id().clone()));
     mut_repo.set_local_branch_target("feature", RefTarget::normal(commit_a.id().clone()));
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
 
     // Create a conflict and export. It should not be exported, but other changes
     // should be.
@@ -1584,7 +1584,7 @@ fn test_export_conflicts() {
             [commit_b.id().clone(), commit_c.id().clone()],
         ),
     );
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
     assert_eq!(
         git_repo
             .find_reference("refs/heads/feature")
@@ -1632,11 +1632,11 @@ fn test_export_branch_on_root_commit() {
         RefTarget::normal(mut_repo.store().root_commit_id().clone()),
     );
     assert_eq!(
-        git::export_refs(mut_repo),
-        Ok(vec![FailedRefExport {
+        git::export_refs(mut_repo).unwrap(),
+        vec![FailedRefExport {
             name: RefName::LocalBranch("on_root".to_string()),
             reason: FailedRefExportReason::OnRootCommit,
-        }])
+        }]
     );
 }
 
@@ -1765,7 +1765,7 @@ fn test_export_reexport_transitions() {
     ] {
         mut_repo.set_local_branch_target(branch, RefTarget::normal(commit_a.id().clone()));
     }
-    assert_eq!(git::export_refs(mut_repo), Ok(vec![]));
+    assert_eq!(git::export_refs(mut_repo).unwrap(), vec![]);
 
     // Make changes on the jj side
     for branch in ["AXA", "AXB", "AXX"] {


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
