### PR TITLE
index: don't store commit ids in sorted lookup table to save disk space

### DIFF
--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -254,8 +254,7 @@ impl MutableIndexSegment {
             buf.extend_from_slice(entry.commit_id.as_bytes());
         }
 
-        for (commit_id, LocalPosition(pos)) in &self.commit_lookup {
-            buf.extend_from_slice(commit_id.as_bytes());
+        for LocalPosition(pos) in self.commit_lookup.values() {
             buf.extend(pos.to_le_bytes());
         }
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
