### PR TITLE
Refactor working copy initializers

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -614,6 +614,18 @@ impl CommandHelper {
         self.for_loaded_repo(ui, workspace, repo)
     }
 
+    pub fn get_working_copy_factory(&self) -> Result<&dyn WorkingCopyFactory, CommandError> {
+        let loader = self.workspace_loader()?;
+
+        // We convert StoreLoadError -> WorkspaceLoadError -> CommandError
+        let factory: Result<_, WorkspaceLoadError> = loader
+            .get_working_copy_factory(&self.working_copy_factories)
+            .map_err(|e| e.into());
+        let factory = factory
+            .map_err(|err| map_workspace_load_error(err, self.global_args.repository.as_deref()))?;
+        Ok(factory)
+    }
+
     #[instrument(skip_all)]
     pub fn load_workspace(&self) -> Result<Workspace, CommandError> {
         let loader = self.workspace_loader()?;

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -23,7 +23,7 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::WorkspaceId;
 use jj_lib::repo::Repo;
 use jj_lib::rewrite::merge_commit_trees;
-use jj_lib::workspace::{default_working_copy_initializer, Workspace};
+use jj_lib::workspace::{default_working_copy_factory, Workspace};
 use tracing::instrument;
 
 use crate::cli_util::{
@@ -153,7 +153,7 @@ fn cmd_workspace_add(
         command.settings(),
         &destination_path,
         repo,
-        default_working_copy_initializer(),
+        &*default_working_copy_factory(),
         workspace_id,
     )?;
     writeln!(

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -23,7 +23,7 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::WorkspaceId;
 use jj_lib::repo::Repo;
 use jj_lib::rewrite::merge_commit_trees;
-use jj_lib::workspace::{default_working_copy_factory, Workspace};
+use jj_lib::workspace::Workspace;
 use tracing::instrument;
 
 use crate::cli_util::{
@@ -148,12 +148,13 @@ fn cmd_workspace_add(
             "Workspace named '{name}' already exists"
         )));
     }
-    // TODO: How do we create a workspace with a non-default working copy?
+
+    let working_copy_factory = command.get_working_copy_factory()?;
     let (new_workspace, repo) = Workspace::init_workspace_with_existing_repo(
         command.settings(),
         &destination_path,
         repo,
-        &*default_working_copy_factory(),
+        working_copy_factory,
         workspace_id,
     )?;
     writeln!(

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -64,7 +64,7 @@ use crate::store::Store;
 use crate::tree::Tree;
 use crate::working_copy::{
     CheckoutError, CheckoutStats, LockedWorkingCopy, ResetError, SnapshotError, SnapshotOptions,
-    SnapshotProgress, WorkingCopy, WorkingCopyStateError,
+    SnapshotProgress, WorkingCopy, WorkingCopyFactory, WorkingCopyStateError,
 };
 
 #[cfg(unix)]
@@ -1650,6 +1650,36 @@ impl LocalWorkingCopy {
                 message: "Failed to query watchman".to_string(),
                 err: err.into(),
             })
+    }
+}
+
+pub struct LocalWorkingCopyFactory {}
+
+impl WorkingCopyFactory for LocalWorkingCopyFactory {
+    fn init_working_copy(
+        &self,
+        store: Arc<Store>,
+        working_copy_path: PathBuf,
+        state_path: PathBuf,
+        operation_id: OperationId,
+        workspace_id: WorkspaceId,
+    ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError> {
+        Ok(Box::new(LocalWorkingCopy::init(
+            store,
+            working_copy_path,
+            state_path,
+            operation_id,
+            workspace_id,
+        )?))
+    }
+
+    fn load_working_copy(
+        &self,
+        store: Arc<Store>,
+        working_copy_path: PathBuf,
+        state_path: PathBuf,
+    ) -> Box<dyn WorkingCopy> {
+        Box::new(LocalWorkingCopy::load(store, working_copy_path, state_path))
     }
 }
 

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -30,6 +30,7 @@ use crate::merged_tree::MergedTree;
 use crate::op_store::{OperationId, WorkspaceId};
 use crate::repo_path::{RepoPath, RepoPathBuf};
 use crate::settings::HumanByteSize;
+use crate::store::Store;
 
 /// The trait all working-copy implementations must implement.
 pub trait WorkingCopy {
@@ -61,6 +62,27 @@ pub trait WorkingCopy {
     /// Locks the working copy and returns an instance with methods for updating
     /// the working copy files and state.
     fn start_mutation(&self) -> Result<Box<dyn LockedWorkingCopy>, WorkingCopyStateError>;
+}
+
+/// The factory which creates and loads a specific type of working copy.
+pub trait WorkingCopyFactory {
+    /// Create a new working copy from scratch.
+    fn init_working_copy(
+        &self,
+        store: Arc<Store>,
+        working_copy_path: PathBuf,
+        state_path: PathBuf,
+        operation_id: OperationId,
+        workspace_id: WorkspaceId,
+    ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError>;
+
+    /// Load an existing working copy.
+    fn load_working_copy(
+        &self,
+        store: Arc<Store>,
+        working_copy_path: PathBuf,
+        state_path: PathBuf,
+    ) -> Box<dyn WorkingCopy>;
 }
 
 /// A working copy that's being modified.

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -16,7 +16,7 @@ use assert_matches::assert_matches;
 use jj_lib::op_store::WorkspaceId;
 use jj_lib::repo::Repo;
 use jj_lib::workspace::{
-    default_working_copy_factories, default_working_copy_initializer, Workspace, WorkspaceLoadError,
+    default_working_copy_factories, default_working_copy_factory, Workspace, WorkspaceLoadError,
 };
 use testutils::{TestRepo, TestWorkspace};
 
@@ -51,7 +51,7 @@ fn test_init_additional_workspace() {
         &settings,
         &ws2_root,
         &test_workspace.repo,
-        default_working_copy_initializer(),
+        &*default_working_copy_factory(),
         ws2_id.clone(),
     )
     .unwrap();


### PR DESCRIPTION
This combines the `WorkingCopyInitializer` and `WorkingCopyFactory` types into a single `WorkingCopyFactory` trait that implements both. This allows `jj workspace add` to create new working copies for custom implementations with minimal changes.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
