### PR TITLE
Implement ContentHash for u32 and u64

### DIFF
--- a/lib/src/content_hash.rs
+++ b/lib/src/content_hash.rs
@@ -39,7 +39,19 @@ impl ContentHash for u8 {
     }
 }
 
+impl ContentHash for u32 {
+    fn hash(&self, state: &mut impl digest::Update) {
+        state.update(&self.to_le_bytes());
+    }
+}
+
 impl ContentHash for i32 {
+    fn hash(&self, state: &mut impl digest::Update) {
+        state.update(&self.to_le_bytes());
+    }
+}
+
+impl ContentHash for u64 {
     fn hash(&self, state: &mut impl digest::Update) {
         state.update(&self.to_le_bytes());
     }


### PR DESCRIPTION
This is for completeness and to avoid accidents such as someone calling `ContentHash::hash(1234u32.to_le_bytes())` and expecting it to hash properly as a u32 instead of a 4 byte slice, which produces a different hash due to hashing the length of the slice before its contents.