### PR TITLE
docs: fixup to b318b200, mark code blocks in help as text

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -27,11 +27,9 @@ use crate::ui::Ui;
 /// Move the current working copy commit to the next child revision in the
 /// repository.
 ///
-///
 /// The command moves you to the next child in a linear fashion.
 ///
-///
-/// ```
+/// ```text
 /// D      D @
 /// |      |/
 /// C @ => C
@@ -39,12 +37,10 @@ use crate::ui::Ui;
 /// B      B
 /// ```
 ///
-///
 /// If `--edit` is passed, it will move you directly to the child
 /// revision.
 ///
-///
-/// ```
+/// ```text
 /// D    D
 /// |    |
 /// C    C

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -25,7 +25,7 @@ use crate::ui::Ui;
 ///
 /// The command moves you to the parent in a linear fashion.
 ///
-/// ```
+/// ```text
 /// D @  D
 /// |/   |
 /// A => A @
@@ -36,7 +36,7 @@ use crate::ui::Ui;
 /// If `--edit` is passed, it will move the working copy commit
 /// directly to the parent.
 ///
-/// ```
+/// ```text
 /// D @  D
 /// |/   |
 /// C => @

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -46,7 +46,7 @@ use crate::ui::Ui;
 /// your history like this (letters followed by an apostrophe are post-rebase
 /// versions):
 ///
-/// ```
+/// ```text
 /// O           N'
 /// |           |
 /// | N         M'
@@ -73,7 +73,7 @@ use crate::ui::Ui;
 /// -d O` would transform your history like this (because `L` and `M` are on the
 /// same "branch", relative to the destination):
 ///
-/// ```
+/// ```text
 /// O           N'
 /// |           |
 /// | N         M'
@@ -92,7 +92,7 @@ use crate::ui::Ui;
 /// onto the specified revision's parent(s). For example, `jj rebase -r K -d M`
 /// would transform your history like this:
 ///
-/// ```
+/// ```text
 /// M          K'
 /// |          |
 /// | L        M
@@ -107,7 +107,7 @@ use crate::ui::Ui;
 /// order to work (in addition to its current parent K), you can run `jj rebase
 /// -s L -d K -d M`:
 ///
-/// ```
+/// ```text
 /// M          L'
 /// |          |\
 /// | L        M |

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1133,11 +1133,9 @@ For more information, see https://github.com/martinvonz/jj/blob/main/docs/workin
 Move the current working copy commit to the next child revision in the
 repository.
 
-
 The command moves you to the next child in a linear fashion.
 
-
-```
+```text
 D      D @
 |      |/
 C @ => C
@@ -1145,12 +1143,10 @@ C @ => C
 B      B
 ```
 
-
 If `--edit` is passed, it will move you directly to the child
 revision.
 
-
-```
+```text
 D    D
 |    |
 C    C
@@ -1339,7 +1335,7 @@ Move the working copy commit to the parent of the current revision.
 
 The command moves you to the parent in a linear fashion.
 
-```
+```text
 D @  D
 |/   |
 A => A @
@@ -1350,7 +1346,7 @@ B    B
 If `--edit` is passed, it will move the working copy commit
 directly to the parent.
 
-```
+```text
 D @  D
 |/   |
 C => @
@@ -1391,7 +1387,7 @@ onto the destination. For example, `jj rebase -s M -d O` would transform
 your history like this (letters followed by an apostrophe are post-rebase
 versions):
 
-```
+```text
 O           N'
 |           |
 | N         M'
@@ -1418,7 +1414,7 @@ single root). For example, either `jj rebase -b L -d O` or `jj rebase -b M
 -d O` would transform your history like this (because `L` and `M` are on the
 same "branch", relative to the destination):
 
-```
+```text
 O           N'
 |           |
 | N         M'
@@ -1437,7 +1433,7 @@ destination. Any "hole" left behind will be filled by rebasing descendants
 onto the specified revision's parent(s). For example, `jj rebase -r K -d M`
 would transform your history like this:
 
-```
+```text
 M          K'
 |          |
 | L        M
@@ -1452,7 +1448,7 @@ For example, if you realize that commit L actually depends on commit M in
 order to work (in addition to its current parent K), you can run `jj rebase
 -s L -d K -d M`:
 
-```
+```text
 M          L'
 |          |\
 | L        M |


### PR DESCRIPTION
This prevents rust doctests from trying to compile the code blocks.

I don't think we use doctests much or at all, but I'd like `cargo insta test --test-runner nextest --accept --workspace` to pass.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
