### PR TITLE
cli: Move external git repo canonicalization into Workspace::init_g…

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -191,6 +191,9 @@ impl From<WorkspaceInitError> for CommandError {
             WorkspaceInitError::Path(err) => {
                 CommandError::InternalError(format!("Failed to access the repository: {err}"))
             }
+            WorkspaceInitError::PathNotFound(path) => {
+                user_error(format!("{} doesn't exist", path.display()))
+            }
             WorkspaceInitError::Backend(err) => {
                 user_error(format!("Failed to access the repository: {err}"))
             }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -66,17 +66,7 @@ pub(crate) fn cmd_init(
     let relative_wc_path = file_util::relative_path(&cwd, &wc_path);
 
     if let Some(git_store_str) = &args.git_repo {
-        let mut git_store_path = command.cwd().join(git_store_str);
-        git_store_path = git_store_path
-            .canonicalize()
-            .map_err(|_| user_error(format!("{} doesn't exist", git_store_path.display())))?;
-        if !git_store_path.ends_with(".git") {
-            git_store_path.push(".git");
-            // Undo if .git doesn't exist - likely a bare repo.
-            if !git_store_path.exists() {
-                git_store_path.pop();
-            }
-        }
+        let git_store_path = cwd.join(git_store_str);
         let (workspace, repo) =
             Workspace::init_external_git(command.settings(), &wc_path, &git_store_path)?;
         let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -48,6 +48,8 @@ pub enum WorkspaceInitError {
     DestinationExists(PathBuf),
     #[error("Repo path could not be interpreted as Unicode text")]
     NonUnicodePath,
+    #[error("Path {0} does not exist")]
+    PathNotFound(PathBuf),
     #[error(transparent)]
     CheckOutCommit(#[from] CheckOutCommitError),
     #[error(transparent)]
@@ -194,6 +196,17 @@ impl Workspace {
         workspace_root: &Path,
         git_repo_path: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
+        let mut git_repo_path = git_repo_path
+            .canonicalize()
+            .map_err(|_| WorkspaceInitError::PathNotFound(git_repo_path.to_path_buf()))?;
+        if !git_repo_path.ends_with(".git") {
+            git_repo_path.push(".git");
+
+            if !git_repo_path.exists() {
+                git_repo_path.pop();
+            }
+        }
+
         let backend_initializer =
             |settings: &UserSettings, store_path: &Path| -> Result<Box<dyn Backend>, _> {
                 // If the git repo is inside the workspace, use a relative path to it so the
@@ -203,7 +216,7 @@ impl Workspace {
                 // Workspace::new(), but it's not yet here.
                 let store_relative_git_repo_path = match (
                     workspace_root.canonicalize(),
-                    canonicalize_git_repo_path(git_repo_path),
+                    canonicalize_git_repo_path(&git_repo_path),
                 ) {
                     (Ok(workspace_root), Ok(git_repo_path))
                         if git_repo_path.starts_with(&workspace_root) =>


### PR DESCRIPTION
Move the user input canonicalization closer to where it is actually used, so the code reads better as a whole.

Split out from #2807 