### PR TITLE
github(nix): don't build `jj` twice when testing

### DIFF
--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -19,4 +19,4 @@ jobs:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
       - uses: DeterminateSystems/magic-nix-cache-action@eeabdb06718ac63a7021c6132129679a8e22d0c7
-      - run: nix build --print-build-logs --show-trace
+      - run: nix flake check -L --show-trace


### PR DESCRIPTION
When running the `nix build`, the `buildRustPackage` function -- which builds the `jj` crates -- calls `cargo build --release` with flags like `HOST_CXX` set. This is called the `buildPhase`. Then, it runs the `checkPhase`, which calls `cargo nextest`, in our case. However, it does not set `HOST_CXX`, for some reason.

The intent of `buildRustPackage` is that the `buildPhase` and `checkPhase` have their compilation options fully aligned so that they reuse the local cargo `target/` cache directory, avoiding a full recompilation. However, the lack of `HOST_CXX` above among others causes a cache miss, and a bunch of cascading recompilations. The net impact is that we compile all of the codebase once in `buildPhase`, then again in `checkPhase`, making the Nix CI build 2x slower on average than the other Linux runners; 2-3 minutes versus 7 minutes, on average.

Instead, re-introduce a 'check' into the Flake directly, which overrides the `jujustsu` package, but stubs out the `buildPhase`. This means it will only run `checkPhase`, which is what we want. Then, modify the CI to run `nix flake check` again, like it used to in the past.

Unfortunately, this doesn't fix the cache miss when running `nix build` yourself, it recompiles from scratch in both phases still. That needs to be fixed in the future, but it's tolerable for now.

This reverts most of 71a3045032f512.