### PR TITLE
docs: emphasize and clarify log revsets relevant to people coming from git

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -181,14 +181,19 @@ parent.
       <td><code>git commit -a</code></td>
     </tr>
     <tr>
-      <td>See log of commits</td>
-      <td><code>jj log</code></td>
+      <td>See log of ancestors of the current commit</td>
+      <td><code>jj log -r ::@</code></td>
       <td><code>git log --oneline --graph --decorate</code></td>
     </tr>
     <tr>
-      <td>Show log of ancestors of the current commit only, including all ancestors, not just stopping at immutable commits</td>
-      <td><code>jj log -r ::@</code></td>
-      <td><code>git log</code></td>
+      <td>See log of all reachable commits</td>
+      <td><code>jj log -r 'all()'</code> or <code>jj log -r ::</code></td>
+      <td><code>git log --oneline --graph --decorate --branches</code></td>
+    </tr>
+    <tr>
+      <td>Show log of commits not on the main branch</td>
+      <td><code>jj log</code></td>
+      <td>(TODO)</td>
     </tr>
     <tr>
       <td>Search among files versioned in the repository</td>

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -227,6 +227,12 @@ Show the parent(s) of the working-copy commit (like `git log -1 HEAD`):
 jj log -r @-
 ```
 
+Show all ancestors of the working copy (like plain `git log`)
+
+```
+jj log -r ::@
+```
+
 Show commits not on any remote branch:
 
 ```
@@ -237,12 +243,6 @@ Show commits not on `origin` (if you have other remotes like `fork`):
 
 ```
 jj log -r 'remote_branches(remote=origin)..'
-```
-
-Show all ancestors of the working copy (almost like plain `git log`)
-
-```
-jj log -r ::@
 ```
 
 Show the initial commits in the repo (the ones Git calls "root commits"):


### PR DESCRIPTION
I couldn't come up with a Git analogue of `jj log`, but I think it's OK leaving it as a TODO makes the point. Perhaps somebody can figure it out.

Also, all the correspondences are not completely precise, so I didn't emphasize it every single time.
