### PR TITLE
cli `branch`: add alias `t` for `track`

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -52,6 +52,7 @@ pub enum BranchCommand {
     Rename(BranchRenameArgs),
     #[command(visible_alias("s"))]
     Set(BranchSetArgs),
+    #[command(visible_alias("t"))]
     Track(BranchTrackArgs),
     Untrack(BranchUntrackArgs),
 }


### PR DESCRIPTION
This goes with `c`, `s`, `f`. I feel like it's a relatively common command now that `auto-local-branch` defaults to `false`.

I didn't add `u` for `untrack` because it seems a little ambiguous (un-what?); there may be other `branch` commands that undo something in the future.