### PR TITLE
docs: update CLI output in Tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,26 +10,29 @@ If you haven't already, make sure you
 ## Cloning a Git repo
 
 Let's start by cloning GitHub's Hello-World repo using `jj`:
+
 ```shell
 # Note the "git" before "clone" (there is no support for cloning native jj
 # repos yet)
 $ jj git clone https://github.com/octocat/Hello-World
 Fetching into new repo in "/tmp/tmp.O1DWMiaKd4/Hello-World"
-Working copy now at: d7439b06fbef (no description set)
+Working copy now at: kntqzsqt d7439b06 (empty) (no description set)
+Parent commit      : orrkosyo 7fd1a60b master | (empty) Merge pull request #6 from Spaceghost/patch-1
 Added 1 files, modified 0 files, removed 0 files
 $ cd Hello-World
 ```
 
-Running `jj st` (short for`jj status`) now yields something like this:
+Running `jj st` (short for `jj status`) now yields something like this:
+
 ```shell
 $ jj st
-Parent commit: 7fd1a60b01f9 Merge pull request #6 from Spaceghost/patch-1
-Working copy : d7439b06fbef (no description set)
 The working copy is clean
+Working copy : kntqzsqt d7439b06 (empty) (no description set)
+Parent commit: orrkosyo 7fd1a60b master | (empty) Merge pull request #6 from Spaceghost/patch-1
 ```
 
 We can see from the output above that our working copy is a real commit with a
-commit ID (`d7439b06fbef` in the example). When you make a change in the working
+commit ID (`d7439b06` in the example). When you make a change in the working
 copy, the working-copy commit gets automatically amended by the next `jj`
 command.
 
@@ -38,30 +41,35 @@ command.
 Now let's say we want to edit the `README` file in the repo to say "Goodbye"
 instead of "Hello". Let's start by describing the change (adding a
 commit message) so we don't forget what we're working on:
+
 ```shell
 # This will bring up $EDITOR (or `pico` or `Notepad` by default). Enter
 # something like "Say goodbye" in the editor and then save the file and close
 # the editor.
 $ jj describe
-Working copy now at: e427edcfd0ba Say goodbye
+Working copy now at: kntqzsqt e427edcf (empty) Say goodbye
+Parent commit      : orrkosyo 7fd1a60b master | (empty) Merge pull request #6 from Spaceghost/patch-1
 ```
 
 Now make the change in the README:
+
 ```shell
 # Adjust as necessary for compatibility with your flavor of `sed`
 $ sed -i 's/Hello/Goodbye/' README
 $ jj st
-Parent commit: 7fd1a60b01f9 Merge pull request #6 from Spaceghost/patch-1
-Working copy : 5d39e19dac36 Say goodbye
 Working copy changes:
 M README
+Working copy : kntqzsqt 5d39e19d Say goodbye
+Parent commit: orrkosyo 7fd1a60b master | (empty) Merge pull request #6 from Spaceghost/patch-1
 ```
+
 Note that you didn't have to tell Jujutsu to add the change like you would with
 `git add`. You actually don't even need to tell it when you add new files or
 remove existing files. To untrack a path, add it to your `.gitignore` and run
 `jj untrack <path>`.
 
 To see the diff, run `jj diff`:
+
 ```shell
 $ jj diff --git  # Feel free to skip the `--git` flag
 diff --git a/README b/README
@@ -72,6 +80,7 @@ index 980a0d5f19...1ce3f81130 100644
 -Hello World!
 +Goodbye World!
 ```
+
 Jujutsu's diff format currently defaults to inline coloring of the diff (like
 `git diff --color-words`), so we used `--git` above to make the diff readable in
 this tutorial.
@@ -87,13 +96,15 @@ VCSs, there is also a `jj checkout/co` command, which is practically a synonym
 for `jj new` (you can specify a destination for `jj new` as well).
 
 So, let's say we're now done with this change, so we create a new change:
