### PR TITLE
github: use `macos-14`, add new `aarch64-apple-darwin` release binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         cargo_flags: [""]
         include:
         - os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
         - build: macos
           os: macos-11
           target: x86_64-apple-darwin
+        - build: macos
+          os: macos-14
+          target: aarch64-apple-darwin
         - build: win-msvc
           os: windows-2022
           target: x86_64-pc-windows-msvc


### PR DESCRIPTION
GitHub announced these new Apple Silicon based runners today. Let's take them for a spin.

Let's also add an entry in the release matrix to build and publish `aarch64- apple-darwin` binaries, too. This doesn't migrate the old release matrix entry; it still uses a `macos-11` runner. This means the x86 binaries should work on a few older macOS versions if users need it.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
