### PR TITLE
GitHub workflow: document how one can install old Poetry locally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,9 @@ jobs:
           # Test with the version of Poetry in Debian stable. If this starts
           # failing, we should increase this version and document the minimum
           # necessary version of Poetry in contributing.md.
+          #
+          # One way to install old `poetry` is using `pipx`:
+          #    pipx install 'poetry<1.4' --suffix -1.3
           poetry-version: 1.3.2
       - name: Install dependencies
         run: poetry install --no-root


### PR DESCRIPTION
This is quite minor, but it took me a few minutes to figure out
the correct command. (I wanted to check whether CI would fail
without running CI or making a pull request).

It might be slightly better to print this text inside the build
logs, where people will be looking for certain if the CI fails,
but I didn't immediately find a good way to do so without
complicating the config too much.