+
 ```shell
 $ jj new
-Working copy now at: aef4df99ea11 (no description set)
+Working copy now at: mpqrykyp aef4df99 (empty) (no description set)
+Parent commit      : kntqzsqt 5d39e19d Say goodbye
 $ jj st
-Parent commit: 5d39e19dac36 Say goodbye
-Working copy : aef4df99ea11 (no description set)
 The working copy is clean
+Working copy : mpqrykyp aef4df99 (empty) (no description set)
+Parent commit: kntqzsqt 5d39e19d Say goodbye
 ```
 
 If we later realize that we want to make further changes, we can make them
@@ -114,19 +125,24 @@ sense to use `jj checkout` so you can easily review your adjustments with
 
 You're probably familiar with `git log`. Jujutsu has very similar functionality
 in its `jj log` command:
+
 ```shell
 $ jj log
-@  mpqrykypylvy martinvonz@google.com 2023-02-12 15:00:22.000 -08:00 aef4df99ea11
+@  mpqrykyp martinvonz@google.com 2023-02-12 15:00:22.000 -08:00 aef4df99
 │  (empty) (no description set)
-◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+◉  kntqzsqt martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19d
 │  Say goodbye
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+│ ◉  tpstlust support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1@origin b1b3f972
+├─╯  sentence case
+│ ◉  kowxouwz octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test@origin b3cbd5bb
+├─╯  Create CONTRIBUTING.md
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
 
 The `@` indicates the working-copy commit. The first ID on a line
-(e.g. "mpqrykypylvy" above) is the "change ID", which is an ID that follows the
+(e.g. "mpqrykyp" above) is the "change ID", which is an ID that follows the
 commit as it's rewritten (similar to Gerrit's Change-Id). The second ID is the
 commit ID, which changes when you rewrite the commit. You can give either ID
 to commands that take revisions as arguments. We will generally prefer change
@@ -141,21 +157,17 @@ example, `@` refers to the working-copy commit, `root()` refers to the root
 commit, `branches()` refers to all commits pointed to by branches. We can
 combine expressions with `|` for union, `&` for intersection and `~` for
 difference. For example:
+
 ```shell
 $ jj log -r '@ | root() | branches()'
-@  mpqrykypylvy martinvonz@google.com 2023-02-12 15:00:22.000 -08:00 aef4df99ea11
+@  mpqrykyp martinvonz@google.com 2023-02-12 15:00:22.000 -08:00 aef4df99
 ╷  (empty) (no description set)
-╷ ◉  kowxouwzwxmv octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test b3cbd5bbd7e8
-╭─╯  Create CONTRIBUTING.md
-│ ◉  tpstlustrvsn support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1 b1b3f9723831
-├─╯  sentence case
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 ╷  (empty) Merge pull request #6 from Spaceghost/patch-1
-◉  zzzzzzzzzzzz 1970-01-01 00:00:00.000 +00:00 000000000000
-   (empty) (no description set)
+◉  zzzzzzzz root() 00000000
 ```
 
-The `000000000000` commit (change ID `zzzzzzzzzzzz`) is a virtual commit that's
+The `00000000` commit (change ID `zzzzzzzz`) is a virtual commit that's
 called the "root commit". It's the root commit of every repo. The `root()`
 function in the revset matches it.
 
@@ -173,26 +185,34 @@ descriptions (commit messages) right away.
 ```shell
 # Start creating a chain of commits off of the `master` branch
 $ jj new master -m A; echo a > file1
-Working copy now at: 00a2aeed556a A
+Working copy now at: nuvyytnq 00a2aeed (empty) A
+Parent commit      : orrkosyo 7fd1a60b master | (empty) Merge pull request #6 from Spaceghost/patch-1
 Added 0 files, modified 1 files, removed 0 files
 $ jj new -m B1; echo b1 > file1
-Working copy now at: 967d9f9fd288 B1
+Working copy now at: ovknlmro 967d9f9f (empty) B1
+Parent commit      : nuvyytnq 5dda2f09 A
 $ jj new -m B2; echo b2 > file1
-Working copy now at: 8ebeaffa332b B2
+Working copy now at: puqltutt 8ebeaffa (empty) B2
+Parent commit      : ovknlmro 7d7c6e6b B1
 $ jj new -m C; echo c > file2
