### PR TITLE
cli: change `R` to `D` for "deleted" in diff summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* (Minor) Diff summaries (e.g. `jj diff -s`) now use `D` for "Deleted" instead
+  of `R` for "Removed". @joyously pointed out that `R` could also mean
+  "Renamed".
+
 ### New features
 
 * New `jj op abandon` command is added to clean up the operation history. If GC

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -48,7 +48,7 @@ use crate::ui::Ui;
 #[command(group(clap::ArgGroup::new("short-format").args(&["summary", "stat", "types"])))]
 #[command(group(clap::ArgGroup::new("long-format").args(&["git", "color_words", "tool"])))]
 pub struct DiffFormatArgs {
-    /// For each path, show only whether it was modified, added, or removed
+    /// For each path, show only whether it was modified, added, or deleted
     #[arg(long, short)]
     pub summary: bool,
     /// Show a histogram of the changes
@@ -793,7 +793,7 @@ pub fn show_diff_summary(
                 } else {
                     writeln!(
                         formatter.labeled("removed"),
-                        "R {}",
+                        "D {}", // `R` could be interpreted as "renamed"
                         workspace_command.format_file_path(&repo_path)
                     )?;
                 }

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -43,7 +43,7 @@ fn test_diff_basic() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     A file3
     "###);
@@ -82,7 +82,7 @@ fn test_diff_basic() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     A file3
     diff --git a/file1 b/file1

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -45,7 +45,7 @@ fn test_diffedit() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     "###);
 
@@ -56,7 +56,7 @@ fn test_diffedit() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     "###);
 
@@ -72,7 +72,7 @@ fn test_diffedit() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     "###);
 
     // Changes to a commit are propagated to descendants
@@ -109,8 +109,8 @@ fn test_diffedit() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
-    R file2
+    D file1
+    D file2
     "###);
 }
 
@@ -140,7 +140,7 @@ fn test_diffedit_new_file() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     A file2
     "###);
 
@@ -175,7 +175,7 @@ fn test_diffedit_new_file() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     A file2
     "###);
 }
@@ -224,7 +224,7 @@ fn test_diffedit_3pane() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     "###);
     // Nothing happens if we make no changes, `config_with_right_as_after` version
@@ -238,7 +238,7 @@ fn test_diffedit_3pane() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     "###);
 
@@ -257,7 +257,7 @@ fn test_diffedit_3pane() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     "###);
 
     // Can write something new to `file1`
@@ -293,7 +293,7 @@ fn test_diffedit_3pane() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     "###);
 
@@ -348,7 +348,7 @@ fn test_diffedit_merge() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     A file3
     "###);
     assert!(!repo_path.join("file1").exists());
@@ -387,7 +387,7 @@ fn test_diffedit_old_restore_interactive_tests() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     A file3
     "###);
@@ -399,7 +399,7 @@ fn test_diffedit_old_restore_interactive_tests() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     M file2
     A file3
     "###);
@@ -416,7 +416,7 @@ fn test_diffedit_old_restore_interactive_tests() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     "###);
 
     // Can make unrelated edits

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -89,7 +89,7 @@ fn test_restore() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file2
+    D file2
     "###);
 
     // Can restore into other revision
@@ -106,7 +106,7 @@ fn test_restore() {
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     A file2
     A file3
     "###);
@@ -126,7 +126,7 @@ fn test_restore() {
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     A file2
     A file3
     "###);
@@ -143,7 +143,7 @@ fn test_restore() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    R file1
+    D file1
     "###);
 }
 


### PR DESCRIPTION
@joyously ponted out that `R` could be interpreted as "renamed" instead of "removed".  "Deleted" is unambiguous.

I'm not sure if this qualifies as a breaking change, but I put it there for now.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (n/a?) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
