### PR TITLE
Support extensions of the commit template language

### DIFF
--- a/cli/examples/custom-commit-templater/main.rs
+++ b/cli/examples/custom-commit-templater/main.rs
@@ -1,0 +1,87 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use jj_cli::cli_util::CliRunner;
+use jj_cli::commit_templater::{CommitTemplateBuildFnTable, CommitTemplateLanguageExtension};
+use jj_cli::template_builder::TemplateLanguage;
+use jj_cli::template_parser::{self, TemplateParseError};
+use jj_cli::templater::{TemplateFunction, TemplatePropertyError};
+use jj_lib::commit::Commit;
+use jj_lib::object_id::ObjectId;
+
+struct HexCounter;
+
+fn num_digits_in_id(commit: Commit) -> Result<i64, TemplatePropertyError> {
+    let mut count = 0;
+    for ch in commit.id().hex().chars() {
+        if ch.is_ascii_digit() {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn num_char_in_id(commit: Commit, ch_match: char) -> Result<i64, TemplatePropertyError> {
+    let mut count = 0;
+    for ch in commit.id().hex().chars() {
+        if ch == ch_match {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+impl CommitTemplateLanguageExtension for HexCounter {
+    fn build_fn_table<'repo>(&self) -> CommitTemplateBuildFnTable<'repo> {
+        let mut table = CommitTemplateBuildFnTable::empty();
+        table.commit_methods.insert(
+            "num_digits_in_id",
+            |language, _build_context, property, call| {
+                template_parser::expect_no_arguments(call)?;
+                Ok(language.wrap_integer(TemplateFunction::new(property, num_digits_in_id)))
+            },
+        );
+        table.commit_methods.insert(
+            "num_char_in_id",
+            |language, _build_context, property, call| {
+                let [string_arg] = template_parser::expect_exact_arguments(call)?;
+                let char_arg =
+                    template_parser::expect_string_literal_with(string_arg, |string, span| {
+                        let chars: Vec<_> = string.chars().collect();
+                        match chars[..] {
+                            [ch] => Ok(ch),
+                            _ => Err(TemplateParseError::unexpected_expression(
+                                "Expected singular character argument",
+                                span,
+                            )),
+                        }
+                    })?;
+
+                Ok(
+                    language.wrap_integer(TemplateFunction::new(property, move |commit| {
+                        num_char_in_id(commit, char_arg)
+                    })),
+                )
+            },
+        );
+
+        table
+    }
+}
+
+fn main() -> std::process::ExitCode {
+    CliRunner::init()
+        .set_commit_template_extension(Box::new(HexCounter))
+        .run()
+}

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -40,7 +40,7 @@ use crate::templater::{
 };
 use crate::text_util;
 
-struct CommitTemplateLanguage<'repo> {
+pub struct CommitTemplateLanguage<'repo> {
     repo: &'repo dyn Repo,
     workspace_id: WorkspaceId,
     id_prefix_context: &'repo IdPrefixContext,
@@ -160,7 +160,7 @@ impl<'repo> CommitTemplateLanguage<'repo> {
     }
 }
 
-enum CommitTemplatePropertyKind<'repo> {
+pub enum CommitTemplatePropertyKind<'repo> {
     Core(CoreTemplatePropertyKind<'repo, Commit>),
     Commit(Box<dyn TemplateProperty<Commit, Output = Commit> + 'repo>),
     CommitList(Box<dyn TemplateProperty<Commit, Output = Vec<Commit>> + 'repo>),
@@ -232,15 +232,15 @@ type CommitTemplateBuildMethodFnMap<'repo, T> =
     TemplateBuildMethodFnMap<'repo, CommitTemplateLanguage<'repo>, T>;
 
 /// Symbol table of methods available in the commit template.
-struct CommitTemplateBuildFnTable<'repo> {
-    core: CoreTemplateBuildFnTable<'repo, CommitTemplateLanguage<'repo>>,
-    commit_methods: CommitTemplateBuildMethodFnMap<'repo, Commit>,
-    ref_name_methods: CommitTemplateBuildMethodFnMap<'repo, RefName>,
-    commit_or_change_id_methods: CommitTemplateBuildMethodFnMap<'repo, CommitOrChangeId>,
-    shortest_id_prefix_methods: CommitTemplateBuildMethodFnMap<'repo, ShortestIdPrefix>,
+pub struct CommitTemplateBuildFnTable<'repo> {
+    pub core: CoreTemplateBuildFnTable<'repo, CommitTemplateLanguage<'repo>>,
+    pub commit_methods: CommitTemplateBuildMethodFnMap<'repo, Commit>,
+    pub ref_name_methods: CommitTemplateBuildMethodFnMap<'repo, RefName>,
+    pub commit_or_change_id_methods: CommitTemplateBuildMethodFnMap<'repo, CommitOrChangeId>,
+    pub shortest_id_prefix_methods: CommitTemplateBuildMethodFnMap<'repo, ShortestIdPrefix>,
 }
 
-impl CommitTemplateBuildFnTable<'_> {
+impl<'repo> CommitTemplateBuildFnTable<'repo> {
     /// Creates new symbol table containing the builtin methods.
     fn builtin() -> Self {
         CommitTemplateBuildFnTable {
@@ -249,6 +249,16 @@ impl CommitTemplateBuildFnTable<'_> {
             ref_name_methods: builtin_ref_name_methods(),
             commit_or_change_id_methods: builtin_commit_or_change_id_methods(),
             shortest_id_prefix_methods: builtin_shortest_id_prefix_methods(),
+        }
+    }
+
+    pub fn empty() -> Self {
+        CommitTemplateBuildFnTable {
+            core: CoreTemplateBuildFnTable::empty(),
+            commit_methods: HashMap::new(),
+            ref_name_methods: HashMap::new(),
+            commit_or_change_id_methods: HashMap::new(),
+            shortest_id_prefix_methods: HashMap::new(),
         }
     }
 }
@@ -506,7 +516,7 @@ fn extract_working_copies(repo: &dyn Repo, commit: &Commit) -> String {
 
 /// Branch or tag name with metadata.
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct RefName {
+pub struct RefName {
     /// Local name.
     name: String,
     /// Remote name if this is a remote or Git-tracking ref.
@@ -656,7 +666,7 @@ fn extract_git_head(repo: &dyn Repo, commit: &Commit) -> Vec<RefName> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-enum CommitOrChangeId {
+pub enum CommitOrChangeId {
     Commit(CommitId),
     Change(ChangeId),
 }
@@ -736,7 +746,7 @@ fn builtin_commit_or_change_id_methods<'repo>(
     map
 }
 
-struct ShortestIdPrefix {
+pub struct ShortestIdPrefix {
     pub prefix: String,
     pub rest: String,
 }


### PR DESCRIPTION
If this pattern looks good, I'll look into providing hooks for the OperationTemplateLanguage as well as the Revset language in a similar fashion; this PR is something of a dry-run.  I added some `examples` to show how this would look in a custom binary.

This doesn't support custom types (yet), I'm not sure if that's something we really care to support or if there's a good way to do it. Open to suggestions

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
