### PR TITLE
chore: replace all copyright comments with SPDX file tags

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 use std::process::Command;

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
 use std::io::Read;

--- a/cli/examples/custom-command/main.rs
+++ b/cli/examples/custom-command/main.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write as _;
 

--- a/cli/examples/custom-global-flag/main.rs
+++ b/cli/examples/custom-global-flag/main.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write as _;
 

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
 use std::path::{Path, PathBuf};

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use core::fmt;
 use std::collections::{HashMap, HashSet};

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/backout.rs
+++ b/cli/src/commands/backout.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::object_id::ObjectId;
 use jj_lib::rewrite::back_out_commit;

--- a/cli/src/commands/bench.rs
+++ b/cli/src/commands/bench.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;
 use std::io;

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
 use std::fmt;

--- a/cli/src/commands/cat.rs
+++ b/cli/src/commands/cat.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/checkout.rs
+++ b/cli/src/commands/checkout.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;

--- a/cli/src/commands/chmod.rs
+++ b/cli/src/commands/chmod.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::backend::TreeValue;

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
 use std::fmt::Debug;

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::{self, Read, Write};
 

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/files.rs
+++ b/cli/src/commands/files.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
 use std::io::Write;

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use clap::ArgGroup;
 use jj_lib::rewrite::rebase_to_dest_parent;

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::backend::CommitId;

--- a/cli/src/commands/merge.rs
+++ b/cli/src/commands/merge.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use tracing::instrument;
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 mod abandon;
 mod backout;

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use clap::ArgGroup;
 use jj_lib::object_id::ObjectId;

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::commit::Commit;
 use jj_lib::dag_walk::topo_order_reverse;

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write as _;
 use std::slice;

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::repo::Repo;

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::io::Write;

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
 use std::io::Write;

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/root.rs
+++ b/cli/src/commands/root.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use tracing::instrument;
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! This file contains the internal implementation of `run`.
 

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::matchers::EverythingMatcher;
 use tracing::instrument;

--- a/cli/src/commands/sparse.rs
+++ b/cli/src/commands/sparse.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
 use std::fmt::Write as _;

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -1,16 +1,6 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::io::Write;
 
 use jj_lib::object_id::ObjectId;

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use clap::parser::ValueSource;
 use jj_lib::object_id::ObjectId;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::matchers::EverythingMatcher;

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::str_util::StringPattern;
 

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::object_id::ObjectId;

--- a/cli/src/commands/untrack.rs
+++ b/cli/src/commands/untrack.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/util.rs
+++ b/cli/src/commands/util.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 use std::slice;

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;
 use std::fs;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::max;
 use std::collections::HashMap;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::max;
 use std::collections::VecDeque;

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::BorrowMut;
 use std::collections::HashMap;

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Git utilities shared by various commands.
 

--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::hash::Hash;
 use std::io;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![deny(unused_must_use)]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_cli::cli_util::CliRunner;
 

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 mod builtin;
 mod external;

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io;
 

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// 
-// https://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Example:
 // "commit: " ++ short(commit_id) ++ "\n"

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::num::ParseIntError;

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
 use std::io;

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2022-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
 use std::{cmp, io};

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::{IsTerminal as _, Stderr, StderrLock, Stdout, StdoutLock, Write};
 use std::process::{Child, ChildStdin, Stdio};

--- a/cli/testing/fake-diff-editor.rs
+++ b/cli/testing/fake-diff-editor.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};

--- a/cli/testing/fake-editor.rs
+++ b/cli/testing/fake-editor.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
 use std::process::exit;

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fs;
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
 

--- a/cli/tests/test_cat_command.rs
+++ b/cli/tests/test_cat_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_checkout.rs
+++ b/cli/tests/test_checkout.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_chmod_command.rs
+++ b/cli/tests/test_chmod_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;
 

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use insta::assert_snapshot;
 use itertools::Itertools;

--- a/cli/tests/test_debug_command.rs
+++ b/cli/tests/test_debug_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use insta::assert_snapshot;
 use regex::Regex;

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{get_stderr_string, TestEnvironment};
 

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{escaped_fake_diff_editor_path, TestEnvironment};
 

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_generate_md_cli_help.rs
+++ b/cli/tests/test_generate_md_cli_help.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use insta::assert_snapshot;
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::{self, Path, PathBuf};
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1,16 +1,6 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::common::TestEnvironment;

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -1,16 +1,6 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use itertools::Itertools as _;

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
 

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fs;
 

--- a/cli/tests/test_git_submodule.rs
+++ b/cli/tests/test_git_submodule.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::ffi::OsString;
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::{Path, PathBuf};
 

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{get_stdout_string, TestEnvironment};
 

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -1,17 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{get_stderr_string, get_stdout_string, TestEnvironment};
 

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{get_stdout_string, TestEnvironment};
 

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_shell_completion.rs
+++ b/cli/tests/test_shell_completion.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use insta::assert_snapshot;
 

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use regex::Regex;

