### PR TITLE
Use `minus` as a builtin pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj next/prev` now infer `--edit` when you're already editing a non-head
   commit (a commit with children).
 
+* Built-in pager based on [minus](https://github.com/arijit79/minus/)
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now materialized as regular files in the
   working copy (instead of resulting in a crash).
+
+* On Windows, the pager will now be the built-in instead of disabled.
 
 ## [0.14.0] - 2024-02-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,7 @@ dependencies = [
  "jj-lib",
  "libc",
  "maplit",
+ "minus",
  "once_cell",
  "pest",
  "pest_derive",
@@ -1859,6 +1860,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "minus"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b5f31d6666667f707078608f25e7615c48c2243a06b66ca0fa6c4ecb96362d"
+dependencies = [
+ "crossbeam-channel",
+ "crossterm",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "textwrap",
+ "thiserror",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +1954,9 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "oorandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ insta = { version = "1.34.0", features = ["filters"] }
 itertools = "0.12.1"
 libc = { version = "0.2.153" }
 maplit = "1.0.2"
+minus = { version = "5.5.0", features = [ "dynamic_output", "search" ] }
 num_cpus = "1.16.0"
 once_cell = "1.19.0"
 ouroboros = "0.18.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 jj-lib = { workspace = true }
 maplit = { workspace = true }
+minus = { workspace = true }
 once_cell = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }

--- a/cli/src/config/windows.toml
+++ b/cli/src/config/windows.toml
@@ -1,3 +1,3 @@
 [ui]
-paginate = "never"
+pager = ":builtin"
 editor = "Notepad"

--- a/docs/config.md
+++ b/docs/config.md
@@ -300,16 +300,26 @@ Can be customized by the `format_short_signature()` template alias.
 
 ## Pager
 
-Windows users: Note that pagination is disabled by default on Windows for now
-([#2040](https://github.com/martinvonz/jj/issues/2040)).
-
 The default pager is can be set via `ui.pager` or the `PAGER` environment
 variable. The priority is as follows (environment variables are marked with
 a `$`):
 
 `ui.pager` > `$PAGER`
 
-`less -FRX` is the default pager in the absence of any other setting.
+`less -FRX` is the default pager in the absence of any other setting, except
+on Windows where it is `:builtin`.
+
+The special value `:builtin` enables usage of the
+[integrated pager](https://github.com/arijit79/minus/). It is likely if you
+are using a standard Linux distro, your system has `$PAGER` set already
+and that will be preferred over the built-in. To use the built-in:
+
+```
+jj config set --user ui.pager :builtin
+```
+
+It is possible the default will change to `:builtin` for all platforms in the
+future.
 
 Additionally, paging behavior can be toggled via `ui.paginate` like so:
 


### PR DESCRIPTION
Added a built-in pager since the solution in #2928 felt hacky. Also should address #2044

# Checklist

If applicable:
- [X ] I have updated `CHANGELOG.md`
- [X ] I have updated the documentation (README.md, docs/, demos/)
- [X ] I have updated the config schema (cli/src/config-schema.json)
