### PR TITLE
cli `branch track`, `branch untrack`: document remote branches in `jj help`

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -150,7 +150,9 @@ pub struct BranchTrackArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
-    #[arg(required = true)]
+    ///
+    /// Examples: branch@remote, glob:main@*, glob:jjfan-*@upstream
+    #[arg(required = true, value_name = "BRANCH@REMOTE")]
     pub names: Vec<RemoteBranchNamePattern>,
 }
 
@@ -165,7 +167,9 @@ pub struct BranchUntrackArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
-    #[arg(required = true)]
+    ///
+    /// Examples: branch@remote, glob:main@*, glob:jjfan-*@upstream
+    #[arg(required = true, value_name = "BRANCH@REMOTE")]
     pub names: Vec<RemoteBranchNamePattern>,
 }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -812,7 +812,7 @@ fn test_branch_track_untrack_patterns() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "main"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_cli_error(&repo_path, &["branch", "track", "main"]), @r###"
-    error: invalid value 'main' for '<NAMES>...': remote branch must be specified in branch@remote form
+    error: invalid value 'main' for '<BRANCH@REMOTE>...': remote branch must be specified in branch@remote form
 
     For more information, try '--help'.
     "###);


### PR DESCRIPTION
This tries to clarify the fact that the branches must be remote and the syntax for specifying them as globs.

Cc @yuja, https://github.com/martinvonz/jj/pull/2625#discussion_r1423379351

Here is the result (excerpt):

```
$ jj branch track --help
Start tracking given remote branches

A tracking remote branch will be imported as a local branch of the same name. Changes to it
will propagate to the existing local branch on future pulls.

Usage: jj branch track [OPTIONS] <BRANCH@REMOTE>...

Arguments:
  <BRANCH@REMOTE>...
          Remote branches to track

          By default, the specified name matches exactly. Use `glob:` prefix to select
          branches by wildcard pattern. For details, see
          https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.

          Examples: branch@remote, glob:main@*, glob:jjfan-*@upstream
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
