### PR TITLE
templater: add support for logical operators: `||`, `&&`, `!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Templates now support logical operators: `||`, `&&`, `!`
+
 ### Fixed bugs
 
 ## [0.14.0] - 2024-02-07

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -31,6 +31,12 @@ integer_literal = {
 
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
+logical_or_op = { "||" }
+logical_and_op = { "&&" }
+logical_not_op = { "!" }
+prefix_ops = _{ logical_not_op }
+infix_ops = _{ logical_or_op | logical_and_op }
+
 function = { identifier ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")" }
 function_arguments = {
   template ~ (whitespace* ~ "," ~ whitespace* ~ template)* ~ (whitespace* ~ ",")?
@@ -58,11 +64,18 @@ term = {
   primary ~ ("." ~ function)*
 }
 
+expression = {
+  (prefix_ops ~ whitespace*)* ~ term
+  ~ (whitespace* ~ infix_ops ~ whitespace* ~ (prefix_ops ~ whitespace*)* ~ term)*
+}
+
+// Use 'term' instead of 'expression' to disallow 'x || y ++ z'. It can be
+// parsed, but the precedence isn't obvious.
 concat = _{
   term ~ (whitespace* ~ "++" ~ whitespace* ~ term)+
 }
 
-template = { concat | term }
+template = { concat | expression }
 
 program = _{ SOI ~ whitespace* ~ template? ~ whitespace* ~ EOI }
 

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -31,6 +31,7 @@ integer_literal = {
 
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
+concat_op = { "++" }
 logical_or_op = { "||" }
 logical_and_op = { "&&" }
 logical_not_op = { "!" }
@@ -72,7 +73,7 @@ expression = {
 // Use 'term' instead of 'expression' to disallow 'x || y ++ z'. It can be
 // parsed, but the precedence isn't obvious.
 concat = _{
-  term ~ (whitespace* ~ "++" ~ whitespace* ~ term)+
+  term ~ (whitespace* ~ concat_op ~ whitespace* ~ term)+
 }
 
 template = { concat | expression }

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -803,6 +803,8 @@ pub fn build_expression<'a, L: TemplateLanguage<'a>>(
             let property = language.wrap_string(Literal(value.clone()));
             Ok(Expression::unlabeled(property))
         }
+        ExpressionKind::Unary(..) => todo!(),
+        ExpressionKind::Binary(..) => todo!(),
         ExpressionKind::Concat(nodes) => {
             let templates = nodes
                 .iter()
@@ -1030,7 +1032,7 @@ mod tests {
         1 | description ()
           |             ^---
           |
-          = expected EOI
+          = expected EOI, logical_or_op, or logical_and_op
         "###);
 
         insta::assert_snapshot!(env.parse_err(r#"foo"#), @r###"

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1075,7 +1075,7 @@ mod tests {
         1 | description ()
           |             ^---
           |
-          = expected EOI, logical_or_op, or logical_and_op
+          = expected <EOI>, `||`, or `&&`
         "###);
 
         insta::assert_snapshot!(env.parse_err(r#"foo"#), @r###"
@@ -1152,7 +1152,7 @@ mod tests {
         1 | (-empty)
           |  ^---
           |
-          = expected template
+          = expected <template>
         "###);
 
         insta::assert_snapshot!(env.parse_err(r#"("foo" ++ "bar").baz()"#), @r###"

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1075,7 +1075,7 @@ mod tests {
         1 | description ()
           |             ^---
           |
-          = expected <EOI>, `||`, or `&&`
+          = expected <EOI>, `++`, `||`, or `&&`
         "###);
 
         insta::assert_snapshot!(env.parse_err(r#"foo"#), @r###"

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -39,6 +39,7 @@ impl Rule {
             Rule::literal => None,
             Rule::integer_literal => None,
             Rule::identifier => None,
+            Rule::concat_op => Some("++"),
             Rule::logical_or_op => Some("||"),
             Rule::logical_and_op => Some("&&"),
             Rule::logical_not_op => Some("!"),
@@ -462,9 +463,10 @@ fn parse_template_node(pair: Pair<Rule>) -> TemplateParseResult<ExpressionNode> 
     let span = pair.as_span();
     let inner = pair.into_inner();
     let mut nodes: Vec<_> = inner
-        .map(|pair| match pair.as_rule() {
-            Rule::term => parse_term_node(pair),
-            Rule::expression => parse_expression_node(pair),
+        .filter_map(|pair| match pair.as_rule() {
+            Rule::concat_op => None,
+            Rule::term => Some(parse_term_node(pair)),
+            Rule::expression => Some(parse_expression_node(pair)),
             r => panic!("unexpected template item rule {r:?}"),
         })
         .try_collect()?;

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -719,10 +719,10 @@ pub fn expect_lambda_with<'a, 'i, T>(
 ) -> TemplateParseResult<T> {
     match &node.kind {
         ExpressionKind::Lambda(lambda) => f(lambda, node.span),
-        ExpressionKind::String(_)
-        | ExpressionKind::Identifier(_)
+        ExpressionKind::Identifier(_)
         | ExpressionKind::Boolean(_)
         | ExpressionKind::Integer(_)
+        | ExpressionKind::String(_)
         | ExpressionKind::Concat(_)
         | ExpressionKind::FunctionCall(_)
         | ExpressionKind::MethodCall(_) => Err(TemplateParseError::unexpected_expression(

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -29,7 +29,7 @@ fn test_templater_parse_error() {
     1 | description ()
       |             ^---
       |
-      = expected <EOI>, `||`, or `&&`
+      = expected <EOI>, `++`, `||`, or `&&`
     "###);
 }
 

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -29,7 +29,7 @@ fn test_templater_parse_error() {
     1 | description ()
       |             ^---
       |
-      = expected EOI, logical_or_op, or logical_and_op
+      = expected <EOI>, `||`, or `&&`
     "###);
 }
 
@@ -84,7 +84,7 @@ fn test_templater_alias() {
     1 | foo.
       |     ^---
       |
-      = expected identifier
+      = expected <identifier>
     "###);
 
     insta::assert_snapshot!(render_err("commit_id ++ name_error"), @r###"

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -29,7 +29,7 @@ fn test_templater_parse_error() {
     1 | description ()
       |             ^---
       |
-      = expected EOI
+      = expected EOI, logical_or_op, or logical_and_op
     "###);
 }
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -57,6 +57,9 @@ The following keywords can be used in `jj op log` templates.
 The following operators are supported.
 
 * `x.f()`: Method call.
+* `!x`: Logical not.
+* `x && y`: Logical and.
+* `x || y`: Logical or.
 * `x ++ y`: Concatenate `x` and `y` templates.
 
 ## Global functions


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
