### PR TITLE
lib refs.rs: rename `TrackingRefPair` to `LocalAndRemoteRef`

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -29,7 +29,7 @@ use jj_lib::git::{
 use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::RefTarget;
 use jj_lib::refs::{
-    classify_branch_push_action, BranchPushAction, BranchPushUpdate, TrackingRefPair,
+    classify_branch_push_action, BranchPushAction, BranchPushUpdate, LocalAndRemoteRef,
 };
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::repo_path::RepoPath;
@@ -870,7 +870,7 @@ fn cmd_git_push(
             }
             tx.mut_repo()
                 .set_local_branch_target(&branch_name, RefTarget::normal(commit.id().clone()));
-            let targets = TrackingRefPair {
+            let targets = LocalAndRemoteRef {
                 local_target: tx.repo().view().get_local_branch(&branch_name),
                 remote_ref: tx.repo().view().get_remote_branch(&branch_name, &remote),
             };
@@ -1125,7 +1125,7 @@ impl From<RejectedBranchUpdateReason> for CommandError {
 fn classify_branch_update(
     branch_name: &str,
     remote_name: &str,
-    targets: TrackingRefPair,
+    targets: LocalAndRemoteRef,
 ) -> Result<Option<BranchPushUpdate>, RejectedBranchUpdateReason> {
     let push_action = classify_branch_push_action(targets);
     match push_action {
@@ -1155,7 +1155,7 @@ fn find_branches_to_push<'a>(
     branch_patterns: &[StringPattern],
     remote_name: &str,
     seen_branches: &mut HashSet<String>,
-) -> Result<Vec<(&'a str, TrackingRefPair<'a>)>, CommandError> {
+) -> Result<Vec<(&'a str, LocalAndRemoteRef<'a>)>, CommandError> {
     let mut matching_branches = vec![];
     let mut unmatched_patterns = vec![];
     for pattern in branch_patterns {

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -159,9 +159,9 @@ fn find_pair_to_remove(
     None
 }
 
-/// Pair of local and remote targets which usually represents a tracking branch.
+/// Pair of local and remote targets.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct TrackingRefPair<'a> {
+pub struct LocalAndRemoteRef<'a> {
     pub local_target: &'a RefTarget,
     pub remote_ref: &'a RemoteRef,
 }
@@ -183,7 +183,7 @@ pub enum BranchPushAction {
 
 /// Figure out what changes (if any) need to be made to the remote when pushing
 /// this branch.
-pub fn classify_branch_push_action(targets: TrackingRefPair) -> BranchPushAction {
+pub fn classify_branch_push_action(targets: LocalAndRemoteRef) -> BranchPushAction {
     let local_target = targets.local_target;
     let remote_target = targets.remote_ref.tracking_target();
     if local_target == remote_target {
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn test_classify_branch_push_action_unchanged() {
         let commit_id1 = CommitId::from_hex("11");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id1.clone()),
             remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1)),
         };
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_classify_branch_push_action_added() {
         let commit_id1 = CommitId::from_hex("11");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id1.clone()),
             remote_ref: RemoteRef::absent_ref(),
         };
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn test_classify_branch_push_action_removed() {
         let commit_id1 = CommitId::from_hex("11");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: RefTarget::absent_ref(),
             remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1.clone())),
         };
@@ -270,7 +270,7 @@ mod tests {
     fn test_classify_branch_push_action_updated() {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id2.clone()),
             remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1.clone())),
         };
@@ -288,7 +288,7 @@ mod tests {
         // This is not RemoteUntracked error since non-tracking remote branches
         // have no relation to local branches, and there's nothing to push.
         let commit_id1 = CommitId::from_hex("11");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: RefTarget::absent_ref(),
             remote_ref: &new_remote_ref(RefTarget::normal(commit_id1.clone())),
         };
@@ -302,7 +302,7 @@ mod tests {
     fn test_classify_branch_push_action_updated_untracked() {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id2.clone()),
             remote_ref: &new_remote_ref(RefTarget::normal(commit_id1.clone())),
         };
@@ -316,7 +316,7 @@ mod tests {
     fn test_classify_branch_push_action_local_conflicted() {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: &RefTarget::from_legacy_form([], [commit_id1.clone(), commit_id2]),
             remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1)),
         };
@@ -330,7 +330,7 @@ mod tests {
     fn test_classify_branch_push_action_remote_conflicted() {
         let commit_id1 = CommitId::from_hex("11");
         let commit_id2 = CommitId::from_hex("22");
-        let targets = TrackingRefPair {
+        let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id1.clone()),
             remote_ref: &tracking_remote_ref(RefTarget::from_legacy_form(
                 [],

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 
 use crate::backend::CommitId;
 use crate::op_store::{BranchTarget, RefTarget, RefTargetOptionExt as _, RemoteRef, WorkspaceId};
-use crate::refs::TrackingRefPair;
+use crate::refs::LocalAndRemoteRef;
 use crate::str_util::StringPattern;
 use crate::{op_store, refs};
 
@@ -224,10 +224,10 @@ impl View {
     pub fn local_remote_branches<'a>(
         &'a self,
         remote_name: &str,
-    ) -> impl Iterator<Item = (&'a str, TrackingRefPair<'a>)> + 'a {
+    ) -> impl Iterator<Item = (&'a str, LocalAndRemoteRef<'a>)> + 'a {
         refs::iter_named_local_remote_refs(self.local_branches(), self.remote_branches(remote_name))
             .map(|(name, (local_target, remote_ref))| {
-                let targets = TrackingRefPair {
+                let targets = LocalAndRemoteRef {
                     local_target,
                     remote_ref,
                 };
@@ -248,7 +248,7 @@ impl View {
         &'a self,
         branch_pattern: &'b StringPattern,
         remote_name: &str,
-    ) -> impl Iterator<Item = (&'a str, TrackingRefPair<'a>)> + 'b {
+    ) -> impl Iterator<Item = (&'a str, LocalAndRemoteRef<'a>)> + 'b {
         // Change remote_name to StringPattern if needed, but merge-join adapter won't
         // be usable.
         let maybe_remote_view = self.data.remote_views.get(remote_name);
@@ -260,7 +260,7 @@ impl View {
                 .flatten(),
         )
         .map(|(name, (local_target, remote_ref))| {
-            let targets = TrackingRefPair {
+            let targets = LocalAndRemoteRef {
                 local_target,
                 remote_ref,
             };


### PR DESCRIPTION
As discussed in
https://github.com/martinvonz/jj/pull/2962#discussion_r1479384841, the previous name is confusing since the struct is used for pairs where the remote branch is not tracked by the local branch.

------------

Another name I considered was just `RefPair`. If you don't like either, we could keep it as is for now.