### PR TITLE
working_copy: make reset() take a commit instead of a tree

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -23,7 +23,6 @@ use jj_lib::backend::{Backend, MergedTreeId};
 use jj_lib::commit::Commit;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::local_working_copy::LocalWorkingCopy;
-use jj_lib::merged_tree::MergedTree;
 use jj_lib::op_store::{OperationId, WorkspaceId};
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo_path::RepoPathBuf;
@@ -237,8 +236,8 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
         self.inner.check_out(commit)
     }
 
-    fn reset(&mut self, new_tree: &MergedTree) -> Result<(), ResetError> {
-        self.inner.reset(new_tree)
+    fn reset(&mut self, commit: &Commit) -> Result<(), ResetError> {
+        self.inner.reset(commit)
     }
 
     fn sparse_patterns(&self) -> Result<&[RepoPathBuf], WorkingCopyStateError> {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -923,8 +923,7 @@ impl WorkspaceCommandHelper {
             // The working copy was presumably updated by the git command that updated
             // HEAD, so we just need to reset our working copy
             // state to it without updating working copy files.
-            let new_git_head_tree = new_git_head_commit.tree()?;
-            locked_ws.locked_wc().reset(&new_git_head_tree)?;
+            locked_ws.locked_wc().reset(&new_git_head_commit)?;
             tx.mut_repo().rebase_descendants(&self.settings)?;
             self.user_repo = ReadonlyUserRepo::new(tx.commit("import git head"));
             locked_ws.finish(self.user_repo.repo.op_id().clone())?;

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1739,14 +1739,15 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         Ok(stats)
     }
 
-    fn reset(&mut self, new_tree: &MergedTree) -> Result<(), ResetError> {
+    fn reset(&mut self, commit: &Commit) -> Result<(), ResetError> {
+        let new_tree = commit.tree()?;
         self.wc
             .tree_state_mut()
             .map_err(|err| ResetError::Other {
                 message: "Failed to read the working copy state".to_string(),
                 err: err.into(),
             })?
-            .reset(new_tree)
+            .reset(&new_tree)
             .block_on()?;
         self.tree_state_dirty = true;
         Ok(())

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -26,7 +26,6 @@ use crate::backend::{BackendError, MergedTreeId};
 use crate::commit::Commit;
 use crate::fsmonitor::FsmonitorKind;
 use crate::gitignore::GitIgnoreFile;
-use crate::merged_tree::MergedTree;
 use crate::op_store::{OperationId, WorkspaceId};
 use crate::repo_path::{RepoPath, RepoPathBuf};
 use crate::settings::HumanByteSize;
@@ -105,8 +104,8 @@ pub trait LockedWorkingCopy {
     /// Check out the specified commit in the working copy.
     fn check_out(&mut self, commit: &Commit) -> Result<CheckoutStats, CheckoutError>;
 
-    /// Update to another tree without touching the files in the working copy.
-    fn reset(&mut self, new_tree: &MergedTree) -> Result<(), ResetError>;
+    /// Update to another commit without touching the files in the working copy.
+    fn reset(&mut self, commit: &Commit) -> Result<(), ResetError>;
 
     /// See `WorkingCopy::sparse_patterns()`
     fn sparse_patterns(&self) -> Result<&[RepoPathBuf], WorkingCopyStateError>;


### PR DESCRIPTION
Our virtual file system at Google (CitC) would like to know the commit so it can scan backwards and find the closest mainline tree based on it. Since we always record an operation id (which resolves to a working-copy commit) when we write the working-copy state, it doesn't seem like a restriction to require a commit.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
