### PR TITLE
revset: remove unused lifetime parameter from Revset<'index>

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1139,7 +1139,7 @@ Set which revision the branch points to with `jj branch set {branch_name} -r <RE
     pub fn evaluate_revset<'repo>(
         &'repo self,
         revset_expression: Rc<RevsetExpression>,
-    ) -> Result<Box<dyn Revset<'repo> + 'repo>, CommandError> {
+    ) -> Result<Box<dyn Revset + 'repo>, CommandError> {
         let symbol_resolver = self.revset_symbol_resolver()?;
         let revset_expression =
             revset_expression.resolve_user_expression(self.repo().as_ref(), &symbol_resolver)?;

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -307,7 +307,7 @@ impl<'a> CompositeIndex<'a> {
         &self,
         expression: &ResolvedExpression,
         store: &Arc<Store>,
-    ) -> Result<Box<dyn Revset<'a> + 'a>, RevsetEvaluationError> {
+    ) -> Result<Box<dyn Revset + 'a>, RevsetEvaluationError> {
         let revset_impl = revset_engine::evaluate(expression, store, *self)?;
         Ok(Box::new(revset_impl))
     }
@@ -400,7 +400,7 @@ impl Index for CompositeIndex<'_> {
         &'index self,
         expression: &ResolvedExpression,
         store: &Arc<Store>,
-    ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
+    ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError> {
         CompositeIndex::evaluate_revset(self, expression, store)
     }
 }

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -453,7 +453,7 @@ impl Index for DefaultMutableIndex {
         &'index self,
         expression: &ResolvedExpression,
         store: &Arc<Store>,
-    ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
+    ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError> {
         self.as_composite().evaluate_revset(expression, store)
     }
 }

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -521,7 +521,7 @@ impl Index for DefaultReadonlyIndex {
         &'index self,
         expression: &ResolvedExpression,
         store: &Arc<Store>,
-    ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
+    ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError> {
         self.as_composite().evaluate_revset(expression, store)
     }
 }

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -110,11 +110,7 @@ impl<I> fmt::Debug for RevsetImpl<I> {
     }
 }
 
-impl<'index, I> Revset<'index> for RevsetImpl<I>
-where
-    // Clone + Send + Sync for change_id_index()
-    I: AsCompositeIndex + Clone + Send + Sync + 'index,
-{
+impl<I: AsCompositeIndex> Revset for RevsetImpl<I> {
     fn iter(&self) -> Box<dyn Iterator<Item = CommitId> + '_> {
         Box::new(self.entries().map(|index_entry| index_entry.commit_id()))
     }

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -81,7 +81,7 @@ pub trait Index: Send + Sync {
         &'index self,
         expression: &ResolvedExpression,
         store: &Arc<Store>,
-    ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError>;
+    ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError>;
 }
 
 pub trait ReadonlyIndex: Send + Sync {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -663,7 +663,7 @@ impl RevsetExpression {
     pub fn evaluate_programmatic<'index>(
         self: Rc<Self>,
         repo: &'index dyn Repo,
-    ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
+    ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError> {
         optimize(self).resolve_programmatic(repo).evaluate(repo)
     }
 }
@@ -728,7 +728,7 @@ impl ResolvedExpression {
     pub fn evaluate<'index>(
         &self,
         repo: &'index dyn Repo,
-    ) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
+    ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError> {
         repo.index().evaluate_revset(self, repo.store())
     }
 }
@@ -1945,7 +1945,7 @@ pub fn walk_revs<'index>(
     repo: &'index dyn Repo,
     wanted: &[CommitId],
     unwanted: &[CommitId],
-) -> Result<Box<dyn Revset<'index> + 'index>, RevsetEvaluationError> {
+) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError> {
     RevsetExpression::commits(unwanted.to_vec())
         .range(&RevsetExpression::commits(wanted.to_vec()))
         .evaluate_programmatic(repo)
@@ -2404,7 +2404,7 @@ impl VisibilityResolutionContext<'_> {
     }
 }
 
-pub trait Revset<'index>: fmt::Debug {
+pub trait Revset: fmt::Debug {
     /// Iterate in topological order with children before parents.
     fn iter(&self) -> Box<dyn Iterator<Item = CommitId> + '_>;
 

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -61,7 +61,7 @@ fn resolve_symbol(repo: &dyn Repo, symbol: &str) -> Result<Vec<CommitId>, Revset
 fn revset_for_commits<'index>(
     repo: &'index dyn Repo,
     commits: &[&Commit],
-) -> Box<dyn Revset<'index> + 'index> {
+) -> Box<dyn Revset + 'index> {
     let symbol_resolver = DefaultSymbolResolver::new(repo);
     RevsetExpression::commits(commits.iter().map(|commit| commit.id().clone()).collect())
         .resolve_user_expression(repo, &symbol_resolver)


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
