### PR TITLE
Support `--user` and `--repo` argument for `config list` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj config list` gained a `--include-overridden` option to allow
   printing overridden config values.
 
+* `jj config list` now accepts `--user` or `--repo` option to specify
+  config origin.
+
 ### Fixed bugs
 
 


### PR DESCRIPTION
Fix #2827
# Example

user level configuration file(`"$HOME/Library/Application Support/jj/config.toml"`)
```toml
[user]
name = "Daehyeok Mun"
email = "daehyeok@gmail.com"

[ui]
pager = "bat -l toml --plain"
editor = "emacs -nw -q"
```

repo level configuration file(`.jj/repo/config.toml`)
```toml
[user]
email = "daehyeok@google.com"
```
example outputs.

```bash
#Release binary(v0.13.0)
 ~/workspace/jj ❯ jj config list

ui.editor="emacs -nw -q"
ui.pager="bat -l toml --plain"
user.name="Daehyeok Mun"
user.email="daehyeok@google.com"

#jj config list without any argument
#Doens't change anything.
 ~/workspace/jj ❯ ./target/debug/jj config list

ui.editor="emacs -nw -q"
ui.pager="bat -l toml --plain"
user.name="Daehyeok Mun"
user.email="daehyeok@google.com"

#print config options which defined in user level
#Doens't include overwriten value(user.email in this case)
 ~/workspace/jj ❯ ./target/debug/jj config list --user

ui.editor="emacs -nw -q"
ui.pager="bat -l toml --plain"
user.name="Daehyeok Mun"

#print config options which defined in repo level
 ~/workspace/jj ❯ ./target/debug/jj config list --repo

user.email="daehyeok@google.com"
```

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
