### PR TITLE
index: fix change id resolution test to not depend on deterministic order

### DIFF
--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -127,6 +127,8 @@ pub trait MutableIndex {
 
 pub trait ChangeIdIndex: Send + Sync {
     /// Resolve an unambiguous change ID prefix to the commit IDs in the index.
+    ///
+    /// The order of the returned commit IDs is unspecified.
     fn resolve_prefix(&self, prefix: &HexPrefix) -> PrefixResolution<Vec<CommitId>>;
 
     /// This function returns the shortest length of a prefix of `key` that


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
