### PR TITLE
Refactor MutRepo to make DescendantRebaser private (pt 2)

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -885,7 +885,7 @@ impl MutableRepo {
     /// Creates a `DescendantRebaser` to rebase descendants of the recorded
     /// rewritten and abandoned commits.
     // TODO(ilyagr): Inline this. It's only used in tests.
-    pub fn create_descendant_rebaser<'settings, 'repo>(
+    fn create_descendant_rebaser<'settings, 'repo>(
         &'repo mut self,
         settings: &'settings UserSettings,
     ) -> DescendantRebaser<'settings, 'repo> {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -882,21 +882,6 @@ impl MutableRepo {
         !(self.rewritten_commits.is_empty() && self.abandoned_commits.is_empty())
     }
 
-    /// Creates a `DescendantRebaser` to rebase descendants of the recorded
-    /// rewritten and abandoned commits.
-    // TODO(ilyagr): Inline this. It's only used in tests.
-    fn create_descendant_rebaser<'settings, 'repo>(
-        &'repo mut self,
-        settings: &'settings UserSettings,
-    ) -> DescendantRebaser<'settings, 'repo> {
-        DescendantRebaser::new(
-            settings,
-            self,
-            self.rewritten_commits.clone(),
-            self.abandoned_commits.clone(),
-        )
-    }
-
     /// After the rebaser returned by this function is dropped,
     /// self.clear_descendant_rebaser_plans() needs to be called.
     fn rebase_descendants_return_rebaser<'settings, 'repo>(
@@ -908,7 +893,12 @@ impl MutableRepo {
             // Optimization
             return Ok(None);
         }
-        let mut rebaser = self.create_descendant_rebaser(settings);
+        let mut rebaser = DescendantRebaser::new(
+            settings,
+            self,
+            self.rewritten_commits.clone(),
+            self.abandoned_commits.clone(),
+        );
         *rebaser.mut_options() = options;
         rebaser.rebase_all()?;
         Ok(Some(rebaser))

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -600,8 +600,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         self.heads_to_remove.clear();
         self.heads_to_add.clear();
         self.mut_repo.set_view(view);
-        self.mut_repo.clear_rewritten_commits();
-        self.mut_repo.clear_abandoned_commits();
         Ok(None)
     }
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -242,7 +242,7 @@ pub struct RebaseOptions {
 }
 
 /// Rebases descendants of a commit onto a new commit (or several).
-pub struct DescendantRebaser<'settings, 'repo> {
+pub(crate) struct DescendantRebaser<'settings, 'repo> {
     settings: &'settings UserSettings,
     mut_repo: &'repo mut MutableRepo,
     // The commit identified by the key has been replaced by all the ones in the value, typically
@@ -521,7 +521,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
 
     // TODO: Perhaps change the interface since it's not just about rebasing
     // commits.
-    pub fn rebase_next(&mut self) -> Result<Option<RebasedDescendant>, TreeMergeError> {
+    fn rebase_next(&mut self) -> Result<Option<RebasedDescendant>, TreeMergeError> {
         while let Some(old_commit) = self.to_visit.pop() {
             let old_commit_id = old_commit.id().clone();
             if let Some(new_parent_ids) = self.parent_mapping.get(&old_commit_id).cloned() {

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -587,9 +587,12 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
                 new_commit,
             }));
         }
-        // TODO: As the TODO above says, we should probably change the API. Even if we
-        // don't, we should at least make this code not do any work if you call
-        // rebase_next() after we've returned None.
+        Ok(None)
+    }
+
+    pub fn rebase_all(&mut self) -> Result<(), TreeMergeError> {
+        while self.rebase_next()?.is_some() {}
+        // TODO: As the TODO above says, we should probably change the API.
         let mut view = self.mut_repo.view().store_view().clone();
         for commit_id in &self.heads_to_remove {
             view.head_ids.remove(commit_id);
@@ -600,11 +603,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         self.heads_to_remove.clear();
         self.heads_to_add.clear();
         self.mut_repo.set_view(view);
-        Ok(None)
-    }
-
-    pub fn rebase_all(&mut self) -> Result<(), TreeMergeError> {
-        while self.rebase_next()?.is_some() {}
         Ok(())
     }
 }


### PR DESCRIPTION
This finishes up #2737, making DescendantRebaser private to the library crate, and removing the use of the newly internal APIs from all the tests.

# Checklist

If applicable:
- [x] I have added tests to cover my changes
