### PR TITLE
Minor cleanup of DescendantRebaser 

### DIFF
--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -539,8 +539,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         Ok(())
     }
 
-    // TODO: Perhaps change the interface since it's not just about rebasing
-    // commits.
     fn rebase_next(&mut self) -> Result<Option<RebasedDescendant>, TreeMergeError> {
         while let Some(old_commit) = self.to_visit.pop() {
             let old_commit_id = old_commit.id().clone();
@@ -616,7 +614,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
 
     pub fn rebase_all(&mut self) -> Result<(), TreeMergeError> {
         while self.rebase_next()?.is_some() {}
-        // TODO: As the TODO above says, we should probably change the API.
         let mut view = self.mut_repo.view().store_view().clone();
         for commit_id in &self.heads_to_remove {
             view.head_ids.remove(commit_id);


### PR DESCRIPTION
Seeing #2901 made me decide to send these commits I wrote a few days ago before they go stale. It doesn't look like anything conflicts with that PR. FYI, I'm working on #2600 a little bit here and there. I guess I should assign that to myself. I'll do that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
