### PR TITLE
add "op abandon root..head" command that "reparents" operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* New `jj op abandon` command is added to clean up the operation history. If GC
+  is implemented, Git refs and commit objects can be compacted.
+
 ### Fixed bugs
 
 

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -76,6 +76,7 @@ impl OpHeadsStore for SimpleOpHeadsStore {
     }
 
     fn update_op_heads(&self, old_ids: &[OperationId], new_id: &OperationId) {
+        assert!(!old_ids.contains(new_id));
         self.add_op_head(new_id);
         for old_id in old_ids {
             self.remove_op_head(old_id)


### PR DESCRIPTION
In order to implement GC (#12), we'll need to somehow prune old operations. Perhaps the easiest implementation is to just remove unwanted operation files and put tombstone file instead (like git shallow.) However, the removed operations might be referenced by another jj process running in parallel. Since the parallel operation thinks all the historical head commits are reachable, the removed operations would have to be resurrected (or fix up index data, etc.) when the op heads get merged.

The idea behind this patch is to split the "op log" GC into two steps:
 1. recreate operations to be retained and make the old history unreachable,
 2. delete unreachable operations if the head was created e.g. 3 days ago. The latter will be run by "jj util gc". I don't think GC can be implemented 100% safe against lock-less append-only storage, and we'll probably need some timestamp-based mechanism to not remove objects that might be referenced by uncommitted operation.

FWIW, another nice thing about this implementation is that the index is automatically invalidated as the op id changes. The bad thing is that the "undo" description would contain an old op id. It seems the performance is pretty okay.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
