### PR TITLE
give a warning when redefining a built-in command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecations
 
+- Attempting to alias a built-in command now gives a warning, rather than being silently ignored.
+
 ### New features
 
 * `jj branch list`/`tag list` now accept `-T`/`--template` option. The tag list

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2600,6 +2600,7 @@ fn resolve_default_command(
 }
 
 fn resolve_aliases(
+    ui: &Ui,
     config: &config::Config,
     app: &Command,
     mut string_args: Vec<String>,
@@ -2616,6 +2617,7 @@ fn resolve_aliases(
             }
         }
     }
+
     let mut resolved_aliases = HashSet::new();
     let mut real_commands = HashSet::new();
     for command in app.get_subcommands() {
@@ -2624,6 +2626,15 @@ fn resolve_aliases(
             real_commands.insert(alias.to_string());
         }
     }
+    for alias in aliases_map.keys() {
+        if real_commands.contains(alias) {
+            writeln!(
+                ui.warning_default(),
+                "Cannot define an alias that overrides the built-in command '{alias}'"
+            )?;
+        }
+    }
+
     loop {
         let app_clone = app.clone().allow_external_subcommands(true);
         let matches = app_clone.try_get_matches_from(&string_args).ok();
@@ -2713,7 +2724,7 @@ pub fn expand_args(
     }
 
     let string_args = resolve_default_command(ui, config, app, string_args)?;
-    resolve_aliases(config, app, string_args)
+    resolve_aliases(ui, config, app, string_args)
 }
 
 pub fn parse_args(

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -164,11 +164,10 @@ fn test_alias_cannot_override_builtin() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.add_config(r#"aliases.log = ["rebase"]"#);
-    // Alias should be ignored
-    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root()"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
-    "###);
+    // Alias should give a warning
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "root()"]);
+    insta::assert_snapshot!(stdout, @"◉  zzzzzzzz root() 00000000\n");
+    insta::assert_snapshot!(stderr, @"Warning: Cannot define an alias that overrides the built-in command 'log'\n");
 }
 
 #[test]


### PR DESCRIPTION
happened to notice this while working on https://github.com/martinvonz/jj/issues/2866

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
