### PR TITLE
workspace: create transaction using workspace_command

### DIFF
--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -288,13 +288,13 @@ fn create_and_check_out_recovery_commit(
 ) -> Result<Arc<ReadonlyRepo>, CommandError> {
     let mut workspace_command = command.workspace_helper_no_snapshot(ui)?;
     let workspace_id = workspace_command.workspace_id().clone();
-    let repo = workspace_command.repo().clone();
-    let tree_id = repo.store().empty_merged_tree_id();
+    let mut tx = workspace_command.start_transaction().into_inner();
+
+    let tree_id = workspace_command.repo().store().empty_merged_tree_id();
     let (mut locked_workspace, commit) =
         workspace_command.unchecked_start_working_copy_mutation()?;
     let commit_id = commit.id();
 
-    let mut tx = repo.start_transaction(command.settings());
     let mut_repo = tx.mut_repo();
     let new_commit = mut_repo
         .new_commit(command.settings(), vec![commit_id.clone()], tree_id.clone())


### PR DESCRIPTION
Using workspace_command means that we record the command arguments into the ops log.

This also allows us to avoid a clone of an Arc.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
