### PR TITLE
doc: suggest ripgrep as an equivalent of `git grep`

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -190,7 +190,7 @@ parent.
     </tr>
     <tr>
       <td>Search among files versioned in the repository</td>
-      <td><code>grep foo $(jj files)</code></td>
+      <td><code>grep foo $(jj files)</code>, or <code>rg --no-require-git foo</code></td>
       <td><code>git grep foo</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Sadly, ripgrep won't honor the .gitignore files in the absence of a .git directory, so we need to pass an annoying flag (for non-colocated repos).

That seems worth adding despite the existing suggestion, because rg is faster, and for existing users for rg, it would teach them how to make rg work as expected.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
