### PR TITLE
ui: remove redundant .to_lowercase() from prompt_yes_no()

### DIFF
--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -404,7 +404,7 @@ impl Ui {
             &["y", "n", "yes", "no", "Yes", "No", "YES", "NO"],
             default_choice,
         )?;
-        Ok(choice.to_lowercase().starts_with(['y', 'Y']))
+        Ok(choice.starts_with(['y', 'Y']))
     }
 
     pub fn prompt_password(&mut self, prompt: &str) -> io::Result<String> {


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
