### PR TITLE
Rewrite instead of abandoning empty commits.

### DIFF
--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -148,6 +148,7 @@ pub(crate) struct RebaseArgs {
     /// If true, when rebasing would produce an empty commit, the commit is
     /// skipped.
     /// Will never skip merge commits with multiple non-empty parents.
+    /// Will never skip the working commit.
     #[arg(long, conflicts_with = "revision")]
     skip_empty: bool,
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -159,11 +159,10 @@ pub fn rebase_commit_with_options(
             EmptyBehaviour::AbandonAllEmpty => *parent.tree_id() == new_tree_id,
         };
         if should_abandon {
-            mut_repo.record_abandoned_commit(old_commit.id().clone());
-            // Record old_commit as being succeeded by the parent for the purposes of
-            // the rebase.
+            // Record old_commit as being succeeded by the parent.
             // This ensures that when we stack commits, the second commit knows to
             // rebase on top of the parent commit, rather than the abandoned commit.
+            mut_repo.record_rewritten_commit(old_commit.id().clone(), parent.id().clone());
             return Ok(parent.clone());
         }
     }


### PR DESCRIPTION
Fixes #2760


Given the tree:
```
A-B-C
 \
  B2
```
And the command `jj rebase -s B -d B2`

We were previously marking B as abandoned, despite the comment stating that we were marking it as being succeeded by B2. This resulted in a call to `rewrite(rewrites={}, abandoned={B})` instead of `rewrite(rewrites={B=>B2}, abandoned={})`, which then made the new parent of `C` into `A` instead of `B2`