### PR TITLE
cli `git push`: change warning if default revset contains no branches

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -780,11 +780,20 @@ fn cmd_git_push(
                 Err(reason) => reason.print(ui)?,
             }
         }
-        if (!args.revisions.is_empty() || use_default_revset) && branches_targeted.is_empty() {
-            writeln!(
-                ui.warning(),
-                "No branches point to the specified revisions."
-            )?;
+        if branches_targeted.is_empty() {
+            if use_default_revset {
+                writeln!(
+                    ui.warning(),
+                    "No branches found in the default push revset, \
+                     `remote_branches(remote={remote})..@`."
+                )?;
+            } else if !args.revisions.is_empty() {
+                writeln!(
+                    ui.warning(),
+                    "No branches point to the specified revisions."
+                )?;
+            } else { /* A plain "Nothing changed" message will suffice */
+            }
         }
 
         tx_description = format!(

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -135,7 +135,7 @@ fn test_git_push_no_matching_branch() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    No branches point to the specified revisions.
+    No branches found in the default push revset, `remote_branches(remote=origin)..@`.
     Nothing changed.
     "###);
 }
@@ -147,7 +147,7 @@ fn test_git_push_matching_branch_unchanged() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    No branches point to the specified revisions.
+    No branches found in the default push revset, `remote_branches(remote=origin)..@`.
     Nothing changed.
     "###);
 }
@@ -190,7 +190,7 @@ fn test_git_push_other_remote_has_branch() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    No branches point to the specified revisions.
+    No branches found in the default push revset, `remote_branches(remote=origin)..@`.
     Nothing changed.
     "###);
     // But it will still get pushed to another remote


### PR DESCRIPTION
Previously, `jj git push; jj git push` would tell the user that "No branches point to the specified revisions.". I found this confusing, even though strictly speaking it is correct (as the default revset only considers revisions that haven't been pushed to the remote).

Fixes #2241

# Checklist

If applicable:
- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (README.md, docs/, demos/)
- n/a I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
