### PR TITLE
two minor documentation improvements

### DIFF
--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -48,6 +48,11 @@ pub(crate) struct DescribeArgs {
     /// Reset the author to the configured user
     ///
     /// This resets the author name, email, and timestamp.
+    ///
+    /// You can use it in combination with the JJ_USER and JJ_EMAIL
+    /// environment variables to set a different author:
+    ///
+    /// $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj describe --reset-author
     #[arg(long)]
     reset_author: bool,
 }

--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -189,6 +189,11 @@ parent.
       <td><code>git log</code></td>
     </tr>
     <tr>
+      <td>Search among files versioned in the repository</td>
+      <td><code>grep foo $(jj files)</code></td>
+      <td><code>git grep foo</code></td>
+    </tr>
+    <tr>
       <td>Abandon the current change and start a new change</td>
       <td><code>jj abandon</code></td>
       <td><code>git reset --hard</code> (cannot be undone)</td>


### PR DESCRIPTION
1. Document the use of `JJ_USER='Foo Bar' JJ_EMAIL=foo.bar@example.com describe --reset--author` to set the author, mentioned by @dbarnett in https://github.com/martinvonz/jj/issues/328#issuecomment-1475583173

2. In git-comparison.md, propose a way to do `git grep foo` -- `grep foo $(jj files)`.