### PR TITLE
cli: list new remote branches during git fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When creating a new workspace, the sparse patterns are now copied over from
   the current workspace.
 
+* `jj git fetch` now automatically prints new remote branches and tags by default.
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now materialized as regular files in the

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -953,7 +953,7 @@ impl WorkspaceCommandHelper {
             return Ok(());
         }
 
-        print_git_import_stats(ui, &stats)?;
+        print_git_import_stats(ui, tx.repo(), &stats, false)?;
         let mut tx = tx.into_inner();
         // Rebase here to show slightly different status message.
         let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -447,7 +447,7 @@ fn init_git_refs(
     if !tx.mut_repo().has_changes() {
         return Ok(repo);
     }
-    print_git_import_stats(ui, &stats)?;
+    print_git_import_stats(ui, tx.repo(), &stats, false)?;
     if colocated {
         // If git.auto-local-branch = true, local branches could be created for
         // the imported remote branches.
@@ -537,7 +537,7 @@ fn cmd_git_fetch(
             GitFetchError::InternalGitError(err) => map_git_error(err),
             _ => user_error(err),
         })?;
-        print_git_import_stats(ui, &stats.import_stats)?;
+        print_git_import_stats(ui, tx.repo(), &stats.import_stats, true)?;
     }
     tx.finish(
         ui,
@@ -751,7 +751,7 @@ fn do_git_clone(
             unreachable!("we didn't provide any globs")
         }
     })?;
-    print_git_import_stats(ui, &stats.import_stats)?;
+    print_git_import_stats(ui, fetch_tx.repo(), &stats.import_stats, true)?;
     fetch_tx.finish(ui, "fetch from git remote into empty repo")?;
     Ok((workspace_command, stats))
 }
@@ -1190,7 +1190,7 @@ fn cmd_git_import(
     // That's why cmd_git_export() doesn't export the HEAD ref.
     git::import_head(tx.mut_repo())?;
     let stats = git::import_refs(tx.mut_repo(), &command.settings().git_settings())?;
-    print_git_import_stats(ui, &stats)?;
+    print_git_import_stats(ui, tx.repo(), &stats, true)?;
     tx.finish(ui, "import git refs")?;
     Ok(())
 }

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -536,7 +536,9 @@ fn test_branch_forget_fetched_branch() {
     // We can fetch feature1 again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
@@ -548,7 +550,9 @@ fn test_branch_forget_fetched_branch() {
     // Fetch works even without the export-import
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
@@ -574,7 +578,9 @@ fn test_branch_forget_fetched_branch() {
     // Fetching a moved branch does not create a conflict
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: ooosovrs 38aefb17 (empty) another message
       @origin: ooosovrs 38aefb17 (empty) another message
@@ -687,7 +693,12 @@ fn test_branch_track_untrack() {
     );
     test_env.add_config("git.auto-local-branch = false");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [new] untracked
+    branch: feature2@origin [new] untracked
+    branch: main@origin     [new] untracked
+
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1@origin: sptzoqmo 7b33f629 commit 1
     feature2@origin: sptzoqmo 7b33f629 commit 1
@@ -759,7 +770,12 @@ fn test_branch_track_untrack() {
         ],
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [updated] untracked
+    branch: feature2@origin [updated] untracked
+    branch: main@origin     [updated] tracked
+
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: sptzoqmo 7b33f629 commit 1
     feature1@origin: mmqqkyyt 40dabdaf commit 2
@@ -791,6 +807,10 @@ fn test_branch_track_untrack() {
     test_env.add_config("git.auto-local-branch = true");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [updated] untracked
+    branch: feature2@origin [updated] untracked
+    branch: feature3@origin [new] tracked
+    branch: main@origin     [updated] tracked
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
@@ -847,7 +867,11 @@ fn test_branch_track_untrack_patterns() {
     // Fetch new commit without auto tracking
     test_env.add_config("git.auto-local-branch = false");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: feature1@origin [new] untracked
+    branch: feature2@origin [new] untracked
+
+    "###);
 
     // Track local branch
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "main"]);

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -63,6 +63,7 @@ fn test_git_clone() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
+    branch: main@origin [new] tracked
     Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
@@ -173,6 +174,7 @@ fn test_git_clone_colocate() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/clone"
+    branch: main@origin [new] tracked
     Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
@@ -328,6 +330,8 @@ fn test_git_clone_remote_default_branch() {
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "clone1"]);
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/clone1"
+    branch: feature1@origin [new] tracked
+    branch: main@origin     [new] tracked
     Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 feature1 main | message
     Added 1 files, modified 0 files, removed 0 files
@@ -346,6 +350,8 @@ fn test_git_clone_remote_default_branch() {
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "clone2"]);
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/clone2"
+    branch: feature1@origin [new] untracked
+    branch: main@origin     [new] untracked
     Working copy now at: pmmvwywv fa729b1e (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 feature1@origin main | message
     Added 1 files, modified 0 files, removed 0 files

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -507,6 +507,8 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    branch: B_to_delete@origin [deleted] untracked
+    branch: C_to_move@origin   [updated] tracked
     Abandoned 2 commits that are no longer reachable.
     "###);
     // "original C" and "B_to_delete" are abandoned, as the corresponding branches

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -148,7 +148,9 @@ fn test_git_import_undo() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: a [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
@@ -162,7 +164,9 @@ fn test_git_import_undo() {
     // Try "git import" again, which should re-import the branch "a".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: a [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
@@ -191,7 +195,9 @@ fn test_git_import_move_export_with_default_undo() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: a [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
@@ -237,7 +243,9 @@ fn test_git_import_move_export_with_default_undo() {
     // intuitive result here.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    branch: a [new] tracked
+    "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git: yqosqzyt 096dc80d (empty) (no description set)


### PR DESCRIPTION
Adds imported branches list for git fetch.
```
jj git fetch
From origin
* [new untracked branch]  test2
 ```
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
