### PR TITLE
object_id: don't allow ObjectId::from_hex() a dynamically allocated string

### DIFF
--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -930,7 +930,7 @@ mod tests {
         let mut index = DefaultMutableIndex::full(3, 16);
         // Long linear history with some short branches
         let ids = (0..11)
-            .map(|n| CommitId::from_hex(&format!("{n:06x}")))
+            .map(|n| CommitId::try_from_hex(&format!("{n:06x}")).unwrap())
             .collect_vec();
         index.add_commit_data(ids[0].clone(), new_change_id(), &[]);
         for i in 1..ids.len() {

--- a/lib/src/object_id.rs
+++ b/lib/src/object_id.rs
@@ -44,8 +44,9 @@ macro_rules! impl_id_type {
 
             /// Parses the given hex string into an ObjectId.
             ///
-            /// The given string is usually a literal, and must be valid.
-            pub fn from_hex(hex: &str) -> Self {
+            /// The given string must be valid. A static str is required to
+            /// prevent API misuse.
+            pub fn from_hex(hex: &'static str) -> Self {
                 Self::try_from_hex(hex).unwrap()
             }
 

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -757,12 +757,12 @@ mod tests {
 
     #[test]
     fn test_migrate_git_refs_remote_named_git() {
-        let normal_ref_target = |id_hex: &str| RefTarget::normal(CommitId::from_hex(id_hex));
-        let normal_new_remote_ref = |id_hex: &str| RemoteRef {
+        let normal_ref_target = |id_hex| RefTarget::normal(CommitId::from_hex(id_hex));
+        let normal_new_remote_ref = |id_hex| RemoteRef {
             target: normal_ref_target(id_hex),
             state: RemoteRefState::New,
         };
-        let normal_tracking_remote_ref = |id_hex: &str| RemoteRef {
+        let normal_tracking_remote_ref = |id_hex| RemoteRef {
             target: normal_ref_target(id_hex),
             state: RemoteRefState::Tracking,
         };

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2792,7 +2792,7 @@ fn test_change_id_index() {
 
     let root_commit = repo.store().root_commit();
     let mut commit_number = 0;
-    let mut commit_with_change_id = |change_id: &str| {
+    let mut commit_with_change_id = |change_id| {
         commit_number += 1;
         tx.mut_repo()
             .new_commit(


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
