### PR TITLE
Make `jj show` accept a template to render its output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Templates now support logical operators: `||`, `&&`, `!`
 
+* `jj show` now accepts `-T`/`--template` option to render its output using
+  template
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now materialized as regular files in the

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -28,6 +28,11 @@ pub(crate) struct ShowArgs {
     /// Ignored (but lets you pass `-r` for consistency with other commands)
     #[arg(short = 'r', hide = true)]
     unused_revision: bool,
+    /// Render a revision using the given template
+    ///
+    /// For the syntax, see https://github.com/martinvonz/jj/blob/main/docs/templates.md
+    #[arg(long, short = 'T')]
+    template: Option<String>,
     #[command(flatten)]
     format: DiffFormatArgs,
 }
@@ -40,7 +45,10 @@ pub(crate) fn cmd_show(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
-    let template_string = command.settings().config().get_string("templates.show")?;
+    let template_string = match &args.template {
+        Some(value) => value.to_string(),
+        None => command.settings().config().get_string("templates.show")?,
+    };
     let template = workspace_command.parse_commit_template(&template_string)?;
     let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
     ui.request_pager();

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1551,6 +1551,7 @@ Show commit description and changes in a revision
 
   Possible values: `true`, `false`
 
+* `-T`, `--template <TEMPLATE>` — Render a revision using the given template
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 
   Possible values: `true`, `false`

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -35,6 +35,20 @@ fn test_show() {
 }
 
 #[test]
+fn test_show_with_template() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(&repo_path, &["new", "-m", "a new commit"]);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-T", "description"]);
+
+    insta::assert_snapshot!(stdout, @r###"
+    a new commit
+    "###);
+}
+
+#[test]
 fn test_show_relative_timestamps() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This makes `jj show` accept `-T`/`--template` option to render its output. I've looked how `jj log` does it for inspiration :)

Closes #2969

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
