### PR TITLE
Refactor MutRepo to make DescendantRebaser private (pt 1)

### DIFF
--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -113,9 +113,10 @@ from the source will be moved into the destination.
         // rewritten source. Otherwise it will likely already have the content
         // changes we're moving, so applying them will have no effect and the
         // changes will disappear.
-        let mut rebaser = tx.mut_repo().create_descendant_rebaser(command.settings());
-        rebaser.rebase_all()?;
-        let rebased_destination_id = rebaser.rebased().get(destination.id()).unwrap().clone();
+        let rebase_map = tx
+            .mut_repo()
+            .rebase_descendants_return_map(command.settings())?;
+        let rebased_destination_id = rebase_map.get(destination.id()).unwrap().clone();
         destination = tx.mut_repo().store().get_commit(&rebased_destination_id)?;
     }
     // Apply the selected changes onto the destination

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -32,7 +32,8 @@ pub struct CommitBuilder<'repo> {
 }
 
 impl CommitBuilder<'_> {
-    pub fn for_new_commit<'repo>(
+    // Use MutRepo::new_commit() instead
+    pub(crate) fn for_new_commit<'repo>(
         mut_repo: &'repo mut MutableRepo,
         settings: &UserSettings,
         parents: Vec<CommitId>,
@@ -61,7 +62,8 @@ impl CommitBuilder<'_> {
         }
     }
 
-    pub fn for_rewrite_from<'repo>(
+    // Use MutRepo::rewrite_commit() instead
+    pub(crate) fn for_rewrite_from<'repo>(
         mut_repo: &'repo mut MutableRepo,
         settings: &UserSettings,
         predecessor: &Commit,

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -796,6 +796,8 @@ impl MutableRepo {
         predecessor: &Commit,
     ) -> CommitBuilder {
         CommitBuilder::for_rewrite_from(self, settings, predecessor)
+        // CommitBuilder::write will record the rewrite in
+        // `self.rewritten_commits`
     }
 
     pub fn write_commit(

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -849,6 +849,7 @@ impl MutableRepo {
 
     /// Creates a `DescendantRebaser` to rebase descendants of the recorded
     /// rewritten and abandoned commits.
+    // TODO(ilyagr): Inline this. It's only used in tests.
     pub fn create_descendant_rebaser<'settings, 'repo>(
         &'repo mut self,
         settings: &'settings UserSettings,

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1119,6 +1119,7 @@ fn test_rebase_descendants_update_branches_after_divergent_rewrite() {
     // B main         |/B2 main?
     // |         =>   |/
     // A              A
+    // TODO(ilyagr): Check what happens if B had a descendant with a branch on it.
     let mut tx = repo.start_transaction(&settings);
     let mut graph_builder = CommitGraphBuilder::new(&settings, tx.mut_repo());
     let commit_a = graph_builder.initial_commit();


### PR DESCRIPTION
After this PR, the soon-to-be-internal APIs are used only in tests. The second part of this will be #2738.

The goal is to be able to more freely refactor DescendantRebaser after this. The new public API is not necessarily final or perfect, but should already be more manageable.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
