### PR TITLE
Add ssh signing backend implementation

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -717,7 +717,8 @@ impl CommandHelper {
                         start_repo_transaction(&base_repo, &self.settings, &self.string_args);
                     for other_op_head in op_heads.into_iter().skip(1) {
                         tx.merge_operation(other_op_head)?;
-                        let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;
+                        let rebase_counts = tx.mut_repo().rebase_descendants(&self.settings)?;
+                        let num_rebased = rebase_counts.rebased;
                         if num_rebased > 0 {
                             writeln!(
                                 ui.stderr(),
@@ -725,6 +726,7 @@ impl CommandHelper {
                                  by other operation"
                             )?;
                         }
+                        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
                     }
                     Ok(tx
                         .write("resolve concurrent operations")
@@ -951,13 +953,15 @@ impl WorkspaceCommandHelper {
         print_git_import_stats(ui, &stats)?;
         let mut tx = tx.into_inner();
         // Rebase here to show slightly different status message.
-        let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(&self.settings)?;
+        let num_rebased = rebase_counts.rebased;
         if num_rebased > 0 {
             writeln!(
                 ui.stderr(),
                 "Rebased {num_rebased} descendant commits off of commits rewritten from git"
             )?;
         }
+        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
         self.finish_transaction(ui, tx, "import git refs")?;
         writeln!(
             ui.stderr(),
@@ -1484,13 +1488,15 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             mut_repo.set_wc_commit(workspace_id, commit.id().clone())?;
 
             // Rebase descendants
-            let num_rebased = mut_repo.rebase_descendants(&self.settings)?;
+            let rebase_counts = mut_repo.rebase_descendants(&self.settings)?;
+            let num_rebased = rebase_counts.rebased;
             if num_rebased > 0 {
                 writeln!(
                     ui.stderr(),
                     "Rebased {num_rebased} descendant commits onto updated working copy"
                 )?;
             }
+            print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
 
             if self.working_copy_shared_with_git {
                 let failed_branches = git::export_refs(mut_repo)?;
@@ -1517,6 +1523,16 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             new_commit,
         )?;
         if Some(new_commit) != maybe_old_commit {
+            if let Some(old_commit) = maybe_old_commit {
+                if old_commit.is_signed() && !new_commit.is_signed() {
+                    writeln!(
+                        ui.warning(),
+                        "Working copy was signed, but that signature was dropped. You should \
+                         probably configure signing"
+                    )?;
+                }
+            }
+
             write!(ui.stderr(), "Working copy now at: ")?;
             ui.stderr_formatter().with_label("working_copy", |fmt| {
                 self.write_commit_summary(fmt, new_commit)
@@ -1550,10 +1566,12 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             writeln!(ui.stderr(), "Nothing changed.")?;
             return Ok(());
         }
-        let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(&self.settings)?;
+        let num_rebased = rebase_counts.rebased;
         if num_rebased > 0 {
             writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
         }
+        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
 
         let old_repo = tx.base_repo().clone();
 
@@ -2058,6 +2076,24 @@ pub fn print_trackable_remote_branches(ui: &Ui, view: &View) -> io::Result<()> {
     Ok(())
 }
 
+pub fn check_dropped_signature(
+    ui: &Ui,
+    old_commit: &Commit,
+    rewritten: &Commit,
+) -> Result<(), std::io::Error> {
+    if old_commit.is_signed() && !rewritten.is_signed() {
+        writeln!(ui.warning(), "Dropped a commit signature")?;
+    }
+    Ok(())
+}
+
+pub fn print_dropped_signatures(ui: &Ui, num_dropped: usize) -> Result<(), std::io::Error> {
+    if num_dropped > 0 {
+        writeln!(ui.warning(), "Dropped {} commit signatures", num_dropped)?;
+    }
+    Ok(())
+}
+ 
 pub fn parse_string_pattern(src: &str) -> Result<StringPattern, StringPatternParseError> {
     if let Some((kind, pat)) = src.split_once(':') {
         StringPattern::from_str_kind(pat, kind)

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -18,7 +18,8 @@ use jj_lib::object_id::ObjectId;
 use tracing::instrument;
 
 use crate::cli_util::{
-    resolve_multiple_nonempty_revsets, CommandError, CommandHelper, RevisionArg,
+    print_dropped_signatures, resolve_multiple_nonempty_revsets, CommandError, CommandHelper,
+    RevisionArg,
 };
 use crate::ui::Ui;
 
@@ -53,7 +54,8 @@ pub(crate) fn cmd_abandon(
     for commit in &to_abandon {
         tx.mut_repo().record_abandoned_commit(commit.id().clone());
     }
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = rebase_counts.rebased;
 
     if to_abandon.len() == 1 {
         write!(ui.stderr(), "Abandoned commit ")?;
@@ -86,6 +88,7 @@ pub(crate) fn cmd_abandon(
             to_abandon.len() - 1
         )
     };
+    print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
     tx.finish(ui, transaction_description)?;
     Ok(())
 }

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -17,7 +17,9 @@ use std::io::{self, Read, Write};
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;
 
-use crate::cli_util::{join_message_paragraphs, CommandError, CommandHelper, RevisionArg};
+use crate::cli_util::{
+    check_dropped_signature, join_message_paragraphs, CommandError, CommandHelper, RevisionArg,
+};
 use crate::description_util::{description_template_for_describe, edit_description};
 use crate::ui::Ui;
 
@@ -91,7 +93,8 @@ pub(crate) fn cmd_describe(
             let new_author = commit_builder.committer().clone();
             commit_builder = commit_builder.set_author(new_author);
         }
-        commit_builder.write()?;
+        let rewritten = commit_builder.write()?;
+        check_dropped_signature(ui, &commit, &rewritten)?;
         tx.finish(ui, format!("describe commit {}", commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -19,7 +19,7 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;
 
-use crate::cli_util::{CommandError, CommandHelper, RevisionArg};
+use crate::cli_util::{print_dropped_signatures, CommandError, CommandHelper, RevisionArg};
 use crate::ui::Ui;
 
 /// Touch up the content changes in a revision with a diff editor
@@ -102,13 +102,15 @@ don't make any changes, then the operation will be aborted.",
             .write()?;
         // rebase_descendants early; otherwise `new_commit` would always have
         // a conflicted change id at this point.
-        let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
         write!(ui.stderr(), "Created ")?;
         tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
         writeln!(ui.stderr())?;
+        let num_rebased = rebase_counts.rebased;
         if num_rebased > 0 {
             writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
         }
+        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
         tx.finish(ui, format!("edit commit {}", target_commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -46,6 +46,7 @@ mod restore;
 mod root;
 mod run;
 mod show;
+mod sign;
 mod sparse;
 mod split;
 mod squash;
@@ -127,6 +128,7 @@ enum Command {
     // TODO: Flesh out.
     Run(run::RunArgs),
     Show(show::ShowArgs),
+    Sign(sign::SignArgs),
     #[command(subcommand)]
     Sparse(sparse::SparseArgs),
     Split(split::SplitArgs),
@@ -169,6 +171,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Cat(sub_args) => cat::cmd_cat(ui, command_helper, sub_args),
         Command::Diff(sub_args) => diff::cmd_diff(ui, command_helper, sub_args),
         Command::Show(sub_args) => show::cmd_show(ui, command_helper, sub_args),
+        Command::Sign(sub_args) => sign::cmd_sign(ui, command_helper, sub_args),
         Command::Status(sub_args) => status::cmd_status(ui, command_helper, sub_args),
         Command::Log(sub_args) => log::cmd_log(ui, command_helper, sub_args),
         Command::Interdiff(sub_args) => interdiff::cmd_interdiff(ui, command_helper, sub_args),

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -1,0 +1,71 @@
+use std::io::Write;
+
+use jj_lib::object_id::ObjectId;
+use jj_lib::signing::SignBehavior;
+
+use crate::cli_util::{user_error, CommandError, CommandHelper, RevisionArg};
+use crate::ui::Ui;
+
+/// Cryptographically sign a revision
+#[derive(clap::Args, Clone, Debug)]
+pub struct SignArgs {
+    /// What key to use, depends on the configured signing backend.
+    #[arg()]
+    key: Option<String>,
+    /// What revision to sign
+    #[arg(long, short, default_value = "@")]
+    revision: RevisionArg,
+    /// Sign the commit that is not authored by you or was already signed.
+    #[arg(long, short)]
+    force: bool,
+    /// Drop the signature, explicitly "un-signing" the commit.
+    #[arg(long, short = 'D', conflicts_with = "force")]
+    drop: bool,
+}
+
+pub fn cmd_sign(ui: &mut Ui, command: &CommandHelper, args: &SignArgs) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    workspace_command.check_rewritable([&commit])?;
+
+    if !args.force {
+        if !args.drop && commit.is_signed() {
+            return Err(user_error(
+                "Commit is already signed, use --force to sign anyway",
+            ));
+        }
+        if commit.author().email != command.settings().user_email() {
+            return Err(user_error(
+                "Commit is not authored by you, use --force to sign anyway",
+            ));
+        }
+    }
+
+    let mut tx = workspace_command.start_transaction();
+
+    let behavior = if args.drop {
+        SignBehavior::Drop
+    } else if args.force {
+        SignBehavior::Force
+    } else {
+        SignBehavior::Own
+    };
+    let rewritten = tx
+        .mut_repo()
+        .rewrite_commit(command.settings(), &commit)
+        .override_sign_key(args.key.clone())
+        .set_sign_behavior(behavior)
+        .write()?;
+
+    tx.finish(ui, format!("sign commit {}", commit.id().hex()))?;
+
+    let summary = workspace_command.format_commit_summary(&rewritten);
+    if args.drop {
+        writeln!(ui.stderr(), "Signature was dropped: {summary}")?;
+    } else {
+        writeln!(ui.stderr(), "Commit was signed: {summary}")?;
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -148,7 +148,8 @@ don't make any changes, then the operation will be aborted.
     // descendants.
     tx.mut_repo()
         .set_rewritten_commit(commit.id().clone(), [second_commit.id().clone()]);
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = rebase_counts.rebased;
     if num_rebased > 0 {
         writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
     }

--- a/cli/src/commands/untrack.rs
+++ b/cli/src/commands/untrack.rs
@@ -21,7 +21,9 @@ use jj_lib::repo::Repo;
 use jj_lib::working_copy::SnapshotOptions;
 use tracing::instrument;
 
-use crate::cli_util::{user_error_with_hint, CommandError, CommandHelper};
+use crate::cli_util::{
+    print_dropped_signatures, user_error_with_hint, CommandError, CommandHelper,
+};
 use crate::ui::Ui;
 
 /// Stop tracking specified paths in the working copy
@@ -97,10 +99,12 @@ Make sure they're ignored, then try again.",
             locked_ws.locked_wc().reset(&new_commit)?;
         }
     }
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = rebase_counts.rebased;
     if num_rebased > 0 {
         writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
     }
+    print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
     let repo = tx.commit("untrack paths");
     locked_ws.finish(repo.op_id().clone())?;
     Ok(())

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -376,7 +376,23 @@
                 "backends": {
                     "type": "object",
                     "description": "Tables of options to pass to specific signing backends",
-                    "properties": {},
+                    "properties": {
+                        "GPG": {
+                            "type": "object",
+                            "properties": {
+                                "program": {
+                                    "type": "string",
+                                    "description": "Path to the gpg program to be called",
+                                    "default": "gpg2"
+                                },
+                                "consider-expired-keys-bad": {
+                                    "type": "boolean",
+                                    "description": "Whether to consider signatures made with an expired key as bad",
+                                    "default": false
+                                }
+                            }
+                        }
+                    },
                     "additionalProperties": true
                 }
             }

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -73,3 +73,9 @@
 "op_log current_operation id" = "bright blue"
 "op_log current_operation user" = "yellow"  # No bright yellow, see comment above
 "op_log current_operation time" = "bright cyan"
+"signature good" = "green"
+"signature unknown" = "bright black"
+"signature bad" = "red"
+"signature invalid" = "yellow"
+"signature key" = "blue"
+"signature display" = "yellow"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -2,6 +2,7 @@
 commit_summary = '''
 separate(" ",
   builtin_change_id_with_hidden_and_divergent_info,
+  builtin_sig_status,
   format_short_commit_id(commit_id),
   separate(commit_summary_separator,
     branches,
@@ -17,6 +18,7 @@ separate(" ",
 commit_summary_no_branches = '''
 separate(" ",
   builtin_change_id_with_hidden_and_divergent_info,
+  builtin_sig_status,
   format_short_commit_id(commit_id),
   if(conflict, label("conflict", "(conflict)")),
   if(empty, label("empty", "(empty)")),
@@ -36,6 +38,7 @@ if(root,
     concat(
       separate(" ",
         builtin_change_id_with_hidden_and_divergent_info,
+        builtin_sig_status,
         if(author.email(), author.username(), email_placeholder),
         format_timestamp(committer.timestamp()),
         branches,
@@ -58,6 +61,7 @@ if(root,
     concat(
       separate(" ",
         builtin_change_id_with_hidden_and_divergent_info,
+        builtin_sig_status,
         format_short_signature(author),
         format_timestamp(committer.timestamp()),
         branches,
@@ -84,6 +88,7 @@ concat(
   surround("Tags: ", "\n", tags),
   "Author: " ++ format_detailed_signature(author) ++ "\n",
   "Committer: " ++ format_detailed_signature(committer)  ++ "\n",
+  builtin_sig_detailed,
   "\n",
   indent("    ", if(description, description, description_placeholder ++ "\n")),
   "\n",
@@ -150,11 +155,54 @@ commit_summary_separator = 'label("separator", " | ")'
 # commit id to refer to a hidden revision regardless.
 builtin_change_id_with_hidden_and_divergent_info = '''
 if(hidden,
-  label("hidden", 
+  label("hidden",
     format_short_change_id(change_id) ++ " hidden"
   ),
   label(if(divergent, "divergent"),
     format_short_change_id(change_id) ++ if(divergent,"??")
+  )
+)
+'''
+
+builtin_sig_status = '''
+if(signature.present(),
+  label("signature",
+    concat(
+      "[",
+      label("status",
+        if(signature.good(), label("good", "✓︎"),
+          if(signature.unknown(), label("unknown", "?"),
+            if(signature.bad(), label("bad", "❌︎"),
+              if(signature.invalid(), label("invalid", "?!"))
+            )
+          )
+        )
+      ),
+      "]"
+    )
+  )
+)
+'''
+
+builtin_sig_detailed = '''
+if(signature.present(),
+  concat(
+    "Signature: ",
+    label("signature",
+      if(signature.good(), label("good", "Good"),
+        if(signature.unknown(), label("unknown", "Unknown"),
+          if(signature.bad(), label("bad", "Bad"),
+            if(signature.invalid(), label("invalid", "Invalid"))
+          )
+        )
+      )
+    ),
+    if(signature.backend(), " " ++ label("backend", signature.backend()) ++ " signature"),
+    if(signature.display(),
+      ". By " ++ label("display", signature.display()) ++ if(signature.key(), " (key " ++ label("key", signature.key()) ++ ")"),
+      if(signature.key(), ". Key " ++ label("key", signature.key()))
+    ),
+    "\n"
   )
 )
 '''

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -73,6 +73,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj restore`↴](#jj-restore)
 * [`jj root`↴](#jj-root)
 * [`jj show`↴](#jj-show)
+* [`jj sign`↴](#jj-sign)
 * [`jj sparse`↴](#jj-sparse)
 * [`jj sparse list`↴](#jj-sparse-list)
 * [`jj sparse set`↴](#jj-sparse-set)
@@ -137,6 +138,7 @@ repository.
 * `restore` — Restore paths from another revision
 * `root` — Show the current workspace root directory
 * `show` — Show commit description and changes in a revision
+* `sign` — Cryptographically sign a revision
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
 * `split` — Split a revision in two
 * `squash` — Move changes from a revision into its parent
@@ -165,6 +167,11 @@ repository.
 
 * `--color <WHEN>` — When to colorize output (always, never, auto)
 * `--no-pager` — Disable the pager
+
+  Possible values: `true`, `false`
+
+* `--sign-with <KEY>` — Override the configured key to be used for the commit signing. Is only used when a commit signing operation has to be performed by the operation
+* `--no-sign` — Don't sign unsigned commits when configured to sign all, is ignored otherwise
 
   Possible values: `true`, `false`
 
@@ -1572,6 +1579,32 @@ Show commit description and changes in a revision
   Possible values: `true`, `false`
 
 * `--tool <TOOL>` — Generate diff by external command
+
+
+
+## `jj sign`
+
+Cryptographically sign a revision
+
+**Usage:** `jj sign [OPTIONS] [KEY]`
+
+###### **Arguments:**
+
+* `<KEY>` — What key to use, depends on the configured signing backend
+
+###### **Options:**
+
+* `-r`, `--revision <REVISION>` — What revision to sign
+
+  Default value: `@`
+* `-f`, `--force` — Sign the commit that is not authored by you or was already signed
+
+  Possible values: `true`, `false`
+
+* `-D`, `--drop` — Drop the signature, explicitly "un-signing" the commit
+
+  Possible values: `true`, `false`
+
 
 
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -449,6 +449,11 @@ fn test_help() {
       -v, --verbose                      Enable verbose logging
           --color <WHEN>                 When to colorize output (always, never, auto)
           --no-pager                     Disable the pager
+          --sign-with <KEY>              Override the configured key to be used for the commit signing.
+                                         Is only used when a commit signing operation has to be
+                                         performed by the operation
+          --no-sign                      Don't sign unsigned commits when configured to sign all, is
+                                         ignored otherwise
           --config-toml <TOML>           Additional configuration options (can be repeated)
     "###);
 }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -21,6 +21,7 @@ The following keywords can be used in `jj log`/`jj obslog` templates.
 * `parents: List<Commit>`
 * `author: Signature`
 * `committer: Signature`
+* `signature: CommitSignature`: The information about a cryptographic signature of the commit.
 * `working_copies: String`: For multi-workspace repository, indicate
   working-copy commit as `<workspace name>@`.
 * `current_working_copy: Boolean`: True for the working-copy commit of the
@@ -149,6 +150,18 @@ The following methods are defined.
 * `.email() -> String`
 * `.username() -> String`
 * `.timestamp() -> Timestamp`
+
+### CommitSignature type
+
+The following methods are defined.
+
+* `.present() -> Boolean`: True if the commit has a cryptographic signature.
+* `.good() -> Boolean`: True if the signature matches the commit data.
+* `.unknown() -> Boolean`: True if the signing backend cannot verify the signature (e.g. due a missing public key), or if there's no backend implemented that can verify the signature.
+* `.bad() -> Boolean`: True if the signature does not match the commit data.
+* `.invalid() -> Boolean`: True if the signature is detected to be made with a signing backend (e.g. has a PGP prefix) but is otherwise invalid.
+* `.key() -> String`: Signing backend specific key id. For GPG, it's a long key ID, present for all non-invalid signatures.
+* `.display() -> String`: Signing backend specific display string. For GPG, it's a formatted primary user ID, only present if the public key is known (only for good/bad signatures).
 
 ### String type
 

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
     in
     {
       packages = {
-        jujutsu = ourRustPlatform.buildRustPackage rec {
+        jujutsu = ourRustPlatform.buildRustPackage {
           pname = "jujutsu";
           version = "unstable-${self.shortRev or "dirty"}";
 
@@ -82,6 +82,7 @@
             installShellFiles
             makeWrapper
             pkg-config
+            gnupg # for signing tests
           ] ++ linuxNativeDeps;
           buildInputs = with pkgs; [
             openssl zstd libgit2 libssh2
@@ -143,6 +144,9 @@
 
           # In case you need to run `cargo run --bin gen-protos`
           protobuf
+
+          # To run the signing tests
+          gnupg
 
           # For building the documentation website
           poetry

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,10 @@
             installShellFiles
             makeWrapper
             pkg-config
-            gnupg # for signing tests
+
+            # for signing tests
+            gnupg 
+            openssh
           ] ++ linuxNativeDeps;
           buildInputs = with pkgs; [
             openssl zstd libgit2 libssh2
@@ -147,6 +150,7 @@
 
           # To run the signing tests
           gnupg
+          openssh
 
           # For building the documentation website
           poetry

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -172,8 +172,8 @@ impl CommitBuilder<'_> {
         self
     }
 
-    pub fn set_sign_key(mut self, sign_key: Option<String>) -> Self {
-        self.sign_settings.key = sign_key;
+    pub fn override_sign_key(mut self, sign_key: Option<String>) -> Self {
+        self.sign_settings.key = sign_key.or(self.sign_settings.key);
         self
     }
 

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -171,11 +171,7 @@ impl SigningBackend for GpgBackend {
                 let display = parts
                     .next()
                     .and_then(|bs| String::from_utf8(bs.to_owned()).ok());
-                Verification {
-                    status,
-                    key,
-                    display,
-                }
+                Verification::new(status, key, display)
             })
             .ok_or(SignError::InvalidSignatureFormat)
     }

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -1,0 +1,182 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::io::Write;
+use std::process::{Command, ExitStatus, Stdio};
+
+use thiserror::Error;
+
+use crate::signing::{SigStatus, SignError, SigningBackend, Verification};
+
+#[derive(Debug)]
+pub struct GpgBackend {
+    program: OsString,
+    consider_expired_keys_bad: bool,
+    extra_args: Vec<OsString>,
+}
+
+#[derive(Debug, Error)]
+pub enum GpgError {
+    #[error("GPG failed with exit status {exit_status}:\n{stderr}")]
+    Command {
+        exit_status: ExitStatus,
+        stderr: String,
+    },
+    #[error("Failed to run GPG: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<GpgError> for SignError {
+    fn from(e: GpgError) -> Self {
+        SignError::Backend(Box::new(e))
+    }
+}
+
+impl GpgBackend {
+    pub fn new(program: OsString, consider_expired_keys_bad: bool) -> Self {
+        Self {
+            program,
+            consider_expired_keys_bad,
+            extra_args: vec![],
+        }
+    }
+
+    /// Primarily intended for testing
+    pub fn with_extra_args(mut self, args: &[OsString]) -> Self {
+        self.extra_args.extend_from_slice(args);
+        self
+    }
+
+    pub fn from_config(config: &config::Config) -> Self {
+        Self::new(
+            config
+                .get_string("signing.backends.GPG.program")
+                .unwrap_or_else(|_| "gpg2".into())
+                .into(),
+            config
+                .get_bool("signing.backends.GPG.consider-expired-keys-bad")
+                .unwrap_or(false),
+        )
+    }
+
+    fn run(&self, input: &[u8], args: &[&OsStr], check: bool) -> Result<Vec<u8>, GpgError> {
+        let process = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(if check { Stdio::piped() } else { Stdio::null() })
+            .args(&self.extra_args)
+            .args(args)
+            .spawn()?;
+        process.stdin.as_ref().unwrap().write_all(input)?;
+        let output = process.wait_with_output()?;
+        if check && !output.status.success() {
+            Err(GpgError::Command {
+                exit_status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            })
+        } else {
+            Ok(output.stdout)
+        }
+    }
+}
+
+impl SigningBackend for GpgBackend {
+    fn name(&self) -> &str {
+        "gpg"
+    }
+
+    fn can_read(&self, signature: &[u8]) -> bool {
+        signature.starts_with(b"-----BEGIN PGP SIGNATURE-----")
+    }
+
+    fn sign(&self, data: &[u8], key: Option<&str>) -> Result<Vec<u8>, SignError> {
+        Ok(match key {
+            Some(key) => self.run(data, &["-abu".as_ref(), key.as_ref()], true)?,
+            None => self.run(data, &["-ab".as_ref()], true)?,
+        })
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<Verification, SignError> {
+        let mut signature_file = tempfile::Builder::new()
+            .prefix(".jj-gpg-sig-tmp-")
+            .tempfile()
+            .map_err(GpgError::Io)?;
+        signature_file.write_all(signature).map_err(GpgError::Io)?;
+        signature_file.flush().map_err(GpgError::Io)?;
+
+        let output = self.run(
+            data,
+            &[
+                "--status-fd=1".as_ref(),
+                "--verify".as_ref(),
+                signature_file.path().as_os_str(), /* the only reason we have those .as_refs
+                                                    * transmuting to &OsStr everywhere.. */
+                "-".as_ref(),
+            ],
+            false,
+        )?;
+
+        // Search for one of the:
+        //  [GNUPG:] GOODSIG <long keyid> <primary uid..>
+        //  [GNUPG:] EXPKEYSIG <long keyid> <primary uid..>
+        //  [GNUPG:] NO_PUBKEY <long keyid>
+        //  [GNUPG:] BADSIG <long keyid> <primary uid..>
+        // in the output from --status-fd=1
+        // Assume signature is invalid if none of the above was found
+        output
+            .split(|&b| b == b'\n')
+            .filter_map(|line| line.strip_prefix(b"[GNUPG:] "))
+            .find_map(|line| {
+                line.strip_prefix(b"GOODSIG ")
+                    .map(|rest| (SigStatus::Good, rest))
+                    .or_else(|| {
+                        line.strip_prefix(b"EXPKEYSIG ").map(|rest| {
+                            let status = if self.consider_expired_keys_bad {
+                                SigStatus::Bad
+                            } else {
+                                SigStatus::Good
+                            };
+                            (status, rest)
+                        })
+                    })
+                    .or_else(|| {
+                        line.strip_prefix(b"NO_PUBKEY ")
+                            .map(|rest| (SigStatus::Unknown, rest))
+                    })
+                    .or_else(|| {
+                        line.strip_prefix(b"BADSIG ")
+                            .map(|rest| (SigStatus::Bad, rest))
+                    })
+            })
+            .map(|(status, line)| {
+                let mut parts = line.splitn(2, |&b| b == b' ');
+                let key = parts
+                    .next()
+                    .and_then(|bs| String::from_utf8(bs.to_owned()).ok());
+                let display = parts
+                    .next()
+                    .and_then(|bs| String::from_utf8(bs.to_owned()).ok());
+                Verification {
+                    status,
+                    key,
+                    display,
+                }
+            })
+            .ok_or(SignError::InvalidSignatureFormat)
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,7 @@ pub mod fsmonitor;
 pub mod git;
 pub mod git_backend;
 pub mod gitignore;
+pub mod gpg_signing;
 pub mod hex_util;
 pub mod id_prefix;
 pub mod index;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -37,6 +37,7 @@ pub mod git;
 pub mod git_backend;
 pub mod gitignore;
 pub mod gpg_signing;
+pub mod ssh_signing;
 pub mod hex_util;
 pub mod id_prefix;
 pub mod index;

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -264,6 +264,7 @@ pub(crate) struct DescendantRebaser<'settings, 'repo> {
     abandoned: HashSet<CommitId>,
     new_commits: HashSet<CommitId>,
     rebased: HashMap<CommitId, CommitId>,
+    dropped_signatures: HashSet<CommitId>,
     // Names of branches where local target includes the commit id in the key.
     branches: HashMap<CommitId, HashSet<String>>,
     // Parents of rebased/abandoned commit that should become new heads once their descendants
@@ -371,6 +372,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
             abandoned,
             new_commits,
             rebased: Default::default(),
+            dropped_signatures: Default::default(),
             branches,
             heads_to_add,
             heads_to_remove: Default::default(),
@@ -388,6 +390,12 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
     /// `rebase_descendants`.
     pub fn into_map(self) -> HashMap<CommitId, CommitId> {
         self.rebased
+    }
+
+    /// Returns a set of commits whose cryptographic signatures were dropped
+    /// during the rebase.
+    pub fn dropped_signatures(&self) -> &HashSet<CommitId> {
+        &self.dropped_signatures
     }
 
     /// Panics if `parent_mapping` contains cycles
@@ -572,6 +580,10 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
             &new_parents,
             &self.options,
         )?;
+
+        if old_commit.is_signed() && !new_commit.is_signed() {
+            self.dropped_signatures.insert(old_commit_id.clone());
+        }
         let previous_rebased_value = self
             .rebased
             .insert(old_commit_id.clone(), new_commit.id().clone());

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -49,6 +49,11 @@ pub struct Verification {
     /// A display string, if available. For GPG, this will be formatted primary
     /// user ID.
     pub display: Option<String>,
+    /// The name of the backend that provided this verification.
+    /// Is `None` when no backend was found that could read the signature.
+    ///
+    /// Always set by the signer.
+    backend: Option<String>,
 }
 
 impl Verification {
@@ -59,7 +64,23 @@ impl Verification {
             status: SigStatus::Unknown,
             key: None,
             display: None,
+            backend: None,
         }
+    }
+
+    /// Create a new verification
+    pub fn new(status: SigStatus, key: Option<String>, display: Option<String>) -> Self {
+        Self {
+            status,
+            key,
+            display,
+            backend: None,
+        }
+    }
+
+    /// The name of the backend that provided this verification.
+    pub fn backend(&self) -> Option<&str> {
+        self.backend.as_deref()
     }
 }
 
@@ -220,7 +241,10 @@ impl Signer {
             .find_map(|backend| match backend.verify(data, signature) {
                 Ok(check) if check.status == SigStatus::Unknown => None,
                 Err(SignError::InvalidSignatureFormat) => None,
-                e => Some(e),
+                e => Some(e.map(|mut v| {
+                    v.backend = Some(backend.name().to_owned());
+                    v
+                })),
             })
             .transpose()?;
 

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 
 use crate::backend::CommitId;
 use crate::gpg_signing::GpgBackend;
+use crate::ssh_signing::SshBackend;
 use crate::settings::UserSettings;
 
 /// A status of the signature, part of the [Verification] type.
@@ -174,7 +175,7 @@ impl Signer {
     pub fn from_settings(settings: &UserSettings) -> Result<Self, SignInitError> {
         let mut backends = vec![
             Box::new(GpgBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
-            // Box::new(SshBackend::from_settings(settings)?) as Box<dyn SigningBackend>,
+            Box::new(SshBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
             // Box::new(X509Backend::from_settings(settings)?) as Box<dyn SigningBackend>,
         ];
 

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -22,6 +22,7 @@ use std::sync::RwLock;
 use thiserror::Error;
 
 use crate::backend::CommitId;
+use crate::gpg_signing::GpgBackend;
 use crate::settings::UserSettings;
 
 /// A status of the signature, part of the [Verification] type.
@@ -150,10 +151,10 @@ impl Signer {
     /// Creates a signer based on user settings. Uses all known backends, and
     /// chooses one of them to be used for signing depending on the config.
     pub fn from_settings(settings: &UserSettings) -> Result<Self, SignInitError> {
-        let mut backends: Vec<Box<dyn SigningBackend>> = vec![
-            // Box::new(GpgBackend::from_settings(settings)?),
-            // Box::new(SshBackend::from_settings(settings)?),
-            // Box::new(X509Backend::from_settings(settings)?),
+        let mut backends = vec![
+            Box::new(GpgBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
+            // Box::new(SshBackend::from_settings(settings)?) as Box<dyn SigningBackend>,
+            // Box::new(X509Backend::from_settings(settings)?) as Box<dyn SigningBackend>,
         ];
 
         let main_backend = settings

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -1,0 +1,254 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::io::Write;
+use std::process::{Command, ExitStatus, Stdio};
+
+use thiserror::Error;
+
+use crate::signing::{SigStatus, SignError, SigningBackend, Verification};
+
+#[derive(Debug)]
+pub struct SshBackend {
+    program: OsString,
+    allowed_signers: Option<OsString>,
+}
+
+#[derive(Debug, Error)]
+pub enum SshError {
+    #[error("SSH sign failed with exit status {exit_status}:\n{stderr}")]
+    Command {
+        exit_status: ExitStatus,
+        stderr: String,
+    },
+    #[error("Failed to run ssh-keygen: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Signing key required")]
+    MissingKey {},
+    #[error("Allowed signers file not provided")]
+    MissingAllowedSigners {},
+}
+
+impl From<SshError> for SignError {
+    fn from(e: SshError) -> Self {
+        SignError::Backend(Box::new(e))
+    }
+}
+
+impl SshBackend {
+    pub fn new(program: OsString, allowed_signers: Option<OsString>) -> Self {
+        Self {
+            program,
+            allowed_signers,
+        }
+    }
+
+    pub fn from_config(config: &config::Config) -> Self {
+        Self::new(
+            config
+                .get_string("signing.backends.ssh.program")
+                .unwrap_or_else(|_| "ssh-keygen".into())
+                .into(),
+            config
+                .get_string("signing.backends.ssh.allowed-signers")
+                .map_or_else(|_| None, |value| Some(value.into())),
+        )
+    }
+
+    fn run(&self, input: &[u8], args: &[&OsStr]) -> Result<Vec<u8>, SshError> {
+        let process = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(args)
+            .arg("-n")
+            .arg("git")
+            .spawn()?;
+
+        process.stdin.as_ref().unwrap().write_all(input)?;
+        let output = process.wait_with_output()?;
+
+        if !output.status.success() {
+            Err(SshError::Command {
+                exit_status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into(),
+            })
+        } else {
+            Ok(output.stdout)
+        }
+    }
+
+    fn get_allowed_signers(&self) -> Result<OsString, SshError> {
+        if let Some(allowed_signers) = &self.allowed_signers {
+            Ok(allowed_signers.into())
+        } else {
+            Err(SshError::MissingAllowedSigners {})
+        }
+    }
+
+    fn find_principal(&self, signature_file_path: &OsStr) -> Result<Option<String>, SshError> {
+        let allowed_signers = self.get_allowed_signers()?;
+
+        let process = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args([
+                "-Y".as_ref(),
+                "find-principals".as_ref(),
+                "-f".as_ref(),
+                allowed_signers.as_os_str(),
+                "-s".as_ref(),
+                signature_file_path,
+            ])
+            .spawn()?;
+
+        let output = process.wait_with_output()?;
+
+        let result: String = String::from_utf8_lossy(&output.stdout).into();
+
+        let principal = result.split('\n').next().unwrap().trim().to_string();
+
+        if principal.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(principal))
+    }
+}
+
+impl SigningBackend for SshBackend {
+    fn name(&self) -> &str {
+        "ssh"
+    }
+
+    fn can_read(&self, signature: &[u8]) -> bool {
+        let has_signers = match self.allowed_signers {
+            Some(_) => true,
+            None => false,
+        };
+        signature.starts_with(b"-----BEGIN SSH SIGNATURE-----") && has_signers
+    }
+
+    fn sign(&self, data: &[u8], key: Option<&str>) -> Result<Vec<u8>, SignError> {
+        if let Some(key) = key {
+            // The ssh-keygen `-f` flag expects to be given a file which contains either a private or
+            // public key.
+            //
+            // As it expects a file and we will generally have just public key data we need to put it into a
+            // file first.
+            let mut pub_key_file = tempfile::Builder::new()
+                .prefix("jj-signing-pub-key-")
+                .tempfile()
+                .map_err(SshError::Io)?;
+
+            pub_key_file
+                .write_all(key.as_bytes())
+                .map_err(SshError::Io)?;
+            pub_key_file.flush().map_err(SshError::Io)?;
+
+            let result = self.run(
+                data,
+                &[
+                    "-Y".as_ref(),
+                    "sign".as_ref(),
+                    "-f".as_ref(),
+                    pub_key_file.path().as_os_str(),
+                ],
+            );
+
+            Ok(result?)
+        } else {
+            Err(SshError::MissingKey {}.into())
+        }
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<Verification, SignError> {
+        let mut signature_file = tempfile::Builder::new()
+            .prefix(".jj-ssh-sig-")
+            .tempfile()
+            .map_err(SshError::Io)?;
+        signature_file.write_all(signature).map_err(SshError::Io)?;
+        signature_file.flush().map_err(SshError::Io)?;
+
+        let signature_file_path = signature_file.path().as_os_str();
+
+        let principal = self.find_principal(signature_file_path)?;
+
+        if let None = principal {
+            let output = self.run(
+                data,
+                &[
+                    "-Y".as_ref(),
+                    "check-novalidate".as_ref(),
+                    "-s".as_ref(),
+                    signature_file_path,
+                ],
+            );
+
+            return match output {
+                Ok(_) => Ok(Verification::new(
+                    SigStatus::Unknown,
+                    None,
+                    Some("Signature OK. Unknown principal".into()),
+                )),
+                Err(_) => Ok(Verification::new(SigStatus::Bad, None, None)),
+            };
+        }
+
+        match principal {
+            None => {
+                let output = self.run(
+                    data,
+                    &[
+                        "-Y".as_ref(),
+                        "check-novalidate".as_ref(),
+                        "-s".as_ref(),
+                        signature_file_path,
+                    ],
+                );
+
+                match output {
+                    Ok(_) => Ok(Verification::new(SigStatus::Unknown, None, None)),
+                    Err(_) => Ok(Verification::new(SigStatus::Bad, None, None)),
+                }
+            }
+            Some(principal) => {
+                let allowed_signers = self.get_allowed_signers()?;
+
+                let output = self.run(
+                    data,
+                    &[
+                        "-Y".as_ref(),
+                        "verify".as_ref(),
+                        "-s".as_ref(),
+                        signature_file_path,
+                        "-I".as_ref(),
+                        principal.as_ref(),
+                        "-f".as_ref(),
+                        allowed_signers.as_ref(),
+                    ],
+                );
+
+                match output {
+                    Ok(_) => Ok(Verification::new(SigStatus::Good, None, Some(principal))),
+                    Err(_) => Ok(Verification::new(SigStatus::Bad, None, Some(principal))),
+                }
+            }
+        }
+    }
+}

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -29,6 +29,7 @@ mod test_refs;
 mod test_revset;
 mod test_rewrite;
 mod test_signing;
+mod test_ssh_signing;
 mod test_view;
 mod test_workspace;
 mod test_gpg;

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -31,3 +31,4 @@ mod test_rewrite;
 mod test_signing;
 mod test_view;
 mod test_workspace;
+mod test_gpg;

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1070,7 +1070,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten.
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 and feature4 should still be the heads, and all three branches
@@ -1087,7 +1090,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 and feature4 should still be the heads, and both branches
@@ -1103,7 +1109,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 should now be the only head and only branch.

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -1,0 +1,162 @@
+use std::fs::Permissions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::prelude::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use assert_matches::assert_matches;
+use jj_lib::gpg_signing::GpgBackend;
+use jj_lib::signing::{SigStatus, SignError, SigningBackend, Verification};
+use once_cell::sync::Lazy;
+
+static GPG_HOME: Lazy<PathBuf> = Lazy::new(|| {
+    let dir = tempfile::Builder::new()
+        .prefix("jj-test-")
+        .tempdir()
+        .unwrap()
+        .into_path();
+
+    #[cfg(unix)]
+    std::fs::set_permissions(&dir, Permissions::from_mode(0o700)).unwrap();
+
+    let mut gpg = std::process::Command::new("gpg")
+        .arg("--homedir")
+        .arg(&dir)
+        .arg("--import")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    gpg.stdin
+        .as_mut()
+        .unwrap()
+        .write_all(
+            br#"-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+            lFgEZWI3pBYJKwYBBAHaRw8BAQdAaPLTNADvDWapjAPlxaUnx3HXQNIlwSz4EZrW
+            3Z7hxSwAAP9liwHZWJCGI2xW+XNqMT36qpIvoRcd5YPaKYwvnlkG1w+UtDNTb21l
+            b25lIChqaiB0ZXN0IHNpZ25pbmcga2V5KSA8c29tZW9uZUBleGFtcGxlLmNvbT6I
+            kwQTFgoAOxYhBKWOXukGcVPI9eXp6WOHhcsW/qBhBQJlYjekAhsDBQsJCAcCAiIC
+            BhUKCQgLAgQWAgMBAh4HAheAAAoJEGOHhcsW/qBhyBgBAMph1HkBkKlrZmsun+3i
+            kTEaOsWmaW/D6NEdMFiw0S/jAP9G3jOYGiZbUN3dWWB2246Oi7SaMTX8Xb2BrLP2
+            axCbC5RYBGVjxv8WCSsGAQQB2kcPAQEHQE8Oa4ahtVG29gIRssPxjqF4utn8iHPz
+            m5z/8lX/nl3eAAD5AZ6H2pNhiy2gnGkbPLHw3ZyY4d0NXzCa7qc9EXqOj+sRrLQ9
+            U29tZW9uZSBFbHNlIChqaiB0ZXN0IHNpZ25pbmcga2V5KSA8c29tZW9uZS1lbHNl
+            QGV4YW1wbGUuY29tPoiTBBMWCgA7FiEER1BAaEpU3TKUiUvFTtVW6XKeAA8FAmVj
+            xv8CGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQTtVW6XKeAA/6TQEA
+            2DkPm3LmH8uG6qLirtf62kbG7T+qljIsarQKFw3CGakA/AveCtrL7wVSpINiu1Rz
+            lBqJFFP2PqzT0CRfh94HSIMM
+            =6JC8
+            -----END PGP PRIVATE KEY BLOCK-----"#,
+        )
+        .unwrap();
+    gpg.stdin.as_mut().unwrap().flush().unwrap();
+    gpg.wait().unwrap();
+
+    dir
+});
+
+fn backend() -> GpgBackend {
+    // don't really need faked time for current tests,
+    // but probably will need it for end-to-end cli tests
+    GpgBackend::new("gpg".into(), false).with_extra_args(&[
+        "--homedir".into(),
+        GPG_HOME.to_path_buf().into(),
+        "--faked-system-time=1701042000!".into(),
+    ])
+}
+
+#[test]
+fn roundtrip() {
+    let backend = backend();
+    let data = b"hello world";
+    let signature = backend.sign(data, None).unwrap();
+
+    assert_eq!(
+        backend.verify(data, &signature).unwrap(),
+        Verification {
+            status: SigStatus::Good,
+            key: Some("638785CB16FEA061".to_owned()),
+            display: Some("Someone (jj test signing key) <someone@example.com>".to_owned()),
+        }
+    );
+    assert_eq!(
+        backend.verify(b"so so bad", &signature).unwrap(),
+        Verification {
+            status: SigStatus::Bad,
+            key: Some("638785CB16FEA061".to_owned()),
+            display: Some("Someone (jj test signing key) <someone@example.com>".to_owned()),
+        }
+    );
+}
+
+#[test]
+fn roundtrip_explicit_key() {
+    let backend = backend();
+    let data = b"hello world";
+    let signature = backend.sign(data, Some("Someone Else")).unwrap();
+
+    assert_eq!(
+        backend.verify(data, &signature).unwrap(),
+        Verification {
+            status: SigStatus::Good,
+            key: Some("4ED556E9729E000F".to_owned()),
+            display: Some(
+                "Someone Else (jj test signing key) <someone-else@example.com>".to_owned()
+            ),
+        }
+    );
+    assert_eq!(
+        backend.verify(b"so so bad", &signature).unwrap(),
+        Verification {
+            status: SigStatus::Bad,
+            key: Some("4ED556E9729E000F".to_owned()),
+            display: Some(
+                "Someone Else (jj test signing key) <someone-else@example.com>".to_owned()
+            ),
+        }
+    );
+}
+
+#[test]
+fn unknown_key() {
+    let backend = backend();
+    let signature = br"-----BEGIN PGP SIGNATURE-----
+
+    iHUEABYKAB0WIQQs238pU7eC/ROoPJ0HH+PjJN1zMwUCZWPa5AAKCRAHH+PjJN1z
+    MyylAP9WQ3sZdbC4b1C+/nxs+Wl+rfwzeQWGbdcsBMyDABcpmgD/U+4KdO7eZj/I
+    e+U6bvqw3pOBoI53Th35drQ0qPI+jAE=
+    =kwsk
+    -----END PGP SIGNATURE-----";
+    assert_eq!(
+        backend.verify(b"hello world", signature).unwrap(),
+        Verification {
+            status: SigStatus::Unknown,
+            key: Some("071FE3E324DD7333".to_owned()),
+            display: None,
+        }
+    );
+    assert_eq!(
+        backend.verify(b"so bad", signature).unwrap(),
+        Verification {
+            status: SigStatus::Unknown, // no key, no idea ¯\_(ツ)_/¯
+            key: Some("071FE3E324DD7333".to_owned()),
+            display: None,
+        }
+    );
+}
+
+#[test]
+fn invalid_signature() {
+    let backend = backend();
+    let signature = br"-----BEGIN PGP SIGNATURE-----
+
+    super duper invalid
+    -----END PGP SIGNATURE-----";
+    assert_matches!(
+        backend.verify(b"hello world", signature),
+        Err(SignError::InvalidSignatureFormat)
+    );
+}

--- a/lib/tests/test_signing.rs
+++ b/lib/tests/test_signing.rs
@@ -1,7 +1,8 @@
+use assert_matches::assert_matches;
 use jj_lib::backend::{MillisSinceEpoch, Signature, Timestamp};
 use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
-use jj_lib::signing::{SigStatus, SignBehavior, Signer, Verification};
+use jj_lib::signing::{SignBehavior, Signer};
 use test_case::test_case;
 use testutils::test_signing_backend::TestSigningBackend;
 use testutils::{create_random_commit, write_random_commit, TestRepoBackend, TestWorkspace};
@@ -33,13 +34,7 @@ fn someone_else() -> Signature {
     }
 }
 
-fn good_verification() -> Option<Verification> {
-    Some(Verification {
-        status: SigStatus::Good,
-        key: Some("impeccable".to_owned()),
-        display: None,
-    })
-}
+const GOOD_VERIFICATION: &str = r#"Ok(Some(Verification { status: Good, key: Some("impeccable"), display: None, backend: Some("test") }))"#;
 
 #[test_case(TestRepoBackend::Local ; "local backend")]
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -66,10 +61,10 @@ fn manual(backend: TestRepoBackend) {
     tx.commit("test");
 
     let commit1 = repo.store().get_commit(commit1.id()).unwrap();
-    assert_eq!(commit1.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit1.verification()), GOOD_VERIFICATION);
 
     let commit2 = repo.store().get_commit(commit2.id()).unwrap();
-    assert_eq!(commit2.verification().unwrap(), None);
+    assert_matches!(commit2.verification(), Ok(None));
 }
 
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -95,7 +90,7 @@ fn keep_on_rewrite(backend: TestRepoBackend) {
     let rewritten = mut_repo.rewrite_commit(&settings, &commit).write().unwrap();
 
     let commit = repo.store().get_commit(rewritten.id()).unwrap();
-    assert_eq!(commit.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit.verification()), GOOD_VERIFICATION);
 }
 
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -148,7 +143,7 @@ fn forced(backend: TestRepoBackend) {
     tx.commit("test");
 
     let commit = repo.store().get_commit(commit.id()).unwrap();
-    assert_eq!(commit.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit.verification()), GOOD_VERIFICATION);
 }
 
 #[test_case(TestRepoBackend::Git ; "git backend")]
@@ -167,5 +162,5 @@ fn configured(backend: TestRepoBackend) {
     tx.commit("test");
 
     let commit = repo.store().get_commit(commit.id()).unwrap();
-    assert_eq!(commit.verification().unwrap(), good_verification());
+    assert_eq!(format!("{:?}", commit.verification()), GOOD_VERIFICATION);
 }

--- a/lib/tests/test_ssh_signing.rs
+++ b/lib/tests/test_ssh_signing.rs
@@ -1,0 +1,120 @@
+use std::io::Write;
+use std::process::Stdio;
+
+use jj_lib::signing::{SigStatus, SigningBackend};
+use jj_lib::ssh_signing::SshBackend;
+use rustix::path::Arg;
+
+static PRIVATE_KEY: &'static str = r#"-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBo/iejekjvuD/HTman0daImstssYYR52oB+dmr1KsOYQAAAIiuGFMFrhhT
+BQAAAAtzc2gtZWQyNTUxOQAAACBo/iejekjvuD/HTman0daImstssYYR52oB+dmr1KsOYQ
+AAAECcUtn/J/jk/+D5+/+WbQRNN4eInj5L60pt6FioP0nQfGj+J6N6SO+4P8dOZqfR1oia
+y2yxhhHnagH52avUqw5hAAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----
+"#;
+
+static PUBLIC_KEY: &'static str =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h";
+
+static PUBLIC_KEY_BAD: &'static str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO";
+
+fn prepare() {
+    let mut pk = tempfile::Builder::new()
+        .prefix("jj-test-pk-")
+        .tempfile()
+        .unwrap();
+
+    pk.write_all(PRIVATE_KEY.as_bytes()).unwrap();
+    pk.flush().unwrap();
+
+    let mut ssh_add = std::process::Command::new("ssh-add")
+        .arg(pk.path().as_str().unwrap())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    ssh_add.wait().unwrap();
+}
+
+fn cleanup() {
+    let mut ssh_add = std::process::Command::new("ssh-add")
+        .arg("-d")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    ssh_add
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(PUBLIC_KEY.as_bytes())
+        .unwrap();
+
+    ssh_add.stdin.as_mut().unwrap().flush().unwrap();
+
+    ssh_add.wait().unwrap();
+}
+
+fn backend(public_key: &str) -> (SshBackend, tempfile::NamedTempFile) {
+    let mut allowed_signers = tempfile::Builder::new()
+        .prefix("jj-test-allowed-signers-")
+        .tempfile()
+        .unwrap();
+
+    allowed_signers
+        .write_all("test@example.com ".as_bytes())
+        .unwrap();
+    allowed_signers.write_all(public_key.as_bytes()).unwrap();
+    allowed_signers.flush().unwrap();
+
+    let backend = SshBackend::new(
+        "ssh-keygen".into(),
+        Some(allowed_signers.path().as_str().unwrap().into()),
+    );
+
+    (backend, allowed_signers)
+}
+
+#[test]
+fn roundtrip() {
+    let (backend, _allowed_signers) = backend(PUBLIC_KEY);
+    let data = b"hello world";
+
+    prepare();
+    let signature = backend.sign(data, Some(PUBLIC_KEY)).unwrap();
+
+    let check = backend.verify(data, &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Good);
+    assert_eq!(check.backend(), None); // backend is set by the signer
+
+    assert_eq!(check.display.unwrap(), "test@example.com");
+
+    let check = backend.verify(b"invalid-commit-data", &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Bad);
+    assert_eq!(check.backend(), None);
+    assert_eq!(check.display.unwrap(), "test@example.com");
+
+    cleanup();
+}
+
+#[test]
+fn bad_allowed_signers() {
+    let (backend, _allowed_signers) = backend(PUBLIC_KEY_BAD);
+    let data = b"hello world";
+
+    prepare();
+
+    let signature = backend.sign(data, Some(PUBLIC_KEY)).unwrap();
+
+    let check = backend.verify(data, &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Unknown);
+    assert_eq!(check.display.unwrap(), "Signature OK. Unknown principal");
+
+    cleanup();
+}

--- a/lib/testutils/src/test_signing_backend.rs
+++ b/lib/testutils/src/test_signing_backend.rs
@@ -37,18 +37,11 @@ impl SigningBackend for TestSigningBackend {
         let key = (!key.is_empty()).then_some(std::str::from_utf8(key).unwrap().to_owned());
 
         let sig = self.sign(data, key.as_deref())?;
-        if sig == signature {
-            Ok(Verification {
-                status: SigStatus::Good,
-                key,
-                display: None,
-            })
+        let status = if sig == signature {
+            SigStatus::Good
         } else {
-            Ok(Verification {
-                status: SigStatus::Bad,
-                key,
-                display: None,
-            })
-        }
+            SigStatus::Bad
+        };
+        Ok(Verification::new(status, key, None))
     }
 }


### PR DESCRIPTION
Draft implementation of an ssh signing backend.

This is a continuation to #2728

This has been merged with main. I avoided doing a rebase to try make it easier to colaborate on top of necauqua/signing

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
