### PR TITLE
cli: show timestamp in local timezone and without millis and offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Commit templates now support `immutable` keyword.
 
+* Timestamps are now shown in local timezone and without milliseconds and
+  timezone offset by default.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -154,7 +154,7 @@ commit_summary_separator = 'label("separator", " | ")'
   ++ " (" ++ format_timestamp(signature.timestamp()) ++ ")"'''
 'format_time_range(time_range)' = '''
   time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
-'format_timestamp(timestamp)' = 'timestamp'
+'format_timestamp(timestamp)' = 'timestamp.local().format("%Y-%m-%d %H:%M:%S")'
 
 # We have "hidden" override "divergent", since a hidden revision does not cause
 # change id conflicts and is not affected by such conflicts; you have to use the

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -761,7 +761,10 @@ fn builtin_timestamp_methods<'a, L: TemplateLanguage<'a> + ?Sized>(
     });
     map.insert("local", |language, _build_ctx, self_property, function| {
         template_parser::expect_no_arguments(function)?;
-        let tz_offset = chrono::Local::now().offset().local_minus_utc() / 60;
+        let tz_offset = std::env::var("JJ_TZ_OFFSET_MINS")
+            .ok()
+            .and_then(|tz_string| tz_string.parse::<i32>().ok())
+            .unwrap_or_else(|| chrono::Local::now().offset().local_minus_utc() / 60);
         let out_property = TemplateFunction::new(self_property, move |mut timestamp| {
             timestamp.tz_offset = tz_offset;
             Ok(timestamp)

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -97,6 +97,7 @@ impl TestEnvironment {
         cmd.env("JJ_EMAIL", "test.user@example.com");
         cmd.env("JJ_OP_HOSTNAME", "host.example.com");
         cmd.env("JJ_OP_USERNAME", "test-username");
+        cmd.env("JJ_TZ_OFFSET_MINS", "660");
 
         let mut command_number = self.command_number.borrow_mut();
         *command_number += 1;

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -334,7 +334,7 @@ fn test_double_abandon() {
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r", "a"])
         , @r###"
-    rlvkpnrz test.user@example.com 2001-02-03 04:05:09.000 +07:00 a 2443ea76
+    rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 2443ea76
     a
     "###);
 

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -52,7 +52,7 @@ fn test_builtin_alias_trunk_matches_main() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 main 45a3aa29
+    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -64,7 +64,7 @@ fn test_builtin_alias_trunk_matches_master() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 master 45a3aa29
+    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 master 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -76,7 +76,7 @@ fn test_builtin_alias_trunk_matches_trunk() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 trunk 45a3aa29
+    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 trunk 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -91,7 +91,7 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 main 45a3aa29
+    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -107,7 +107,7 @@ fn test_builtin_alias_trunk_override_alias() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 override-trunk 45a3aa29
+    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 override-trunk 45a3aa29
     │  (empty) description 1
     ~
     "###);

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -133,14 +133,14 @@ fn test_log_author_timestamp_local() {
     test_env.add_env_var("TZ", "UTC-05:30");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  2001-02-03 02:35:07.000 +05:30
-    ◉  1970-01-01 05:30:00.000 +05:30
+    @  2001-02-03 08:05:07.000 +11:00
+    ◉  1970-01-01 11:00:00.000 +11:00
     "###);
     test_env.add_env_var("TZ", "UTC+10:00");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  2001-02-02 11:05:07.000 -10:00
-    ◉  1969-12-31 14:00:00.000 -10:00
+    @  2001-02-03 08:05:07.000 +11:00
+    ◉  1970-01-01 11:00:00.000 +11:00
     "###);
 }
 
@@ -158,9 +158,9 @@ fn test_log_default() {
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  kkmpptxz test.user@example.com 2001-02-03 04:05:09.000 +07:00 my-branch 9de54178
+    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-branch 9de54178
     │  (empty) description 1
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 4291e264
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 4291e264
     │  add a file
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -168,9 +168,9 @@ fn test_log_default() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
+    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     │  add a file
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -178,9 +178,9 @@ fn test_log_default() {
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
+    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
-    [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
+    [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     add a file
     [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -207,26 +207,26 @@ fn test_log_builtin_templates() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "my-branch"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397 (empty) (no description set)
-    qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059 (empty) (no description set)
+    rlvkpnrz (no email set) 2001-02-03 08:05:08 my-branch dc315397 (empty) (no description set)
+    qpvuntsm test.user 2001-02-03 08:05:07 230dd059 (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397
+    rlvkpnrz (no email set) 2001-02-03 08:05:08 my-branch dc315397
     (empty) (no description set)
-    qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397
+    rlvkpnrz (no email set) 2001-02-03 08:05:08 my-branch dc315397
     (empty) (no description set)
 
-    qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
 
     zzzzzzzz root() 00000000
@@ -238,22 +238,22 @@ fn test_log_builtin_templates() {
     Commit ID: dc31539712c7294d1d712cec63cef4504b94ca74
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Branches: my-branch
-    Author: (no name set) <(no email set)> (2001-02-03 04:05:08.000 +07:00)
-    Committer: (no name set) <(no email set)> (2001-02-03 04:05:08.000 +07:00)
+    Author: (no name set) <(no email set)> (2001-02-03 08:05:08)
+    Committer: (no name set) <(no email set)> (2001-02-03 08:05:08)
 
         (no description set)
 
     Commit ID: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
-    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
-    Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Author: Test User <test.user@example.com> (2001-02-03 08:05:07)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:07)
 
         (no description set)
 
     Commit ID: 0000000000000000000000000000000000000000
     Change ID: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-    Author: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
-    Committer: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+    Author: (no name set) <(no email set)> (1970-01-01 11:00:00)
+    Committer: (no name set) <(no email set)> (1970-01-01 11:00:00)
 
         (no description set)
 
@@ -280,24 +280,24 @@ fn test_log_builtin_templates_colored() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "my-branch"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
@@ -307,22 +307,22 @@ fn test_log_builtin_templates_colored() {
     @  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
     │  Change ID: [38;5;5mrlvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
     │  Branches: [38;5;5mmy-branch[39m
-    │  Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 04:05:08.000 +07:00[39m)
-    │  Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 04:05:08.000 +07:00[39m)
+    │  Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 08:05:08[39m)
+    │  Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 08:05:08[39m)
     │
     │  [38;5;2m    (no description set)[39m
     │
     ◉  Commit ID: [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     │  Change ID: [38;5;5mqpvuntsmwlqtpsluzzsnyyzlmlwvmlnu[39m
-    │  Author: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 04:05:07.000 +07:00[39m)
-    │  Committer: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 04:05:07.000 +07:00[39m)
+    │  Author: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
+    │  Committer: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
     │
     │  [38;5;2m    (no description set)[39m
     │
     ◉  Commit ID: [38;5;4m0000000000000000000000000000000000000000[39m
        Change ID: [38;5;5mzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz[39m
-       Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 00:00:00.000 +00:00[39m)
-       Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 00:00:00.000 +00:00[39m)
+       Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
+       Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
 
        [38;5;2m    (no description set)[39m
 
@@ -340,7 +340,7 @@ fn test_log_obslog_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 7a17d52e
     │  description 1
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -352,9 +352,9 @@ fn test_log_obslog_divergence() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm?? test.user@example.com 2001-02-03 04:05:10.000 +07:00 8979953d
+    ◉  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 8979953d
     │  description 2
-    │ @  qpvuntsm?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
+    │ @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 7a17d52e
     ├─╯  description 1
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -365,9 +365,9 @@ fn test_log_obslog_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:10.000 +07:00[39m [1m[38;5;4m8[0m[38;5;8m979953d[39m
+    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m8[0m[38;5;8m979953d[39m
     │  description 2
-    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
+    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     ├─╯  [1mdescription 1[0m
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -375,22 +375,22 @@ fn test_log_obslog_divergence() {
     // Obslog and hidden divergent
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm?? test.user@example.com 2001-02-03 04:05:08.000 +07:00 7a17d52e
+    @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 7a17d52e
     │  description 1
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 3b68ce25
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 3b68ce25
     │  (no description set)
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
 
     // Colored obslog
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
+    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     │  [1mdescription 1[0m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
+    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
     │  [38;5;3m(no description set)[39m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     "###);
 }
@@ -496,9 +496,9 @@ fn test_log_git_head() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:09.000 +07:00[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -523,7 +523,7 @@ fn test_log_customize_short_id() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  Q_pvun test.user@example.com 2001-02-03 04:05:08.000 +07:00 6_9542
+    @  Q_pvun test.user@example.com 2001-02-03 08:05:08 6_9542
     │  (empty) first
     ◉  Z_zzzz root() 0_0000
     "###);
@@ -541,7 +541,7 @@ fn test_log_customize_short_id() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  QPVUNTSM test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
+    @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 69542c19
     │  (empty) first
     ◉  ZZZZZZZZ root() 00000000
     "###);

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -779,14 +779,14 @@ fn test_diff_external_tool() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-p", "--tool=fake-diff-editor"]), @r###"
-    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:09.000 +07:00 0cba70c7
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 0cba70c7
     │  (no description set)
     │  file1
     │  file2
     │  --
     │  file2
     │  file3
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 39b5a56f
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 39b5a56f
     │  (no description set)
     │  --
     │  file1
@@ -799,8 +799,8 @@ fn test_diff_external_tool() {
         test_env.jj_cmd_success(&repo_path, &["show", "--tool=fake-diff-editor"]), @r###"
     Commit ID: 0cba70c72186eabb5a2f91be63a8366b9f6da6c6
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
-    Author: Test User <test.user@example.com> (2001-02-03 04:05:08.000 +07:00)
-    Committer: Test User <test.user@example.com> (2001-02-03 04:05:09.000 +07:00)
+    Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
         (no description set)
 
@@ -846,8 +846,8 @@ fn test_diff_external_tool() {
     insta::assert_snapshot!(stdout, @r###"
     Commit ID: 0cba70c72186eabb5a2f91be63a8366b9f6da6c6
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
-    Author: Test User <test.user@example.com> (2001-02-03 04:05:08.000 +07:00)
-    Committer: Test User <test.user@example.com> (2001-02-03 04:05:09.000 +07:00)
+    Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
         (no description set)
 

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -91,7 +91,7 @@ fn test_git_export_undo() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 a 230dd059
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 a 230dd059
     │  (empty) (no description set)
     ~
     "###);
@@ -121,7 +121,7 @@ fn test_git_export_undo() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 a 230dd059
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 a 230dd059
     │  (empty) (no description set)
     ~
     "###);

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -137,7 +137,7 @@ fn test_git_init_external(bare: bool) {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @r###"
-        ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+        ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
         │  My commit message
         ~
         "###);
@@ -205,7 +205,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -214,7 +214,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -242,7 +242,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -251,7 +251,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -278,7 +278,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -287,7 +287,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -317,7 +317,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -326,7 +326,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -358,7 +358,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -367,7 +367,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -481,12 +481,12 @@ fn test_git_init_colocated_dirty_working_copy() {
     // Working-copy changes should have been snapshotted.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-s", "--ignore-working-copy"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 cd1e144d
+    @  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 cd1e144d
     │  (no description set)
     │  A new-staged-file
     │  M some-file
     │  A unstaged-file
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     │  A some-file
     ◉  zzzzzzzz root() 00000000
@@ -532,7 +532,7 @@ fn test_git_init_external_but_git_dir_exists() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###);
@@ -555,7 +555,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -564,7 +564,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -378,11 +378,11 @@ fn test_git_push_multiple() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  yqosqzyt test.user@example.com 2001-02-03 04:05:17.000 +07:00 branch2 my-branch 15dcdaa4
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 branch2 my-branch 15dcdaa4
     │  (empty) foo
-    │ ◉  rlzusymt test.user@example.com 2001-02-03 04:05:10.000 +07:00 8476341e
+    │ ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
     ├─╯  (empty) description 2
-    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 45a3aa29
+    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
     ├─╯  (empty) description 1
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -672,11 +672,11 @@ fn test_git_push_deleted() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  rlzusymt test.user@example.com 2001-02-03 04:05:10.000 +07:00 branch2 8476341e
+    ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 branch2 8476341e
     │  (empty) description 2
-    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 04:05:08.000 +07:00 45a3aa29
+    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
     ├─╯  (empty) description 1
-    │ @  yqosqzyt test.user@example.com 2001-02-03 04:05:13.000 +07:00 5b36783c
+    │ @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     ├─╯  (empty) (no description set)
     ◉  zzzzzzzz root() 00000000
     "###);

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -92,12 +92,12 @@ fn test_no_subcommand() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "show"]);
     // TODO: test_env.jj_cmd_ok(&repo_path, &["-r", "help"])
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 help log show 230dd059
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059
     │  (empty) (no description set)
     ~
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "show"]), @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 help log show 230dd059
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059
     │  (empty) (no description set)
     ~
     "###);

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -28,11 +28,11 @@ fn test_rewrite_immutable_generic() {
     std::fs::write(repo_path.join("file"), "c").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  mzvwutvl test.user@example.com 2001-02-03 04:05:12.000 +07:00 78ebd449
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 78ebd449
     │  c
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 04:05:10.000 +07:00 main c8d4c7ca
+    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main c8d4c7ca
     ├─╯  b
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 46a8dc51
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 46a8dc51
     │  a
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -90,14 +90,14 @@ fn test_rewrite_immutable_commands() {
     // Log shows mutable commits, their parents, and trunk() by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  yqosqzyt test.user@example.com 2001-02-03 04:05:13.000 +07:00 3f89addf
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 3f89addf
     │  (empty) (no description set)
-    │ ◉  mzvwutvl test.user@example.com 2001-02-03 04:05:11.000 +07:00 main 3d14df18 conflict
+    │ ◉  mzvwutvl test.user@example.com 2001-02-03 08:05:11 main 3d14df18 conflict
     ╭─┤  (empty) merge
     │ │
     │ ~
     │
-    ◉  kkmpptxz test.user@example.com 2001-02-03 04:05:10.000 +07:00 c8d4c7ca
+    ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c8d4c7ca
     │  b
     ~
     "###);

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -139,7 +139,7 @@ fn test_init_git_external(bare: bool) {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @r###"
-        ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+        ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
         │  My commit message
         ~
         "###);
@@ -207,7 +207,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -216,7 +216,7 @@ fn test_init_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -246,7 +246,7 @@ fn test_init_git_colocated_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -255,7 +255,7 @@ fn test_init_git_colocated_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -284,7 +284,7 @@ fn test_init_git_colocated_symlink_directory() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -293,7 +293,7 @@ fn test_init_git_colocated_symlink_directory() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -325,7 +325,7 @@ fn test_init_git_colocated_symlink_directory_without_bare_config() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -334,7 +334,7 @@ fn test_init_git_colocated_symlink_directory_without_bare_config() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -368,7 +368,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 01:02:03.000 +01:00 my-branch HEAD@git 8d698d4a
+    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -377,7 +377,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 04:05:07.000 +07:00 HEAD@git f61b77cd
+    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -484,7 +484,7 @@ fn test_init_git_external_but_git_dir_exists() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###);

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -692,7 +692,7 @@ fn test_log_author_format() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "--revisions=@"]),
         @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###
@@ -710,7 +710,7 @@ fn test_log_author_format() {
             ],
         ),
         @r###"
-    @  qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059
+    @  qpvuntsm test.user 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###
@@ -1239,32 +1239,30 @@ fn test_log_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["log", "-r@"], 40, false), @r###"
-    @  mzvwutvl test.user@example.com 2001-02-03 04:05:11.000 +07:00 68518a7e
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 68518a7e
     │  (empty) merge
     ~
     "###);
     insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @r###"
     @  mzvwutvl test.user@example.com
-    │  2001-02-03 04:05:11.000 +07:00
-    ~  68518a7e
-       (empty) merge
+    │  2001-02-03 08:05:11 68518a7e
+    ~  (empty) merge
     "###);
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @r###"
-    mzvwutvl test.user@example.com 2001-02-03 04:05:11.000 +07:00 68518a7e
+    mzvwutvl test.user@example.com 2001-02-03 08:05:11 68518a7e
     (empty) merge
     "###);
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, true), @r###"
     mzvwutvl test.user@example.com
-    2001-02-03 04:05:11.000 +07:00 68518a7e
+    2001-02-03 08:05:11 68518a7e
     (empty) merge
     "###);
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r###"
     @  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
-    │  [1m[38;5;14m2001-02-03 04:05:11.000 +07:00[39m[0m
-    ~  [1m[38;5;12m6[38;5;8m8518a7e[39m[0m
-       [1m[38;5;10m(empty)[39m merge[0m
+    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12m6[38;5;8m8518a7e[39m[0m
+    ~  [1m[38;5;10m(empty)[39m merge[0m
     "###);
 
     // Graph width should be subtracted from the term width
@@ -1295,8 +1293,7 @@ fn test_log_word_wrap() {
     @  mzvwutvl
     │  test.user@example.com
     ~  2001-02-03
-       04:05:11.000
-       +07:00
+       08:05:11
        68518a7e
        (empty)
        merge
@@ -1305,8 +1302,7 @@ fn test_log_word_wrap() {
     @  mzvwutvl
     │  test.user@example.com
     ~  2001-02-03
-       04:05:11.000
-       +07:00
+       08:05:11
        68518a7e
        (empty)
        merge

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -29,26 +29,26 @@ fn test_obslog_with_or_without_diff() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 ebc23d4b conflict
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
        (empty) my description
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 04:05:10.000 +07:00[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
+    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
     │  [1mmy description[0m
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4meb[0m[38;5;8mc23d4b[39m [38;5;1mconflict[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4meb[0m[38;5;8mc23d4b[39m [38;5;1mconflict[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m [1m[38;5;4m6f[0m[38;5;8mbba7bc[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m6f[0m[38;5;8mbba7bc[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m [1m[38;5;4mea[0m[38;5;8mc0d0da[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mea[0m[38;5;8mc0d0da[39m
        [38;5;2m(empty)[39m my description
     "###);
 
@@ -56,7 +56,7 @@ fn test_obslog_with_or_without_diff() {
     // (even even though it resulted in a conflict).
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     │  Resolved conflict in file1:
     │     1    1: <<<<<<<resolved
@@ -66,45 +66,45 @@ fn test_obslog_with_or_without_diff() {
     │     5     : foo
     │     6     : bar
     │     7     : >>>>>>>
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 ebc23d4b conflict
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
        (empty) my description
     "###);
 
     // Test `--limit`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--limit=2"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 ebc23d4b conflict
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     │  my description
     "###);
 
     // Test `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
+    rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 ebc23d4b conflict
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
     (empty) my description
     "###);
 
     // Test `--git` format, and that it implies `-p`
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--no-graph", "--git"]);
     insta::assert_snapshot!(stdout, @r###"
-    rlvkpnrz test.user@example.com 2001-02-03 04:05:10.000 +07:00 66b42ad3
+    rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     my description
     diff --git a/file1 b/file1
     index 0000000000...2ab19ae607 100644
@@ -119,9 +119,9 @@ fn test_obslog_with_or_without_diff() {
     -bar
     ->>>>>>>
     +resolved
-    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 ebc23d4b conflict
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 6fbba7bc
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -137,7 +137,7 @@ fn test_obslog_with_or_without_diff() {
     +++ b/file2
     @@ -1,0 +1,1 @@
     +foo
-    rlvkpnrz hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 eac0d0da
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
     (empty) my description
     "###);
 }
@@ -165,33 +165,31 @@ fn test_obslog_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 69542c19
     │  (empty) first
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
     @  qpvuntsm test.user@example.com
-    │  2001-02-03 04:05:08.000 +07:00
-    │  69542c19
+    │  2001-02-03 08:05:08 69542c19
     │  (empty) first
     ◉  qpvuntsm hidden test.user@example.com
-       2001-02-03 04:05:07.000 +07:00
-       230dd059
+       2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, false), @r###"
-    qpvuntsm test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
+    qpvuntsm test.user@example.com 2001-02-03 08:05:08 69542c19
     (empty) first
-    qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, true), @r###"
     qpvuntsm test.user@example.com
-    2001-02-03 04:05:08.000 +07:00 69542c19
+    2001-02-03 08:05:08 69542c19
     (empty) first
     qpvuntsm hidden test.user@example.com
-    2001-02-03 04:05:07.000 +07:00 230dd059
+    2001-02-03 08:05:07 230dd059
     (empty) (no description set)
     "###);
 }
@@ -213,25 +211,25 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉    qpvuntsm test.user@example.com 2001-02-03 04:05:10.000 +07:00 27e721a5
+    ◉    qpvuntsm test.user@example.com 2001-02-03 08:05:10 27e721a5
     ├─╮  squashed
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 9764e503
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 9764e503
     │ │  first
     │ │  Added regular file file1:
     │ │          1: foo
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:08.000 +07:00 69542c19
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 69542c19
     │ │  (empty) first
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
       │  (empty) (no description set)
-      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 04:05:10.000 +07:00 f09a3889
+      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 f09a3889
       │  second
       │  Modified regular file file1:
       │     1    1: foo
       │          2: bar
-      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 04:05:09.000 +07:00 57996536
+      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 57996536
          (empty) second
     "###);
 }

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -27,8 +27,8 @@ fn test_show() {
     let stdout = stdout.lines().skip(2).join("\n");
 
     insta::assert_snapshot!(stdout, @r###"
-    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
-    Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Author: Test User <test.user@example.com> (2001-02-03 08:05:07)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:07)
 
         (no description set)
     "###);

--- a/cli/tests/test_tree_level_conflicts.rs
+++ b/cli/tests/test_tree_level_conflicts.rs
@@ -39,13 +39,13 @@ fn test_enable_tree_level_conflicts() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  mzvwutvl test.user@example.com 2001-02-03 04:05:11.000 +07:00 f2101bed conflict
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 f2101bed conflict
     │  (empty) (no description set)
-    ◉    zsuskuln test.user@example.com 2001-02-03 04:05:10.000 +07:00 5100e4e1 conflict
+    ◉    zsuskuln test.user@example.com 2001-02-03 08:05:10 5100e4e1 conflict
     ├─╮  (empty) merge
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 04:05:10.000 +07:00 0b65c8fb
+    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 0b65c8fb
     │ │  right
-    ◉ │  rlvkpnrz test.user@example.com 2001-02-03 04:05:09.000 +07:00 32003b88
+    ◉ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 32003b88
     ├─╯  left
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -56,13 +56,13 @@ fn test_enable_tree_level_conflicts() {
     // non-empty
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  mzvwutvl test.user@example.com 2001-02-03 04:05:13.000 +07:00 51f1748d conflict
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 51f1748d conflict
     │  (no description set)
-    ◉    zsuskuln test.user@example.com 2001-02-03 04:05:10.000 +07:00 5100e4e1 conflict
+    ◉    zsuskuln test.user@example.com 2001-02-03 08:05:10 5100e4e1 conflict
     ├─╮  (empty) merge
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 04:05:10.000 +07:00 0b65c8fb
+    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 0b65c8fb
     │ │  right
-    ◉ │  rlvkpnrz test.user@example.com 2001-02-03 04:05:09.000 +07:00 32003b88
+    ◉ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 32003b88
     ├─╯  left
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -75,7 +75,7 @@ fn test_enable_tree_level_conflicts() {
     test_env.jj_cmd_ok(&repo_path, &["new", "k"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r=@"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  yostqsxw test.user@example.com 2001-02-03 04:05:15.000 +07:00 112f0ac2
+    @  yostqsxw test.user@example.com 2001-02-03 08:05:15 112f0ac2
     │  (empty) (no description set)
     ~
     "###);

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -528,9 +528,9 @@ fn test_workspaces_current_op_discarded_by_other() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["obslog"]);
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(stdout, @r###"
-    @  kmkuslsw test.user@example.com 2001-02-03 04:05:18.000 +07:00 secondary@ b93a9242
+    @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ b93a9242
     │  (no description set)
-    ◉  kmkuslsw hidden test.user@example.com 2001-02-03 04:05:18.000 +07:00 30ee0d1f
+    ◉  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 30ee0d1f
        (empty) (no description set)
     "###);
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -276,7 +276,7 @@ Can be customized by the `format_timestamp()` template alias.
 
 ```toml
 [template-aliases]
-# Full timestamp in ISO 8601 format (default)
+# Full timestamp in ISO 8601 format
 'format_timestamp(timestamp)' = 'timestamp'
 # Relative timestamp rendered as "x days/hours/seconds ago"
 'format_timestamp(timestamp)' = 'timestamp.ago()'


### PR DESCRIPTION
As discussed in #2900, the milliseconds are rarely useful, and it can be confusing with different timezones because it makes harder to compare timestamps.

Closes #2900

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
