### PR TITLE
cli `branch rename`: change warning when renaming a branch with remotes

### DIFF
--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -229,7 +229,8 @@ fn test_branch_rename() {
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["branch", "rename", "bremote", "bremote2"]);
     insta::assert_snapshot!(stderr, @r###"
-    warning: Branch bremote has remote branches which will not be renamed
+    Warning: Branch bremote has tracking remote branches which were not renamed.
+    Hint: to rename the branch on the remote, you can `jj git push --branch bremote` first (to delete it on the remote), and then `jj git push --branch bremote2`. `jj git push --all` would also be sufficient.
     "###);
 }
 


### PR DESCRIPTION
A version of this was previously part of #2935