### PR TITLE
DescendantRebaser: change `rebased()` method to `into_map()` that consumes the rebaser

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -914,7 +914,7 @@ impl MutableRepo {
     ) -> Result<usize, TreeMergeError> {
         let result = self
             .rebase_descendants_return_rebaser(settings, options)?
-            .map_or(0, |rebaser| rebaser.rebased().len());
+            .map_or(0, |rebaser| rebaser.into_map().len());
         self.clear_descendant_rebaser_plans();
         Ok(result)
     }
@@ -942,7 +942,7 @@ impl MutableRepo {
             // enough information to describe the results of a rebase if some commits got
             // abandoned
             .rebase_descendants_return_rebaser(settings, options)?
-            .map_or(HashMap::new(), |rebaser| rebaser.rebased().clone()));
+            .map_or(HashMap::new(), |rebaser| rebaser.into_map()));
         self.clear_descendant_rebaser_plans();
         result
     }

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -381,8 +381,8 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
     /// Returns a map from `CommitId` of old commit to new commit. Includes the
     /// commits rebase so far. Does not include the inputs passed to
     /// `rebase_descendants`.
-    pub fn rebased(&self) -> &HashMap<CommitId, CommitId> {
-        &self.rebased
+    pub fn into_map(self) -> HashMap<CommitId, CommitId> {
+        self.rebased
     }
 
     /// Panics if `parent_mapping` contains cycles


### PR DESCRIPTION
This prevents a clone and does not affect the public API, as suggested
in https://github.com/martinvonz/jj/pull/2738#discussion_r1438903463.