### PR TITLE
cli, config: more granular pagination settings

### DIFF
--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -662,7 +662,7 @@ fn cmd_branch_list(
             Ok(())
         };
 
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
 

--- a/cli/src/commands/cat.rs
+++ b/cli/src/commands/cat.rs
@@ -51,11 +51,11 @@ pub(crate) fn cmd_cat(
             return Err(user_error("No such path"));
         }
         MaterializedTreeValue::File { mut reader, .. } => {
-            ui.request_pager();
+            ui.request_pager(command.subcommands());
             std::io::copy(&mut reader, &mut ui.stdout_formatter().as_mut())?;
         }
         MaterializedTreeValue::Conflict { contents, .. } => {
-            ui.request_pager();
+            ui.request_pager(command.subcommands());
             ui.stdout_formatter().write_all(&contents)?;
         }
         MaterializedTreeValue::Symlink { .. }

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -175,7 +175,7 @@ pub(crate) fn cmd_config_list(
     command: &CommandHelper,
     args: &ConfigListArgs,
 ) -> Result<(), CommandError> {
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let name_path = args
         .name
         .as_ref()

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -65,7 +65,7 @@ pub(crate) fn cmd_diff(
     }
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     let diff_formats = diff_formats_for(command.settings(), &args.format)?;
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     show_diff(
         ui,
         ui.stdout_formatter().as_mut(),

--- a/cli/src/commands/files.rs
+++ b/cli/src/commands/files.rs
@@ -40,7 +40,7 @@ pub(crate) fn cmd_files(
     let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
     let tree = commit.tree()?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     for (name, _value) in tree.entries_matching(matcher.as_ref()) {
         writeln!(
             ui.stdout(),

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -55,7 +55,7 @@ pub(crate) fn cmd_interdiff(
     let to_tree = to.tree()?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     diff_util::show_diff(
         ui,
         ui.stdout_formatter().as_mut(),

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -108,7 +108,7 @@ pub(crate) fn cmd_log(
     let with_content_format = LogContentFormat::new(ui, command.settings())?;
 
     {
-        ui.request_pager();
+        ui.request_pager(command.subcommands());
         let mut formatter = ui.stdout_formatter();
         let formatter = formatter.as_mut();
 

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -76,7 +76,7 @@ pub(crate) fn cmd_obslog(
     let template = workspace_command.parse_commit_template(&template_string)?;
     let with_content_format = LogContentFormat::new(ui, command.settings())?;
 
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
     formatter.push_label("log")?;

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -173,7 +173,7 @@ fn cmd_op_log(
     )?;
     let with_content_format = LogContentFormat::new(ui, command.settings())?;
 
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
     let iter = op_walk::walk_ancestors(&head_ops).take(args.limit.unwrap_or(usize::MAX));

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -43,7 +43,7 @@ pub(crate) fn cmd_show(
     let template_string = command.settings().config().get_string("templates.show")?;
     let template = workspace_command.parse_commit_template(&template_string)?;
     let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
     template.format(&commit, formatter)?;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -47,7 +47,7 @@ pub(crate) fn cmd_status(
         .get_wc_commit_id()
         .map(|id| repo.store().get_commit(id))
         .transpose()?;
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
 

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -55,7 +55,7 @@ fn cmd_tag_list(
     let repo = workspace_command.repo();
     let view = repo.view();
 
-    ui.request_pager();
+    ui.request_pager(command.subcommands());
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
 


### PR DESCRIPTION
* Adds "always" as a pagination option
* Adds a new cli arg, `--pagination` that takes a pagination string (always, never, or auto).
* Adds a new type, `Pagination`, which may be either one of the pagination options, or an arbitrarily nested mapping of subcommands. When nested, "default" is the setting for the current level, and may be overridden by deeper subcommands. A setting of "auto" will "fall through" to the previous level.

"help" is a little odd, since it doesn't get the context of the subcommand being attempted. All help messages use the configuration for the top-level "help" subcommand.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
