### PR TITLE
index, stacked_table: clean up integer cast and serialization

### DIFF
--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -124,7 +124,7 @@ impl<'a> CompositeIndex<'a> {
             }
             change_ids.insert(entry.change_id());
         }
-        let num_heads = is_head.iter().filter(|is_head| **is_head).count() as u32;
+        let num_heads = u32::try_from(is_head.iter().filter(|is_head| **is_head).count()).unwrap();
 
         let mut levels = self
             .ancestor_index_segments()
@@ -140,7 +140,7 @@ impl<'a> CompositeIndex<'a> {
             num_merges,
             max_generation_number,
             num_heads,
-            num_changes: change_ids.len() as u32,
+            num_changes: change_ids.len().try_into().unwrap(),
             levels,
         }
     }

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -174,7 +174,7 @@ impl MutableIndexSegment {
         if let Some(parent_file) = &self.parent_file {
             buf.write_u32::<LittleEndian>(parent_file.name().len() as u32)
                 .unwrap();
-            buf.write_all(parent_file.name().as_bytes()).unwrap();
+            buf.extend_from_slice(parent_file.name().as_bytes());
         } else {
             buf.write_u32::<LittleEndian>(0).unwrap();
         }
@@ -212,14 +212,14 @@ impl MutableIndexSegment {
             buf.write_u32::<LittleEndian>(parent_overflow_pos).unwrap();
 
             assert_eq!(entry.change_id.as_bytes().len(), self.change_id_length);
-            buf.write_all(entry.change_id.as_bytes()).unwrap();
+            buf.extend_from_slice(entry.change_id.as_bytes());
 
             assert_eq!(entry.commit_id.as_bytes().len(), self.commit_id_length);
-            buf.write_all(entry.commit_id.as_bytes()).unwrap();
+            buf.extend_from_slice(entry.commit_id.as_bytes());
         }
 
         for (commit_id, pos) in &self.lookup {
-            buf.write_all(commit_id.as_bytes()).unwrap();
+            buf.extend_from_slice(commit_id.as_bytes());
             buf.write_u32::<LittleEndian>(pos.0).unwrap();
         }
 

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -87,19 +87,19 @@ impl CommitGraphEntry<'_> {
     }
 
     fn generation_number(&self) -> u32 {
-        (&self.data[4..]).read_u32::<LittleEndian>().unwrap()
+        u32::from_le_bytes(self.data[4..8].try_into().unwrap())
     }
 
     fn num_parents(&self) -> u32 {
-        (&self.data[8..]).read_u32::<LittleEndian>().unwrap()
+        u32::from_le_bytes(self.data[8..12].try_into().unwrap())
     }
 
     fn parent1_pos(&self) -> IndexPosition {
-        IndexPosition((&self.data[12..]).read_u32::<LittleEndian>().unwrap())
+        IndexPosition(u32::from_le_bytes(self.data[12..16].try_into().unwrap()))
     }
 
     fn parent2_overflow_pos(&self) -> u32 {
-        (&self.data[16..]).read_u32::<LittleEndian>().unwrap()
+        u32::from_le_bytes(self.data[16..20].try_into().unwrap())
     }
 
     // TODO: Consider storing the change ids in a separate table. That table could
@@ -137,11 +137,8 @@ impl CommitLookupEntry<'_> {
     }
 
     fn pos(&self) -> IndexPosition {
-        IndexPosition(
-            (&self.data[self.commit_id_length..][..4])
-                .read_u32::<LittleEndian>()
-                .unwrap(),
-        )
+        let pos = u32::from_le_bytes(self.data[self.commit_id_length..][..4].try_into().unwrap());
+        IndexPosition(pos)
     }
 }
 
@@ -328,11 +325,8 @@ impl ReadonlyIndexSegment {
         let offset = (overflow_pos as usize) * 4
             + (self.num_local_commits as usize) * self.commit_graph_entry_size
             + (self.num_local_commits as usize) * self.commit_lookup_entry_size;
-        IndexPosition(
-            (&self.data[offset..][..4])
-                .read_u32::<LittleEndian>()
-                .unwrap(),
-        )
+        let pos = u32::from_le_bytes(self.data[offset..][..4].try_into().unwrap());
+        IndexPosition(pos)
     }
 
     fn commit_id_byte_prefix_to_lookup_pos(&self, prefix: &CommitId) -> Option<u32> {

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use blake2::{Blake2b512, Digest};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt};
 use tempfile::NamedTempFile;
 use thiserror::Error;
 
@@ -256,20 +256,18 @@ impl MutableTable {
         let mut buf = vec![];
 
         if let Some(parent_file) = &self.parent_file {
-            buf.write_u32::<LittleEndian>(parent_file.name.len() as u32)
-                .unwrap();
+            buf.extend((parent_file.name.len() as u32).to_le_bytes());
             buf.extend_from_slice(parent_file.name.as_bytes());
         } else {
-            buf.write_u32::<LittleEndian>(0).unwrap();
+            buf.extend(0_u32.to_le_bytes());
         }
 
-        buf.write_u32::<LittleEndian>(self.entries.len() as u32)
-            .unwrap();
+        buf.extend((self.entries.len() as u32).to_le_bytes());
 
-        let mut value_offset = 0;
+        let mut value_offset = 0_u32;
         for (key, value) in &self.entries {
             buf.extend_from_slice(key);
-            buf.write_u32::<LittleEndian>(value_offset).unwrap();
+            buf.extend(value_offset.to_le_bytes());
             value_offset += value.len() as u32;
         }
         for value in self.entries.values() {

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -256,19 +256,19 @@ impl MutableTable {
         let mut buf = vec![];
 
         if let Some(parent_file) = &self.parent_file {
-            buf.extend((parent_file.name.len() as u32).to_le_bytes());
+            buf.extend(u32::try_from(parent_file.name.len()).unwrap().to_le_bytes());
             buf.extend_from_slice(parent_file.name.as_bytes());
         } else {
             buf.extend(0_u32.to_le_bytes());
         }
 
-        buf.extend((self.entries.len() as u32).to_le_bytes());
+        buf.extend(u32::try_from(self.entries.len()).unwrap().to_le_bytes());
 
         let mut value_offset = 0_u32;
         for (key, value) in &self.entries {
             buf.extend_from_slice(key);
             buf.extend(value_offset.to_le_bytes());
-            value_offset += value.len() as u32;
+            value_offset += u32::try_from(value.len()).unwrap();
         }
         for value in self.entries.values() {
             buf.extend_from_slice(value);

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -258,7 +258,7 @@ impl MutableTable {
         if let Some(parent_file) = &self.parent_file {
             buf.write_u32::<LittleEndian>(parent_file.name.len() as u32)
                 .unwrap();
-            buf.write_all(parent_file.name.as_bytes()).unwrap();
+            buf.extend_from_slice(parent_file.name.as_bytes());
         } else {
             buf.write_u32::<LittleEndian>(0).unwrap();
         }
@@ -268,12 +268,12 @@ impl MutableTable {
 
         let mut value_offset = 0;
         for (key, value) in &self.entries {
-            buf.write_all(key).unwrap();
+            buf.extend_from_slice(key);
             buf.write_u32::<LittleEndian>(value_offset).unwrap();
             value_offset += value.len() as u32;
         }
         for value in self.entries.values() {
-            buf.write_all(value).unwrap();
+            buf.extend_from_slice(value);
         }
         buf
     }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