-Working copy now at: 62a3c6d315cd C
+Working copy now at: qzvqqupx 62a3c6d3 (empty) C
+Parent commit      : puqltutt daa6ffd5 B2
 $ jj log
-@  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:07:41.946 -08:00 2370ddf3fa39
+@  qzvqqupx martinvonz@google.com 2023-02-12 15:07:41.946 -08:00 2370ddf3
 │  C
-◉  puqltuttrvzp martinvonz@google.com 2023-02-12 15:07:33.000 -08:00 daa6ffd5a09a
+◉  puqltutt martinvonz@google.com 2023-02-12 15:07:33.000 -08:00 daa6ffd5
 │  B2
-◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+◉  ovknlmro martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6b
 │  B1
-◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnq martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f09
 │  A
-│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqt martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19d
 ├─╯  Say goodbye
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+│ ◉  tpstlust support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1@origin b1b3f972
+├─╯  sentence case
+│ ◉  kowxouwz octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test@origin b3cbd5bb
+├─╯  Create CONTRIBUTING.md
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -203,22 +223,35 @@ modifies a different file. Let's now rebase B2 directly onto A. We use the
 on A.
 
 ```shell
-$ jj rebase -s puqltuttrvzp -d nuvyytnqlquo
+$ jj rebase -s puqltutt -d nuvyytnq  # Replace the IDs by what you have for B2 and A
 Rebased 2 commits
-Working copy now at: 1978b53430cd C
+New conflicts appeared in these commits:
+  qzvqqupx 1978b534 (conflict) C
+  puqltutt f7fb5943 (conflict) B2
+To resolve the conflicts, start by updating to the first one:
+  jj new puqltuttzvly
+Then use `jj resolve`, or edit the conflict markers in the file directly.
+Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Then run `jj squash` to move the resolution into the conflicted commit.
+Working copy now at: qzvqqupx 1978b534 (conflict) C
+Parent commit      : puqltutt f7fb5943 (conflict) B2
 Added 0 files, modified 1 files, removed 0 files
 $ jj log
-@  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b53430cd conflict
+@  qzvqqupx martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b534 conflict
 │  C
-◉  puqltuttrvzp martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943ee41 conflict
+◉  puqltutt martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943 conflict
 │  B2
-│ ◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+│ ◉  ovknlmro martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6b
 ├─╯  B1
-◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnq martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f09
 │  A
-│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqt martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19d
 ├─╯  Say goodbye
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+│ ◉  tpstlust support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1@origin b1b3f972
+├─╯  sentence case
+│ ◉  kowxouwz octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test@origin b3cbd5bb
+├─╯  Create CONTRIBUTING.md
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -227,23 +260,25 @@ There are several things worth noting here. First, the `jj rebase` command said
 "Rebased 2 commits". That's because we asked it to rebase commit B2 with the
 `-s` option, which also rebases descendants (commit C in this case). Second,
 because B2 modified the same file (and word) as B1, rebasing
-it resulted in conflicts, as the `jj log` output indicates. Third, the conflicts
+it resulted in conflicts, as the output indicates. Third, the conflicts
 did not prevent the rebase from completing successfully, nor did it prevent C
 from getting rebased on top.
 
 Now let's resolve the conflict in B2. We'll do that by creating a new commit on
 top of B2. Once we've resolved the conflict, we'll squash the conflict
 resolution into the conflicted B2. That might look like this:
+
 ```shell
-$ jj new puqltuttrvzp  # Replace the ID by what you have for B2
-Working copy now at: c7068d1c23fd (no description set)
+$ jj new puqltutt  # Replace the ID by what you have for B2
+Working copy now at: zxoosnnp c7068d1c (conflict) (empty) (no description set)
+Parent commit      : puqltutt f7fb5943 (conflict) B2
 Added 0 files, modified 0 files, removed 1 files
 $ jj st
-Parent commit: f7fb5943ee41 B2
-Working copy : c7068d1c23fd (no description set)
 The working copy is clean
 There are unresolved conflicts at these paths:
 file1    2-sided conflict
+Working copy : zxoosnnp c7068d1c (conflict) (empty) (no description set)
+Parent commit: puqltutt f7fb5943 (conflict) B2
 $ cat file1
 <<<<<<<
 %%%%%%%
