### PR TITLE
cli: add short `-b` option for `--branch` in `jj git fetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj show` now accepts `-T`/`--template` option to render its output using
   template
 
+* `jj git fetch` now accepts `-b` as a shorthand for `--branch`, making it more
+  consistent with other commands that accept a branch
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now materialized as regular files in the

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -156,7 +156,7 @@ pub struct GitFetchArgs {
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// expand `*` as a glob. The other wildcard characters aren't supported.
-    #[arg(long, default_value = "glob:*", value_parser = parse_string_pattern)]
+    #[arg(long, short, default_value = "glob:*", value_parser = parse_string_pattern)]
     branch: Vec<StringPattern>,
     /// The remote to fetch from (only named remotes are supported, can be
     /// repeated)

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -849,7 +849,7 @@ Fetch from a Git remote
 
 ###### **Options:**
 
-* `--branch <BRANCH>` — Fetch only some of the branches
+* `-b`, `--branch <BRANCH>` — Fetch only some of the branches
 
   Default value: `glob:*`
 * `--remote <remote>` — The remote to fetch from (only named remotes are supported, can be repeated)


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Adding short `-b` option for `--branch` in `jj git fetch` makes it consistent among other commands – `jj git push` and `jj rebase`.

I don't think a test for this change is needed but if you think otherwise I'll happily add it.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
