### PR TITLE
Compile insta and similar in opt mode for faster testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,12 @@ zstd = "0.12.4"
 jj-lib = { path = "lib", version = "0.14.0" }
 testutils = { path = "lib/testutils" }
 
+# Insta suggests compiling these packages in opt mode for faster testing.
+# See https://docs.rs/insta/latest/insta/#optional-faster-runs.
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3
+
 [profile.release]
 strip = "debuginfo"
 codegen-units = 1


### PR DESCRIPTION
This is recommended by the insta documentation.
See: https://docs.rs/insta/latest/insta/#optional-faster-runs.

Running on an M1 MacBook Pro

Before:
```
________________________________________________________
Executed in   31.10 secs    fish           external
   usr time  118.87 secs  107.00 micros  118.87 secs
   sys time   46.19 secs  847.00 micros   46.19 secs
```

After:
```
________________________________________________________
Executed in   29.73 secs    fish           external
   usr time  119.58 secs    0.13 millis  119.58 secs
   sys time   46.27 secs    1.74 millis   46.27 secs
```

This doesn't seem like a huge change, and there's noise in the measurements, but I don't think it can hurt and insta recommends it.