### PR TITLE
docs: document that `git push --deleted` only pushes tracked branches

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -210,15 +210,16 @@ pub struct GitPushArgs {
     /// This usually means that the branch was already pushed to or fetched from
     /// the relevant remote. For details, see
     /// https://martinvonz.github.io/jj/latest/branches#remotes-and-tracked-branches
-    ///
-    /// Not yet implemented, TODO(#2946): `jj git push --tracked --deleted`
-    /// would make sense, but is not currently allowed.
     #[arg(long)]
     tracked: bool,
     /// Push all branches (including deleted branches)
     #[arg(long)]
     all: bool,
     /// Push all deleted branches
+    ///
+    /// Only tracked branches can be successfully deleted on the remote. A
+    /// warning will be printed if any untracked branches on the remote
+    /// correspond to missing local branches.
     #[arg(long)]
     deleted: bool,
     /// Push branches pointing to these commits

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -198,13 +198,16 @@ pub struct GitPushArgs {
     /// The remote to push to (only named remotes are supported)
     #[arg(long)]
     remote: Option<String>,
-    /// Push only this branch (can be repeated)
+    /// Push only this branch, or branches matching a pattern (can be repeated)
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://martinvonz.github.io/jj/latest/revsets#string-patterns.
     #[arg(long, short, value_parser = parse_string_pattern)]
     branch: Vec<StringPattern>,
+    /// Push all branches (including deleted branches)
+    #[arg(long)]
+    all: bool,
     /// Push all tracked branches (including deleted branches)
     ///
     /// This usually means that the branch was already pushed to or fetched from
@@ -212,9 +215,6 @@ pub struct GitPushArgs {
     /// https://martinvonz.github.io/jj/latest/branches#remotes-and-tracked-branches
     #[arg(long)]
     tracked: bool,
-    /// Push all branches (including deleted branches)
-    #[arg(long)]
-    all: bool,
     /// Push all deleted branches
     ///
     /// Only tracked branches can be successfully deleted on the remote. A
@@ -222,7 +222,7 @@ pub struct GitPushArgs {
     /// correspond to missing local branches.
     #[arg(long)]
     deleted: bool,
-    /// Push branches pointing to these commits
+    /// Push branches pointing to these commits (can be repeated)
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
     /// Push this commit by creating a branch based on its change ID (can be

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -893,12 +893,12 @@ By default, pushes any branches pointing to `remote_branches(remote=<remote>)..@
 ###### **Options:**
 
 * `--remote <REMOTE>` — The remote to push to (only named remotes are supported)
-* `-b`, `--branch <BRANCH>` — Push only this branch (can be repeated)
-* `--tracked` — Push all tracked branches (including deleted branches)
+* `-b`, `--branch <BRANCH>` — Push only this branch, or branches matching a pattern (can be repeated)
+* `--all` — Push all branches (including deleted branches)
 
   Possible values: `true`, `false`
 
-* `--all` — Push all branches (including deleted branches)
+* `--tracked` — Push all tracked branches (including deleted branches)
 
   Possible values: `true`, `false`
 
@@ -906,7 +906,7 @@ By default, pushes any branches pointing to `remote_branches(remote=<remote>)..@
 
   Possible values: `true`, `false`
 
-* `-r`, `--revisions <REVISIONS>` — Push branches pointing to these commits
+* `-r`, `--revisions <REVISIONS>` — Push branches pointing to these commits (can be repeated)
 * `-c`, `--change <CHANGE>` — Push this commit by creating a branch based on its change ID (can be repeated)
 * `--dry-run` — Only display what will change on the remote
 


### PR DESCRIPTION
It tries to push all deleted branches, but can only succeed for tracked branches.

Closes #2946, as there's probably no need to have `--deleted --tracked` that would only be different in that the warnings wouldn't be printed. Thanks to @yuja for pointing this out.