@@ -255,21 +290,29 @@ b2
 $ echo resolved > file1
 $ jj squash
 Rebased 1 descendant commits
-Working copy now at: e3c279cc2043 (no description set)
+Existing conflicts were resolved or abandoned from these commits:
+  qzvqqupx hidden 1978b534 (conflict) C
+  puqltutt hidden f7fb5943 (conflict) B2
+Working copy now at: ntxxqymr e3c279cc (empty) (no description set)
+Parent commit      : puqltutt 2c7a658e B2
 $ jj log
-@  ntxxqymrlvxu martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 e3c279cc2043
+@  ntxxqymr martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 e3c279cc
 │  (empty) (no description set)
-│ ◉  qzvqqupxlkot martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 b9da9d28b26b
+│ ◉  qzvqqupx martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 b9da9d28
 ├─╯  C
-◉  puqltuttrvzp martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 2c7a658e2586
+◉  puqltutt martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 2c7a658e
 │  B2
-│ ◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+│ ◉  ovknlmro martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6b
 ├─╯  B1
-◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnq martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f09
 │  A
-│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqt martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19d
 ├─╯  Say goodbye
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+│ ◉  tpstlust support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1@origin b1b3f972
+├─╯  sentence case
+│ ◉  kowxouwz octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test@origin b3cbd5bb
+├─╯  Create CONTRIBUTING.md
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -278,7 +321,7 @@ Note that commit C automatically got rebased on top of the resolved B2, and that
 C is also resolved (since it modified only a different file).
 
 By the way, if we want to get rid of B1 now, we can run `jj abandon
-ovknlmrokpkl`. That will hide the commit from the log output and will rebase any
+ovknlmro`. That will hide the commit from the log output and will rebase any
 descendants to its parent.
 
 ## The operation log
@@ -286,44 +329,61 @@ descendants to its parent.
 Jujutsu keeps a record of all changes you've made to the repo in what's called
 the "operation log". Use the `jj op` (short for `jj operation`) family of
 commands to interact with it. To list the operations, use `jj op log`:
+
 ```shell
 $ jj op log
-@  d3b77addea49 martinvonz@vonz.svl.corp.google.com 2023-02-12 19:34:09.549 -08:00 - 2023-02-12 19:34:09.552 -08:00
+@  d3b77addea49 martinvonz@vonz.svl.corp.google.com 3 minutes ago, lasted 3 milliseconds
 │  squash commit 63874fe6c4fba405ffc38b0dd926f03b715cf7ef
 │  args: jj squash
-◉  6fc1873c1180 martinvonz@vonz.svl.corp.google.com 2023-02-12 19:34:09.548 -08:00 - 2023-02-12 19:34:09.549 -08:00
+◉  6fc1873c1180 martinvonz@vonz.svl.corp.google.com 3 minutes ago, lasted 1 milliseconds
 │  snapshot working copy
-◉  ed91f7bcc1fb martinvonz@vonz.svl.corp.google.com 2023-02-12 19:32:46.007 -08:00 - 2023-02-12 19:32:46.008 -08:00
+│  args: jj squash
+◉  ed91f7bcc1fb martinvonz@vonz.svl.corp.google.com 6 minutes ago, lasted 1 milliseconds
 │  new empty commit
-│  args: jj new puqltuttrvzp
-◉  367400773f87 martinvonz@vonz.svl.corp.google.com 2023-02-12 15:08:33.917 -08:00 - 2023-02-12 15:08:33.920 -08:00
+│  args: jj new puqltutt
+◉  367400773f87 martinvonz@vonz.svl.corp.google.com 12 minutes ago, lasted 3 milliseconds
 │  rebase commit daa6ffd5a09a8a7d09a65796194e69b7ed0a566d and descendants
-│  args: jj rebase -s puqltuttrvzp -d nuvyytnqlquo
+│  args: jj rebase -s puqltutt -d nuvyytnq
 [many more lines]
 ```
 
 The most useful command is `jj undo` (alias for `jj op undo`), which will undo
 an operation. By default, it will undo the most recent operation. Let's try it:
+
 ```shell
 $ jj undo
