### PR TITLE
Implement a `rename` subcommand for the `branch` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 
 * Information about new and resolved conflicts is now printed by every command.
+* `jj branch` has gained a new `rename` subcommand that allows changing a branch
+  name atomically. `jj branch help rename` for details.
 
 ### Fixed bugs
 


### PR DESCRIPTION
## Summary
This is really a simple change that does the following in a transaction:

* Set the new branch name to point to the same commit as the old branch name.
* Set the old branch name to point to no commit (hence deleting the old name).

Before it starts, it confirms that the new branch name is not already in use.

## Changes
1. Add `Rename` variant to `BranchSubcommands` enum.
2. Create `BranchRenameArgs` struct needed by `BranchSubcommands::Rename`
3. Implement `cmd_branch_rename`


Fixed: #1457

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
   > N/A
- [ ] I have updated the config schema (cli/src/config-schema.json)
   > N/A
- [x] I have added tests to cover my changes