### PR TITLE
Allow presenting change ids in readable mixed case

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -678,7 +678,6 @@ impl Template<()> for ShortestIdPrefix {
 // in the alphabet and neither should both `O` and `Q`, etc. See also:
 // https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3541865/
 // https://www.readnaturally.com/about-us/blog/a-strategy-for-students-who-confuse-letters
-#[allow(unused)]
 fn to_readable_case(s: &str) -> String {
     s.chars()
         .map(|c| match c.to_ascii_lowercase() {
@@ -699,6 +698,13 @@ impl ShortestIdPrefix {
         Self {
             prefix: self.prefix.to_ascii_uppercase(),
             rest: self.rest.to_ascii_uppercase(),
+        }
+    }
+
+    fn to_readable(&self) -> Self {
+        Self {
+            prefix: to_readable_case(&self.prefix),
+            rest: to_readable_case(&self.rest),
         }
     }
     fn to_lower(&self) -> Self {
@@ -733,6 +739,12 @@ fn build_shortest_id_prefix_method<'repo>(
             template_parser::expect_no_arguments(function)?;
             language
                 .wrap_shortest_id_prefix(TemplateFunction::new(self_property, |id| id.to_lower()))
+        }
+        "readable" => {
+            template_parser::expect_no_arguments(function)?;
+            language.wrap_shortest_id_prefix(TemplateFunction::new(self_property, |id| {
+                id.to_readable()
+            }))
         }
         _ => {
             return Err(TemplateParseError::no_such_method(

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -696,11 +696,11 @@ fn to_readable_case(s: &str) -> String {
 impl ShortestIdPrefix {
     fn to_upper(&self) -> Self {
         Self {
-            prefix: self.prefix.to_ascii_uppercase(),
-            rest: self.rest.to_ascii_uppercase(),
+            // TODO: Undo this
+            prefix: to_readable_case(&self.prefix),
+            rest: to_readable_case(&self.rest),
         }
     }
-
     fn to_readable(&self) -> Self {
         Self {
             prefix: to_readable_case(&self.prefix),

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -512,8 +512,8 @@ fn test_log_customize_short_id() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  QPVUNTSM test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
+    @  QpVuNtsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
     │  (empty) first
-    ◉  ZZZZZZZZ root() 00000000
+    ◉  zzzzzzzz root() 00000000
     "###);
 }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -44,7 +44,7 @@ fn test_templater_upper_lower() {
 
     insta::assert_snapshot!(
       render(r#"change_id.shortest(4).upper() ++ change_id.shortest(4).upper().lower()"#),
-      @"[1m[38;5;5mZ[0m[38;5;8mZZZ[39m[1m[38;5;5mz[0m[38;5;8mzzz[39m");
+      @"[1m[38;5;5mz[0m[38;5;8mzzz[39m[1m[38;5;5mz[0m[38;5;8mzzz[39m");
     insta::assert_snapshot!(
       render(r#""Hello".upper() ++ "Hello".lower()"#), @"HELLOhello");
 }


### PR DESCRIPTION
The idea is that you could put `change_id.readable()` in you commit template.

The concept of "readable case" focuses on the `k-z` part of the alphabet that's used for change ids. The
normal hexadecimal alphabet 0-9a-f doesn't have many confusable letters, except
perhaps `b` and `d`.

Here is what it looks like for me at the moment (my ids are also shorter than normal, 6 chars instead of 8):

![image](https://github.com/martinvonz/jj/assets/4123047/7d83d037-c4d3-411c-88f1-47e13702964c)


## Backstory and design

This is the third attempt at making change ids readable at a glance. Previously,
I was suggesting printing them in uppercase (which I use in my personal config,
but several people disliked the idea since they perceive UPPERCASE as yelling)
or printing half the alphabet in uppercase.

Since then, I found that uppercase doesn't solve all of my issues either, as
it's quite easy to confuse `OQ` or `UV` when reading quickly.

So, I now have a variation of the second idea where I carefully pick which
letters to capitalize. See comments and test in the commit for examples.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