-Working copy now at: 63874fe6c4fb (no description set)
+New conflicts appeared in these commits:
+  qzvqqupx 1978b534 (conflict) C
+  puqltutt f7fb5943 (conflict) B2
+To resolve the conflicts, start by updating to the first one:
+  jj new puqltuttzvly
+Then use `jj resolve`, or edit the conflict markers in the file directly.
+Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Then run `jj squash` to move the resolution into the conflicted commit.
+Working copy now at: zxoosnnp 63874fe6 (no description set)
+Parent commit      : puqltutt f7fb5943 (conflict) B2
 $ jj log
-@  zxoosnnpvvpn martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 63874fe6c4fb
+@  zxoosnnp martinvonz@google.com 2023-02-12 19:34:09.000 -08:00 63874fe6
 │  (no description set)
-│ ◉  qzvqqupxlkot martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b53430cd conflict
+│ ◉  qzvqqupx martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 1978b534 conflict
 ├─╯  C
-◉  puqltuttrvzp martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943ee41 conflict
+◉  puqltutt martinvonz@google.com 2023-02-12 15:08:33.000 -08:00 f7fb5943 conflict
 │  B2
-│ ◉  ovknlmrokpkl martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6bd0b4
+│ ◉  ovknlmro martinvonz@google.com 2023-02-12 15:07:24.000 -08:00 7d7c6e6b
 ├─╯  B1
-◉  nuvyytnqlquo martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f097aa9
+◉  nuvyytnq martinvonz@google.com 2023-02-12 15:07:05.000 -08:00 5dda2f09
 │  A
-│ ◉  kntqzsqtnspv martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19dac36
+│ ◉  kntqzsqt martinvonz@google.com 2023-02-12 14:56:59.000 -08:00 5d39e19d
 ├─╯  Say goodbye
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+│ ◉  tpstlust support+octocat@github.com 2018-05-10 12:55:19.000 -05:00 octocat-patch-1@origin b1b3f972
+├─╯  sentence case
+│ ◉  kowxouwz octocat@nowhere.com 2014-06-10 15:22:26.000 -07:00 test@origin b3cbd5bb
+├─╯  Create CONTRIBUTING.md
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
+
 As you can perhaps see, that undid the `jj squash` invocation we used for
 squashing the conflict resolution into commit B2 earlier. Notice that it also
 updated the working copy.
@@ -336,28 +396,30 @@ try `jj log --at-op=367400773f87` but use the hash from your own `jj op log`.
 
 You have already seen how `jj squash` can combine the changes from two commits
 into one. There are several other commands for changing the contents of existing
