### PR TITLE
RFC: index: add all_heads() that iterates heads of all indexed commits

### DIFF
--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -1143,7 +1143,12 @@ mod tests {
         // Merge commit and other commit
         assert_eq!(
             index.heads(&mut [id_5.clone(), id_3.clone()].iter()),
-            vec![id_3, id_5]
+            vec![id_3.clone(), id_5.clone()]
+        );
+
+        assert_eq!(
+            index.all_heads_for_gc().unwrap().collect_vec(),
+            vec![id_3.clone(), id_5.clone()]
         );
     }
 }

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -35,7 +35,7 @@ use super::readonly::{DefaultReadonlyIndex, ReadonlyIndexSegment};
 use crate::backend::{ChangeId, CommitId};
 use crate::commit::Commit;
 use crate::file_util::persist_content_addressed_temp_file;
-use crate::index::{ChangeIdIndex, Index, MutableIndex, ReadonlyIndex};
+use crate::index::{AllHeadsForGcUnsupported, ChangeIdIndex, Index, MutableIndex, ReadonlyIndex};
 use crate::object_id::{HexPrefix, ObjectId, PrefixResolution};
 use crate::revset::{ResolvedExpression, Revset, RevsetEvaluationError};
 use crate::store::Store;
@@ -432,6 +432,12 @@ impl Index for DefaultMutableIndex {
 
     fn common_ancestors(&self, set1: &[CommitId], set2: &[CommitId]) -> Vec<CommitId> {
         self.as_composite().common_ancestors(set1, set2)
+    }
+
+    fn all_heads_for_gc(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = CommitId> + '_>, AllHeadsForGcUnsupported> {
+        Ok(Box::new(self.as_composite().all_heads()))
     }
 
     fn heads(&self, candidates: &mut dyn Iterator<Item = &CommitId>) -> Vec<CommitId> {

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -30,7 +30,7 @@ use super::composite::{AsCompositeIndex, ChangeIdIndexImpl, CompositeIndex, Inde
 use super::entry::{IndexPosition, LocalPosition, SmallIndexPositionsVec};
 use super::mutable::DefaultMutableIndex;
 use crate::backend::{ChangeId, CommitId};
-use crate::index::{ChangeIdIndex, Index, MutableIndex, ReadonlyIndex};
+use crate::index::{AllHeadsForGcUnsupported, ChangeIdIndex, Index, MutableIndex, ReadonlyIndex};
 use crate::object_id::{HexPrefix, ObjectId, PrefixResolution};
 use crate::revset::{ResolvedExpression, Revset, RevsetEvaluationError};
 use crate::store::Store;
@@ -499,6 +499,12 @@ impl Index for DefaultReadonlyIndex {
 
     fn common_ancestors(&self, set1: &[CommitId], set2: &[CommitId]) -> Vec<CommitId> {
         self.as_composite().common_ancestors(set1, set2)
+    }
+
+    fn all_heads_for_gc(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = CommitId> + '_>, AllHeadsForGcUnsupported> {
+        Ok(Box::new(self.as_composite().all_heads()))
     }
 
     fn heads(&self, candidates: &mut dyn Iterator<Item = &CommitId>) -> Vec<CommitId> {


### PR DESCRIPTION
`GitBackend::gc()` will recreate no-gc refs for the indexed heads. We could collect all historical heads by traversing operation log, but it isn't enough because there may be predecessor links to hidden commits, and "git gc" isn't aware of predecessors.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
