### PR TITLE
working_copy: add Send supertrait

### DIFF
--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -32,7 +32,7 @@ use crate::settings::HumanByteSize;
 use crate::store::Store;
 
 /// The trait all working-copy implementations must implement.
-pub trait WorkingCopy {
+pub trait WorkingCopy: Send {
     /// Should return `self`. For down-casting purposes.
     fn as_any(&self) -> &dyn Any;
 


### PR DESCRIPTION
If we make WorkingCopy Send, then Workspace will be Send, which is useful for long-running servers. All existing impls are Send already, so this is just a marker.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
