### PR TITLE
revset: drop support for legacy dag range operator, better parsing of `kind:"string"` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Dropped support for the "legacy" graph-drawing style. Use "ascii" for a very
   similar result.
 
+* Dropped support for the deprecated `:` revset operator. Use `::` instead.
+
 ### New features
 
 * Templates now support logical operators: `||`, `&&`, `!`

--- a/cli/examples/custom-command/main.rs
+++ b/cli/examples/custom-command/main.rs
@@ -38,7 +38,7 @@ fn run_custom_command(
     match command {
         CustomCommand::Frobnicate(args) => {
             let mut workspace_command = command_helper.workspace_helper(ui)?;
-            let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+            let commit = workspace_command.resolve_single_rev(&args.revision)?;
             let mut tx = workspace_command.start_transaction();
             let new_commit = tx
                 .mut_repo()

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -408,7 +408,12 @@ impl From<RevsetParseError> for CommandError {
         let message = iter::successors(Some(&err), |e| e.origin()).join("\n");
         // Only for the top-level error as we can't attach hint to inner errors
         let hint = match err.kind() {
-            RevsetParseErrorKind::NotPostfixOperator {
+            RevsetParseErrorKind::NotPrefixOperator {
+                op: _,
+                similar_op,
+                description,
+            }
+            | RevsetParseErrorKind::NotPostfixOperator {
                 op: _,
                 similar_op,
                 description,

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -47,7 +47,7 @@ pub(crate) fn cmd_abandon(
     args: &AbandonArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let to_abandon = resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command, ui)?;
+    let to_abandon = resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command)?;
     workspace_command.check_rewritable(to_abandon.iter())?;
     let mut tx = workspace_command.start_transaction();
     for commit in &to_abandon {

--- a/cli/src/commands/backout.rs
+++ b/cli/src/commands/backout.rs
@@ -39,10 +39,10 @@ pub(crate) fn cmd_backout(
     args: &BackoutArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit_to_back_out = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit_to_back_out = workspace_command.resolve_single_rev(&args.revision)?;
     let mut parents = vec![];
     for revision_str in &args.destination {
-        let destination = workspace_command.resolve_single_rev(revision_str, ui)?;
+        let destination = workspace_command.resolve_single_rev(revision_str)?;
         parents.push(destination);
     }
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/bench.rs
+++ b/cli/src/commands/bench.rs
@@ -132,8 +132,8 @@ pub(crate) fn cmd_bench(
     match subcommand {
         BenchCommand::CommonAncestors(args) => {
             let workspace_command = command.workspace_helper(ui)?;
-            let commit1 = workspace_command.resolve_single_rev(&args.revision1, ui)?;
-            let commit2 = workspace_command.resolve_single_rev(&args.revision2, ui)?;
+            let commit1 = workspace_command.resolve_single_rev(&args.revision1)?;
+            let commit2 = workspace_command.resolve_single_rev(&args.revision2)?;
             let index = workspace_command.repo().index();
             let routine =
                 || index.common_ancestors(&[commit1.id().clone()], &[commit2.id().clone()]);
@@ -146,8 +146,8 @@ pub(crate) fn cmd_bench(
         }
         BenchCommand::IsAncestor(args) => {
             let workspace_command = command.workspace_helper(ui)?;
-            let ancestor_commit = workspace_command.resolve_single_rev(&args.ancestor, ui)?;
-            let descendant_commit = workspace_command.resolve_single_rev(&args.descendant, ui)?;
+            let ancestor_commit = workspace_command.resolve_single_rev(&args.ancestor)?;
+            let descendant_commit = workspace_command.resolve_single_rev(&args.descendant)?;
             let index = workspace_command.repo().index();
             let routine = || index.is_ancestor(ancestor_commit.id(), descendant_commit.id());
             run_bench(
@@ -201,7 +201,7 @@ fn bench_revset<M: Measurement>(
     revset: &str,
 ) -> Result<(), CommandError> {
     writeln!(ui.stderr(), "----------Testing revset: {revset}----------")?;
-    let expression = workspace_command.parse_revset(revset, Some(ui))?;
+    let expression = workspace_command.parse_revset(revset)?;
     // Time both evaluation and iteration.
     let routine = |workspace_command: &WorkspaceCommandHelper, expression| {
         workspace_command

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -234,7 +234,7 @@ fn cmd_branch_create(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let target_commit =
-        workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"), ui)?;
+        workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
     let view = workspace_command.repo().view();
     let branch_names = &args.names;
     if let Some(branch_name) = branch_names
@@ -333,7 +333,7 @@ fn cmd_branch_set(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let target_commit =
-        workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"), ui)?;
+        workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
     let repo = workspace_command.repo().as_ref();
     let is_fast_forward = |old_target: &RefTarget| {
         // Strictly speaking, "all" old targets should be ancestors, but we allow
@@ -614,7 +614,7 @@ fn cmd_branch_list(
             let filter_expressions: Vec<_> = args
                 .revisions
                 .iter()
-                .map(|revision_str| workspace_command.parse_revset(revision_str, Some(ui)))
+                .map(|revision_str| workspace_command.parse_revset(revision_str))
                 .try_collect()?;
             let filter_expression = RevsetExpression::union_all(&filter_expressions);
             // Intersects with the set of local branch targets to minimize the lookup space.

--- a/cli/src/commands/cat.rs
+++ b/cli/src/commands/cat.rs
@@ -40,7 +40,7 @@ pub(crate) fn cmd_cat(
     args: &CatArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let tree = commit.tree()?;
     let path = workspace_command.parse_file_path(&args.path)?;
     let repo = workspace_command.repo();

--- a/cli/src/commands/checkout.rs
+++ b/cli/src/commands/checkout.rs
@@ -50,7 +50,7 @@ pub(crate) fn cmd_checkout(
         "warning: `jj checkout` will be removed in a future version, and this will be a hard error"
     )?;
     let mut workspace_command = command.workspace_helper(ui)?;
-    let target = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let target = workspace_command.resolve_single_rev(&args.revision)?;
     let mut tx = workspace_command.start_transaction();
     let commit_builder = tx
         .mut_repo()

--- a/cli/src/commands/chmod.rs
+++ b/cli/src/commands/chmod.rs
@@ -64,7 +64,7 @@ pub(crate) fn cmd_chmod(
         .iter()
         .map(|path| workspace_command.parse_file_path(path))
         .try_collect()?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewritable([&commit])?;
 
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -291,7 +291,7 @@ fn cmd_debug_tree(
     args: &DebugTreeArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let tree = commit.tree()?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     for (path, value) in tree.entries_matching(matcher.as_ref()) {

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -64,7 +64,7 @@ pub(crate) fn cmd_describe(
     args: &DescribeArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewritable([&commit])?;
     let description = if args.stdin {
         let mut buffer = String::new();

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -52,13 +52,13 @@ pub(crate) fn cmd_diff(
     let from_tree;
     let to_tree;
     if args.from.is_some() || args.to.is_some() {
-        let from = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"), ui)?;
+        let from = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"))?;
         from_tree = from.tree()?;
-        let to = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"), ui)?;
+        let to = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;
         to_tree = to.tree()?;
     } else {
         let commit =
-            workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"), ui)?;
+            workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
         let parents = commit.parents();
         from_tree = merge_commit_trees(workspace_command.repo().as_ref(), &parents)?;
         to_tree = commit.tree()?

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -62,17 +62,16 @@ pub(crate) fn cmd_diffedit(
 
     let (target_commit, base_commits, diff_description);
     if args.from.is_some() || args.to.is_some() {
-        target_commit =
-            workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"), ui)?;
+        target_commit = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;
         base_commits =
-            vec![workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"), ui)?];
+            vec![workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"))?];
         diff_description = format!(
             "The diff initially shows the commit's changes relative to:\n{}",
             workspace_command.format_commit_summary(&base_commits[0])
         );
     } else {
         target_commit =
-            workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"), ui)?;
+            workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
         base_commits = target_commit.parents();
         diff_description = "The diff initially shows the commit's changes.".to_string();
     };

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -44,7 +44,7 @@ pub(crate) fn cmd_duplicate(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let to_duplicate: IndexSet<Commit> =
-        resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command, ui)?;
+        resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command)?;
     if to_duplicate
         .iter()
         .any(|commit| commit.id() == workspace_command.repo().store().root_commit_id())

--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -40,7 +40,7 @@ pub(crate) fn cmd_edit(
     args: &EditArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let new_commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let new_commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewritable([&new_commit])?;
     if workspace_command.get_wc_commit_id() == Some(new_commit.id()) {
         writeln!(ui.stderr(), "Already editing that commit")?;

--- a/cli/src/commands/files.rs
+++ b/cli/src/commands/files.rs
@@ -37,7 +37,7 @@ pub(crate) fn cmd_files(
     args: &FilesArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let tree = commit.tree()?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     ui.request_pager();

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -775,7 +775,7 @@ fn cmd_git_push(
     let change_commits: Vec<_> = args
         .change
         .iter()
-        .map(|change_str| workspace_command.resolve_single_rev(change_str, ui))
+        .map(|change_str| workspace_command.resolve_single_rev(change_str))
         .try_collect()?;
 
     let mut tx = workspace_command.start_transaction();
@@ -845,7 +845,7 @@ fn cmd_git_push(
                 let short_change_id = short_change_hash(commit.change_id());
                 if tx
                     .base_workspace_helper()
-                    .resolve_single_rev(&short_change_id, ui)
+                    .resolve_single_rev(&short_change_id)
                     .is_ok()
                 {
                     // Short change ID is not ambiguous, so update the branch name to use it.
@@ -899,7 +899,7 @@ fn cmd_git_push(
         } else {
             // TODO: Narrow search space to local target commits.
             // TODO: Remove redundant CommitId -> Commit -> CommitId round trip.
-            resolve_multiple_nonempty_revsets(&args.revisions, tx.base_workspace_helper(), ui)?
+            resolve_multiple_nonempty_revsets(&args.revisions, tx.base_workspace_helper())?
                 .iter()
                 .map(|commit| commit.id().clone())
                 .collect()
@@ -1215,7 +1215,7 @@ fn cmd_git_submodule_print_gitmodules(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
-    let commit = workspace_command.resolve_single_rev(&args.revisions, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revisions)?;
     let tree = commit.tree()?;
     let gitmodules_path = RepoPath::from_internal_string(".gitmodules");
     let mut gitmodules_file = match tree.path_value(gitmodules_path).into_resolved() {

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -48,8 +48,8 @@ pub(crate) fn cmd_interdiff(
     args: &InterdiffArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let from = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"), ui)?;
-    let to = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"), ui)?;
+    let from = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"))?;
+    let to = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;
 
     let from_tree = rebase_to_dest_parent(workspace_command.repo().as_ref(), &from, &to)?;
     let to_tree = to.tree()?;

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -70,12 +70,12 @@ pub(crate) fn cmd_log(
 
     let revset_expression = {
         let mut expression = if args.revisions.is_empty() {
-            workspace_command.parse_revset(&command.settings().default_revset(), Some(ui))?
+            workspace_command.parse_revset(&command.settings().default_revset())?
         } else {
             let expressions: Vec<_> = args
                 .revisions
                 .iter()
-                .map(|revision_str| workspace_command.parse_revset(revision_str, Some(ui)))
+                .map(|revision_str| workspace_command.parse_revset(revision_str))
                 .try_collect()?;
             RevsetExpression::union_all(&expressions)
         };

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -58,9 +58,9 @@ pub(crate) fn cmd_move(
     args: &MoveArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let source = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"), ui)?;
+    let source = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"))?;
     let mut destination =
-        workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"), ui)?;
+        workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;
     if source.id() == destination.id() {
         return Err(user_error("Source and destination cannot be the same."));
     }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -98,7 +98,7 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
         !args.revisions.is_empty(),
         "expected a non-empty list from clap"
     );
-    let target_commits = cli_util::resolve_all_revs(&workspace_command, ui, &args.revisions)?
+    let target_commits = cli_util::resolve_all_revs(&workspace_command, &args.revisions)?
         .into_iter()
         .collect_vec();
     let target_ids = target_commits.iter().map(|c| c.id().clone()).collect_vec();

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -63,7 +63,7 @@ pub(crate) fn cmd_obslog(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
 
-    let start_commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let start_commit = workspace_command.resolve_single_rev(&args.revision)?;
     let wc_commit_id = workspace_command.get_wc_commit_id();
 
     let diff_formats =

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -186,7 +186,7 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
         },
     };
     let mut workspace_command = command.workspace_helper(ui)?;
-    let new_parents = cli_util::resolve_all_revs(&workspace_command, ui, &args.destination)?
+    let new_parents = cli_util::resolve_all_revs(&workspace_command, &args.destination)?
         .into_iter()
         .collect_vec();
     if let Some(rev_str) = &args.revision {
@@ -214,7 +214,7 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
         )?;
     } else if !args.source.is_empty() {
         let source_commits =
-            resolve_multiple_nonempty_revsets_default_single(&workspace_command, ui, &args.source)?;
+            resolve_multiple_nonempty_revsets_default_single(&workspace_command, &args.source)?;
         rebase_descendants(
             ui,
             command.settings(),
@@ -225,9 +225,9 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
         )?;
     } else {
         let branch_commits = if args.branch.is_empty() {
-            IndexSet::from([workspace_command.resolve_single_rev("@", ui)?])
+            IndexSet::from([workspace_command.resolve_single_rev("@")?])
         } else {
-            resolve_multiple_nonempty_revsets_default_single(&workspace_command, ui, &args.branch)?
+            resolve_multiple_nonempty_revsets_default_single(&workspace_command, &args.branch)?
         };
         rebase_branch(
             ui,
@@ -323,7 +323,7 @@ fn rebase_revision(
     new_parents: &[Commit],
     rev_str: &str,
 ) -> Result<(), CommandError> {
-    let old_commit = workspace_command.resolve_single_rev(rev_str, ui)?;
+    let old_commit = workspace_command.resolve_single_rev(rev_str)?;
     workspace_command.check_rewritable([&old_commit])?;
     if new_parents.contains(&old_commit) {
         return Err(user_error(format!(

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -70,7 +70,7 @@ pub(crate) fn cmd_resolve(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let tree = commit.tree()?;
     let conflicts = tree
         .conflicts()

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -85,13 +85,13 @@ pub(crate) fn cmd_restore(
         ));
     }
     if args.from.is_some() || args.to.is_some() {
-        to_commit = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"), ui)?;
+        to_commit = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;
         from_tree = workspace_command
-            .resolve_single_rev(args.from.as_deref().unwrap_or("@"), ui)?
+            .resolve_single_rev(args.from.as_deref().unwrap_or("@"))?
             .tree()?;
     } else {
         to_commit =
-            workspace_command.resolve_single_rev(args.changes_in.as_deref().unwrap_or("@"), ui)?;
+            workspace_command.resolve_single_rev(args.changes_in.as_deref().unwrap_or("@"))?;
         from_tree = merge_commit_trees(workspace_command.repo().as_ref(), &to_commit.parents())?;
     }
     workspace_command.check_rewritable([&to_commit])?;

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -49,8 +49,7 @@ pub struct RunArgs {
 
 pub fn cmd_run(ui: &mut Ui, command: &CommandHelper, args: &RunArgs) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let _resolved_commits =
-        resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command, ui)?;
+    let _resolved_commits = resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command)?;
     // Jobs are resolved in this order:
     // 1. Commandline argument iff > 0.
     // 2. the amount of cores available.

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -44,7 +44,7 @@ pub(crate) fn cmd_show(
     args: &ShowArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     let template_string = match &args.template {
         Some(value) => value.to_string(),
         None => command.settings().config().get_string("templates.show")?,

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -55,7 +55,7 @@ pub(crate) fn cmd_split(
     args: &SplitArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewritable([&commit])?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -54,7 +54,7 @@ pub(crate) fn cmd_squash(
     args: &SquashArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewritable([&commit])?;
     let parents = commit.parents();
     if parents.len() != 1 {

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -50,7 +50,7 @@ pub(crate) fn cmd_unsquash(
     args: &UnsquashArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision, ui)?;
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
     workspace_command.check_rewritable([&commit])?;
     let parents = commit.parents();
     if parents.len() != 1 {

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -185,7 +185,7 @@ fn cmd_workspace_add(
             vec![tx.repo().store().root_commit()]
         }
     } else {
-        cli_util::resolve_all_revs(&old_workspace_command, ui, &args.revision)?
+        cli_util::resolve_all_revs(&old_workspace_command, &args.revision)?
             .into_iter()
             .collect_vec()
     };

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -29,53 +29,6 @@ fn test_log_with_empty_revision() {
 }
 
 #[test]
-fn test_log_legacy_range_operator() {
-    let test_env = TestEnvironment::default();
-    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
-    let repo_path = test_env.env_root().join("repo");
-
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r=@:"]);
-    insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
-    │  (empty) (no description set)
-    ~
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    The `:` revset operator is deprecated. Please switch to `::`.
-    "###);
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r=:@"]);
-    insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
-    │  (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    The `:` revset operator is deprecated. Please switch to `::`.
-    "###);
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r=root():@"]);
-    insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
-    │  (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    The `:` revset operator is deprecated. Please switch to `::`.
-    "###);
-    let (stdout, stderr) = test_env.jj_cmd_ok(
-        &repo_path,
-        &["log", "-r=x", "--config-toml", "revset-aliases.x = '@:'"],
-    );
-    insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
-    │  (empty) (no description set)
-    ~
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    The `:` revset operator is deprecated. Please switch to `::`.
-    "###);
-}
-
-#[test]
 fn test_log_with_or_without_diff() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -420,7 +420,7 @@ fn test_log_shortest_accessors() {
     "###);
 
     // Can get shorter prefixes in configured revset
-    test_env.add_config(r#"revsets.short-prefixes = "(@----):""#);
+    test_env.add_config(r#"revsets.short-prefixes = "(@----)::""#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
         @r###"

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -20,6 +20,17 @@ fn test_syntax_error() {
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
 
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", ":x"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset:  --> 1:1
+      |
+    1 | :x
+      | ^
+      |
+      = ':' is not a prefix operator
+    Hint: Did you mean '::' for ancestors?
+    "###);
+
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "x &"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Failed to parse revset:  --> 1:4

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -59,8 +59,6 @@ only symbols.
 * `x::y`: Descendants of `x` that are also ancestors of `y`. Equivalent
    to `x:: & ::y`. This is what `git log` calls `--ancestry-path x..y`.
 * `::`: All visible commits in the repo. Equivalent to `all()`.
-* `:x`, `x:`, and `x:y`: Deprecated versions of `::x`, `x::`, and `x::y` We
-  plan to delete them in jj 0.15+.
 * `x..y`: Ancestors of `y` that are not also ancestors of `x`. Equivalent to
   `::y ~ ::x`. This is what `git log` calls `x..y` (i.e. the same as we call it).
 * `..x`: Ancestors of `x`, including the commits in `x` itself, but excluding

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -25,6 +25,7 @@ literal_string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 at_op = { "@" }
+pattern_kind_op = { ":" }
 
 parents_op = { "-" }
 children_op = { "+" }
@@ -66,9 +67,13 @@ formal_parameters = {
   | ""
 }
 
+// TODO: change rhs to literal_string to require quoting? #2101
+string_pattern = { identifier ~ pattern_kind_op ~ symbol }
+
 primary = {
   function_name ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")"
   | "(" ~ whitespace* ~ expression ~ whitespace* ~ ")"
+  | string_pattern
   // "@" operator cannot be nested
   | symbol ~ at_op ~ symbol
   | symbol ~ at_op

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -34,17 +34,16 @@ dag_range_op = { "::" }
 dag_range_pre_op = { "::" }
 dag_range_post_op = { "::" }
 dag_range_all_op = { "::" }
-// TODO: Drop support for these in 0.15+
-legacy_dag_range_op = { ":" }
-legacy_dag_range_pre_op = { ":" }
-legacy_dag_range_post_op = { ":" }
+compat_dag_range_op = { ":" }
+compat_dag_range_pre_op = { ":" }
+compat_dag_range_post_op = { ":" }
 range_op = { ".." }
 range_pre_op = { ".." }
 range_post_op = { ".." }
 range_all_op = { ".." }
-range_ops = _{ dag_range_op | legacy_dag_range_op | range_op }
-range_pre_ops = _{ dag_range_pre_op | legacy_dag_range_pre_op | range_pre_op }
-range_post_ops = _{ dag_range_post_op | legacy_dag_range_post_op | range_post_op }
+range_ops = _{ dag_range_op | compat_dag_range_op | range_op }
+range_pre_ops = _{ dag_range_pre_op | compat_dag_range_pre_op | range_pre_op }
+range_post_ops = _{ dag_range_post_op | compat_dag_range_post_op | range_post_op }
 range_all_ops = _{ dag_range_all_op | range_all_op }
 
 negate_op = { "~" }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1160,14 +1160,14 @@ fn test_evaluate_expression_ancestors() {
 
     // The ancestors of the root commit is just the root commit itself
     assert_eq!(
-        resolve_commit_ids(mut_repo, ":root()"),
+        resolve_commit_ids(mut_repo, "::root()"),
         vec![root_commit.id().clone()]
     );
 
     // Can find ancestors of a specific commit. Commits reachable via multiple paths
     // are not repeated.
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!(":{}", commit4.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("::{}", commit4.id().hex())),
         vec![
             commit4.id().clone(),
             commit3.id().clone(),
@@ -1180,7 +1180,7 @@ fn test_evaluate_expression_ancestors() {
     // Can find ancestors of parents or parents of ancestors, which may be optimized
     // to single query
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!(":({}-)", commit4.id().hex()),),
+        resolve_commit_ids(mut_repo, &format!("::({}-)", commit4.id().hex()),),
         vec![
             commit3.id().clone(),
             commit2.id().clone(),
@@ -1191,7 +1191,7 @@ fn test_evaluate_expression_ancestors() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("(:({}|{}))-", commit3.id().hex(), commit2.id().hex()),
+            &format!("(::({}|{}))-", commit3.id().hex(), commit2.id().hex()),
         ),
         vec![
             commit2.id().clone(),
@@ -1202,7 +1202,7 @@ fn test_evaluate_expression_ancestors() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!(":(({}|{})-)", commit3.id().hex(), commit2.id().hex()),
+            &format!("::(({}|{})-)", commit3.id().hex(), commit2.id().hex()),
         ),
         vec![
             commit2.id().clone(),
@@ -1329,7 +1329,7 @@ fn test_evaluate_expression_dag_range() {
 
     // Can get DAG range of just the root commit
     assert_eq!(
-        resolve_commit_ids(mut_repo, "root():root()"),
+        resolve_commit_ids(mut_repo, "root()::root()"),
         vec![root_commit_id.clone()]
     );
 
@@ -1337,7 +1337,7 @@ fn test_evaluate_expression_dag_range() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("{}:{}", root_commit_id.hex(), commit2.id().hex())
+            &format!("{}::{}", root_commit_id.hex(), commit2.id().hex())
         ),
         vec![
             commit2.id().clone(),
@@ -1350,14 +1350,14 @@ fn test_evaluate_expression_dag_range() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("{}:{}", commit2.id().hex(), commit4.id().hex())
+            &format!("{}::{}", commit2.id().hex(), commit4.id().hex())
         ),
         vec![]
     );
 
     // Empty root
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!("none():{}", commit5.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("none()::{}", commit5.id().hex())),
         vec![],
     );
 
@@ -1366,7 +1366,7 @@ fn test_evaluate_expression_dag_range() {
         resolve_commit_ids(
             mut_repo,
             &format!(
-                "({}|{}):{}",
+                "({}|{})::{}",
                 commit1.id().hex(),
                 commit2.id().hex(),
                 commit3.id().hex()
@@ -1383,7 +1383,7 @@ fn test_evaluate_expression_dag_range() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("{}:{}", commit1.id().hex(), commit5.id().hex())
+            &format!("{}::{}", commit1.id().hex(), commit5.id().hex())
         ),
         vec![
             commit5.id().clone(),
@@ -1398,7 +1398,7 @@ fn test_evaluate_expression_dag_range() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("{}:{}", commit2.id().hex(), commit5.id().hex())
+            &format!("{}::{}", commit2.id().hex(), commit5.id().hex())
         ),
         vec![
             commit5.id().clone(),
@@ -1531,7 +1531,7 @@ fn test_evaluate_expression_descendants() {
 
     // The descendants of the root commit are all the commits in the repo
     assert_eq!(
-        resolve_commit_ids(mut_repo, "root():"),
+        resolve_commit_ids(mut_repo, "root()::"),
         vec![
             commit6.id().clone(),
             commit5.id().clone(),
@@ -1545,7 +1545,7 @@ fn test_evaluate_expression_descendants() {
 
     // Can find descendants of a specific commit
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!("{}:", commit2.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("{}::", commit2.id().hex())),
         vec![
             commit6.id().clone(),
             commit5.id().clone(),
@@ -1557,7 +1557,7 @@ fn test_evaluate_expression_descendants() {
     // Can find descendants of children or children of descendants, which may be
     // optimized to single query
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!("({}+):", commit1.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("({}+)::", commit1.id().hex())),
         vec![
             commit6.id().clone(),
             commit5.id().clone(),
@@ -1567,7 +1567,7 @@ fn test_evaluate_expression_descendants() {
         ]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!("({}++):", commit1.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("({}++)::", commit1.id().hex())),
         vec![
             commit6.id().clone(),
             commit5.id().clone(),
@@ -1577,7 +1577,7 @@ fn test_evaluate_expression_descendants() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("(({}|{}):)+", commit4.id().hex(), commit2.id().hex()),
+            &format!("(({}|{})::)+", commit4.id().hex(), commit2.id().hex()),
         ),
         vec![
             commit6.id().clone(),
@@ -1588,7 +1588,7 @@ fn test_evaluate_expression_descendants() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("(({}|{})+):", commit4.id().hex(), commit2.id().hex()),
+            &format!("(({}|{})+)::", commit4.id().hex(), commit2.id().hex()),
         ),
         vec![
             commit6.id().clone(),
@@ -2052,7 +2052,7 @@ fn test_evaluate_expression_merges() {
     );
     // Searches only among candidates if specified
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!(":{} & merges()", commit5.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("::{} & merges()", commit5.id().hex())),
         vec![commit5.id().clone()]
     );
 }
@@ -2328,7 +2328,7 @@ fn test_evaluate_expression_union() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!(":{} | :{}", commit4.id().hex(), commit5.id().hex())
+            &format!("::{} | ::{}", commit4.id().hex(), commit5.id().hex())
         ),
         vec![
             commit5.id().clone(),
@@ -2345,7 +2345,7 @@ fn test_evaluate_expression_union() {
         resolve_commit_ids(
             mut_repo,
             &format!(
-                "(:{} ~ :{}) | :{}",
+                "(::{} ~ ::{}) | ::{}",
                 commit4.id().hex(),
                 commit2.id().hex(),
                 commit5.id().hex()
@@ -2366,7 +2366,7 @@ fn test_evaluate_expression_union() {
         resolve_commit_ids(
             mut_repo,
             &format!(
-                "(:{} ~ :{}) | {}",
+                "(::{} ~ ::{}) | {}",
                 commit4.id().hex(),
                 commit2.id().hex(),
                 commit5.id().hex(),
@@ -2400,7 +2400,7 @@ fn test_evaluate_expression_intersection() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!(":{} & :{}", commit4.id().hex(), commit5.id().hex())
+            &format!("::{} & ::{}", commit4.id().hex(), commit5.id().hex())
         ),
         vec![
             commit2.id().clone(),
@@ -2437,7 +2437,7 @@ fn test_evaluate_expression_difference() {
 
     // Difference from all
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!("~:{}", commit5.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("~::{}", commit5.id().hex())),
         vec![commit4.id().clone(), commit3.id().clone()]
     );
 
@@ -2445,28 +2445,28 @@ fn test_evaluate_expression_difference() {
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!(":{} ~ :{}", commit4.id().hex(), commit5.id().hex())
+            &format!("::{} ~ ::{}", commit4.id().hex(), commit5.id().hex())
         ),
         vec![commit4.id().clone(), commit3.id().clone()]
     );
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!(":{} ~ :{}", commit5.id().hex(), commit4.id().hex())
+            &format!("::{} ~ ::{}", commit5.id().hex(), commit4.id().hex())
         ),
         vec![commit5.id().clone()]
     );
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!("~:{} & :{}", commit4.id().hex(), commit5.id().hex())
+            &format!("~::{} & ::{}", commit4.id().hex(), commit5.id().hex())
         ),
         vec![commit5.id().clone()]
     );
     assert_eq!(
         resolve_commit_ids(
             mut_repo,
-            &format!(":{} ~ :{}", commit4.id().hex(), commit2.id().hex())
+            &format!("::{} ~ ::{}", commit4.id().hex(), commit2.id().hex())
         ),
         vec![commit4.id().clone(), commit3.id().clone()]
     );
@@ -2476,7 +2476,7 @@ fn test_evaluate_expression_difference() {
         resolve_commit_ids(
             mut_repo,
             &format!(
-                ":{} ~ {} ~ {}",
+                "::{} ~ {} ~ {}",
                 commit4.id().hex(),
                 commit2.id().hex(),
                 commit3.id().hex()
@@ -2494,7 +2494,7 @@ fn test_evaluate_expression_difference() {
         resolve_commit_ids(
             mut_repo,
             &format!(
-                "(:{} ~ :{}) ~ (:{} ~ :{})",
+                "(::{} ~ ::{}) ~ (::{} ~ ::{})",
                 commit4.id().hex(),
                 commit1.id().hex(),
                 commit3.id().hex(),
@@ -2662,7 +2662,7 @@ fn test_evaluate_expression_file() {
     assert_eq!(
         resolve_commit_ids_in_workspace(
             mut_repo,
-            &format!(r#"{}: & file("added_modified_clean")"#, commit2.id().hex()),
+            &format!(r#"{}:: & file("added_modified_clean")"#, commit2.id().hex()),
             &test_workspace.workspace,
             Some(test_workspace.workspace.workspace_root()),
         ),
@@ -2671,7 +2671,7 @@ fn test_evaluate_expression_file() {
 
     // empty() revset, which is identical to ~file(".")
     assert_eq!(
-        resolve_commit_ids(mut_repo, &format!("{}: & empty()", commit1.id().hex())),
+        resolve_commit_ids(mut_repo, &format!("{}:: & empty()", commit1.id().hex())),
         vec![commit4.id().clone()]
     );
 }


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
