### PR TITLE
Allow printing overridden config values via `--include-overridden`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * There's now a virtual root operation, similar to the [virtual root
   commit](docs/glossary.md#root-commit). It appears at the end of `jj op log`.
 
+* `jj config list` gained a `--include-overridden` option to allow
+  printing overridden config values.
+
 ### Fixed bugs
 
 

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -78,6 +78,9 @@ pub(crate) struct ConfigListArgs {
     /// Whether to explicitly include built-in default values in the list.
     #[arg(long)]
     pub include_defaults: bool,
+    /// Allow printing overridden values.
+    #[arg(long)]
+    pub include_overridden: bool,
     // TODO(#1047): Support --show-origin using LayeredConfigs.
     // TODO(#1047): Support ConfigArgs (--user or --repo).
 }
@@ -151,17 +154,18 @@ pub(crate) fn cmd_config_list(
     } in &values
     {
         // Remove overridden values.
-        // TODO(#1047): Allow printing overridden values via `--include-overridden`.
-        if *is_overridden {
+        if *is_overridden && !args.include_overridden {
             continue;
         }
+
         // Skip built-ins if not included.
         if !args.include_defaults && *source == ConfigSource::Default {
             continue;
         }
         writeln!(
             ui.stdout(),
-            "{}={}",
+            "{}{}={}",
+            if *is_overridden { "# " } else { "" },
             path.join("."),
             serialize_config_value(value)
         )?;

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -174,6 +174,24 @@ fn test_config_layer_override_default() {
     insta::assert_snapshot!(stdout, @r###"
     merge-tools.vimdiff.program="command-arg"
     "###);
+
+    // Allow printing overridden values
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "config",
+            "list",
+            config_key,
+            "--include-overridden",
+            "--config-toml",
+            &format!("{config_key}={value:?}", value = "command-arg"),
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    # merge-tools.vimdiff.program="user"
+    # merge-tools.vimdiff.program="repo"
+    merge-tools.vimdiff.program="command-arg"
+    "###);
 }
 
 #[test]
@@ -227,6 +245,26 @@ fn test_config_layer_override_env() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
+    ui.editor="command-arg"
+    "###);
+
+    // Allow printing overridden values
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "config",
+            "list",
+            config_key,
+            "--include-overridden",
+            "--config-toml",
+            &format!("{config_key}={value:?}", value = "command-arg"),
+        ],
+    );
+    insta::assert_snapshot!(stdout, @r###"
+    # ui.editor="env-base"
+    # ui.editor="user"
+    # ui.editor="repo"
+    # ui.editor="env-override"
     ui.editor="command-arg"
     "###);
 }


### PR DESCRIPTION
fix #2828 

# Example

```shell
 ~/workspace/jj ❯ ./target/debug/jj config list       
ui.editor="emacs -nw -q"
ui.pager="bat -l toml --plain"
user.name="Daehyeok Mun"
git.fetch="upstream"
git.push="orgin"
user.email="daehyeok@google.com"

 ~/workspace/jj ❯ ./target/debug/jj config list  --include-overridden
# ui.editor="nano"
# ui.pager="less -R"
ui.editor="emacs -nw -q"
ui.pager="bat -l toml --plain"
# user.email="daehyeok@gmail.com"
user.name="Daehyeok Mun"
git.fetch="upstream"
git.push="orgin"
user.email="daehyeok@google.com"
```
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
