### PR TITLE
cli: implement jj root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj resolve` now displays the file being resolved.
 
+* `jj workspace root` was aliased to `jj root`, for ease of discoverability
+
 ### Fixed bugs
 
 * Fixed snapshots of symlinks in `gitignore`-d directory.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -43,6 +43,7 @@ mod prev;
 mod rebase;
 mod resolve;
 mod restore;
+mod root;
 mod run;
 mod show;
 mod sparse;
@@ -119,6 +120,7 @@ enum Command {
         help_template = "Not a real subcommand; consider `jj backout` or `jj restore`"
     )]
     Revert(DummyCommandArgs),
+    Root(root::RootArgs),
     #[command(hide = true)]
     // TODO: Flesh out.
     Run(run::RunArgs),
@@ -182,6 +184,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Unsquash(sub_args) => unsquash::cmd_unsquash(ui, command_helper, sub_args),
         Command::Restore(sub_args) => restore::cmd_restore(ui, command_helper, sub_args),
         Command::Revert(_args) => revert(),
+        Command::Root(sub_args) => root::cmd_root(ui, command_helper, sub_args),
         Command::Run(sub_args) => run::cmd_run(ui, command_helper, sub_args),
         Command::Diffedit(sub_args) => diffedit::cmd_diffedit(ui, command_helper, sub_args),
         Command::Split(sub_args) => split::cmd_split(ui, command_helper, sub_args),

--- a/cli/src/commands/root.rs
+++ b/cli/src/commands/root.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tracing::instrument;
+
+use crate::cli_util::{CommandError, CommandHelper};
+use crate::commands::workspace;
+use crate::ui::Ui;
+
+/// Show the current workspace root directory
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct RootArgs {}
+
+#[instrument(skip_all)]
+pub(crate) fn cmd_root(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    RootArgs {}: &RootArgs,
+) -> Result<(), CommandError> {
+    workspace::cmd_workspace(
+        ui,
+        command,
+        &workspace::WorkspaceCommand::Root(workspace::WorkspaceRootArgs {}),
+    )
+}

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -1,0 +1,44 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use test_case::test_case;
+use testutils::{TestRepoBackend, TestWorkspace};
+
+use crate::common::TestEnvironment;
+
+pub mod common;
+
+#[test_case(TestRepoBackend::Local ; "local backend")]
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn test_root(backend: TestRepoBackend) {
+    let test_env = TestEnvironment::default();
+    let settings = testutils::user_settings();
+    let test_workspace = TestWorkspace::init_with_backend(&settings, backend);
+    let root = test_workspace.workspace.workspace_root();
+    let subdir = root.join("subdir");
+    std::fs::create_dir(&subdir).unwrap();
+    let stdout = test_env.jj_cmd_success(&subdir, &["root"]);
+    assert_eq!(&stdout, &[root.to_str().unwrap(), "\n"].concat());
+}
+
+#[test]
+fn test_root_outside_a_repo() {
+    let test_env = TestEnvironment::default();
+    let stdout = test_env.jj_cmd_failure(Path::new("/"), &["root"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Error: There is no jj repo in "."
+    "###);
+}


### PR DESCRIPTION
This is a convenient command when scripting around, for things like: $ cd $(jj root) && do something

Currently this fails if the path to the repo contains non-utf8 bytes, similarly to `jj status` failing on non-utf8 paths inside the repo.

This is a proposal out of the blue, but since this is a small change and it seems not contentious, I figured if it was simpler to do it and possibly argue about the utility of the PR, rather than have a round of discussion followed by a round of PR.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
