### PR TITLE
cli: display which file's conflicts are being resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj next` and `jj prev` now prompt in the event of the next/previous commit
   being ambiguous, instead of failing outright.
 
+* `jj resolve` now displays the file being resolved.
+
 ### Fixed bugs
 
 

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -96,6 +96,11 @@ pub(crate) fn cmd_resolve(
 
     let (repo_path, _) = conflicts.first().unwrap();
     workspace_command.check_rewritable([&commit])?;
+    writeln!(
+        ui.stderr(),
+        "Resolving conflicts in: {}",
+        workspace_command.format_file_path(repo_path)
+    )?;
     let mut tx = workspace_command.start_transaction();
     let new_tree_id = tx.run_mergetool(ui, &tree, repo_path)?;
     let new_commit = tx

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -88,6 +88,7 @@ fn test_resolution() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Resolving conflicts in: file
     Working copy now at: vruxwmqv e069f073 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
@@ -184,6 +185,7 @@ conflict
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Resolving conflicts in: file
     New conflicts appeared in these commits:
       vruxwmqv ff4e8c6b conflict | (conflict) conflict
     To resolve the conflicts, start by updating to it:
@@ -251,6 +253,7 @@ conflict
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Resolving conflicts in: file
     Working copy now at: vruxwmqv 95418cb8 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
@@ -297,8 +300,9 @@ fn check_resolve_produces_input_file(
     // in the future. See also https://github.com/mitsuhiko/insta/issues/313.
     assert_eq!(
         &test_env.jj_cmd_failure(repo_path, &["resolve", "--config-toml", &merge_arg_config]),
-        "Error: Failed to resolve conflicts: The output file is either unchanged or empty after \
-         the editor quit (run with --verbose to see the exact invocation).\n"
+        "Resolving conflicts in: file\nError: Failed to resolve conflicts: The output file is \
+         either unchanged or empty after the editor quit (run with --verbose to see the exact \
+         invocation).\n"
     );
 }
 
@@ -406,6 +410,7 @@ fn test_too_many_parents() {
 
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
+    Resolving conflicts in: file
     Error: Failed to resolve conflicts: The conflict at "file" has 3 sides. At most 2 sides are supported.
     "###);
 }
@@ -481,6 +486,7 @@ fn test_file_vs_dir() {
     "###);
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
+    Resolving conflicts in: file
     Error: Failed to resolve conflicts: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
     Conflict:
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
@@ -535,6 +541,7 @@ fn test_description_with_dir_and_deletion() {
     "###);
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
     insta::assert_snapshot!(error, @r###"
+    Resolving conflicts in: file
     Error: Failed to resolve conflicts: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
     Conflict:
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
@@ -642,6 +649,7 @@ fn test_multiple_conflicts() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "another_file"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Resolving conflicts in: another_file
     New conflicts appeared in these commits:
       vruxwmqv c3c25bce conflict | (conflict) conflict
     To resolve the conflicts, start by updating to it:
@@ -678,6 +686,7 @@ fn test_multiple_conflicts() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "--quiet", "another_file"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Resolving conflicts in: another_file
     New conflicts appeared in these commits:
       vruxwmqv fd3874cd conflict | (conflict) conflict
     To resolve the conflicts, start by updating to it:


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Often, I resolve a file, close my merge editor, then wonder exactly which file I was resolving conflicts in. I've found this information helpful.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
