### PR TITLE
cli: use a "leftward harpoon over rightward harpoon" for elided nodes

### DIFF
--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -129,11 +129,11 @@ pub fn get_graphlog<'a, K: Clone + Eq + Hash + 'a>(
             builder.build_box_drawing().with_square_glyphs(),
             formatter,
             "◉",
-            "◌",
+            "⇋",
         ),
-        "ascii" => SaplingGraphLog::create(builder.build_ascii(), formatter, "o", "."),
-        "ascii-large" => SaplingGraphLog::create(builder.build_ascii_large(), formatter, "o", "."),
+        "ascii" => SaplingGraphLog::create(builder.build_ascii(), formatter, "o", "="),
+        "ascii-large" => SaplingGraphLog::create(builder.build_ascii_large(), formatter, "o", "="),
         // "curved"
-        _ => SaplingGraphLog::create(builder.build_box_drawing(), formatter, "◉", "◌"),
+        _ => SaplingGraphLog::create(builder.build_box_drawing(), formatter, "◉", "⇋"),
     }
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1387,10 +1387,10 @@ fn test_elided() {
     ├─╮
     │ ◉  side branch 2
     │ │
-    │ ◌  (elided revisions)
+    │ ⇋  (elided revisions)
     ◉ │  main branch 2
     │ │
-    ◌ │  (elided revisions)
+    ⇋ │  (elided revisions)
     ├─╯
     ◉  initial
     │
@@ -1402,10 +1402,10 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("@-- | root()"), @r###"
     ◉  side branch 1
     │
-    ◌  (elided revisions)
+    ⇋  (elided revisions)
     │ ◉  main branch 1
     │ │
-    │ ◌  (elided revisions)
+    │ ⇋  (elided revisions)
     ├─╯
     ◉
     "###);


### PR DESCRIPTION
This is just an experiment to see how a new elided node looks. I like the feature, but I think the text is a little hard to see due to the lack of surrounding whitespace; having a more distinct marker might help split the difference.

Also, the existing pick, `DOTTED CIRCLE`, seen as `◌`, sometimes renders *very* poorly in certain fonts, depending on a number of factors. I think a contributing factor is that not all fonts have monospace unicode characters for this block of characters; it also seems as if `DOTTED CIRCLE` is not in the same "logical group" of characters in that block that includes our lovely `◉`, which is `FISHEYE`. Maybe another `... CIRCLE` character would be better, but the ones close by don't seem too great for this purpose.

Instead, this picks a completely distinct character, using `LEFTWARD HARPOON OVER RIGHTWARD HARPOON`, seen as `⇋` to mark elided nodes, since it kind of reminded me of a "scissor snip", removing the middle of a string, or something.

To keep a similar visual language, `=` is used in ASCII.

I've been running this for a week or so, and I quite like it. But I figured I'd put it up here in case anyone else wants to try it. We could also make it configurable, but maybe this could be a better default? I'm not sure. We'd have to get people to try it.

Here is an example from my inline VS Code terminal, using PragmataPro Mono:

<img width="654" alt="image" src="https://github.com/martinvonz/jj/assets/3416/d444a2fe-2902-4b8b-adfa-b176224ffb47">
