### PR TITLE
github: try without grouped cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
   open-pull-requests-limit: 10
   commit-message:
     prefix: "cargo:"
-  groups:
-    cargo-dependencies:
-      patterns:
-      - "*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
I noticed some cargo dependencies aren't caught by the dependabot. For example, there are gix updates, but the dependabot somehow thinks it's not possible to update.

```
updater | 2023/12/14 15:57:52 INFO <job_762380319> Checking if gix 0.55.2 needs updating
  proxy | 2023/12/14 15:57:52 [063] GET https://crates.io:443/api/v1/crates/gix
  proxy | 2023/12/14 15:57:52 [063] 200 https://crates.io:443/api/v1/crates/gix
updater | 2023/12/14 15:57:53 INFO <job_762380319> Latest version is 0.56.0
...
updater | 2023/12/14 15:58:00 INFO <job_762380319> Requirements to unlock update_not_possible
updater | 2023/12/14 15:58:00 INFO <job_762380319> Requirements update strategy bump_versions
updater | 2023/12/14 15:58:00 INFO <job_762380319> No update possible for gix 0.55.2
```

I don't know what's wrong, but let's try without the grouped updates as it was working before.

FWIW, this issue looks similar:
https://github.com/dependabot/dependabot-core/issues/7896

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
