### PR TITLE
Make `next/prev` infer `--edit` from running on non-head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * In the templating language, Timestamps now have a `.local()` method for
   converting to the local timezone.
 
+* `jj next/prev` now infer `--edit` when you're already editing a non-head
+  commit (a commit with children).
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now materialized as regular files in the

--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -106,7 +106,6 @@ pub(crate) fn cmd_next(
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
     let current_wc = workspace_command.repo().store().get_commit(current_wc_id)?;
-    let current_short = short_commit_hash(current_wc.id());
     // If we're editing, start at the working-copy commit.
     // Otherwise start from our direct parent.
     let start_id = if edit {
@@ -140,6 +139,7 @@ pub(crate) fn cmd_next(
         }
         commits => choose_commit(ui, &workspace_command, "next", commits)?,
     };
+    let current_short = short_commit_hash(current_wc.id());
     let target_short = short_commit_hash(target.id());
     // We're editing, just move to the target commit.
     if edit {

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -69,7 +69,6 @@ pub(crate) fn cmd_prev(
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
     let current_wc = workspace_command.repo().store().get_commit(current_wc_id)?;
-    let current_short = short_commit_hash(current_wc.id());
     let start_id = if edit {
         current_wc_id
     } else {
@@ -106,6 +105,7 @@ pub(crate) fn cmd_prev(
         commits => choose_commit(ui, &workspace_command, "prev", commits)?,
     };
     // Generate a short commit hash, to make it readable in the op log.
+    let current_short = short_commit_hash(current_wc.id());
     let target_short = short_commit_hash(target.id());
     // If we're editing, just move to the revision directly.
     if edit {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1145,6 +1145,9 @@ C    C
 B => @
 |    |
 @    A
+
+If your working-copy commit already has visible children, then `--edit` is
+implied.
 ```
 
 **Usage:** `jj next [OPTIONS] [AMOUNT]`
@@ -1330,7 +1333,7 @@ The command moves you to the parent in a linear fashion.
 D @  D
 |/   |
 A => A @
-|    | /
+|    |/
 B    B
 ```
 
@@ -1345,6 +1348,9 @@ C => @
 B    B
 |    |
 A    A
+
+If your working-copy commit already has visible children, then `--edit` is
+implied.
 ```
 
 **Usage:** `jj prev [OPTIONS] [AMOUNT]`

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -284,6 +284,13 @@ fn test_prev_editing() {
     Working copy now at: zsuskuln 009f88bf (empty) fourth
     Parent commit      : kkmpptxz 3fa8931e (empty) third
     "###);
+    // --edit is implied when already editing a non-head commit
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: yqosqzyt d2edc95b (empty) (no description set)
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    "###);
 }
 
 #[test]
@@ -296,8 +303,15 @@ fn test_next_editing() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
-    test_env.jj_cmd_ok(&repo_path, &["edit", "@--"]);
+    test_env.jj_cmd_ok(&repo_path, &["edit", "@---"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: kkmpptxz 3fa8931e (empty) third
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    "###);
+    // --edit is implied when already editing a non-head commit
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Working copy now at: zsuskuln 009f88bf (empty) fourth


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
