### PR TITLE
docs: try to clarify that jj doesn't need a staging area

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -17,10 +17,11 @@ various use cases.
 * **The working copy is automatically committed.** That results in a simpler and
   more consistent CLI because the working copy is now treated like any other
   commit. [Details](working-copy.md).
-* **There's no index (staging area).** That also results in a simpler
-  CLI for similar reasons. The index is very similar to an intermediate commit
-  between `HEAD` and the working copy, so workflows that depend on it can be
-  modeled using proper commits instead. [Details](#the-index).
+* **There's no index (staging area).** Because the working copy is automatically
+  committed, an index-like concept doesn't make sense. The index is very similar
+  to an intermediate commit between `HEAD` and the working copy, so workflows
+  that depend on it can be modeled using proper commits instead. Jujutsu has
+  excellent support for moving changes between commits. [Details](#the-index).
 * **No need for branch names (but they are supported).** Git lets you check out
   a commit without attaching a branch. It calls this state "detached HEAD". This
   is the normal state in Jujutsu (there's actually no way -- yet, at least -- to


### PR DESCRIPTION
Wol on lwn.net pointed out that our current description in the Git Comparison doc for why there is no staging area can be interpreted as saying that it's because it simplifies the CLI. It took me a while to see that interpretation, but it makes sense to me now. This patch tries to clarify that we have better tools than the staging area for manipulating commits.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
