### PR TITLE
index: fix partial reindexing to not lose commits only reachable from one side

### DIFF
--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -119,14 +119,16 @@ impl DefaultIndexStore {
             |op: &Operation| op.parents().collect_vec(),
         ) {
             let op = op?;
-            if operations_dir.join(op.id().hex()).is_file() {
-                if parent_op_id.is_none() {
-                    parent_op_id = Some(op.id().clone())
-                }
-            } else {
-                for head in op.view()?.heads() {
-                    new_heads.insert(head.clone());
-                }
+            // Pick the latest existing ancestor operation as the parent
+            // segment. Perhaps, breadth-first search is more appropriate here,
+            // but that wouldn't matter in practice as the operation log is
+            // mostly linear.
+            if parent_op_id.is_none() && operations_dir.join(op.id().hex()).is_file() {
+                parent_op_id = Some(op.id().clone());
+            }
+            // TODO: no need to walk ancestors of the parent_op_id operation
+            for head in op.view()?.heads() {
+                new_heads.insert(head.clone());
             }
         }
         let maybe_parent_file;


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
