### PR TITLE
config cli and docs: make it easier for users to find the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj config list` now accepts `--user` or `--repo` option to specify
   config origin.
 
+* New `jj config path` command to print the config file path without launching
+  an editor.
+
 * `jj tag list` command prints imported git tags.
 
 * `jj next` and `jj prev` now prompt in the event of the next/previous commit

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -134,6 +134,9 @@ pub(crate) struct ConfigSetArgs {
 }
 
 /// Start an editor on a jj config file.
+///
+/// Creates the file if it doesn't already exist regardless of what the editor
+/// does.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct ConfigEditArgs {
     #[clap(flatten)]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -29,6 +29,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj config get`↴](#jj-config-get)
 * [`jj config set`↴](#jj-config-set)
 * [`jj config edit`↴](#jj-config-edit)
+* [`jj config path`↴](#jj-config-path)
 * [`jj describe`↴](#jj-describe)
 * [`jj diff`↴](#jj-diff)
 * [`jj diffedit`↴](#jj-diffedit)
@@ -472,6 +473,7 @@ For file locations, supported config options, and other details about jj config,
 * `get` — Get the value of a given config option.
 * `set` — Update config file to set the given option to a given value
 * `edit` — Start an editor on a jj config file
+* `path` — Print the path to the config file
 
 
 
@@ -555,6 +557,29 @@ Update config file to set the given option to a given value
 Start an editor on a jj config file
 
 **Usage:** `jj config edit <--user|--repo>`
+
+###### **Options:**
+
+* `--user` — Target the user-level config
+
+  Possible values: `true`, `false`
+
+* `--repo` — Target the repo-level config
+
+  Possible values: `true`, `false`
+
+
+
+
+## `jj config path`
+
+Print the path to the config file
+
+A config file at that path may or may not exist.
+
+See `jj config edit` if you'd like to immediately edit the file.
+
+**Usage:** `jj config path <--user|--repo>`
 
 ###### **Options:**
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -554,7 +554,9 @@ Update config file to set the given option to a given value
 
 ## `jj config edit`
 
-Start an editor on a jj config file
+Start an editor on a jj config file.
+
+Creates the file if it doesn't already exist regardless of what the editor does.
 
 **Usage:** `jj config edit <--user|--repo>`
 

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use insta::assert_snapshot;
 use itertools::Itertools;
 use regex::Regex;
 
@@ -562,6 +563,26 @@ fn test_config_edit_repo() {
     )
     .unwrap();
     test_env.jj_cmd_ok(&repo_path, &["config", "edit", "--repo"]);
+}
+
+#[test]
+fn test_config_path() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["config", "path", "--user"]),
+      @r###"
+      $TEST_ENV/config
+      "###
+    );
+    assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["config", "path", "--repo"]),
+      @r###"
+      $TEST_ENV/repo/.jj/repo/config.toml
+      "###
+    );
 }
 
 #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,15 +5,29 @@ These are the config settings available to jj/Jujutsu.
 
 ## Config files and TOML
 
-The config settings are loaded from the following locations. Less common ways to
-specify `jj` config settings are discussed in a later section.
+`jj` loads several types of config settings:
 
-* [The user config file]
-* `.jj/repo/config.toml` (per-repository)
+- The built-in settings. These cannot be edited. They can be viewed in the
+  `cli/src/config/` directory in `jj`'s source repo.
 
-See the [TOML site] and the [syntax guide] for a description of the syntax.
+- The user settings. These can be edited with `jj config edit --user`. User
+settings are located in [the user config file], which can be found with `jj
+config path --user`.
 
-[The user config file]: #user-config-file
+- The repo settings. These can be edited with `jj config edit --repo` and are
+located in `.jj/repo/config.toml`.
+
+- Settings [specified in the command-line](#specifying-config-on-the-command-line).
+
+These are listed in the order they are loaded; the settings from earlier items
+in
+the list are overridden by the settings from later items if they disagree. Every
+type of config except for the built-in settings is optional.
+
+See the [TOML site] and the [syntax guide] for a detailed description of the
+syntax. We cover some of the basics below.
+
+[the user config file]: #user-config-file
 [TOML site]: https://toml.io/en/
 [syntax guide]: https://toml.io/en/v1.0.0
 
@@ -561,7 +575,17 @@ executable on your system](https://facebook.github.io/watchman/docs/install).
 
 Debugging commands are available under `jj debug watchman`.
 
-# User config file
+## Ways to specify `jj` config: details
+
+### User config file
+
+An easy way to find the user config file is:
+
+```bash
+jj config path --user
+```
+
+The rest of this section covers the details of where this file can be located.
 
 On all platforms, the user's global `jj` configuration file is located at either
 `~/.jjconfig.toml` (where `~` represents `$HOME` on Unix-likes, or
@@ -583,6 +607,8 @@ default locations. For example,
 ```shell
 env JJ_CONFIG=/dev/null jj log       # Ignores any settings specified in the config file.
 ```
+
+### Specifying config on the command-line
 
 You can use one or more `--config-toml` options on the command line to specify
 additional configuration settings. This overrides settings defined in config


### PR DESCRIPTION
Instead of `jj config path`, I considered suggesting

    EDITOR=echo jj config edit --user

but Windows. Also, I'm not sure whether that trick would please or annoy people.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
