### PR TITLE
Cargo.toml: update documentation site

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/martinvonz/jj"
 repository = "https://github.com/martinvonz/jj"
-documentation = "https://github.com/martinvonz/jj"
+documentation = "https://martinvonz.github.io/jj/"
 categories = ["version-control", "development-tools"]
 keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
 


### PR DESCRIPTION
I considered also updating the "homepage", but I think it's nice that it points to the README.

This complements @PhilipMetzger's suggestion from
https://discord.com/channels/968932220549103686/1167230861448581167/1192559848777334834
