### PR TITLE
cli: Move git_init() from init.rs to git.rs

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -61,6 +61,7 @@ use jj_lib::signing::SignInitError;
 use jj_lib::str_util::{StringPattern, StringPatternParseError};
 use jj_lib::transaction::Transaction;
 use jj_lib::tree::TreeMergeError;
+use jj_lib::view::View;
 use jj_lib::working_copy::{
     CheckoutStats, LockedWorkingCopy, ResetError, SnapshotError, SnapshotOptions, WorkingCopy,
     WorkingCopyFactory, WorkingCopyStateError,
@@ -2066,6 +2067,40 @@ Discard the conflicting changes with `jj restore --from {}`.",
             short_commit_hash(new_commit.id())
         )?;
     }
+    Ok(())
+}
+
+pub fn print_trackable_remote_branches(ui: &Ui, view: &View) -> io::Result<()> {
+    let remote_branch_names = view
+        .branches()
+        .filter(|(_, branch_target)| branch_target.local_target.is_present())
+        .flat_map(|(name, branch_target)| {
+            branch_target
+                .remote_refs
+                .into_iter()
+                .filter(|&(_, remote_ref)| !remote_ref.is_tracking())
+                .map(move |(remote, _)| format!("{name}@{remote}"))
+        })
+        .collect_vec();
+    if remote_branch_names.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(
+        ui.hint(),
+        "The following remote branches aren't associated with the existing local branches:"
+    )?;
+    let mut formatter = ui.stderr_formatter();
+    for full_name in &remote_branch_names {
+        write!(formatter, "  ")?;
+        writeln!(formatter.labeled("branch"), "{full_name}")?;
+    }
+    drop(formatter);
+    writeln!(
+        ui.hint(),
+        "Hint: Run `jj branch track {names}` to keep local branches updated on future pulls.",
+        names = remote_branch_names.join(" "),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
* Move git_init() to cli/src/commands/git.rs and call it from there.
* Move print_trackable_remote_branches into cli_util since it's not git specific, but would apply to any backend that supports remote branches.
* A no-op change. A follow up PR will make use of this.
* This completes the refactoring of init.rs