### PR TITLE
revset: remove 'index lifetime from InternalRevset

### DIFF
--- a/lib/src/default_index/entry.rs
+++ b/lib/src/default_index/entry.rs
@@ -14,7 +14,6 @@
 
 #![allow(missing_docs)]
 
-use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 
@@ -104,21 +103,6 @@ impl<'a> IndexEntry<'a> {
         self.parent_positions()
             .into_iter()
             .map(move |pos| composite.entry_by_pos(pos))
-    }
-}
-
-#[derive(Clone, Eq, PartialEq)]
-pub struct IndexEntryByPosition<'a>(pub IndexEntry<'a>);
-
-impl Ord for IndexEntryByPosition<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.pos.cmp(&other.0.pos)
-    }
-}
-
-impl PartialOrd for IndexEntryByPosition<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -22,7 +22,7 @@ mod rev_walk;
 mod store;
 
 pub use self::composite::{CompositeIndex, IndexLevelStats, IndexStats};
-pub use self::entry::{IndexEntry, IndexEntryByPosition, IndexPosition};
+pub use self::entry::{IndexEntry, IndexPosition};
 pub use self::mutable::DefaultMutableIndex;
 pub use self::readonly::DefaultReadonlyIndex;
 pub use self::rev_walk::{


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
