### PR TITLE
github: run the nix build with multiple cores

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -18,5 +18,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
+        with:
+          extra-conf: |
+            max-jobs = 4
+            cores = 4
       - uses: DeterminateSystems/magic-nix-cache-action@eeabdb06718ac63a7021c6132129679a8e22d0c7
-      - run: nix build --print-build-logs --show-trace
+      - run: nix build --print-build-logs --show-trace --cores 4 --max-jobs 4

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,8 @@
             openssl zstd libgit2 libssh2
           ] ++ darwinDeps;
 
+          enableParallelBuilding = true;
+
           ZSTD_SYS_USE_PKG_CONFIG = "1";
           LIBSSH2_SYS_USE_PKG_CONFIG = "1";
           RUSTFLAGS = pkgs.lib.optionalString useMoldLinker "-C link-arg=-fuse-ld=mold";


### PR DESCRIPTION
By default, I think we're running the Nix builds with only a single core, while `ubuntu-latest` on GitHub apparently comes with 16GB of RAM and 4 cores. Currently Nix clocks in as the slowest CI build, at about 7-8 minutes.

This should hopefully speed up the Nix build quite a bit and bring it up to par with the rest of the runners, which are completing builds in 3-5 minutes.