### PR TITLE
docs: add git comparison for `jj workspace root`

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -303,6 +303,11 @@ parent.
       <td><code>git co &lt;destination&gt;; git cherry-pick &lt;source&gt;</code></td>
     </tr>
     <tr>
+      <td>Find the root of the working copy (or check if in a repo)</td>
+      <td><code>jj workspace root</code></td>
+      <td><code>git rev-parse --show-toplevel</code></td>
+    </tr>
+    <tr>
       <td>List branches</td>
       <td><code>jj branch list</code></td>
       <td><code>git branch</code></td>


### PR DESCRIPTION
To make the jj command more discoverable.

This seems like a clearly useful thing to add, irrespective of the outcome of the other PR.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
