### PR TITLE
backends: implement as_any() on OpStore and OpHeadsStore too

### DIFF
--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -14,6 +14,7 @@
 
 #![allow(missing_docs)]
 
+use std::any::Any;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -35,6 +36,8 @@ pub trait OpHeadsStoreLock {}
 
 /// Manages the set of current heads of the operation log.
 pub trait OpHeadsStore: Send + Sync + Debug {
+    fn as_any(&self) -> &dyn Any;
+
     fn name(&self) -> &str;
 
     /// Remove the old op heads and add the new one.

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -14,6 +14,7 @@
 
 #![allow(missing_docs)]
 
+use std::any::Any;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Error, Formatter};
 use std::iter;
@@ -434,6 +435,8 @@ pub enum OpStoreError {
 pub type OpStoreResult<T> = Result<T, OpStoreError>;
 
 pub trait OpStore: Send + Sync + Debug {
+    fn as_any(&self) -> &dyn Any;
+
     fn name(&self) -> &str;
 
     fn root_operation_id(&self) -> &OperationId;

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -14,6 +14,7 @@
 
 #![allow(missing_docs)]
 
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -71,6 +72,10 @@ struct SimpleOpHeadsStoreLock {
 impl OpHeadsStoreLock for SimpleOpHeadsStoreLock {}
 
 impl OpHeadsStore for SimpleOpHeadsStore {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn name(&self) -> &str {
         Self::name()
     }

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -14,6 +14,7 @@
 
 #![allow(missing_docs)]
 
+use std::any::Any;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::io::{ErrorKind, Write};
@@ -94,6 +95,10 @@ impl SimpleOpStore {
 }
 
 impl OpStore for SimpleOpStore {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn name(&self) -> &str {
         Self::name()
     }


### PR DESCRIPTION
It's useful for custom commands to be able to downcast to custom backend types.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
