### PR TITLE
cli: Add `--show-origin` option to `config list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#2971](https://github.com/martinvonz/jj/issues/2971)). This may become the
   default depending on feedback.
 
+* `jj config list` gained a `--show-origin` flag to display the source of
+  config values.
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now materialized as regular files in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,11 +440,10 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
 dependencies = [
- "async-trait",
  "lazy_static",
  "nom",
  "pathdiff",
@@ -1636,7 +1635,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "timeago",
- "toml_edit",
+ "toml_edit 0.19.15",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
@@ -2956,11 +2955,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -2977,6 +2979,19 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4.34", default-features = false, features = [
     "std",
     "clock",
 ] }
-config = { version = "0.13.4", default-features = false, features = ["toml"] }
+config = { version = "0.14.0", default-features = false, features = ["toml"] }
 criterion = "0.5.1"
 crossterm = { version = "0.27", default-features = false }
 digest = "0.10.7"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -584,8 +584,8 @@ mod tests {
             command_args,
             CommandNameAndArgs::Structured {
                 env: hashmap! {
-                    "KEY1".to_string() => "value1".to_string(),
-                    "KEY2".to_string() => "value2".to_string(),
+                    "key1".to_string() => "value1".to_string(),
+                    "key2".to_string() => "value2".to_string(),
                 },
                 command: NonEmptyCommandArgsVec(["emacs", "-nw",].map(|s| s.to_owned()).to_vec())
             }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -38,10 +38,21 @@ pub enum ConfigError {
 pub enum ConfigSource {
     Default,
     Env,
-    // TODO: Track explicit file paths, especially for when user config is a dir.
     User,
     Repo,
     CommandArg,
+}
+
+impl ConfigSource {
+    pub fn description(&self) -> &str {
+        match self {
+            ConfigSource::Default => "default",
+            ConfigSource::Env => "env",
+            ConfigSource::User => "usercfg",
+            ConfigSource::Repo => "repocfg",
+            ConfigSource::CommandArg => "cmdline",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -475,6 +475,10 @@ List variables set in config file, along with their values
 
   Possible values: `true`, `false`
 
+* `--show-origin` — Display the source of all listed config values with type (default, env, usercfg, repocfg, command line) and the source file path for usercfg and repocfg
+
+  Possible values: `true`, `false`
+
 * `--user` — Target the user-level config
 
   Possible values: `true`, `false`

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -628,14 +628,16 @@ fn test_config_get() {
     "###);
 
     let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["config", "get", "table.list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    Config error: invalid type: sequence, expected a value convertible to a string
+    insta::with_settings!({filters => vec![(r"config\\config0002.toml", "config/config0002.toml")]}, {
+        insta::assert_snapshot!(stdout, @r###"
+    Config error: invalid type: sequence, expected a value convertible to a string for key `table.list` in config/config0002.toml
     For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
-    "###);
+    "###)
+    });
 
     let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["config", "get", "table"]);
     insta::assert_snapshot!(stdout, @r###"
-    Config error: invalid type: map, expected a value convertible to a string
+    Config error: invalid type: map, expected a value convertible to a string for key `table`
     For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -386,7 +386,13 @@ fn test_invalid_config() {
     test_env.add_config("[section]key = value-missing-quotes");
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Config error: expected newline, found an identifier at line 1 column 10 in config/config0002.toml
+    Config error: TOML parse error at line 1, column 10
+      |
+    1 | [section]key = value-missing-quotes
+      |          ^
+    invalid table header
+    expected newline, `#`
+     in config/config0002.toml
     For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
 }


### PR DESCRIPTION
Add a new `--show-origin` option to `jj config list` to display the
source type and file path (when present) of config values.

Related to https://github.com/martinvonz/jj/issues/1047

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] ~~I have updated the config schema (cli/src/config-schema.json)~~ Not applicable
- [x] I have added tests to cover my changes
