### PR TITLE
cli `untrack --help`: mention that files need to be already be ignored

### DIFF
--- a/cli/src/commands/untrack.rs
+++ b/cli/src/commands/untrack.rs
@@ -27,7 +27,10 @@ use crate::ui::Ui;
 /// Stop tracking specified paths in the working copy
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct UntrackArgs {
-    /// Paths to untrack
+    /// Paths to untrack. They must already be ignored.
+    ///
+    /// The paths could be ignored via a .gitignore or .git/info/exclude (in
+    /// colocated repos).
     #[arg(required = true, value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
 }


### PR DESCRIPTION
Make it clearer what the command does, make the error message when the file
is not ignored less of a surprise.

Also, I think it's nice to mention `.git/info/exclude`, since the path is
not trivial to remember.

--------

This is a bit of a draft; I think it's OK as is, but it's not perfect. Are there FAQ 
entries I could link to? Should we recommend something instead of `.git/info/exclude`
for non-colocated repos?