### PR TITLE
Commit signing backend implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,15 @@ jobs:
         choco install --yes gpg4win
         echo "C:\Program Files (x86)\Gpg4win\..\GnuPG\bin" >> $env:GITHUB_PATH
 
+    # The default version of openssh on windows server is quite old (8.1) and doesn't have
+    # all the necessary signing/verification commands available (such as -Y find-principals)
+    - name: Setup ssh-agent [windows]
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        Remove-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+        Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
+        choco install openssh --pre
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+    # The default version of gpg installed on the runners is a version baked in with git
+    # which only contains the components needed by git and doesn't work for our test cases. 
+    #
+    # This installs the latest gpg4win version, which is a variation of GnuPG built for
+    # Windows.
+    #
+    # There is some issue with windows PATH max length which is what all the PATH wrangling
+    # below is for. Please see the below link for where this fix was derived from:
+    # https://github.com/orgs/community/discussions/24933
+    - name: Setup GnuPG [windows]
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin"
+        [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
+        choco install --yes gpg4win
+        echo "C:\Program Files (x86)\Gpg4win\..\GnuPG\bin" >> $env:GITHUB_PATH
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Added support for commit signing and verification. This comes with 
+  out-of-the-box support for the following backends:
+  * GnuPG
+  * SSH
+
 * Templates now support logical operators: `||`, `&&`, `!`
 
 * `jj show` now accepts `-T`/`--template` option to render its output using

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -366,11 +366,12 @@
             "properties": {
                 "backend": {
                     "type": "string",
-                    "description": "Which backend to use to create commit signatures"
+                    "enum": ["gpg", "ssh"],
+                    "description": "The backend to use for signing commits"
                 },
                 "key": {
                     "type": "string",
-                    "description": "The key parameter to pass to the signing backend. Overridden by `jj sign` parameter or by the global `--sign-with` option"
+                    "description": "The key the configured signing backend will use to to sign commits. Overridden by `jj sign` parameter or by the global `--sign-with` option"
                 },
                 "sign-all": {
                     "type": "boolean",
@@ -380,7 +381,38 @@
                 "backends": {
                     "type": "object",
                     "description": "Tables of options to pass to specific signing backends",
-                    "properties": {},
+                    "properties": {
+                        "gpg": {
+                            "type": "object",
+                            "properties": {
+                                "program": {
+                                    "type": "string",
+                                    "description": "Path to the gpg program to be called",
+                                    "default": "gpg"
+                                },
+                                "allow-expired-keys": {
+                                    "type": "boolean",
+                                    "description": "Whether to consider signatures generated with an expired key as invalid",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "ssh": {
+                            "type": "object",
+                            "properties": {
+                                "program": {
+                                    "type": "string",
+                                    "description": "Path to the ssh-keygen program to be called",
+                                    "default": "ssh-keygen"
+                                },
+                                "allowed-signers": {
+                                    "type": "boolean",
+                                    "description": "Path to an allowed signers file used for signature verification",
+                                    "default": true
+                                }
+                            }
+                        }
+                    },
                     "additionalProperties": true
                 }
             }

--- a/docs/config.md
+++ b/docs/config.md
@@ -521,6 +521,63 @@ the conflict is done, `jj` assumes that the conflict was only partially resolved
 and parses the conflict markers to get the new state of the conflict. The
 conflict is considered fully resolved when there are no conflict markers left.
 
+## Commit Signing
+
+`jj` can be configured to sign and verify the commits it creates using either 
+GnuPG or SSH signing keys.
+
+To do this you need to configure a signing backend.
+
+### GnuPG Signing
+
+```toml
+[signing]
+sign-all = true
+backend = "gpg"
+key = "4ED556E9729E000F"
+```
+
+By default the gpg backend will look for a `gpg` binary on your path. If you want
+to change the program used or specify a path to `gpg` explicitly you can set:
+
+```toml
+signing.backends.gpg.program = "gpg2"
+```
+
+Also by default the gpg backend will ignore key expiry when verifying commit signatures.
+To consider expired keys as invalid you can set:
+
+```toml
+signing.backends.gpg.allow-expired-keys = false
+```
+
+### SSH Signing
+
+```toml
+[signing]
+sign-all = true
+backend = "ssh"
+key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h"
+```
+
+By default the ssh backend will look for a `ssh-keygen` binary on your path. If you want
+to change the program used or specify a path to `ssh-keygen` explicitly you can set:
+
+```toml
+signing.backends.ssh.program = "/path/to/ssh-keygen"
+```
+
+When verifying commit signatures the ssh backend needs to be provided with an allowed-signers
+file containing the public keys of authors whose signatures you want to be able to verify.
+
+You can find the format for this file in the 
+[ssh-keygen man page](https://man.openbsd.org/ssh-keygen#ALLOWED_SIGNERS). This can be provided 
+as follows:
+
+```toml
+signing.backends.ssh.allowed-signers = "/path/to/allowed-signers"
+```
+
 ## Git settings
 
 ### Default remotes for `jj git fetch` and `jj git push`

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
     in
     {
       packages = {
-        jujutsu = ourRustPlatform.buildRustPackage rec {
+        jujutsu = ourRustPlatform.buildRustPackage {
           pname = "jujutsu";
           version = "unstable-${self.shortRev or "dirty"}";
 
@@ -82,6 +82,7 @@
             installShellFiles
             makeWrapper
             pkg-config
+            gnupg # for signing tests
           ] ++ linuxNativeDeps;
           buildInputs = with pkgs; [
             openssl zstd libgit2 libssh2
@@ -143,6 +144,9 @@
 
           # In case you need to run `cargo run --bin gen-protos`
           protobuf
+
+          # To run the signing tests
+          gnupg
 
           # For building the documentation website
           poetry

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,10 @@
             installShellFiles
             makeWrapper
             pkg-config
-            gnupg # for signing tests
+
+            # for signing tests
+            gnupg 
+            openssh
           ] ++ linuxNativeDeps;
           buildInputs = with pkgs; [
             openssl zstd libgit2 libssh2
@@ -147,6 +150,7 @@
 
           # To run the signing tests
           gnupg
+          openssh
 
           # For building the documentation website
           poetry

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -1,0 +1,232 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use std::ffi::{OsStr, OsString};
+use std::fmt::Debug;
+use std::io::Write;
+use std::process::{Command, ExitStatus, Stdio};
+use std::str;
+
+use thiserror::Error;
+
+use crate::signing::{SigStatus, SignError, SigningBackend, Verification};
+
+// Search for one of the:
+//  [GNUPG:] GOODSIG <long keyid> <primary uid..>
+//  [GNUPG:] EXPKEYSIG <long keyid> <primary uid..>
+//  [GNUPG:] NO_PUBKEY <long keyid>
+//  [GNUPG:] BADSIG <long keyid> <primary uid..>
+// in the output from --status-fd=1
+// Assume signature is invalid if none of the above was found
+fn parse_gpg_verify_output(
+    output: &[u8],
+    allow_expired_keys: bool,
+) -> Result<Verification, SignError> {
+    output
+        .split(|&b| b == b'\n')
+        .filter_map(|line| line.strip_prefix(b"[GNUPG:] "))
+        .find_map(|line| {
+            let mut parts = line.splitn(3, |&b| b == b' ').fuse();
+            let status = match parts.next()? {
+                b"GOODSIG" => SigStatus::Good,
+                b"EXPKEYSIG" => {
+                    if allow_expired_keys {
+                        SigStatus::Good
+                    } else {
+                        SigStatus::Bad
+                    }
+                }
+                b"NO_PUBKEY" => SigStatus::Unknown,
+                b"BADSIG" => SigStatus::Bad,
+                _ => return None,
+            };
+            let key = parts
+                .next()
+                .and_then(|bs| str::from_utf8(bs).ok())
+                .map(|value| value.trim().to_owned());
+            let display = parts
+                .next()
+                .and_then(|bs| str::from_utf8(bs).ok())
+                .map(|value| value.trim().to_owned());
+            Some(Verification::new(status, key, display))
+        })
+        .ok_or(SignError::InvalidSignatureFormat)
+}
+
+#[derive(Debug)]
+pub struct GpgBackend {
+    program: OsString,
+    allow_expired_keys: bool,
+    extra_args: Vec<OsString>,
+}
+
+#[derive(Debug, Error)]
+pub enum GpgError {
+    #[error("GPG failed with exit status {exit_status}:\n{stderr}")]
+    Command {
+        exit_status: ExitStatus,
+        stderr: String,
+    },
+    #[error("Failed to run GPG")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<GpgError> for SignError {
+    fn from(e: GpgError) -> Self {
+        SignError::Backend(Box::new(e))
+    }
+}
+
+impl GpgBackend {
+    pub fn new(program: OsString, allow_expired_keys: bool) -> Self {
+        Self {
+            program,
+            allow_expired_keys,
+            extra_args: vec![],
+        }
+    }
+
+    /// Primarily intended for testing
+    pub fn with_extra_args(mut self, args: &[OsString]) -> Self {
+        self.extra_args.extend_from_slice(args);
+        self
+    }
+
+    pub fn from_config(config: &config::Config) -> Self {
+        Self::new(
+            config
+                .get_string("signing.backends.gpg.program")
+                .unwrap_or_else(|_| "gpg2".into())
+                .into(),
+            config
+                .get_bool("signing.backends.gpg.allow-expired-keys")
+                .unwrap_or(false),
+        )
+    }
+
+    fn run(&self, input: &[u8], args: &[&OsStr], check: bool) -> Result<Vec<u8>, GpgError> {
+        let process = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(if check { Stdio::piped() } else { Stdio::null() })
+            .args(&self.extra_args)
+            .args(args)
+            .spawn()?;
+        process.stdin.as_ref().unwrap().write_all(input)?;
+        let output = process.wait_with_output()?;
+        if check && !output.status.success() {
+            Err(GpgError::Command {
+                exit_status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).trim_end().into(),
+            })
+        } else {
+            Ok(output.stdout)
+        }
+    }
+}
+
+impl SigningBackend for GpgBackend {
+    fn name(&self) -> &str {
+        "gpg"
+    }
+
+    fn can_read(&self, signature: &[u8]) -> bool {
+        signature.starts_with(b"-----BEGIN PGP SIGNATURE-----")
+    }
+
+    fn sign(&self, data: &[u8], key: Option<&str>) -> Result<Vec<u8>, SignError> {
+        Ok(match key {
+            Some(key) => self.run(data, &["-abu".as_ref(), key.as_ref()], true)?,
+            None => self.run(data, &["-ab".as_ref()], true)?,
+        })
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<Verification, SignError> {
+        let mut signature_file = tempfile::Builder::new()
+            .prefix(".jj-gpg-sig-tmp-")
+            .tempfile()
+            .map_err(GpgError::Io)?;
+        signature_file.write_all(signature).map_err(GpgError::Io)?;
+        signature_file.flush().map_err(GpgError::Io)?;
+
+        let sig_path = signature_file.into_temp_path();
+
+        let output = self.run(
+            data,
+            &[
+                "--status-fd=1".as_ref(),
+                "--verify".as_ref(),
+                // the only reason we have those .as_refs transmuting to &OsStr everywhere
+                sig_path.as_os_str(),
+                "-".as_ref(),
+            ],
+            false,
+        )?;
+
+        parse_gpg_verify_output(&output, self.allow_expired_keys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpg_verify_invalid_signature_format() {
+        use assert_matches::assert_matches;
+        assert_matches!(
+            parse_gpg_verify_output(b"", true),
+            Err(SignError::InvalidSignatureFormat)
+        );
+    }
+
+    #[test]
+    fn gpg_verify_bad_signature() {
+        assert_eq!(
+            parse_gpg_verify_output(b"[GNUPG:] BADSIG 123 456", true).unwrap(),
+            Verification::new(SigStatus::Bad, Some("123".into()), Some("456".into()))
+        );
+    }
+
+    #[test]
+    fn gpg_verify_unknown_signature() {
+        assert_eq!(
+            parse_gpg_verify_output(b"[GNUPG:] NO_PUBKEY 123", true).unwrap(),
+            Verification::new(SigStatus::Unknown, Some("123".into()), None)
+        );
+    }
+
+    #[test]
+    fn gpg_verify_good_signature() {
+        assert_eq!(
+            parse_gpg_verify_output(b"[GNUPG:] GOODSIG 123 456", true).unwrap(),
+            Verification::new(SigStatus::Good, Some("123".into()), Some("456".into()))
+        );
+    }
+
+    #[test]
+    fn gpg_verify_expired_signature() {
+        assert_eq!(
+            parse_gpg_verify_output(b"[GNUPG:] EXPKEYSIG 123 456", true).unwrap(),
+            Verification::new(SigStatus::Good, Some("123".into()), Some("456".into()))
+        );
+
+        assert_eq!(
+            parse_gpg_verify_output(b"[GNUPG:] EXPKEYSIG 123 456", false).unwrap(),
+            Verification::new(SigStatus::Bad, Some("123".into()), Some("456".into()))
+        );
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,7 @@ pub mod fsmonitor;
 pub mod git;
 pub mod git_backend;
 pub mod gitignore;
+pub mod gpg_signing;
 pub mod hex_util;
 pub mod id_prefix;
 pub mod index;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -63,6 +63,7 @@ pub mod settings;
 pub mod signing;
 pub mod simple_op_heads_store;
 pub mod simple_op_store;
+pub mod ssh_signing;
 pub mod stacked_table;
 pub mod store;
 pub mod str_util;

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -22,6 +22,7 @@ use std::sync::RwLock;
 use thiserror::Error;
 
 use crate::backend::CommitId;
+use crate::gpg_signing::GpgBackend;
 use crate::settings::UserSettings;
 
 /// A status of the signature, part of the [Verification] type.
@@ -58,6 +59,15 @@ impl Verification {
             status: SigStatus::Unknown,
             key: None,
             display: None,
+        }
+    }
+
+    /// Create a new verification
+    pub fn new(status: SigStatus, key: Option<String>, display: Option<String>) -> Self {
+        Self {
+            status,
+            key,
+            display,
         }
     }
 }
@@ -150,10 +160,10 @@ impl Signer {
     /// Creates a signer based on user settings. Uses all known backends, and
     /// chooses one of them to be used for signing depending on the config.
     pub fn from_settings(settings: &UserSettings) -> Result<Self, SignInitError> {
-        let mut backends: Vec<Box<dyn SigningBackend>> = vec![
-            // Box::new(GpgBackend::from_settings(settings)?),
-            // Box::new(SshBackend::from_settings(settings)?),
-            // Box::new(X509Backend::from_settings(settings)?),
+        let mut backends = vec![
+            Box::new(GpgBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
+            // Box::new(SshBackend::from_settings(settings)?) as Box<dyn SigningBackend>,
+            // Box::new(X509Backend::from_settings(settings)?) as Box<dyn SigningBackend>,
         ];
 
         let main_backend = settings

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -24,6 +24,7 @@ use thiserror::Error;
 use crate::backend::CommitId;
 use crate::gpg_signing::GpgBackend;
 use crate::settings::UserSettings;
+use crate::ssh_signing::SshBackend;
 
 /// A status of the signature, part of the [Verification] type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -162,7 +163,7 @@ impl Signer {
     pub fn from_settings(settings: &UserSettings) -> Result<Self, SignInitError> {
         let mut backends = vec![
             Box::new(GpgBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
-            // Box::new(SshBackend::from_settings(settings)?) as Box<dyn SigningBackend>,
+            Box::new(SshBackend::from_config(settings.config())) as Box<dyn SigningBackend>,
             // Box::new(X509Backend::from_settings(settings)?) as Box<dyn SigningBackend>,
         ];
 

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -1,0 +1,308 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use std::ffi::OsString;
+use std::fmt::Debug;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
+
+use either::Either;
+use thiserror::Error;
+
+use crate::signing::{SigStatus, SignError, SigningBackend, Verification};
+
+#[derive(Debug)]
+pub struct SshBackend {
+    program: OsString,
+    allowed_signers: Option<OsString>,
+}
+
+#[derive(Debug, Error)]
+pub enum SshError {
+    #[error("SSH sign failed with exit status {exit_status}:\n{stderr}")]
+    Command {
+        exit_status: ExitStatus,
+        stderr: String,
+    },
+    #[error("Failed to parse ssh program response")]
+    BadResult,
+    #[error("Failed to run ssh-keygen")]
+    Io(#[from] std::io::Error),
+    #[error("Signing key required")]
+    MissingKey,
+}
+
+impl From<SshError> for SignError {
+    fn from(e: SshError) -> Self {
+        SignError::Backend(Box::new(e))
+    }
+}
+
+type SshResult<T> = Result<T, SshError>;
+
+fn parse_utf8_string(data: Vec<u8>) -> SshResult<String> {
+    String::from_utf8(data).map_err(|_| SshError::BadResult)
+}
+
+fn run_command(command: &mut Command, stdin: &[u8]) -> SshResult<Vec<u8>> {
+    let process = command.spawn()?;
+    process.stdin.as_ref().unwrap().write_all(stdin)?;
+
+    let output = process.wait_with_output()?;
+
+    if !output.status.success() {
+        return Err(SshError::Command {
+            exit_status: output.status,
+            stderr: String::from_utf8_lossy(&output.stderr).trim_end().into(),
+        });
+    }
+
+    Ok(output.stdout)
+}
+
+// This attempts to convert given key data into a file and return the filepath.
+// If the given data is actually already a filepath to a key on disk then the
+// key input is returned directly.
+fn ensure_key_as_file(key: &str) -> SshResult<Either<PathBuf, tempfile::TempPath>> {
+    let is_inlined_ssh_key = key.starts_with("ssh-");
+    if !is_inlined_ssh_key {
+        let key_path = Path::new(key);
+        return Ok(either::Left(key_path.to_path_buf()));
+    }
+
+    let mut pub_key_file = tempfile::Builder::new()
+        .prefix("jj-signing-key-")
+        .tempfile()
+        .map_err(SshError::Io)?;
+
+    pub_key_file
+        .write_all(key.as_bytes())
+        .map_err(SshError::Io)?;
+    pub_key_file.flush().map_err(SshError::Io)?;
+
+    // This is converted into a TempPath so that the underlying file handle is
+    // closed. On Windows systems this is required for other programs to be able
+    // to open the file for reading.
+    let pub_key_path = pub_key_file.into_temp_path();
+    Ok(either::Right(pub_key_path))
+}
+
+impl SshBackend {
+    pub fn new(program: OsString, allowed_signers: Option<OsString>) -> Self {
+        Self {
+            program,
+            allowed_signers,
+        }
+    }
+
+    pub fn from_config(config: &config::Config) -> Self {
+        Self::new(
+            config
+                .get_string("signing.backends.ssh.program")
+                .unwrap_or_else(|_| "ssh-keygen".into())
+                .into(),
+            config
+                .get_string("signing.backends.ssh.allowed-signers")
+                .map_or(None, |v| Some(v.into())),
+        )
+    }
+
+    fn create_command(&self) -> Command {
+        let mut command = Command::new(&self.program);
+
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        command
+    }
+
+    fn find_principal(&self, signature_file_path: &Path) -> Result<Option<String>, SshError> {
+        let Some(allowed_signers) = &self.allowed_signers else {
+            return Ok(None);
+        };
+
+        let mut command = self.create_command();
+
+        command
+            .arg("-Y")
+            .arg("find-principals")
+            .arg("-f")
+            .arg(allowed_signers)
+            .arg("-s")
+            .arg(signature_file_path);
+
+        // We can't use the existing run_command helper here as `-Y find-principals`
+        // will return a non-0 exit code if no principals are found.
+        //
+        // In this case we don't want to error out, just return None.
+        let process = command.spawn()?;
+        let output = process.wait_with_output()?;
+
+        let principal = parse_utf8_string(output.stdout)?
+            .split('\n')
+            .next()
+            .unwrap()
+            .trim()
+            .to_string();
+
+        if principal.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(principal))
+    }
+}
+
+impl SigningBackend for SshBackend {
+    fn name(&self) -> &str {
+        "ssh"
+    }
+
+    fn can_read(&self, signature: &[u8]) -> bool {
+        signature.starts_with(b"-----BEGIN SSH SIGNATURE-----")
+    }
+
+    fn sign(&self, data: &[u8], key: Option<&str>) -> Result<Vec<u8>, SignError> {
+        let Some(key) = key else {
+            return Err(SshError::MissingKey.into());
+        };
+
+        // The ssh-keygen `-f` flag expects to be given a file which contains either a
+        // private or public key.
+        //
+        // As it expects a file and we might have an inlined public key instead, we need
+        // to ensure it is written to a file first.
+        let pub_key_path = ensure_key_as_file(key)?;
+        let mut command = self.create_command();
+
+        let path = match &pub_key_path {
+            either::Left(path) => path.as_os_str(),
+            either::Right(path) => path.as_os_str(),
+        };
+
+        command
+            .arg("-Y")
+            .arg("sign")
+            .arg("-f")
+            .arg(path)
+            .arg("-n")
+            .arg("git");
+
+        Ok(run_command(&mut command, data)?)
+    }
+
+    fn verify(&self, data: &[u8], signature: &[u8]) -> Result<Verification, SignError> {
+        let mut signature_file = tempfile::Builder::new()
+            .prefix(".jj-ssh-sig-")
+            .tempfile()
+            .map_err(SshError::Io)?;
+        signature_file.write_all(signature).map_err(SshError::Io)?;
+        signature_file.flush().map_err(SshError::Io)?;
+
+        let signature_file_path = signature_file.into_temp_path();
+
+        let principal = self.find_principal(&signature_file_path)?;
+
+        let mut command = self.create_command();
+
+        match (principal, self.allowed_signers.as_ref()) {
+            (Some(principal), Some(allowed_signers)) => {
+                command
+                    .arg("-Y")
+                    .arg("verify")
+                    .arg("-s")
+                    .arg(&signature_file_path)
+                    .arg("-I")
+                    .arg(&principal)
+                    .arg("-f")
+                    .arg(allowed_signers)
+                    .arg("-n")
+                    .arg("git");
+
+                let result = run_command(&mut command, data);
+
+                let status = match result {
+                    Ok(_) => SigStatus::Good,
+                    Err(_) => SigStatus::Bad,
+                };
+                Ok(Verification::new(status, None, Some(principal)))
+            }
+            _ => {
+                command
+                    .arg("-Y")
+                    .arg("check-novalidate")
+                    .arg("-s")
+                    .arg(&signature_file_path)
+                    .arg("-n")
+                    .arg("git");
+
+                let result = run_command(&mut command, data);
+
+                match result {
+                    Ok(_) => Ok(Verification::new(
+                        SigStatus::Unknown,
+                        None,
+                        Some("Signature OK. Unknown principal".into()),
+                    )),
+                    Err(_) => Ok(Verification::new(SigStatus::Bad, None, None)),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::{Read, Write};
+
+    use super::*;
+
+    #[test]
+    fn test_ssh_key_to_file_conversion_raw_key_data() {
+        let keydata = "ssh-ed25519 some-key-data";
+        let path = ensure_key_as_file(keydata).unwrap();
+
+        let mut buf = vec![];
+        let mut file = File::open(path.right().unwrap()).unwrap();
+        file.read_to_end(&mut buf).unwrap();
+
+        assert_eq!("ssh-ed25519 some-key-data", String::from_utf8(buf).unwrap());
+    }
+
+    #[test]
+    fn test_ssh_key_to_file_conversion_existing_file() {
+        let mut file = tempfile::Builder::new()
+            .prefix("jj-signing-key-")
+            .tempfile()
+            .map_err(SshError::Io)
+            .unwrap();
+
+        file.write_all(b"some-data").map_err(SshError::Io).unwrap();
+        file.flush().map_err(SshError::Io).unwrap();
+
+        let file_path = file.into_temp_path();
+
+        let path = ensure_key_as_file(file_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            file_path.to_str().unwrap(),
+            path.left().unwrap().to_str().unwrap()
+        );
+    }
+}

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -30,5 +30,6 @@ mod test_refs;
 mod test_revset;
 mod test_rewrite;
 mod test_signing;
+mod test_ssh_signing;
 mod test_view;
 mod test_workspace;

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -14,6 +14,7 @@ mod test_default_revset_graph_iterator;
 mod test_diff_summary;
 mod test_git;
 mod test_git_backend;
+mod test_gpg;
 mod test_id_prefix;
 mod test_index;
 mod test_init;

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -1,0 +1,186 @@
+#[cfg(unix)]
+use std::fs::Permissions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::prelude::PermissionsExt;
+use std::process::Stdio;
+
+use assert_matches::assert_matches;
+use insta::assert_debug_snapshot;
+use jj_lib::gpg_signing::GpgBackend;
+use jj_lib::signing::{SigStatus, SignError, SigningBackend};
+
+static PRIVATE_KEY: &str = r#"-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+lFgEZWI3pBYJKwYBBAHaRw8BAQdAaPLTNADvDWapjAPlxaUnx3HXQNIlwSz4EZrW
+3Z7hxSwAAP9liwHZWJCGI2xW+XNqMT36qpIvoRcd5YPaKYwvnlkG1w+UtDNTb21l
+b25lIChqaiB0ZXN0IHNpZ25pbmcga2V5KSA8c29tZW9uZUBleGFtcGxlLmNvbT6I
+kwQTFgoAOxYhBKWOXukGcVPI9eXp6WOHhcsW/qBhBQJlYjekAhsDBQsJCAcCAiIC
+BhUKCQgLAgQWAgMBAh4HAheAAAoJEGOHhcsW/qBhyBgBAMph1HkBkKlrZmsun+3i
+kTEaOsWmaW/D6NEdMFiw0S/jAP9G3jOYGiZbUN3dWWB2246Oi7SaMTX8Xb2BrLP2
+axCbC5RYBGVjxv8WCSsGAQQB2kcPAQEHQE8Oa4ahtVG29gIRssPxjqF4utn8iHPz
+m5z/8lX/nl3eAAD5AZ6H2pNhiy2gnGkbPLHw3ZyY4d0NXzCa7qc9EXqOj+sRrLQ9
+U29tZW9uZSBFbHNlIChqaiB0ZXN0IHNpZ25pbmcga2V5KSA8c29tZW9uZS1lbHNl
+QGV4YW1wbGUuY29tPoiTBBMWCgA7FiEER1BAaEpU3TKUiUvFTtVW6XKeAA8FAmVj
+xv8CGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQTtVW6XKeAA/6TQEA
+2DkPm3LmH8uG6qLirtf62kbG7T+qljIsarQKFw3CGakA/AveCtrL7wVSpINiu1Rz
+lBqJFFP2PqzT0CRfh94HSIMM
+=6JC8
+-----END PGP PRIVATE KEY BLOCK-----
+"#;
+
+struct GpgEnvironment {
+    homedir: tempfile::TempDir,
+}
+
+impl GpgEnvironment {
+    fn new() -> Result<Self, std::process::Output> {
+        let dir = tempfile::Builder::new()
+            .prefix("jj-gpg-signing-test-")
+            .tempdir()
+            .unwrap();
+
+        let path = dir.path();
+
+        #[cfg(unix)]
+        std::fs::set_permissions(path, Permissions::from_mode(0o700)).unwrap();
+
+        let mut gpg = std::process::Command::new("gpg")
+            .arg("--homedir")
+            .arg(path)
+            .arg("--import")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        gpg.stdin
+            .as_mut()
+            .unwrap()
+            .write_all(PRIVATE_KEY.as_bytes())
+            .unwrap();
+
+        gpg.stdin.as_mut().unwrap().flush().unwrap();
+
+        let res = gpg.wait_with_output().unwrap();
+
+        if !res.status.success() {
+            println!("Failed to add private key to gpg-agent. Make sure it is running!");
+            println!("{}", String::from_utf8_lossy(&res.stderr));
+            return Err(res);
+        }
+
+        Ok(GpgEnvironment { homedir: dir })
+    }
+}
+
+fn backend(env: &GpgEnvironment) -> GpgBackend {
+    // don't really need faked time for current tests,
+    // but probably will need it for end-to-end cli tests
+    GpgBackend::new("gpg".into(), false).with_extra_args(&[
+        "--homedir".into(),
+        env.homedir.path().as_os_str().into(),
+        "--faked-system-time=1701042000!".into(),
+    ])
+}
+
+#[test]
+fn gpg_singing_roundtrip() {
+    let env = GpgEnvironment::new().unwrap();
+    let backend = backend(&env);
+    let data = b"hello world";
+    let signature = backend.sign(data, None).unwrap();
+
+    let check = backend.verify(data, &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Good);
+    assert_eq!(check.key.unwrap(), "638785CB16FEA061");
+    assert_eq!(
+        check.display.unwrap(),
+        "Someone (jj test signing key) <someone@example.com>"
+    );
+
+    let check = backend.verify(b"so so bad", &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Bad);
+    assert_eq!(check.key.unwrap(), "638785CB16FEA061");
+    assert_eq!(
+        check.display.unwrap(),
+        "Someone (jj test signing key) <someone@example.com>"
+    );
+}
+
+#[test]
+fn gpg_signing_roundtrip_explicit_key() {
+    let env = GpgEnvironment::new().unwrap();
+    let backend = backend(&env);
+    let data = b"hello world";
+    let signature = backend.sign(data, Some("Someone Else")).unwrap();
+
+    assert_debug_snapshot!(backend.verify(data, &signature).unwrap(), @r###"
+    Verification {
+        status: Good,
+        key: Some(
+            "4ED556E9729E000F",
+        ),
+        display: Some(
+            "Someone Else (jj test signing key) <someone-else@example.com>",
+        ),
+    }
+    "###);
+    assert_debug_snapshot!(backend.verify(b"so so bad", &signature).unwrap(), @r###"
+    Verification {
+        status: Bad,
+        key: Some(
+            "4ED556E9729E000F",
+        ),
+        display: Some(
+            "Someone Else (jj test signing key) <someone-else@example.com>",
+        ),
+    }
+    "###);
+}
+
+#[test]
+fn unknown_key() {
+    let env = GpgEnvironment::new().unwrap();
+    let backend = backend(&env);
+    let signature = br"-----BEGIN PGP SIGNATURE-----
+
+    iHUEABYKAB0WIQQs238pU7eC/ROoPJ0HH+PjJN1zMwUCZWPa5AAKCRAHH+PjJN1z
+    MyylAP9WQ3sZdbC4b1C+/nxs+Wl+rfwzeQWGbdcsBMyDABcpmgD/U+4KdO7eZj/I
+    e+U6bvqw3pOBoI53Th35drQ0qPI+jAE=
+    =kwsk
+    -----END PGP SIGNATURE-----";
+    assert_debug_snapshot!(backend.verify(b"hello world", signature).unwrap(), @r###"
+    Verification {
+        status: Unknown,
+        key: Some(
+            "071FE3E324DD7333",
+        ),
+        display: None,
+    }
+    "###);
+    assert_debug_snapshot!(backend.verify(b"so bad", signature).unwrap(), @r###"
+    Verification {
+        status: Unknown,
+        key: Some(
+            "071FE3E324DD7333",
+        ),
+        display: None,
+    }
+    "###);
+}
+
+#[test]
+fn invalid_signature() {
+    let env = GpgEnvironment::new().unwrap();
+    let backend = backend(&env);
+    let signature = br"-----BEGIN PGP SIGNATURE-----
+
+    super duper invalid
+    -----END PGP SIGNATURE-----";
+    assert_matches!(
+        backend.verify(b"hello world", signature),
+        Err(SignError::InvalidSignatureFormat)
+    );
+}

--- a/lib/tests/test_ssh_signing.rs
+++ b/lib/tests/test_ssh_signing.rs
@@ -1,0 +1,167 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+#[cfg(unix)]
+use std::fs::Permissions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::prelude::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use jj_lib::signing::{SigStatus, SigningBackend};
+use jj_lib::ssh_signing::SshBackend;
+
+static PRIVATE_KEY: &str = r#"-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBo/iejekjvuD/HTman0daImstssYYR52oB+dmr1KsOYQAAAIiuGFMFrhhT
+BQAAAAtzc2gtZWQyNTUxOQAAACBo/iejekjvuD/HTman0daImstssYYR52oB+dmr1KsOYQ
+AAAECcUtn/J/jk/+D5+/+WbQRNN4eInj5L60pt6FioP0nQfGj+J6N6SO+4P8dOZqfR1oia
+y2yxhhHnagH52avUqw5hAAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----
+"#;
+
+static PUBLIC_KEY: &str =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h";
+
+struct SshEnvironment {
+    _keys: tempfile::TempDir,
+    private_key_path: PathBuf,
+    allowed_signers: Option<tempfile::TempPath>,
+}
+
+impl SshEnvironment {
+    fn new() -> Result<Self, std::process::Output> {
+        let keys_dir = tempfile::Builder::new()
+            .prefix("jj-test-signing-keys-")
+            .tempdir()
+            .unwrap();
+
+        let private_key_path = Path::new(keys_dir.path()).join("key");
+
+        fs::write(&private_key_path, PRIVATE_KEY).unwrap();
+
+        #[cfg(unix)]
+        std::fs::set_permissions(&private_key_path, Permissions::from_mode(0o700)).unwrap();
+
+        let mut env = SshEnvironment {
+            _keys: keys_dir,
+            private_key_path,
+            allowed_signers: None,
+        };
+
+        env.with_good_public_key();
+
+        Ok(env)
+    }
+
+    fn with_good_public_key(&mut self) {
+        let mut allowed_signers = tempfile::Builder::new()
+            .prefix("jj-test-allowed-signers-")
+            .tempfile()
+            .unwrap();
+
+        allowed_signers
+            .write_all("test@example.com ".as_bytes())
+            .unwrap();
+        allowed_signers.write_all(PUBLIC_KEY.as_bytes()).unwrap();
+        allowed_signers.flush().unwrap();
+
+        let allowed_signers_path = allowed_signers.into_temp_path();
+
+        self.allowed_signers = Some(allowed_signers_path);
+    }
+
+    fn with_bad_public_key(&mut self) {
+        let mut allowed_signers = tempfile::Builder::new()
+            .prefix("jj-test-allowed-signers-")
+            .tempfile()
+            .unwrap();
+
+        allowed_signers
+            .write_all("test@example.com ".as_bytes())
+            .unwrap();
+        allowed_signers
+            .write_all("INVALID PUBLIC KEY".as_bytes())
+            .unwrap();
+        allowed_signers.flush().unwrap();
+
+        let allowed_signers_path = allowed_signers.into_temp_path();
+
+        self.allowed_signers = Some(allowed_signers_path);
+    }
+}
+
+fn backend(env: &SshEnvironment) -> SshBackend {
+    SshBackend::new(
+        "ssh-keygen".into(),
+        env.allowed_signers
+            .as_ref()
+            .map(|allowed_signers| allowed_signers.as_os_str().into()),
+    )
+}
+
+#[test]
+fn ssh_signing_roundtrip() {
+    let env = SshEnvironment::new().unwrap();
+    let backend = backend(&env);
+    let data = b"hello world";
+
+    let signature = backend
+        .sign(data, Some(env.private_key_path.to_str().unwrap()))
+        .unwrap();
+
+    let check = backend.verify(data, &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Good);
+
+    assert_eq!(check.display.unwrap(), "test@example.com");
+
+    let check = backend.verify(b"invalid-commit-data", &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Bad);
+    assert_eq!(check.display.unwrap(), "test@example.com");
+}
+
+#[test]
+fn ssh_signing_bad_allowed_signers() {
+    let mut env = SshEnvironment::new().unwrap();
+    env.with_bad_public_key();
+
+    let backend = backend(&env);
+    let data = b"hello world";
+
+    let signature = backend
+        .sign(data, Some(env.private_key_path.to_str().unwrap()))
+        .unwrap();
+
+    let check = backend.verify(data, &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Unknown);
+    assert_eq!(check.display.unwrap(), "Signature OK. Unknown principal");
+}
+
+#[test]
+fn ssh_signing_missing_allowed_signers() {
+    let mut env = SshEnvironment::new().unwrap();
+    env.allowed_signers = None;
+
+    let backend = backend(&env);
+    let data = b"hello world";
+
+    let signature = backend
+        .sign(data, Some(env.private_key_path.to_str().unwrap()))
+        .unwrap();
+
+    let check = backend.verify(data, &signature).unwrap();
+    assert_eq!(check.status, SigStatus::Unknown);
+    assert_eq!(check.display.unwrap(), "Signature OK. Unknown principal");
+}


### PR DESCRIPTION
This is an expansion on the work that was started by @necauqua in #2728 with the intent of getting the core implementation ready to land.

This involved some small behavioural tweaks such as adding config to control whether or not commit signatures are verified and displayed by default. This also involved a lot of massaging to get the test suite green again.

One significant addition to the original work is the addition of an SSH signing backend which works as closely as possible to the git SSH signing workflow.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
