### PR TITLE
Teach the Revset trait a way to estimate commit counts

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,7 +84,7 @@ jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 default = ["watchman"]
 bench = ["dep:criterion"]
 packaging = []
-test-fakes = []
+test-fakes = ["jj-lib/testing"]
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]
 

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -763,16 +763,24 @@ fn cmd_branch_list(
                     revset::walk_revs(repo.as_ref(), &remote_added_ids, &local_added_ids)?.count();
                 let local_ahead_count =
                     revset::walk_revs(repo.as_ref(), &local_added_ids, &remote_added_ids)?.count();
-                if remote_ahead_count != 0 && local_ahead_count == 0 {
-                    write!(formatter, " (ahead by {remote_ahead_count} commits)")?;
-                } else if remote_ahead_count == 0 && local_ahead_count != 0 {
-                    write!(formatter, " (behind by {local_ahead_count} commits)")?;
-                } else if remote_ahead_count != 0 && local_ahead_count != 0 {
-                    write!(
-                        formatter,
-                        " (ahead by {remote_ahead_count} commits, behind by {local_ahead_count} \
-                         commits)"
-                    )?;
+                let remote_ahead_message = if remote_ahead_count != 0 {
+                    Some(format!("ahead by {remote_ahead_count} commits"))
+                } else {
+                    None
+                };
+                let local_ahead_message = if local_ahead_count != 0 {
+                    Some(format!("behind by {local_ahead_count} commits"))
+                } else {
+                    None
+                };
+                match (remote_ahead_message, local_ahead_message) {
+                    (Some(rm), Some(lm)) => {
+                        write!(formatter, " ({rm}, {lm})")?;
+                    }
+                    (Some(m), None) | (None, Some(m)) => {
+                        write!(formatter, " ({m})")?;
+                    }
+                    (None, None) => { /* do nothing */ }
                 }
             }
             print_branch_target(formatter, &remote_ref.target)?;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -74,3 +74,4 @@ tokio = { workspace = true, features = ["full"] }
 default = []
 vendored-openssl = ["git2/vendored-openssl"]
 watchman = ["dep:tokio", "dep:watchman_client"]
+testing = []

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -130,8 +130,21 @@ impl<I: AsCompositeIndex> Revset for RevsetImpl<I> {
         self.entries().next().is_none()
     }
 
-    fn count(&self) -> usize {
-        self.entries().count()
+    fn count_estimate(&self) -> (usize, Option<usize>) {
+        if cfg!(feature = "testing") {
+            // Exercise the estimation feature in tests. (If we ever have a Revset
+            // implementation in production code that returns estimates, we can probably
+            // remove this and rewrite the associated tests.)
+            let count = self.entries().take(10).count();
+            if count < 10 {
+                (count, Some(count))
+            } else {
+                (10, None)
+            }
+        } else {
+            let count = self.iter().count();
+            (count, Some(count))
+        }
     }
 }
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2415,7 +2415,11 @@ pub trait Revset: fmt::Debug {
 
     fn is_empty(&self) -> bool;
 
-    fn count(&self) -> usize;
+    /// Inclusive lower bound and, optionally, inclusive upper bound of how many
+    /// commits are in the revset. The implementation can use its discretion as
+    /// to how much effort should be put into the estimation, and how accurate
+    /// the resulting estimate should be.
+    fn count_estimate(&self) -> (usize, Option<usize>);
 }
 
 pub trait RevsetIteratorExt<'index, I> {


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This is so that backends (especially backends that don't have all commits locally, but this is also useful for backends that do, since commit walking is not cost-free) don't need to walk commits unnecessarily when calculating ahead/behind when reporting branches.

I don't think this warrants a change in CHANGELOG.md, but if you think this should go under "New features" or "Fixed bugs", let me know and I'll amend the commit.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
