### PR TITLE
cli: allow arg list in `ui.default-command`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* `ui.default-command` now accepts a both a list of arguments (eg: `["log", "-l", "5"]`),
+  or just the command name (eg: `"log"`, like before).
+
 ### Breaking changes
 
 ### New features

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2658,7 +2658,7 @@ fn resolve_default_command(
 
     if let Some(matches) = matches {
         if matches.subcommand_name().is_none() {
-            let mut default_command = match config.get("ui.default-command") {
+            let default_command = match config.get("ui.default-command") {
                 Err(_) | Ok(CommandNameAndArgs::Structured { .. }) => {
                     writeln!(
                         ui.hint(),
@@ -2674,11 +2674,11 @@ fn resolve_default_command(
                 Ok(CommandNameAndArgs::String(name)) => vec![name],
                 Ok(CommandNameAndArgs::Vec(v)) => v.into(),
             };
-            default_command.reverse();
-            for arg in default_command {
-                // Insert the default command directly after the path to the binary.
-                string_args.insert(1, arg);
-            }
+            // Insert the default command directly after the path to the binary.
+            //
+            // default_command = [cmd, argA, argB]
+            // string_args = [jj, ...default_command, arg0, arg1]
+            let _: Vec<_> = string_args.splice(1..1, default_command).collect();
         }
     }
     Ok(string_args)

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -45,6 +45,17 @@
                     "type": "string",
                     "description": "Default command to run when no explicit command is given",
                     "default": "log"
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 },
                 "default-description": {
                     "type": "string",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -525,6 +525,12 @@ impl TryFrom<Vec<String>> for NonEmptyCommandArgsVec {
     }
 }
 
+impl From<NonEmptyCommandArgsVec> for Vec<String> {
+    fn from(args: NonEmptyCommandArgsVec) -> Self {
+        args.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use maplit::hashmap;

--- a/docs/config.md
+++ b/docs/config.md
@@ -132,7 +132,10 @@ When `jj` is run with no explicit subcommand, the value of the
 subcommand name, subcommand alias, or user-defined alias (defaults to `"log"`).
 
 ```toml
+# No arguments
 ui.default-command = "log"
+# With arguments
+ui.default-command = ["log", "-r", "::@", "-l", "5"]
 ```
 
 ### Default description


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Summary

Hello, I use `ui.default-command` a lot, but I miss it having default arguments too.

Since `ui.diff.tool` accepts both `String` and `Vec<String>`, I thought it wouldn't be a problem to implement it. If this is against any design consideration you all have, feel free to close it.

Thanks a lot for the CLI though, I've been enjoying it a lot over `git` :blush: 

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
> I'm not sure this is necessary
