### PR TITLE
Refactor init command in preparation to move git related portions.

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -191,6 +191,9 @@ impl From<WorkspaceInitError> for CommandError {
             WorkspaceInitError::Path(err) => {
                 CommandError::InternalError(format!("Failed to access the repository: {err}"))
             }
+            WorkspaceInitError::PathNotFound(path) => {
+                user_error(format!("{} doesn't exist", path.display().to_string()))
+            }
             WorkspaceInitError::Backend(err) => {
                 user_error(format!("Failed to access the repository: {err}"))
             }


### PR DESCRIPTION
* Add Workspace::create_workspace_root() which is needed by all init functionality regardless of the backend.
* Move canonicalization of the external git repo path into the Workspace::init_git_external(). This keeps necessary code together.
* Create a git_init() function in cli/src/commands/init.rs where all git related work is done. This function will be moved to cli/src/commands/git.rs in a subsequent PR.
* Add a new variant of WorkspaceInitError for reporting path not found errors. The user error string is written to pass existing tests.

# Checklist

If applicable:
- [ ] I have added tests to cover my changes
> Existing tests pass after the refactor.
