### PR TITLE
cli: allow non-static version strings from custom binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,12 @@ backoff = "0.4.0"
 blake2 = "0.10.6"
 bytes = "1.5.0"
 cargo_metadata = "0.17.0"
-clap = { version = "4.4.13", features = ["derive", "deprecated", "wrap_help"] }
+clap = { version = "4.4.13", features = [
+    "derive",
+    "deprecated",
+    "wrap_help",
+    "string",
+] }
 clap_complete = "4.4.6"
 clap_mangen = "0.2.10"
 chrono = { version = "0.4.31", default-features = false, features = [

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2783,8 +2783,8 @@ impl CliRunner {
     }
 
     /// Set the version to be displayed by `jj version`.
-    pub fn version(mut self, version: &'static str) -> Self {
-        self.app = self.app.version(version);
+    pub fn version(mut self, version: &str) -> Self {
+        self.app = self.app.version(version.to_string());
         self
     }
 


### PR DESCRIPTION
We would like to use a non-static version string at Google. We have a workaround using Lazy, but it seems unfortunate to have to do that. Using dynamic strings requires Clap's `string` feature, which increases the binary size by 140 kiB (0.6%).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
