### PR TITLE
op_store: remove unneeded repr(u8) from RemoteRefState

### DIFF
--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -203,7 +203,6 @@ impl RemoteRef {
 
 /// Whether the ref is tracked or not.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[repr(u8)]
 pub enum RemoteRefState {
     /// Remote ref is not merged in to the local ref.
     New,


### PR DESCRIPTION
It no longer makes sense after e1fd402d3948 "Fix the ContentHash implementations for std::Option, MergedTreeId, and RemoteRefState."


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
