### PR TITLE
git-comparison: explain why equivalent of `git stash` is not needed

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -222,7 +222,7 @@ parent.
     </tr>
     <tr>
       <td>Temporarily put away the current change</td>
-      <td>Not needed</td>
+      <td><code>jj new @-</code> (the old working-copy commit remains as a sibling commit)</td>
       <td><code>git stash</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Someone felt that our "Not needed" sounded dismissive. This patch tries to clarify that it's the *command* (not the use case) we consider not needed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
