### PR TITLE
graphlog: refactor graphlog::Edge enum and its usage

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -140,23 +140,14 @@ pub(crate) fn cmd_log(
                             has_missing = true;
                         }
                         RevsetGraphEdgeType::Direct => {
-                            graphlog_edges.push(Edge::Present {
-                                direct: true,
-                                target: (edge.target, false),
-                            });
+                            graphlog_edges.push(Edge::Direct((edge.target, false)));
                         }
                         RevsetGraphEdgeType::Indirect => {
                             if use_elided_nodes {
                                 elided_targets.push(edge.target.clone());
-                                graphlog_edges.push(Edge::Present {
-                                    direct: true,
-                                    target: (edge.target, true),
-                                });
+                                graphlog_edges.push(Edge::Direct((edge.target, true)));
                             } else {
-                                graphlog_edges.push(Edge::Present {
-                                    direct: false,
-                                    target: (edge.target, false),
-                                });
+                                graphlog_edges.push(Edge::Indirect((edge.target, false)));
                             }
                         }
                     }
@@ -201,10 +192,7 @@ pub(crate) fn cmd_log(
                 for elided_target in elided_targets {
                     let elided_key = (elided_target, true);
                     let real_key = (elided_key.0.clone(), false);
-                    let edges = [Edge::Present {
-                        direct: true,
-                        target: real_key,
-                    }];
+                    let edges = [Edge::Direct(real_key)];
                     let mut buffer = vec![];
                     with_content_format.write_graph_text(
                         ui.new_formatter(&mut buffer).as_mut(),

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -95,7 +95,7 @@ pub(crate) fn cmd_obslog(
         for commit in commits {
             let mut edges = vec![];
             for predecessor in &commit.predecessors() {
-                edges.push(Edge::direct(predecessor.id().clone()));
+                edges.push(Edge::Direct(predecessor.id().clone()));
             }
             let mut buffer = vec![];
             with_content_format.write_graph_text(

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -184,7 +184,7 @@ fn cmd_op_log(
             let op = op?;
             let mut edges = vec![];
             for id in op.parent_ids() {
-                edges.push(Edge::direct(id.clone()));
+                edges.push(Edge::Direct(id.clone()));
             }
             let is_current_op = Some(op.id()) == current_op_id;
             let mut buffer = vec![];

--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -23,28 +23,9 @@ use renderdag::{Ancestor, GraphRowRenderer, Renderer};
 #[derive(Debug, Clone, PartialEq, Eq)]
 // An edge to another node in the graph
 pub enum Edge<T> {
-    Present { target: T, direct: bool },
+    Direct(T),
+    Indirect(T),
     Missing,
-}
-
-impl<T> Edge<T> {
-    pub fn missing() -> Self {
-        Edge::Missing
-    }
-
-    pub fn direct(id: T) -> Self {
-        Edge::Present {
-            target: id,
-            direct: true,
-        }
-    }
-
-    pub fn indirect(id: T) -> Self {
-        Edge::Present {
-            target: id,
-            direct: false,
-        }
-    }
 }
 
 pub trait GraphLog<K: Clone + Eq + Hash> {
@@ -73,11 +54,8 @@ pub struct SaplingGraphLog<'writer, R> {
 impl<K: Clone> From<&Edge<K>> for Ancestor<K> {
     fn from(e: &Edge<K>) -> Self {
         match e {
-            Edge::Present {
-                target,
-                direct: true,
-            } => Ancestor::Parent(target.clone()),
-            Edge::Present { target, .. } => Ancestor::Ancestor(target.clone()),
+            Edge::Direct(target) => Ancestor::Parent(target.clone()),
+            Edge::Indirect(target) => Ancestor::Ancestor(target.clone()),
             Edge::Missing => Ancestor::Anonymous,
         }
     }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

`graphlog::Edge` is used somewhat inconsistently. I've replaced `Edge::Present` with two distinct `Edge::Direct` and `Edge::Indirect` which simplifies the construction of the enum.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
