### PR TITLE
cli `git push`: add `--tracked` option to push all *tracked* branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj branch rename` will now warn if the renamed branch has a remote branch, since
   those will have to be manually renamed outside of `jj`.
 
+* `jj git push` gained a `--tracked` option, to push all the tracked branches.
+
 * There's now a virtual root operation, similar to the [virtual root
   commit](docs/glossary.md#root-commit). It appears at the end of `jj op log`.
 

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -158,7 +158,7 @@ pub struct GitPushArgs {
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
-    /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
+    /// https://martinvonz.github.io/jj/latest/revsets#string-patterns.
     #[arg(long, short, value_parser = parse_string_pattern)]
     branch: Vec<StringPattern>,
     /// Push all branches (including deleted branches)

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -862,6 +862,10 @@ By default, pushes any branches pointing to `remote_branches(remote=<remote>)..@
 
 * `--remote <REMOTE>` — The remote to push to (only named remotes are supported)
 * `-b`, `--branch <BRANCH>` — Push only this branch (can be repeated)
+* `--tracked` — Push all tracked branches (including deleted branches)
+
+  Possible values: `true`, `false`
+
 * `--all` — Push all branches (including deleted branches)
 
   Possible values: `true`, `false`

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -51,6 +51,14 @@ fn set_up() -> (TestEnvironment, PathBuf) {
 #[test]
 fn test_git_push_nothing() {
     let (test_env, workspace_root) = set_up();
+    // Show the setup. `insta` has trouble if this is done inside `set_up()`
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    insta::assert_snapshot!(stdout, @r###"
+    branch1: lzmmnrxq 45a3aa29 (empty) description 1
+      @origin: lzmmnrxq 45a3aa29 (empty) description 1
+    branch2: rlzusymt 8476341e (empty) description 2
+      @origin: rlzusymt 8476341e (empty) description 2
+    "###);
     // No branches to push yet
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
     insta::assert_snapshot!(stdout, @"");


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
