### PR TITLE
docs CLI reference: add a warning that it is experimental

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2,6 +2,14 @@
 source: cli/tests/test_generate_md_cli_help.rs
 description: "AUTO-GENERATED FILE, DO NOT EDIT. This cli reference is generated as an `insta` snapshot. MkDocs follows they symlink from docs/cli-reference.md to the snap. Unfortunately, `insta` unavoidably creates this header. Luckily, MkDocs ignores the header since it has the same format as Markdown headers. TODO: MkDocs may fail on Windows if symlinks are not enabled in the OS settings"
 ---
+
+!!! warning
+
+    This CLI reference is experimental. It is automatically generated, but
+    does not match the `jj help` output exactly.
+
+    <!-- See also https://github.com/ConnorGray/clap-markdown/issues -->
+
 # Command-Line Help for `jj`
 
 This document contains the help content for the `jj` command-line program.

--- a/cli/tests/test_generate_md_cli_help.rs
+++ b/cli/tests/test_generate_md_cli_help.rs
@@ -18,10 +18,22 @@ use crate::common::TestEnvironment;
 
 pub mod common;
 
+const PREAMBLE: &str = r#"
+!!! warning
+
+    This CLI reference is experimental. It is automatically generated, but
+    does not match the `jj help` output exactly.
+
+    <!-- See also https://github.com/ConnorGray/clap-markdown/issues -->
+
+"#;
+
 #[test]
 fn test_generate_markdown_docs_in_docs_dir() {
     let test_env = TestEnvironment::default();
-    let markdown_help = test_env.jj_cmd_success(test_env.env_root(), &["util", "markdown-help"]);
+    let mut markdown_help = PREAMBLE.to_string();
+    markdown_help
+        .push_str(&test_env.jj_cmd_success(test_env.env_root(), &["util", "markdown-help"]));
     // Validate partial snapshot, redacting any lines nested 2+ indent levels.
     insta::with_settings!({
         snapshot_path => ".",


### PR DESCRIPTION
There are many minor bugs that are difficult to fix in the short-term.

See also the commit message for https://github.com/martinvonz/jj/commit/a197409b2b9bd61c297c12207a2bd088c5c1a723

The warning looks like this:

![image](https://github.com/martinvonz/jj/assets/4123047/3684740e-bc37-495d-b9a9-aa51c3027da8)
