### PR TITLE
Implementation of the rest of the gpg signing support

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2602,7 +2602,6 @@ pub struct EarlyArgs {
     /// Disable the pager
     #[arg(
         long,
-        value_name = "WHEN",
         global = true,
         help_heading = "Global Options",
         action = ArgAction::SetTrue
@@ -2610,6 +2609,25 @@ pub struct EarlyArgs {
     // Parsing with ignore_errors will crash if this is bool, so use
     // Option<bool>.
     pub no_pager: Option<bool>,
+    /// Override the configured key to be used for the commit signing.
+    /// Is only used when a commit signing operation has to be performed by the
+    /// operation.
+    #[arg(
+        long,
+        value_name = "KEY",
+        global = true,
+        help_heading = "Global Options"
+    )]
+    pub sign_with: Option<String>,
+    /// Don't sign unsigned commits when configured to sign all, is ignored
+    /// otherwise.
+    #[arg(
+        long,
+        global = true,
+        help_heading = "Global Options",
+        action = ArgAction::SetTrue
+    )]
+    pub no_sign: Option<bool>,
     /// Additional configuration options (can be repeated)
     //  TODO: Introduce a `--config` option with simpler syntax for simple
     //  cases, designed so that `--config ui.color=auto` works
@@ -2801,6 +2819,13 @@ fn handle_early_args(
     }
     if args.no_pager.unwrap_or_default() {
         args.config_toml.push(r#"ui.paginate="never""#.to_owned());
+    }
+    if let Some(key) = args.sign_with {
+        args.config_toml.push(format!(r#"signing.key="{key}""#));
+    }
+    if args.no_sign.unwrap_or_default() {
+        args.config_toml
+            .push(r#"signing.sign-all=false"#.to_owned());
     }
     if !args.config_toml.is_empty() {
         layered_configs.parse_config_args(&args.config_toml)?;

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -17,7 +17,9 @@ use std::io::{self, Read, Write};
 use jj_lib::backend::ObjectId;
 use tracing::instrument;
 
-use crate::cli_util::{join_message_paragraphs, CommandError, CommandHelper, RevisionArg};
+use crate::cli_util::{
+    check_dropped_signature, join_message_paragraphs, CommandError, CommandHelper, RevisionArg,
+};
 use crate::description_util::{description_template_for_describe, edit_description};
 use crate::ui::Ui;
 
@@ -91,7 +93,8 @@ pub(crate) fn cmd_describe(
             let new_author = commit_builder.committer().clone();
             commit_builder = commit_builder.set_author(new_author);
         }
-        commit_builder.write()?;
+        let rewritten = commit_builder.write()?;
+        check_dropped_signature(ui, &commit, &rewritten)?;
         tx.finish(ui, format!("describe commit {}", commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -19,7 +19,7 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;
 
-use crate::cli_util::{CommandError, CommandHelper, RevisionArg};
+use crate::cli_util::{print_dropped_signatures, CommandError, CommandHelper, RevisionArg};
 use crate::ui::Ui;
 
 /// Touch up the content changes in a revision with a diff editor
@@ -102,13 +102,15 @@ don't make any changes, then the operation will be aborted.",
             .write()?;
         // rebase_descendants early; otherwise `new_commit` would always have
         // a conflicted change id at this point.
-        let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
         write!(ui.stderr(), "Created ")?;
         tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
         writeln!(ui.stderr())?;
+        let num_rebased = rebase_counts.rebased;
         if num_rebased > 0 {
             writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
         }
+        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
         tx.finish(ui, format!("edit commit {}", target_commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -45,6 +45,7 @@ mod resolve;
 mod restore;
 mod run;
 mod show;
+mod sign;
 mod sparse;
 mod split;
 mod squash;
@@ -122,6 +123,7 @@ enum Command {
     // TODO: Flesh out.
     Run(run::RunArgs),
     Show(show::ShowArgs),
+    Sign(sign::SignArgs),
     #[command(subcommand)]
     Sparse(sparse::SparseArgs),
     Split(split::SplitArgs),
@@ -162,6 +164,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Cat(sub_args) => cat::cmd_cat(ui, command_helper, sub_args),
         Command::Diff(sub_args) => diff::cmd_diff(ui, command_helper, sub_args),
         Command::Show(sub_args) => show::cmd_show(ui, command_helper, sub_args),
+        Command::Sign(sub_args) => sign::cmd_sign(ui, command_helper, sub_args),
         Command::Status(sub_args) => status::cmd_status(ui, command_helper, sub_args),
         Command::Log(sub_args) => log::cmd_log(ui, command_helper, sub_args),
         Command::Interdiff(sub_args) => interdiff::cmd_interdiff(ui, command_helper, sub_args),

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -27,8 +27,9 @@ use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
 use crate::cli_util::{
-    self, resolve_multiple_nonempty_revsets_default_single, short_commit_hash, user_error,
-    CommandError, CommandHelper, RevisionArg, WorkspaceCommandHelper,
+    self, print_dropped_signatures, resolve_multiple_nonempty_revsets_default_single,
+    short_commit_hash, user_error, CommandError, CommandHelper, RevisionArg,
+    WorkspaceCommandHelper,
 };
 use crate::ui::Ui;
 
@@ -280,18 +281,24 @@ fn rebase_descendants(
     let mut tx = workspace_command.start_transaction();
     // `rebase_descendants` takes care of sorting in reverse topological order, so
     // no need to do it here.
+    let mut dropped_signatures = 0;
     for old_commit in old_commits {
-        rebase_commit_with_options(
+        let rebased = rebase_commit_with_options(
             settings,
             tx.mut_repo(),
             old_commit,
             new_parents,
             &rebase_options,
         )?;
+        if old_commit.is_signed() && !rebased.is_signed() {
+            dropped_signatures += 1;
+        }
     }
-    let num_rebased = old_commits.len()
-        + tx.mut_repo()
-            .rebase_descendants_with_options(settings, rebase_options)?;
+    let counts = tx
+        .mut_repo()
+        .rebase_descendants_with_options(settings, rebase_options)?;
+    dropped_signatures += counts.dropped_signatures;
+    let num_rebased = old_commits.len() + counts.rebased;
     writeln!(ui.stderr(), "Rebased {num_rebased} commits")?;
     let tx_message = if old_commits.len() == 1 {
         format!(
@@ -301,6 +308,7 @@ fn rebase_descendants(
     } else {
         format!("rebase {} commits and their descendants", old_commits.len())
     };
+    print_dropped_signatures(ui, dropped_signatures)?;
     tx.finish(ui, tx_message)?;
     Ok(())
 }
@@ -377,6 +385,7 @@ fn rebase_revision(
     // Now, rebase the descendants of the children.
     // TODO(ilyagr): Consider making it possible for these descendants to become
     // emptied, like --skip_empty. This would require writing careful tests.
+
     rebased_commit_ids.extend(tx.mut_repo().rebase_descendants_return_map(settings)?);
     let num_rebased_descendants = rebased_commit_ids.len();
 
@@ -420,7 +429,7 @@ fn rebase_revision(
     // have any children; they have all been rebased and the originals have been
     // abandoned.
     rebase_commit(settings, tx.mut_repo(), &old_commit, &new_parents)?;
-    debug_assert_eq!(tx.mut_repo().rebase_descendants(settings)?, 0);
+    debug_assert_eq!(tx.mut_repo().rebase_descendants(settings)?.rebased, 0);
 
     if num_rebased_descendants > 0 {
         writeln!(

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -18,7 +18,9 @@ use jj_lib::backend::ObjectId;
 use jj_lib::rewrite::{merge_commit_trees, restore_tree};
 use tracing::instrument;
 
-use crate::cli_util::{user_error, CommandError, CommandHelper, RevisionArg};
+use crate::cli_util::{
+    print_dropped_signatures, user_error, CommandError, CommandHelper, RevisionArg,
+};
 use crate::ui::Ui;
 
 /// Restore paths from another revision
@@ -110,13 +112,15 @@ pub(crate) fn cmd_restore(
             .write()?;
         // rebase_descendants early; otherwise `new_commit` would always have
         // a conflicted change id at this point.
-        let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+        let num_rebased = rebase_counts.rebased;
         write!(ui.stderr(), "Created ")?;
         tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
         writeln!(ui.stderr())?;
         if num_rebased > 0 {
             writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
         }
+        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
         tx.finish(ui, format!("restore into commit {}", to_commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -1,0 +1,71 @@
+use std::io::Write;
+
+use jj_lib::backend::ObjectId;
+use jj_lib::signing::SignBehavior;
+
+use crate::cli_util::{user_error, CommandError, CommandHelper, RevisionArg};
+use crate::ui::Ui;
+
+/// Cryptographically sign a revision
+#[derive(clap::Args, Clone, Debug)]
+pub struct SignArgs {
+    /// What key to use, depends on the configured signing backend.
+    #[arg()]
+    key: Option<String>,
+    /// What revision to sign
+    #[arg(long, short, default_value = "@")]
+    revision: RevisionArg,
+    /// Sign the commit that is not authored by you or was already signed.
+    #[arg(long, short)]
+    force: bool,
+    /// Drop the signature, explicitly "un-signing" the commit.
+    #[arg(long, short = 'D', conflicts_with = "force")]
+    drop: bool,
+}
+
+pub fn cmd_sign(ui: &mut Ui, command: &CommandHelper, args: &SignArgs) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    workspace_command.check_rewritable([&commit])?;
+
+    if !args.force {
+        if !args.drop && commit.is_signed() {
+            return Err(user_error(
+                "Commit is already signed, use --force to sign anyway",
+            ));
+        }
+        if commit.author().email != command.settings().user_email() {
+            return Err(user_error(
+                "Commit is not authored by you, use --force to sign anyway",
+            ));
+        }
+    }
+
+    let mut tx = workspace_command.start_transaction();
+
+    let behavior = if args.drop {
+        SignBehavior::Drop
+    } else if args.force {
+        SignBehavior::Force
+    } else {
+        SignBehavior::Own
+    };
+    let rewritten = tx
+        .mut_repo()
+        .rewrite_commit(command.settings(), &commit)
+        .override_sign_key(args.key.clone())
+        .set_sign_behavior(behavior)
+        .write()?;
+
+    tx.finish(ui, format!("sign commit {}", commit.id().hex()))?;
+
+    let summary = workspace_command.format_commit_summary(&rewritten);
+    if args.drop {
+        writeln!(ui.stderr(), "Signature was dropped: {summary}")?;
+    } else {
+        writeln!(ui.stderr(), "Commit was signed: {summary}")?;
+    }
+
+    Ok(())
+}

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -24,6 +24,7 @@ use jj_lib::hex_util::to_reverse_hex;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::op_store::{RefTarget, WorkspaceId};
 use jj_lib::repo::Repo;
+use jj_lib::signing::{SigStatus, SignError, Verification};
 use jj_lib::{git, rewrite};
 use once_cell::unsync::OnceCell;
 
@@ -97,6 +98,9 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo, '_> {
             CommitTemplatePropertyKind::ShortestIdPrefix(property) => {
                 build_shortest_id_prefix_method(self, build_ctx, property, function)
             }
+            CommitTemplatePropertyKind::CommitSignature(property) => {
+                build_commit_signature_method(self, build_ctx, property, function)
+            }
         }
     }
 }
@@ -145,6 +149,13 @@ impl<'repo> CommitTemplateLanguage<'repo, '_> {
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::ShortestIdPrefix(Box::new(property))
     }
+
+    fn wrap_commit_signature(
+        &self,
+        property: impl TemplateProperty<Commit, Output = CommitSignature> + 'repo,
+    ) -> CommitTemplatePropertyKind<'repo> {
+        CommitTemplatePropertyKind::CommitSignature(Box::new(property))
+    }
 }
 
 enum CommitTemplatePropertyKind<'repo> {
@@ -155,6 +166,51 @@ enum CommitTemplatePropertyKind<'repo> {
     RefNameList(Box<dyn TemplateProperty<Commit, Output = Vec<RefName>> + 'repo>),
     CommitOrChangeId(Box<dyn TemplateProperty<Commit, Output = CommitOrChangeId> + 'repo>),
     ShortestIdPrefix(Box<dyn TemplateProperty<Commit, Output = ShortestIdPrefix> + 'repo>),
+    CommitSignature(Box<dyn TemplateProperty<Commit, Output = CommitSignature> + 'repo>),
+}
+
+enum CommitSignature {
+    Present(Verification),
+    Absent,
+    Invalid,
+}
+
+impl CommitSignature {
+    fn is_present(&self) -> bool {
+        matches!(self, CommitSignature::Present(_))
+    }
+
+    fn is_invalid(&self) -> bool {
+        matches!(self, CommitSignature::Invalid)
+    }
+
+    fn is(&self, status: SigStatus) -> bool {
+        match self {
+            CommitSignature::Present(v) => v.status == status,
+            _ => false,
+        }
+    }
+
+    fn key(self) -> String {
+        match self {
+            CommitSignature::Present(v) => v.key.unwrap_or_default(),
+            _ => Default::default(),
+        }
+    }
+
+    fn display(self) -> String {
+        match self {
+            CommitSignature::Present(v) => v.display.unwrap_or_default(),
+            _ => Default::default(),
+        }
+    }
+
+    fn backend(self) -> String {
+        match self {
+            CommitSignature::Present(v) => v.backend().unwrap_or_default().to_owned(),
+            _ => Default::default(),
+        }
+    }
 }
 
 impl<'repo> IntoTemplateProperty<'repo, Commit> for CommitTemplatePropertyKind<'repo> {
@@ -171,6 +227,7 @@ impl<'repo> IntoTemplateProperty<'repo, Commit> for CommitTemplatePropertyKind<'
             }
             CommitTemplatePropertyKind::CommitOrChangeId(_) => None,
             CommitTemplatePropertyKind::ShortestIdPrefix(_) => None,
+            CommitTemplatePropertyKind::CommitSignature(_) => None,
         }
     }
 
@@ -206,6 +263,7 @@ impl<'repo> IntoTemplateProperty<'repo, Commit> for CommitTemplatePropertyKind<'
             CommitTemplatePropertyKind::ShortestIdPrefix(property) => {
                 Some(property.into_template())
             }
+            CommitTemplatePropertyKind::CommitSignature(_) => None,
         }
     }
 }
@@ -299,6 +357,15 @@ fn build_commit_keyword_opt<'repo>(
         "author" => language.wrap_signature(wrap_fn(property, |commit| commit.author().clone())),
         "committer" => {
             language.wrap_signature(wrap_fn(property, |commit| commit.committer().clone()))
+        }
+        "signature" => {
+            language.wrap_commit_signature(wrap_fn(property, |commit| {
+                match commit.verification() {
+                    Ok(Some(v)) => CommitSignature::Present(v),
+                    Err(SignError::InvalidSignatureFormat) => CommitSignature::Invalid,
+                    _ => CommitSignature::Absent, // todo don't ignore verification errors
+                }
+            }))
         }
         "working_copies" => {
             language.wrap_string(wrap_repo_fn(repo, property, extract_working_copies))
@@ -702,6 +769,32 @@ fn build_shortest_id_prefix_method<'repo>(
         _ => {
             return Err(TemplateParseError::no_such_method(
                 "ShortestIdPrefix",
+                function,
+            ))
+        }
+    };
+    Ok(property)
+}
+
+fn build_commit_signature_method<'repo>(
+    lang: &CommitTemplateLanguage<'repo, '_>,
+    _build_ctx: &BuildContext<CommitTemplatePropertyKind<'repo>>,
+    prop: impl TemplateProperty<Commit, Output = CommitSignature> + 'repo,
+    function: &FunctionCallNode,
+) -> TemplateParseResult<CommitTemplatePropertyKind<'repo>> {
+    template_parser::expect_no_arguments(function)?;
+    let property = match function.name {
+        "present" => lang.wrap_boolean(TemplateFunction::new(prop, |s| s.is_present())),
+        "good" => lang.wrap_boolean(TemplateFunction::new(prop, |s| s.is(SigStatus::Good))),
+        "unknown" => lang.wrap_boolean(TemplateFunction::new(prop, |s| s.is(SigStatus::Unknown))),
+        "bad" => lang.wrap_boolean(TemplateFunction::new(prop, |s| s.is(SigStatus::Bad))),
+        "invalid" => lang.wrap_boolean(TemplateFunction::new(prop, |s| s.is_invalid())),
+        "key" => lang.wrap_string(TemplateFunction::new(prop, |v| v.key())),
+        "display" => lang.wrap_string(TemplateFunction::new(prop, |v| v.display())),
+        "backend" => lang.wrap_string(TemplateFunction::new(prop, |v| v.backend())),
+        _ => {
+            return Err(TemplateParseError::no_such_method(
+                "CommitSignature",
                 function,
             ))
         }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -376,7 +376,23 @@
                 "backends": {
                     "type": "object",
                     "description": "Tables of options to pass to specific signing backends",
-                    "properties": {},
+                    "properties": {
+                        "GPG": {
+                            "type": "object",
+                            "properties": {
+                                "program": {
+                                    "type": "string",
+                                    "description": "Path to the gpg program to be called",
+                                    "default": "gpg2"
+                                },
+                                "consider-expired-keys-bad": {
+                                    "type": "boolean",
+                                    "description": "Whether to consider signatures made with an expired key as bad",
+                                    "default": false
+                                }
+                            }
+                        }
+                    },
                     "additionalProperties": true
                 }
             }

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -68,3 +68,9 @@
 "op_log current_operation id" = "bright blue"
 "op_log current_operation user" = "yellow"  # No bright yellow, see comment above
 "op_log current_operation time" = "bright cyan"
+"signature good" = "green"
+"signature unknown" = "bright black"
+"signature bad" = "red"
+"signature invalid" = "yellow"
+"signature key" = "blue"
+"signature display" = "yellow"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -2,6 +2,7 @@
 commit_summary = '''
 separate(" ",
   builtin_change_id_with_hidden_and_divergent_info,
+  builtin_sig_status,
   format_short_commit_id(commit_id),
   separate(commit_summary_separator,
     branches,
@@ -17,6 +18,7 @@ separate(" ",
 commit_summary_no_branches = '''
 separate(" ",
   builtin_change_id_with_hidden_and_divergent_info,
+  builtin_sig_status,
   format_short_commit_id(commit_id),
   if(conflict, label("conflict", "(conflict)")),
   if(empty, label("empty", "(empty)")),
@@ -36,6 +38,7 @@ if(root,
     concat(
       separate(" ",
         builtin_change_id_with_hidden_and_divergent_info,
+        builtin_sig_status,
         if(author.email(), author.username(), email_placeholder),
         format_timestamp(committer.timestamp()),
         branches,
@@ -58,6 +61,7 @@ if(root,
     concat(
       separate(" ",
         builtin_change_id_with_hidden_and_divergent_info,
+        builtin_sig_status,
         format_short_signature(author),
         format_timestamp(committer.timestamp()),
         branches,
@@ -83,6 +87,7 @@ concat(
   "Change ID: " ++ change_id ++ "\n",
   "Author: " ++ format_detailed_signature(author) ++ "\n",
   "Committer: " ++ format_detailed_signature(committer)  ++ "\n",
+  builtin_sig_detailed,
   "\n",
   indent("    ", if(description, description, description_placeholder ++ "\n")),
   "\n",
@@ -138,11 +143,54 @@ commit_summary_separator = 'label("separator", " | ")'
 # commit id to refer to a hidden revision regardless.
 builtin_change_id_with_hidden_and_divergent_info = '''
 if(hidden,
-  label("hidden", 
+  label("hidden",
     format_short_change_id(change_id) ++ " hidden"
   ),
   label(if(divergent, "divergent"),
     format_short_change_id(change_id) ++ if(divergent,"??")
+  )
+)
+'''
+
+builtin_sig_status = '''
+if(signature.present(),
+  label("signature",
+    concat(
+      "[",
+      label("status",
+        if(signature.good(), label("good", "✓︎"),
+          if(signature.unknown(), label("unknown", "?"),
+            if(signature.bad(), label("bad", "❌︎"),
+              if(signature.invalid(), label("invalid", "?!"))
+            )
+          )
+        )
+      ),
+      "]"
+    )
+  )
+)
+'''
+
+builtin_sig_detailed = '''
+if(signature.present(),
+  concat(
+    "Signature: ",
+    label("signature",
+      if(signature.good(), label("good", "Good"),
+        if(signature.unknown(), label("unknown", "Unknown"),
+          if(signature.bad(), label("bad", "Bad"),
+            if(signature.invalid(), label("invalid", "Invalid"))
+          )
+        )
+      )
+    ),
+    if(signature.backend(), " " ++ label("backend", signature.backend()) ++ " signature"),
+    if(signature.display(),
+      ". By " ++ label("display", signature.display()) ++ if(signature.key(), " (key " ++ label("key", signature.key()) ++ ")"),
+      if(signature.key(), ". Key " ++ label("key", signature.key()))
+    ),
+    "\n"
   )
 )
 '''

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -434,6 +434,11 @@ fn test_help() {
       -v, --verbose                      Enable verbose logging
           --color <WHEN>                 When to colorize output (always, never, auto)
           --no-pager                     Disable the pager
+          --sign-with <KEY>              Override the configured key to be used for the commit signing.
+                                         Is only used when a commit signing operation has to be
+                                         performed by the operation
+          --no-sign                      Don't sign unsigned commits when configured to sign all, is
+                                         ignored otherwise
           --config-toml <TOML>           Additional configuration options (can be repeated)
     "###);
 }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -21,6 +21,7 @@ The following keywords can be used in `jj log`/`jj obslog` templates.
 * `parents: List<Commit>`
 * `author: Signature`
 * `committer: Signature`
+* `signature: CommitSignature`: The information about a cryptographic signature of the commit.
 * `working_copies: String`: For multi-workspace repository, indicate
   working-copy commit as `<workspace name>@`.
 * `current_working_copy: Boolean`: True for the working-copy commit of the
@@ -143,6 +144,18 @@ The following methods are defined.
 * `.email() -> String`
 * `.username() -> String`
 * `.timestamp() -> Timestamp`
+
+### CommitSignature type
+
+The following methods are defined.
+
+* `.present() -> Boolean`: True if the commit has a cryptographic signature.
+* `.good() -> Boolean`: True if the signature matches the commit data.
+* `.unknown() -> Boolean`: True if the signing backend cannot verify the signature (e.g. due a missing public key), or if there's no backend implemented that can verify the signature.
+* `.bad() -> Boolean`: True if the signature does not match the commit data.
+* `.invalid() -> Boolean`: True if the signature is detected to be made with a signing backend (e.g. has a PGP prefix) but is otherwise invalid.
+* `.key() -> String`: Signing backend specific key id. For GPG, it's a long key ID, present for all non-invalid signatures.
+* `.display() -> String`: Signing backend specific display string. For GPG, it's a formatted primary user ID, only present if the public key is known (only for good/bad signatures).
 
 ### String type
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
     in
     {
       packages = {
-        jujutsu = ourRustPlatform.buildRustPackage rec {
+        jujutsu = ourRustPlatform.buildRustPackage {
           pname = "jujutsu";
           version = "unstable-${self.shortRev or "dirty"}";
 
@@ -72,6 +72,7 @@
             installShellFiles
             makeWrapper
             pkg-config
+            gnupg # for signing tests
           ];
           buildInputs = with pkgs; [
             openssl zstd libgit2 libssh2
@@ -132,6 +133,9 @@
 
           # In case you need to run `cargo run --bin gen-protos`
           protobuf
+
+          # To run the signing tests
+          gnupg
 
           # For building the documentation website
           poetry

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -170,8 +170,8 @@ impl CommitBuilder<'_> {
         self
     }
 
-    pub fn set_sign_key(mut self, sign_key: Option<String>) -> Self {
-        self.sign_settings.key = sign_key;
+    pub fn override_sign_key(mut self, sign_key: Option<String>) -> Self {
+        self.sign_settings.key = sign_key.or(self.sign_settings.key);
         self
     }
 

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -171,11 +171,7 @@ impl SigningBackend for GpgBackend {
                 let display = parts
                     .next()
                     .and_then(|bs| String::from_utf8(bs.to_owned()).ok());
-                Verification {
-                    status,
-                    key,
-                    display,
-                }
+                Verification::new(status, key, display)
             })
             .ok_or(SignError::InvalidSignatureFormat)
     }

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -1,0 +1,182 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::io::Write;
+use std::process::{Command, ExitStatus, Stdio};
+
+use thiserror::Error;
+
+use crate::signing::{SigStatus, SignError, SigningBackend, Verification};
+
+#[derive(Debug)]
+pub struct GpgBackend {
+    program: OsString,
+    consider_expired_keys_bad: bool,
+    extra_args: Vec<OsString>,
+}
+
+#[derive(Debug, Error)]
+pub enum GpgError {
+    #[error("GPG failed with exit status {exit_status}:\n{stderr}")]
+    Command {
+        exit_status: ExitStatus,
+        stderr: String,
+    },
+    #[error("Failed to run GPG: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<GpgError> for SignError {
+    fn from(e: GpgError) -> Self {
+        SignError::Backend(Box::new(e))
+    }
+}
+
+impl GpgBackend {
+    pub fn new(program: OsString, consider_expired_keys_bad: bool) -> Self {
+        Self {
+            program,
+            consider_expired_keys_bad,
+            extra_args: vec![],
+        }
+    }
+
+    /// Primarily intended for testing
+    pub fn with_extra_args(mut self, args: &[OsString]) -> Self {
+        self.extra_args.extend_from_slice(args);
+        self
+    }
+
+    pub fn from_config(config: &config::Config) -> Self {
+        Self::new(
+            config
+                .get_string("signing.backends.GPG.program")
+                .unwrap_or_else(|_| "gpg2".into())
+                .into(),
+            config
+                .get_bool("signing.backends.GPG.consider-expired-keys-bad")
+                .unwrap_or(false),
+        )
+    }
+
+    fn run(&self, input: &[u8], args: &[&OsStr], check: bool) -> Result<Vec<u8>, GpgError> {
+        let process = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(if check { Stdio::piped() } else { Stdio::null() })
+            .args(&self.extra_args)
+            .args(args)
+            .spawn()?;
+        process.stdin.as_ref().unwrap().write_all(input)?;
+        let output = process.wait_with_output()?;
+        if check && !output.status.success() {
+            Err(GpgError::Command {
+                exit_status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            })
+        } else {
+            Ok(output.stdout)
+        }
+    }
+}
+
+impl SigningBackend for GpgBackend {
+    fn name(&self) -> &str {
+        "GPG"
+    }
+
+    fn can_read(&self, signature: &[u8]) -> bool {
+        signature.starts_with(b"-----BEGIN PGP SIGNATURE-----")
+    }
+
+    fn sign(&self, data: &[u8], key: Option<&str>) -> Result<Vec<u8>, SignError> {
+        Ok(match key {
+            Some(key) => self.run(data, &["-abu".as_ref(), key.as_ref()], true)?,
+            None => self.run(data, &["-ab".as_ref()], true)?,
+        })
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<Verification, SignError> {
+        let mut signature_file = tempfile::Builder::new()
+            .prefix(".jj-gpg-sig-tmp-")
+            .tempfile()
+            .map_err(GpgError::Io)?;
+        signature_file.write_all(signature).map_err(GpgError::Io)?;
+        signature_file.flush().map_err(GpgError::Io)?;
+
+        let output = self.run(
+            data,
+            &[
+                "--status-fd=1".as_ref(),
+                "--verify".as_ref(),
+                signature_file.path().as_os_str(), /* the only reason we have those .as_refs
+                                                    * transmuting to &OsStr everywhere.. */
+                "-".as_ref(),
+            ],
+            false,
+        )?;
+
+        // Search for one of the:
+        //  [GNUPG:] GOODSIG <long keyid> <primary uid..>
+        //  [GNUPG:] EXPKEYSIG <long keyid> <primary uid..>
+        //  [GNUPG:] NO_PUBKEY <long keyid>
+        //  [GNUPG:] BADSIG <long keyid> <primary uid..>
+        // in the output from --status-fd=1
+        // Assume signature is invalid if none of the above was found
+        output
+            .split(|&b| b == b'\n')
+            .filter_map(|line| line.strip_prefix(b"[GNUPG:] "))
+            .find_map(|line| {
+                line.strip_prefix(b"GOODSIG ")
+                    .map(|rest| (SigStatus::Good, rest))
+                    .or_else(|| {
+                        line.strip_prefix(b"EXPKEYSIG ").map(|rest| {
+                            let status = if self.consider_expired_keys_bad {
+                                SigStatus::Bad
+                            } else {
+                                SigStatus::Good
+                            };
+                            (status, rest)
+                        })
+                    })
+                    .or_else(|| {
+                        line.strip_prefix(b"NO_PUBKEY ")
+                            .map(|rest| (SigStatus::Unknown, rest))
+                    })
+                    .or_else(|| {
+                        line.strip_prefix(b"BADSIG ")
+                            .map(|rest| (SigStatus::Bad, rest))
+                    })
+            })
+            .map(|(status, line)| {
+                let mut parts = line.splitn(2, |&b| b == b' ');
+                let key = parts
+                    .next()
+                    .and_then(|bs| String::from_utf8(bs.to_owned()).ok());
+                let display = parts
+                    .next()
+                    .and_then(|bs| String::from_utf8(bs.to_owned()).ok());
+                Verification {
+                    status,
+                    key,
+                    display,
+                }
+            })
+            .ok_or(SignError::InvalidSignatureFormat)
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -38,6 +38,7 @@ pub mod fsmonitor;
 pub mod git;
 pub mod git_backend;
 pub mod gitignore;
+pub mod gpg_signing;
 pub mod hex_util;
 pub mod id_prefix;
 pub mod index;

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -49,6 +49,11 @@ pub struct Verification {
     /// A display string, if available. For GPG, this will be formatted primary
     /// user ID.
     pub display: Option<String>,
+    /// The name of the backend that provided this verification.
+    /// Is `None` when no backend was found that could read the signature.
+    ///
+    /// Always set by the signer.
+    backend: Option<String>,
 }
 
 impl Verification {
@@ -59,7 +64,23 @@ impl Verification {
             status: SigStatus::Unknown,
             key: None,
             display: None,
+            backend: None,
         }
+    }
+
+    /// Create a new verification
+    pub fn new(status: SigStatus, key: Option<String>, display: Option<String>) -> Self {
+        Self {
+            status,
+            key,
+            display,
+            backend: None,
+        }
+    }
+
+    /// The name of the backend that provided this verification.
+    pub fn backend(&self) -> Option<&str> {
+        self.backend.as_deref()
     }
 }
 
@@ -220,7 +241,10 @@ impl Signer {
             .find_map(|backend| match backend.verify(data, signature) {
                 Ok(check) if check.status == SigStatus::Unknown => None,
                 Err(SignError::InvalidSignatureFormat) => None,
-                e => Some(e),
+                e => Some(e.map(|mut v| {
+                    v.backend = Some(backend.name().to_owned());
+                    v
+                })),
             })
             .transpose()?;
 

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -22,6 +22,7 @@ use std::sync::RwLock;
 use thiserror::Error;
 
 use crate::backend::CommitId;
+use crate::gpg_signing::GpgBackend;
 use crate::settings::UserSettings;
 
 /// A status of the signature, part of the [Verification] type.
@@ -150,10 +151,10 @@ impl Signer {
     /// Creates a signer based on user settings. Uses all known backends, and
     /// chooses one of them to be used for signing depending on the config.
     pub fn from_settings(settings: &UserSettings) -> Result<Self, SignInitError> {
-        let mut backends: Vec<Box<dyn SigningBackend>> = vec![
-            // Box::new(GpgBackend::from_settings(settings)?),
-            // Box::new(SshBackend::from_settings(settings)?),
-            // Box::new(X509Backend::from_settings(settings)?),
+        let mut backends = vec![
+            Box::new(GpgBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
+            // Box::new(SshBackend::from_settings(settings)?) as Box<dyn SigningBackend>,
+            // Box::new(X509Backend::from_settings(settings)?) as Box<dyn SigningBackend>,
         ];
 
         let main_backend = settings

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1062,7 +1062,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten.
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 and feature4 should still be the heads, and all three branches
@@ -1079,7 +1082,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 and feature4 should still be the heads, and both branches
@@ -1095,7 +1101,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 should now be the only head and only branch.

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -1,0 +1,162 @@
+use std::fs::Permissions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::prelude::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use assert_matches::assert_matches;
+use jj_lib::gpg_signing::GpgBackend;
+use jj_lib::signing::{SigStatus, SignError, SigningBackend, Verification};
+use once_cell::sync::Lazy;
+
+static GPG_HOME: Lazy<PathBuf> = Lazy::new(|| {
+    let dir = tempfile::Builder::new()
+        .prefix("jj-test-")
+        .tempdir()
+        .unwrap()
+        .into_path();
+
+    #[cfg(unix)]
+    std::fs::set_permissions(&dir, Permissions::from_mode(0o700)).unwrap();
+
+    let mut gpg = std::process::Command::new("gpg")
+        .arg("--homedir")
+        .arg(&dir)
+        .arg("--import")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    gpg.stdin
+        .as_mut()
+        .unwrap()
+        .write_all(
+            br#"-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+            lFgEZWI3pBYJKwYBBAHaRw8BAQdAaPLTNADvDWapjAPlxaUnx3HXQNIlwSz4EZrW
+            3Z7hxSwAAP9liwHZWJCGI2xW+XNqMT36qpIvoRcd5YPaKYwvnlkG1w+UtDNTb21l
+            b25lIChqaiB0ZXN0IHNpZ25pbmcga2V5KSA8c29tZW9uZUBleGFtcGxlLmNvbT6I
+            kwQTFgoAOxYhBKWOXukGcVPI9eXp6WOHhcsW/qBhBQJlYjekAhsDBQsJCAcCAiIC
+            BhUKCQgLAgQWAgMBAh4HAheAAAoJEGOHhcsW/qBhyBgBAMph1HkBkKlrZmsun+3i
+            kTEaOsWmaW/D6NEdMFiw0S/jAP9G3jOYGiZbUN3dWWB2246Oi7SaMTX8Xb2BrLP2
+            axCbC5RYBGVjxv8WCSsGAQQB2kcPAQEHQE8Oa4ahtVG29gIRssPxjqF4utn8iHPz
+            m5z/8lX/nl3eAAD5AZ6H2pNhiy2gnGkbPLHw3ZyY4d0NXzCa7qc9EXqOj+sRrLQ9
+            U29tZW9uZSBFbHNlIChqaiB0ZXN0IHNpZ25pbmcga2V5KSA8c29tZW9uZS1lbHNl
+            QGV4YW1wbGUuY29tPoiTBBMWCgA7FiEER1BAaEpU3TKUiUvFTtVW6XKeAA8FAmVj
+            xv8CGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQTtVW6XKeAA/6TQEA
+            2DkPm3LmH8uG6qLirtf62kbG7T+qljIsarQKFw3CGakA/AveCtrL7wVSpINiu1Rz
+            lBqJFFP2PqzT0CRfh94HSIMM
+            =6JC8
+            -----END PGP PRIVATE KEY BLOCK-----"#,
+        )
+        .unwrap();
+    gpg.stdin.as_mut().unwrap().flush().unwrap();
+    gpg.wait().unwrap();
+
+    dir
+});
+
+fn backend() -> GpgBackend {
+    // don't really need faked time for current tests,
+    // but probably will need it for end-to-end cli tests
+    GpgBackend::new("gpg".into(), false).with_extra_args(&[
+        "--homedir".into(),
+        GPG_HOME.to_path_buf().into(),
+        "--faked-system-time=1701042000!".into(),
+    ])
+}
+
+#[test]
+fn roundtrip() {
+    let backend = backend();
+    let data = b"hello world";
+    let signature = backend.sign(data, None).unwrap();
+
+    assert_eq!(
+        backend.verify(data, &signature).unwrap(),
+        Verification {
+            status: SigStatus::Good,
+            key: Some("638785CB16FEA061".to_owned()),
+            display: Some("Someone (jj test signing key) <someone@example.com>".to_owned()),
+        }
+    );
+    assert_eq!(
+        backend.verify(b"so so bad", &signature).unwrap(),
+        Verification {
+            status: SigStatus::Bad,
+            key: Some("638785CB16FEA061".to_owned()),
+            display: Some("Someone (jj test signing key) <someone@example.com>".to_owned()),
+        }
+    );
+}
+
+#[test]
+fn roundtrip_explicit_key() {
+    let backend = backend();
+    let data = b"hello world";
+    let signature = backend.sign(data, Some("Someone Else")).unwrap();
+
+    assert_eq!(
+        backend.verify(data, &signature).unwrap(),
+        Verification {
+            status: SigStatus::Good,
+            key: Some("4ED556E9729E000F".to_owned()),
+            display: Some(
+                "Someone Else (jj test signing key) <someone-else@example.com>".to_owned()
+            ),
+        }
+    );
+    assert_eq!(
+        backend.verify(b"so so bad", &signature).unwrap(),
+        Verification {
+            status: SigStatus::Bad,
+            key: Some("4ED556E9729E000F".to_owned()),
+            display: Some(
+                "Someone Else (jj test signing key) <someone-else@example.com>".to_owned()
+            ),
+        }
+    );
+}
+
+#[test]
+fn unknown_key() {
+    let backend = backend();
+    let signature = br"-----BEGIN PGP SIGNATURE-----
+
+    iHUEABYKAB0WIQQs238pU7eC/ROoPJ0HH+PjJN1zMwUCZWPa5AAKCRAHH+PjJN1z
+    MyylAP9WQ3sZdbC4b1C+/nxs+Wl+rfwzeQWGbdcsBMyDABcpmgD/U+4KdO7eZj/I
+    e+U6bvqw3pOBoI53Th35drQ0qPI+jAE=
+    =kwsk
+    -----END PGP SIGNATURE-----";
+    assert_eq!(
+        backend.verify(b"hello world", signature).unwrap(),
+        Verification {
+            status: SigStatus::Unknown,
+            key: Some("071FE3E324DD7333".to_owned()),
+            display: None,
+        }
+    );
+    assert_eq!(
+        backend.verify(b"so bad", signature).unwrap(),
+        Verification {
+            status: SigStatus::Unknown, // no key, no idea ¯\_(ツ)_/¯
+            key: Some("071FE3E324DD7333".to_owned()),
+            display: None,
+        }
+    );
+}
+
+#[test]
+fn invalid_signature() {
+    let backend = backend();
+    let signature = br"-----BEGIN PGP SIGNATURE-----
+
+    super duper invalid
+    -----END PGP SIGNATURE-----";
+    assert_matches!(
+        backend.verify(b"hello world", signature),
+        Err(SignError::InvalidSignatureFormat)
+    );
+}

--- a/lib/tests/test_signing.rs
+++ b/lib/tests/test_signing.rs
@@ -1,7 +1,8 @@
+use assert_matches::assert_matches;
 use jj_lib::backend::{MillisSinceEpoch, Signature, Timestamp};
 use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
-use jj_lib::signing::{SigStatus, SignBehavior, Signer, Verification};
+use jj_lib::signing::{SignBehavior, Signer};
 use test_case::test_case;
 use testutils::test_signing_backend::TestSigningBackend;
 use testutils::{create_random_commit, write_random_commit, TestRepoBackend, TestWorkspace};
@@ -33,13 +34,7 @@ fn someone_else() -> Signature {
     }
 }
 
-fn good_verification() -> Option<Verification> {
-    Some(Verification {
-        status: SigStatus::Good,
-        key: Some("impeccable".to_owned()),
-        display: None,
-    })
-}
+const GOOD_VERIFICATION: &str = r#"Ok(Some(Verification { status: Good, key: Some("impeccable"), display: None, backend: Some("test") }))"#;
 
 #[test_case(TestRepoBackend::Local ; "local backend")]
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -66,10 +61,10 @@ fn manual(backend: TestRepoBackend) {
     tx.commit("test");
 
     let commit1 = repo.store().get_commit(commit1.id()).unwrap();
-    assert_eq!(commit1.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit1.verification()), GOOD_VERIFICATION);
 
     let commit2 = repo.store().get_commit(commit2.id()).unwrap();
-    assert_eq!(commit2.verification().unwrap(), None);
+    assert_matches!(commit2.verification(), Ok(None));
 }
 
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -95,7 +90,7 @@ fn keep_on_rewrite(backend: TestRepoBackend) {
     let rewritten = mut_repo.rewrite_commit(&settings, &commit).write().unwrap();
 
     let commit = repo.store().get_commit(rewritten.id()).unwrap();
-    assert_eq!(commit.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit.verification()), GOOD_VERIFICATION);
 }
 
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -148,7 +143,7 @@ fn forced(backend: TestRepoBackend) {
     tx.commit("test");
 
     let commit = repo.store().get_commit(commit.id()).unwrap();
-    assert_eq!(commit.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit.verification()), GOOD_VERIFICATION);
 }
 
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -167,5 +162,5 @@ fn configured(backend: TestRepoBackend) {
     tx.commit("test");
 
     let commit = repo.store().get_commit(commit.id()).unwrap();
-    assert_eq!(commit.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit.verification()), GOOD_VERIFICATION);
 }

--- a/lib/testutils/src/test_signing_backend.rs
+++ b/lib/testutils/src/test_signing_backend.rs
@@ -37,18 +37,11 @@ impl SigningBackend for TestSigningBackend {
         let key = (!key.is_empty()).then_some(std::str::from_utf8(key).unwrap().to_owned());
 
         let sig = self.sign(data, key.as_deref())?;
-        if sig == signature {
-            Ok(Verification {
-                status: SigStatus::Good,
-                key,
-                display: None,
-            })
+        let status = if sig == signature {
+            SigStatus::Good
         } else {
-            Ok(Verification {
-                status: SigStatus::Bad,
-                key,
-                display: None,
-            })
-        }
+            SigStatus::Bad
+        };
+        Ok(Verification::new(status, key, None))
     }
 }


### PR DESCRIPTION
So I've been using this stack locally for a while and I'm very happy with it, but I couldn't find it in me (at least for a little while at the moment) to actually finish it, and the _only_ thing that has to be done here is just more tests 🤷

And well also I just noticed the changelog checkbox, changelog too
And also SSH impl, I was focused on GPG, but an SSH impl should be trivial at this point (cc @chriskrycho)

I'm just pushing this just so that it's not only on my machine, and maybe for someone to take it and make the final push to have it in main (maybe me after a few months) - every commit is independent and can be cherry-picked (hm, except I think in the templater one I touch some stuff in the signer, could conflict a little, eh)

Also the GPG impl commit has those weird tests that need a gpg binary in path which I'm 95% certain will fail on windows/mac, and maybe on linux too :upside_down_face: 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
