### PR TITLE
nix: overwrite, don't append, to `$RUSTFLAGS`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
           export ZSTD_SYS_USE_PKG_CONFIG=1
           export LIBSSH2_SYS_USE_PKG_CONFIG=1
         '' + pkgs.lib.optionalString useMoldLinker ''
-          export RUSTFLAGS="-C link-arg=-fuse-ld=mold $RUSTFLAGS"
+          export RUSTFLAGS="-C link-arg=-fuse-ld=mold"
         '';
       };
     }));


### PR DESCRIPTION
This matches the behavior of the actual `nix build` more closely, and might also help Anton, since he was debugging some recompilation issues on his machine, where `RUSTFLAGS` might have become inconsistent due to VS Code.