### PR TITLE
readme: fix `[!WARNING]` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,9 @@ And it adds several innovative, useful features of its own:
   well. In effect, this is a completely transparent version of `git rebase
   --update-refs` combined with `git rerere`, supported by design.
 
-  > [!WARNING]
-  > The following features are available for use, but experimental; they may
-  > have bugs, backwards incompatible storage changes, and user-interface
-  > changes!
+> [!WARNING]
+> The following features are available for use, but experimental; they may have
+> bugs, backwards incompatible storage changes, and user-interface changes!
 
 - **Safe, concurrent replication**: Have you ever wanted to store your version
   controlled repositories inside a Dropbox folder? Or continuously backup


### PR DESCRIPTION
Apparently this previously-beta markdown syntax from GitHub "graduated" to a full feature in such a way that it it actually regressed in features, so doing this `[!WARNING]` inline inside of a list is no longer valid. Sigh. Scoot it up a level in the document, and just make it part of the section and not inside the list.