### PR TITLE
cli: include command to set config in hint about default command

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2703,7 +2703,7 @@ fn resolve_default_command(
                 )?;
                 writeln!(
                     ui.hint(),
-                    "Set the config `ui.default-command = \"log\"` to disable this message."
+                    "Run `jj config set --user ui.default-command log` to disable this message."
                 )?;
             }
             let default_command = config

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -68,7 +68,7 @@ fn test_no_subcommand() {
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &[]);
     insta::assert_snapshot!(stderr, @r###"
     Hint: Use `jj -h` for a list of available commands.
-    Set the config `ui.default-command = "log"` to disable this message.
+    Run `jj config set --user ui.default-command log` to disable this message.
     Error: There is no jj repo in "."
     "###);
 


### PR DESCRIPTION
When the user doesn't have a configured default command, we show a hint saying to set `ui.default-command`. I think the user is very likely to want to set that in the user-wide config, so let's include the command in the hint.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
