### PR TITLE
github: cap builds to 15 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,18 @@ jobs:
           cargo_flags: "--all-features"
     runs-on: ${{ matrix.os }}
 
+    # TODO FIXME (aseipp): keep the timeout limit to ~15 minutes. this is long
+    # enough to give us runway for the future, but also once we hit it, we're at
+    # the "builds are taking too long" stage and we should start looking at ways
+    # to optimize the CI.
+    #
+    # at the same time, this avoids some issues where some flaky, bugged tests
+    # seem to be causing multi-hour runs on Windows (GPG signing issues), which
+    # is a problem we should fix. in the mean time, this will make these flakes
+    # less harmful, as it won't cause builds to spin for multiple hours, requiring
+    # manual cancellation.
+    timeout-minutes: 15
+
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -12,7 +12,7 @@ jobs:
   nix:
     runs-on: ubuntu-latest
     name: nix-build
-    timeout-minutes: 20
+    timeout-minutes: 15 # NOTE (aseipp): keep in-sync with the build.yml timeout limit
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:


### PR DESCRIPTION
This should nerf some of the impact of the flaky Windows GPG tests right now, which are currently non-deterministically running into hangs, causing a lot of PRs to stall out. 15 minutes was chosen as a good trade-off between "pretty far from our current build times" while also catching obvious bugs and flakes.