### PR TITLE
cli: change default log revset to not include all tagged heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Dropped support for the "legacy" graph-drawing style. Use "ascii" for a very
   similar result.
 
+* The default log output no longer lists all tagged heads. Set `revsets.log =
+  "@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())"` to restore
+  the old behavior.
+
 * Dropped support for the deprecated `:` revset operator. Use `::` instead.
 
 ### New features

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -30,8 +30,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
     /// Which revisions to show. Defaults to the `revsets.log` setting, or
-    /// `@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())` if
-    /// it is not set.
+    /// `@ | ancestors(immutable_heads().., 2) | trunk()` if it is not set.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
     /// Show commits modifying the given paths

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -303,7 +303,7 @@
                 "log": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",
-                    "default": "@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())"
+                    "default": "@ | ancestors(immutable_heads().., 2) | trunk()"
                 },
                 "short-prefixes": {
                     "type": "string",

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1002,7 +1002,7 @@ Show commit history
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVISIONS>` — Which revisions to show. Defaults to the `revsets.log` setting, or `@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())` if it is not set
+* `-r`, `--revisions <REVISIONS>` — Which revisions to show. Defaults to the `revsets.log` setting, or `@ | ancestors(immutable_heads().., 2) | trunk()` if it is not set
 * `--reversed` — Show revisions in the opposite order (older revisions first)
 
   Possible values: `true`, `false`

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -64,7 +64,7 @@ fn test_rewrite_immutable_generic() {
     insta::assert_snapshot!(stderr, @r###"
     Config error: Invalid `revsets.short-prefixes`:  --> 1:31
       |
-    1 | @ | ancestors(immutable_heads().., 2) | heads(immutable_heads())
+    1 | @ | ancestors(immutable_heads().., 2) | trunk()
       |                               ^
       |
       = Invalid arguments to revset function "immutable_heads": Expected 1 arguments
@@ -93,8 +93,9 @@ fn test_rewrite_immutable_commands() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "description(b)"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
+    test_env.add_config(r#"revset-aliases."trunk()" = "main""#);
 
-    // Log shows mutable commits and immutable heads by default
+    // Log shows mutable commits, their parents, and trunk() by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
     @  yqosqzyt test.user@example.com 2001-02-03 04:05:13.000 +07:00 3f89addf

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -209,9 +209,7 @@ impl UserSettings {
             // For compatibility with old config files (<0.8.0)
             self.config
                 .get_string("ui.default-revset")
-                .unwrap_or_else(|_| {
-                    "@ | ancestors(immutable_heads().., 2) | heads(immutable_heads())".to_string()
-                })
+                .unwrap_or_else(|_| "@ | ancestors(immutable_heads().., 2) | trunk()".to_string())
         })
     }
 


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
