### PR TITLE
docs `branches.md`: explain the new defaults and reorganize 

### DIFF
--- a/docs/branches.md
+++ b/docs/branches.md
@@ -51,6 +51,27 @@ some remote.
 If you want to know the internals of branch tracking, consult the 
 [Design Doc][design].
 
+### Terminology summary
+
+- A **remote branch** is a branch ref on the remote. `jj` can find out its
+  actual state only when it's actively communicating with the remote. However,
+  `jj` does store the last-seen position of the remote branch; this is the
+  commit `jj show <branch name>@<remote name>` would show. This notion is
+  completely analogous to Git's "remote-tracking branches".
+- A **tracked (remote) branch** is defined above. You can make a remote branch
+  tracked with the [`jj branch track` command](#manually-tracking-a-branch), for
+  example.
+- A **tracking (local) branch** is the local branch that `jj` tries to keep in
+  sync with the tracked remote branch. For example, after `jj branch track
+  mybranch@origin`, there will be a local branch `mybranch` that's tracking the
+  remote `mybranch@origin` branch. A local branch can track a branch of the same
+  name on 0 or more remotes.
+
+The notion of tracked branches serves a similar function to the Git notion of an
+"upstream branch". Unlike Git, a single local branch can be tracking remote
+branches on multiple remotes, and the names of the local and remote branches
+must match.
+
 ### Manually tracking a branch
 
 To track a branch permanently use `jj branch track <branch name>@<remote name>`. 

--- a/docs/branches.md
+++ b/docs/branches.md
@@ -51,7 +51,7 @@ some remote.
 If you want to know the internals of branch tracking, consult the 
 [Design Doc][design].
 
-### Tracking a branch
+### Manually tracking a branch
 
 To track a branch permanently use `jj branch track <branch name>@<remote name>`. 
 It will now be imported as a local branch until you untrack it or it is deleted
@@ -66,16 +66,17 @@ $ # Find the branch.
 $ # [...]
 $ # Actually track the branch.
 $ jj branch track <branch name>@<remote name> # Example: jj branch track my-feature@origin
-$ # From this point on, branch <name> is tracked and will always be imported.
-$ jj git fetch # Update the repository
-$ jj new <name> # Do some local testing, etc.
+$ # From this point on, <branch name> will be imported when fetching from <remote name>.
+$ jj git fetch --remote <remote name>
+$ # A local branch <branch name> should have been created or updated while fetching.
+$ jj new <branch name> # Do some local testing, etc.
 ```
 
 ### Untracking a branch
 
-To no longer have a branch available in a repository, you can 
-`jj branch untrack` it. After that subsequent fetches will no longer copy the 
-branch into the local repository. 
+To stop following a remote branch, you can `jj branch untrack` it. After that,
+subsequent fetches of that remote will no longer move the local branch to match
+the position of the remote branch.
 
 Example: 
 
@@ -86,7 +87,9 @@ $ # Find the branch we no longer want to track.
 $ # [...]
 # # Actually untrack it.
 $ jj branch untrack <branch name>@<remote name> # Example: jj branch untrack stuff@origin
-$ # From this point on, it won't be imported anymore. 
+$ # From this point on, this remote branch won't be imported anymore.
+$ # The local branch (e.g. stuff) is unaffected. It may or may not still
+$ # be tracking branches on other remotes (e.g. stuff@upstream).
 ```
 
 ### Automatic tracking of branches & `git.auto-local-branch` option

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -173,6 +173,14 @@ A tree object represents a snapshot of a directory in the repository. Tree
 objects are defined recursively; each tree object only has the files and
 directories contained directly in the directory it represents.
 
+## Tracked branches and tracking branches
+
+A remote branch can be made "tracked" with the `jj branch track` command. This
+results in a "tracking" local branch that tracks the remote branch.
+
+See [the branches documentation](branches.md#terminology-summary) for a more
+detailed definition of these terms.
+
 ## Visible commits
 
 Visible commits are the commits you see in `jj log -r 'all()'`. They are the


### PR DESCRIPTION
This follows up on #2625 and updates all sections of `branches.md` to represent the new default of `git.auto-local-branch=false`.

I also realized that the paragraph we discussed for so long with @PhilipMetzger actually repeats information that was already present a bit earlier in the file. So, I removed most of it and moved the rest. Sorry I didn't notice this earlier.