--- a/cli/tests/test_sparse_command.rs
+++ b/cli/tests/test_sparse_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_tree_level_conflicts.rs
+++ b/cli/tests/test_tree_level_conflicts.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -1,16 +1,6 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use crate::common::TestEnvironment;

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/cli/tests/test_untrack_command.rs
+++ b/cli/tests/test_untrack_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
 

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use insta::assert_snapshot;
 

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::common::TestEnvironment;
 

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Result;
 use std::path::Path;

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/dag_walk.rs
+++ b/lib/src/dag_walk.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! General-purpose DAG algorithms.
 

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/entry.rs
+++ b/lib/src/default_index/entry.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/rev_walk.rs
+++ b/lib/src/default_index/rev_walk.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/default_submodule_store.rs
+++ b/lib/src/default_submodule_store.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/fmt_util.rs
+++ b/lib/src/fmt_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Common formatting helpers
 

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Interfaces with a filesystem monitor tool to efficiently query for
 //! filesystem updates, without having to crawl the entire working copy. This is

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/hex_util.rs
+++ b/lib/src/hex_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Jujutsu version control system.
 

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/lock.rs
+++ b/lib/src/lock.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/lock/fallback.rs
+++ b/lib/src/lock/fallback.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;

--- a/lib/src/lock/unix.rs
+++ b/lib/src/lock/unix.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(dead_code, missing_docs)]
 

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Generic algorithms for working with merged values, plus specializations for
 //! some common types of merged values.

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! A lazily merged view of a set of trees.
 

--- a/lib/src/object_id.rs
+++ b/lib/src/object_id.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -1,16 +1,5 @@
-// Copyright 2020-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Utility for operation id resolution and traversal.
 

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/protos/git_store.proto
+++ b/lib/src/protos/git_store.proto
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
 

--- a/lib/src/protos/local_store.proto
+++ b/lib/src/protos/local_store.proto
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
 

--- a/lib/src/protos/op_store.proto
+++ b/lib/src/protos/op_store.proto
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
 

--- a/lib/src/protos/working_copy.proto
+++ b/lib/src/protos/working_copy.proto
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto3";
 

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// 
-// https://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
 identifier = @{

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/revset_graph.rs
+++ b/lib/src/revset_graph.rs
@@ -1,16 +1,5 @@
-// Copyright 2021-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Generic APIs to work with cryptographic signatures created and verified by
 //! various backends.

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -1,16 +1,5 @@
-// Copyright 2021-2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! A persistent table of fixed-size keys to variable-size values. The keys are
 //! stored in sorted order, with each key followed by an integer offset into the

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/str_util.rs
+++ b/lib/src/str_util.rs
@@ -1,16 +1,5 @@
-// Copyright 2021-2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! String helpers.
 

--- a/lib/src/submodule_store.rs
+++ b/lib/src/submodule_store.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/tree_builder.rs
+++ b/lib/src/tree_builder.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 //! Defines the interface for the working copy. See `LocalWorkingCopy` for the
 //! default local-disk implementation.

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(missing_docs)]
 

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::backend::{ChangeId, MillisSinceEpoch, Signature, Timestamp};
 use jj_lib::matchers::EverythingMatcher;

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::max;
 use std::sync::Arc;

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::backend::FileId;
 use jj_lib::conflicts::{

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::commit::Commit;

--- a/lib/tests/test_diff_summary.rs
+++ b/lib/tests/test_diff_summary.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::matchers::{EverythingMatcher, FilesMatcher};
 use jj_lib::merged_tree::DiffSummary;

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -1,16 +1,5 @@
-// Copyright 2024 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
 use std::process::Command;

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::backend::{CommitId, MillisSinceEpoch, Signature, Timestamp};

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fs;
 use std::sync::Arc;

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::{Path, PathBuf};
 

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::repo::RepoLoader;
 use testutils::{write_random_commit, TestRepo};

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/lib/tests/test_local_working_copy_concurrent.rs
+++ b/lib/tests/test_local_working_copy_concurrent.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::max;
 use std::thread;

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -1,16 +1,5 @@
-// Copyright 2022 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::local_working_copy::LocalWorkingCopy;

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
 use jj_lib::backend::TreeValue;

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use futures::executor::block_on;
 use futures::StreamExt;

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::backend::CommitId;
 use jj_lib::op_store::{RefTarget, RemoteRef, RemoteRefState, WorkspaceId};

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 use std::slice;

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use jj_lib::merge::Merge;
 use jj_lib::op_store::RefTarget;

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
 

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools as _;
 use jj_lib::commit::Commit;

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
 

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
 use jj_lib::op_store::WorkspaceId;

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -1,16 +1,5 @@
-// Copyright 2020 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::env;

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -1,16 +1,5 @@
-// Copyright 2023 The Jujutsu Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: © 2020-2024 The Jujutsu Authors
+// SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
 use std::collections::HashMap;


### PR DESCRIPTION
SPDX identifiers are ubiquitous, shorter, easy to remember, and easier to copy/paste. Let's get rid of the old copyright comments and save some precious bytes.

This also replaces all copyright notice years with the proper the range `2020-2024`, since some of them were out of date.