### PR TITLE
fsmonitor: allow `core.fsmonitor = "none"` to disable

### DIFF
--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -24,6 +24,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 /// The recognized kinds of filesystem monitors.
+#[derive(Eq, PartialEq)]
 pub enum FsmonitorKind {
     /// The Watchman filesystem monitor (https://facebook.github.io/watchman/).
     Watchman,
@@ -34,6 +35,13 @@ pub enum FsmonitorKind {
         /// reporting.
         changed_files: Vec<PathBuf>,
     },
+
+    /// No filesystem monitor. This is the default if nothing is configured, but
+    /// also makes it possible to turn off the monitor on a case-by-case basis
+    /// when the user gives an option like
+    /// `--config-toml='core.fsmonitor="none"'`; useful when e.g. when doing
+    /// analysis of snapshot performance.
+    None,
 }
 
 impl FromStr for FsmonitorKind {
@@ -45,6 +53,7 @@ impl FromStr for FsmonitorKind {
             "test" => Err(config::ConfigError::Message(
                 "cannot use test fsmonitor in real repository".to_string(),
             )),
+            "none" => Ok(Self::None),
             other => Err(config::ConfigError::Message(format!(
                 "unknown fsmonitor kind: {}",
                 other

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -164,10 +164,10 @@ impl UserSettings {
         self.config.get_string("user.email").unwrap_or_default()
     }
 
-    pub fn fsmonitor_kind(&self) -> Result<Option<FsmonitorKind>, config::ConfigError> {
+    pub fn fsmonitor_kind(&self) -> Result<FsmonitorKind, config::ConfigError> {
         match self.config.get_string("core.fsmonitor") {
-            Ok(fsmonitor_kind) => Ok(Some(fsmonitor_kind.parse()?)),
-            Err(config::ConfigError::NotFound(_)) => Ok(None),
+            Ok(fsmonitor_kind) => Ok(fsmonitor_kind.parse()?),
+            Err(config::ConfigError::NotFound(_)) => Ok(FsmonitorKind::None),
             Err(err) => Err(err),
         }
     }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -188,7 +188,7 @@ pub struct SnapshotOptions<'a> {
     /// The fsmonitor (e.g. Watchman) to use, if any.
     // TODO: Should we make this a field on `LocalWorkingCopy` instead since it's quite specific to
     // that implementation?
-    pub fsmonitor_kind: Option<FsmonitorKind>,
+    pub fsmonitor_kind: FsmonitorKind,
     /// A callback for the UI to display progress.
     pub progress: Option<&'a SnapshotProgress<'a>>,
     /// The size of the largest file that should be allowed to become tracked
@@ -204,7 +204,7 @@ impl SnapshotOptions<'_> {
     pub fn empty_for_test() -> Self {
         SnapshotOptions {
             base_ignores: GitIgnoreFile::empty(),
-            fsmonitor_kind: None,
+            fsmonitor_kind: FsmonitorKind::None,
             progress: None,
             max_new_file_size: u64::MAX,
         }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -976,9 +976,9 @@ fn test_fsmonitor() {
         locked_ws
             .locked_wc()
             .snapshot(SnapshotOptions {
-                fsmonitor_kind: Some(FsmonitorKind::Test {
+                fsmonitor_kind: FsmonitorKind::Test {
                     changed_files: fs_paths,
-                }),
+                },
                 ..SnapshotOptions::empty_for_test()
             })
             .unwrap()


### PR DESCRIPTION
I wanted to see how the `ignore` update (#3071) changed the snapshot performance on nixpkgs, but I don't want to generally turn off the fsmonitor since it's useful there. Add the ability to disable it through an explicit `"none"` option.

I also thought about fixing this in `fsmonitor_kind()` by short-circuiting the `"none"` string in `settings.rs`, but this seems more type safe and is only 1 or 2 extra lines.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