-commits. These commands assume that you have `meld` installed. If you prefer a
-terminal-based diff editor, you
-can [configure `scm-diff-editor`](config.md#setting-up-scm-diff-editor) instead.
+commits.
 
 We'll need some more complex content to test these commands, so let's create a
 few more commits:
+
 ```shell
 $ jj new master -m abc; printf 'a\nb\nc\n' > file
-Working copy now at: f94e49cf2547 abc
+Working copy now at: ztqrpvnw f94e49cf (empty) abc
+Parent commit      : orrkosyo 7fd1a60b master | (empty) Merge pull request #6 from Spaceghost/patch-1
 Added 0 files, modified 0 files, removed 1 files
 $ jj new -m ABC; printf 'A\nB\nc\n' > file
-Working copy now at: 6f30cd1fb351 ABC
+Working copy now at: kwtuwqnm 6f30cd1f (empty) ABC
+Parent commit      : ztqrpvnw 51002261 ab
 $ jj new -m ABCD; printf 'A\nB\nC\nD\n' > file
-Working copy now at: a67491542e10 ABCD
+Working copy now at: mrxqplyk a6749154 (empty) ABCD
+Parent commit      : kwtuwqnm 30aecc08 ABC
 $ jj log -r master::@
-@  mrxqplykzpkw martinvonz@google.com 2023-02-12 19:38:21.000 -08:00 b98c607bf87f
+@  mrxqplyk martinvonz@google.com 2023-02-12 19:38:21.000 -08:00 b98c607b
 │  ABCD
-◉  kwtuwqnmqyqp martinvonz@google.com 2023-02-12 19:38:12.000 -08:00 30aecc0871ea
+◉  kwtuwqnm martinvonz@google.com 2023-02-12 19:38:12.000 -08:00 30aecc08
 │  ABC
-◉  ztqrpvnwqqnq martinvonz@google.com 2023-02-12 19:38:03.000 -08:00 510022615871
+◉  ztqrpvnw martinvonz@google.com 2023-02-12 19:38:03.000 -08:00 51002261
 │  abc
-◉  orrkosyozysx octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b01f9
+◉  orrkosyo octocat@nowhere.com 2012-03-06 15:06:50.000 -08:00 master 7fd1a60b
 │  (empty) Merge pull request #6 from Spaceghost/patch-1
 ~
 ```
@@ -369,15 +431,21 @@ that by running `jj squash` with the `--interactive`/`-i` option on the
 third commit. Remember that `jj squash` moves all the changes from one commit
 into its parent. `jj squash -i` moves only part of the changes into its parent.
 Now try that:
+
 ```shell
 $ jj squash -i
-Using default editor 'meld'; you can change this by setting ui.diff-editor
-Working copy now at: 52a6c7fda1e3 ABCD
+Using default editor ':builtin'; you can change this by setting ui.diff-editor
+Working copy now at: mrxqplyk 52a6c7fd ABCD
+Parent commit      : kwtuwqnm 643061ac ABC
 ```
-That will bring up Meld with a diff of the changes in the "ABCD" commit. Modify
-the right side of the diff to have the desired end state in "ABC" by removing
-the "D" line. Then save the changes and close Meld. If we look at the diff of
-the second commit, we now see that all three lines got capitalized:
+
+That will bring up the built-in diff editor with a diff of the changes in
+the "ABCD" commit. If you prefer another diff editor, you can configure
+[`ui.diff-editor`](config.md#editing-diffs) instead. Modify the right side of
+the diff to have the desired end state in "ABC" by removing the "D" line. Then
+save the changes and close Meld. If we look at the diff of the second commit, we
+now see that all three lines got capitalized:
+
 ```shell
 $ jj diff -r @-
 Modified regular file file:
@@ -394,16 +462,26 @@ conflicts.
 Let's try one final command for changing the contents of an exiting commit. That
 command is `jj diffedit`, which lets you edit the contents of a commit without
 checking it out.
+
 ```shell
 $ jj diffedit -r @-
-Using default editor 'meld'; you can change this by setting ui.diff-editor
-Created 70985eaa924f ABC
+Using default editor ':builtin'; you can change this by setting ui.diff-editor
+Created kwtuwqnm 70985eaa (empty) ABC
 Rebased 1 descendant commits
-Working copy now at: 1c72cd50525d ABCD
+New conflicts appeared in these commits:
+  mrxqplyk 1c72cd50 (conflict) ABCD
+To resolve the conflicts, start by updating to it:
+  jj new mrxqplykmyqv
+Then use `jj resolve`, or edit the conflict markers in the file directly.
+Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Then run `jj squash` to move the resolution into the conflicted commit.
+Working copy now at: mrxqplyk 1c72cd50 (conflict) ABCD
+Parent commit      : kwtuwqnm 70985eaa (empty) ABC
 Added 0 files, modified 1 files, removed 0 files
 ```
-When Meld starts, edit the right side by e.g. adding something to the first
-line. Then save the changes and close Meld. You can now inspect the rewritten
+
+In the diff editor, edit the right side by e.g. adding something to the first
+line. Press 'c' to save the changes and close it. You can now inspect the rewritten
 commit with `jj diff -r @-` again and you should see your addition to the first
 line. Unlike `jj squash -i`, which left the content state of the commit
 unchanged, `jj diffedit` (typically) results in a different state, which means


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Update the tutorial with current CLI outputs which seem to have changed substantially since the Tutorial was written, like expanded status output with change IDs and conflicts, longer log output, etc. The old data like commit IDs, change IDs, and author dates are kept, though the old author date could potentially be confusing.

Also some minor fixes in wording around the built-in merge tool and formatting.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
