### PR TITLE
cli: colorize choices of prev/next commits

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -70,18 +70,17 @@ pub fn choose_commit<'a>(
     commits: &'a [Commit],
 ) -> Result<&'a Commit, CommandError> {
     writeln!(ui.stdout(), "ambiguous {cmd} commit, choose one to target:")?;
+    let mut formatter = ui.stdout_formatter();
     let mut choices: Vec<String> = Default::default();
     for (i, commit) in commits.iter().enumerate() {
-        writeln!(
-            ui.stdout(),
-            "{}: {}",
-            i + 1,
-            workspace_command.format_commit_summary(commit)
-        )?;
+        write!(formatter, "{}: ", i + 1)?;
+        workspace_command.write_commit_summary(formatter.as_mut(), commit)?;
+        writeln!(formatter)?;
         choices.push(format!("{}", i + 1));
     }
-    writeln!(ui.stdout(), "q: quit the prompt")?;
+    writeln!(formatter, "q: quit the prompt")?;
     choices.push("q".to_string());
+    drop(formatter);
 
     let choice = ui.prompt_choice(
         "enter the index of the commit you want to target",


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
