### PR TITLE
Implement FR #2338 for current branches / automatically advancing branches

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -57,6 +57,7 @@ pub(crate) fn cmd_commit(
     let matcher = workspace_command
         .parse_file_patterns(&args.paths)?
         .to_matcher();
+    let advanceable_branches = workspace_command.get_advanceable_branches(commit.parent_ids())?;
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let mut tx = workspace_command.start_transaction();
@@ -121,6 +122,10 @@ new working-copy commit.
                 commit.tree_id().clone(),
             )
             .write()?;
+
+        // Does nothing if there's no branches to advance.
+        tx.advance_branches(advanceable_branches, new_commit.id());
+
         for workspace_id in workspace_ids {
             tx.mut_repo().edit(workspace_id, &new_wc_commit).unwrap();
         }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -405,6 +405,26 @@
                 }
             }
         },
+        "experimental-advance-branches": {
+            "type": "object",
+            "description": "Settings controlling the 'advance-branches' feature which moves branches forward when new commits are created.",
+            "properties": {
+                "enabled-branches": {
+                    "type": "array",
+                    "description": "Patterns used to identify branches which may be advanced.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "disabled-branches": {
+                    "type": "array",
+                    "description": "Patterns used to identify branches which are not advanced. Takes precedence over 'enabled-branches'.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "signing": {
             "type": "object",
             "description": "Settings for verifying and creating cryptographic commit signatures",

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -9,6 +9,7 @@ fn test_no_forgotten_test_files() {
 }
 
 mod test_abandon_command;
+mod test_advance_branches;
 mod test_alias;
 mod test_branch_command;
 mod test_builtin_aliases;

--- a/cli/tests/test_advance_branches.rs
+++ b/cli/tests/test_advance_branches.rs
@@ -14,117 +14,134 @@
 
 use std::path::Path;
 
-use itertools::Itertools;
+use test_case::test_case;
 
 use crate::common::TestEnvironment;
 
 fn get_log_output_with_branches(test_env: &TestEnvironment, cwd: &Path) -> String {
-    let template = r#"commit_id.short() ++ " br:{" ++ local_branches ++ "} dsc: " ++ description"#;
+    // Don't include commit IDs since they will be different depending on
+    // whether the test runs with `jj commit` or `jj describe` + `jj new`.
+    let template = r#""branches{" ++ local_branches ++ "} desc: " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 
-fn enable_advance_branches_for_patterns(test_env: &TestEnvironment, cwd: &Path, patterns: &[&str]) {
-    #[rustfmt::skip]
-    let pattern_string: String = patterns.iter().map(|x| format!("\"{}\"", x)).join(",");
-    test_env.jj_cmd_success(
-        cwd,
-        &[
-            "config",
-            "set",
-            "--repo",
-            "experimental-advance-branches.enabled-branches",
-            &format!("[{}]", pattern_string),
-        ],
-    );
-}
-
-fn set_advance_branches(test_env: &TestEnvironment, cwd: &Path, value: bool) {
-    if value {
-        enable_advance_branches_for_patterns(test_env, cwd, &["glob:*"]);
+fn set_advance_branches(test_env: &TestEnvironment, enabled: bool) {
+    if enabled {
+        test_env.add_config(
+            r#"[experimental-advance-branches]
+        enabled-branches = ["glob:*"]
+        "#,
+        );
     } else {
-        enable_advance_branches_for_patterns(test_env, cwd, &[""]);
+        test_env.add_config(
+            r#"[experimental-advance-branches]
+        enabled-branches = [""]
+        "#,
+        );
     }
 }
 
+// Runs a command in the specified test environment and workspace path that
+// describes the current commit with `commit_message` and creates a new commit
+// on top of it.
+type CommitFn = fn(env: &TestEnvironment, workspace_path: &Path, commit_message: &str);
+
+// Implements CommitFn using the `jj commit` command.
+fn commit_cmd(env: &TestEnvironment, workspace_path: &Path, commit_message: &str) {
+    env.jj_cmd_ok(workspace_path, &["commit", "-m", commit_message]);
+}
+
 // Check that enabling and disabling advance-branches works as expected.
-#[test]
-fn test_advance_branches_enabled() {
+#[test_case(commit_cmd ; "commit")]
+fn test_advance_branches_enabled(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let workspace_path = test_env.env_root().join("repo");
 
     // First, test with advance-branches enabled. Start by creating a branch on the
     // root commit.
-    set_advance_branches(&test_env, &workspace_path, true);
+    set_advance_branches(&test_env, true);
     test_env.jj_cmd_ok(
         &workspace_path,
         &["branch", "create", "-r", "@-", "test_branch"],
     );
 
     // Check the initial state of the repo.
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  230dd059e1b0 br:{} dsc:
-    ◉  000000000000 br:{test_branch} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch} desc:
     "###);
+    }
 
     // Run jj commit, which will advance the branch pointing to @-.
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    make_commit(&test_env, &workspace_path, "first");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  24bb7f9da598 br:{} dsc:
-    ◉  95f2456c4bbd br:{test_branch} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 
     // Now disable advance branches and commit again. The branch shouldn't move.
-    set_advance_branches(&test_env, &workspace_path, false);
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=second"]);
+    set_advance_branches(&test_env, false);
+    make_commit(&test_env, &workspace_path, "second");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  b29edd893970 br:{} dsc:
-    ◉  ebf7d96fb6ad br:{} dsc: second
-    ◉  95f2456c4bbd br:{test_branch} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{} desc: second
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 }
 
 // Check that only a branch pointing to @- advances. Branches pointing to @ are
 // not advanced.
-#[test]
-fn test_advance_branches_at_minus() {
+#[test_case(commit_cmd ; "commit")]
+fn test_advance_branches_at_minus(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let workspace_path = test_env.env_root().join("repo");
 
-    set_advance_branches(&test_env, &workspace_path, true);
+    set_advance_branches(&test_env, true);
     test_env.jj_cmd_ok(&workspace_path, &["branch", "create", "test_branch"]);
 
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  230dd059e1b0 br:{test_branch} dsc:
-    ◉  000000000000 br:{} dsc:
+    @  branches{test_branch} desc:
+    ◉  branches{} desc:
     "###);
+    }
 
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    make_commit(&test_env, &workspace_path, "first");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  24bb7f9da598 br:{} dsc:
-    ◉  95f2456c4bbd br:{test_branch} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 
     // Create a second branch pointing to @. On the next commit, only the first
     // branch, which points to @-, will advance.
     test_env.jj_cmd_ok(&workspace_path, &["branch", "create", "test_branch2"]);
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=second"]);
+    make_commit(&test_env, &workspace_path, "second");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  b29edd893970 br:{} dsc:
-    ◉  ebf7d96fb6ad br:{test_branch test_branch2} dsc: second
-    ◉  95f2456c4bbd br:{} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch test_branch2} desc: second
+    ◉  branches{} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 }
 
 // Test that per-branch overrides invert the behavior of
 // experimental-advance-branches.enabled.
-#[test]
-fn test_advance_branches_overrides() {
+#[test_case(commit_cmd ; "commit")]
+fn test_advance_branches_overrides(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let workspace_path = test_env.env_root().join("repo");
@@ -136,18 +153,22 @@ fn test_advance_branches_overrides() {
     );
 
     // Check the initial state of the repo.
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  230dd059e1b0 br:{} dsc:
-    ◉  000000000000 br:{test_branch} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch} desc:
     "###);
+    }
 
     // Commit will not advance the branch since advance-branches is disabled.
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    make_commit(&test_env, &workspace_path, "first");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  7e3a6f5e0f15 br:{} dsc:
-    ◉  307e33f70413 br:{} dsc: first
-    ◉  000000000000 br:{test_branch} dsc:
+    @  branches{} desc:
+    ◉  branches{} desc: first
+    ◉  branches{test_branch} desc:
     "###);
+    }
 
     // Now enable advance branches for "test_branch", move the branch, and commit
     // again.
@@ -160,18 +181,22 @@ fn test_advance_branches_overrides() {
         &workspace_path,
         &["branch", "set", "test_branch", "-r", "@-"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  7e3a6f5e0f15 br:{} dsc:
-    ◉  307e33f70413 br:{test_branch} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
     "###);
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=second"]);
+    }
+    make_commit(&test_env, &workspace_path, "second");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  8c1bd3e7de60 br:{} dsc:
-    ◉  468d1ab20fb3 br:{test_branch} dsc: second
-    ◉  307e33f70413 br:{} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{test_branch} desc: second
+    ◉  branches{} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 
     // Now disable advance branches for "test_branch" and "second_branch", which
     // we will use later. Disabling always takes precedence over enabling.
@@ -181,14 +206,16 @@ fn test_advance_branches_overrides() {
     disabled-branches = ["test_branch"]
     "#,
     );
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=third"]);
+    make_commit(&test_env, &workspace_path, "third");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  5888a83948dd br:{} dsc:
-    ◉  50e9c28e6d85 br:{} dsc: third
-    ◉  468d1ab20fb3 br:{test_branch} dsc: second
-    ◉  307e33f70413 br:{} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{} desc: third
+    ◉  branches{test_branch} desc: second
+    ◉  branches{} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 
     // If we create a new branch at @- and move test_branch there as well. When
     // we commit, only "second_branch" will advance since "test_branch" is disabled.
@@ -200,32 +227,36 @@ fn test_advance_branches_overrides() {
         &workspace_path,
         &["branch", "set", "test_branch", "-r", "@-"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  5888a83948dd br:{} dsc:
-    ◉  50e9c28e6d85 br:{second_branch test_branch} dsc: third
-    ◉  468d1ab20fb3 br:{} dsc: second
-    ◉  307e33f70413 br:{} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{second_branch test_branch} desc: third
+    ◉  branches{} desc: second
+    ◉  branches{} desc: first
+    ◉  branches{} desc:
     "###);
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=fourth"]);
+    }
+    make_commit(&test_env, &workspace_path, "fourth");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  666d42aedca7 br:{} dsc:
-    ◉  f23aa63eeb99 br:{second_branch} dsc: fourth
-    ◉  50e9c28e6d85 br:{test_branch} dsc: third
-    ◉  468d1ab20fb3 br:{} dsc: second
-    ◉  307e33f70413 br:{} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{second_branch} desc: fourth
+    ◉  branches{test_branch} desc: third
+    ◉  branches{} desc: second
+    ◉  branches{} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 }
 
 // If multiple eligible branches point to @-, all of them will be advanced.
-#[test]
-fn test_advance_branches_multiple_branches() {
+#[test_case(commit_cmd ; "commit")]
+fn test_advance_branches_multiple_branches(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let workspace_path = test_env.env_root().join("repo");
 
-    set_advance_branches(&test_env, &workspace_path, true);
+    set_advance_branches(&test_env, true);
     test_env.jj_cmd_ok(
         &workspace_path,
         &["branch", "create", "-r", "@-", "first_branch"],
@@ -234,17 +265,22 @@ fn test_advance_branches_multiple_branches() {
         &workspace_path,
         &["branch", "create", "-r", "@-", "second_branch"],
     );
+
+    insta::allow_duplicates! {
     // Check the initial state of the repo.
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  230dd059e1b0 br:{} dsc:
-    ◉  000000000000 br:{first_branch second_branch} dsc:
+    @  branches{} desc:
+    ◉  branches{first_branch second_branch} desc:
     "###);
+    }
 
     // Both branches are eligible and both will advance.
-    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    make_commit(&test_env, &workspace_path, "first");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    @  f307e5d9f90b br:{} dsc:
-    ◉  0fca5c9228e6 br:{first_branch second_branch} dsc: first
-    ◉  000000000000 br:{} dsc:
+    @  branches{} desc:
+    ◉  branches{first_branch second_branch} desc: first
+    ◉  branches{} desc:
     "###);
+    }
 }

--- a/cli/tests/test_advance_branches.rs
+++ b/cli/tests/test_advance_branches.rs
@@ -1,0 +1,250 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use itertools::Itertools;
+
+use crate::common::TestEnvironment;
+
+fn get_log_output_with_branches(test_env: &TestEnvironment, cwd: &Path) -> String {
+    let template = r#"commit_id.short() ++ " br:{" ++ local_branches ++ "} dsc: " ++ description"#;
+    test_env.jj_cmd_success(cwd, &["log", "-T", template])
+}
+
+fn enable_advance_branches_for_patterns(test_env: &TestEnvironment, cwd: &Path, patterns: &[&str]) {
+    #[rustfmt::skip]
+    let pattern_string: String = patterns.iter().map(|x| format!("\"{}\"", x)).join(",");
+    test_env.jj_cmd_success(
+        cwd,
+        &[
+            "config",
+            "set",
+            "--repo",
+            "experimental-advance-branches.enabled-branches",
+            &format!("[{}]", pattern_string),
+        ],
+    );
+}
+
+fn set_advance_branches(test_env: &TestEnvironment, cwd: &Path, value: bool) {
+    if value {
+        enable_advance_branches_for_patterns(test_env, cwd, &["glob:*"]);
+    } else {
+        enable_advance_branches_for_patterns(test_env, cwd, &[""]);
+    }
+}
+
+// Check that enabling and disabling advance-branches works as expected.
+#[test]
+fn test_advance_branches_enabled() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    // First, test with advance-branches enabled. Start by creating a branch on the
+    // root commit.
+    set_advance_branches(&test_env, &workspace_path, true);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@-", "test_branch"],
+    );
+
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  230dd059e1b0 br:{} dsc:
+    ◉  000000000000 br:{test_branch} dsc:
+    "###);
+
+    // Run jj commit, which will advance the branch pointing to @-.
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  24bb7f9da598 br:{} dsc:
+    ◉  95f2456c4bbd br:{test_branch} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+
+    // Now disable advance branches and commit again. The branch shouldn't move.
+    set_advance_branches(&test_env, &workspace_path, false);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=second"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  b29edd893970 br:{} dsc:
+    ◉  ebf7d96fb6ad br:{} dsc: second
+    ◉  95f2456c4bbd br:{test_branch} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+}
+
+// Check that only a branch pointing to @- advances. Branches pointing to @ are
+// not advanced.
+#[test]
+fn test_advance_branches_at_minus() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    set_advance_branches(&test_env, &workspace_path, true);
+    test_env.jj_cmd_ok(&workspace_path, &["branch", "create", "test_branch"]);
+
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  230dd059e1b0 br:{test_branch} dsc:
+    ◉  000000000000 br:{} dsc:
+    "###);
+
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  24bb7f9da598 br:{} dsc:
+    ◉  95f2456c4bbd br:{test_branch} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+
+    // Create a second branch pointing to @. On the next commit, only the first
+    // branch, which points to @-, will advance.
+    test_env.jj_cmd_ok(&workspace_path, &["branch", "create", "test_branch2"]);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=second"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  b29edd893970 br:{} dsc:
+    ◉  ebf7d96fb6ad br:{test_branch test_branch2} dsc: second
+    ◉  95f2456c4bbd br:{} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+}
+
+// Test that per-branch overrides invert the behavior of
+// experimental-advance-branches.enabled.
+#[test]
+fn test_advance_branches_overrides() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    // advance-branches is disabled by default.
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@-", "test_branch"],
+    );
+
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  230dd059e1b0 br:{} dsc:
+    ◉  000000000000 br:{test_branch} dsc:
+    "###);
+
+    // Commit will not advance the branch since advance-branches is disabled.
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  7e3a6f5e0f15 br:{} dsc:
+    ◉  307e33f70413 br:{} dsc: first
+    ◉  000000000000 br:{test_branch} dsc:
+    "###);
+
+    // Now enable advance branches for "test_branch", move the branch, and commit
+    // again.
+    test_env.add_config(
+        r#"[experimental-advance-branches]
+    enabled-branches = ["test_branch"]
+    "#,
+    );
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "set", "test_branch", "-r", "@-"],
+    );
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  7e3a6f5e0f15 br:{} dsc:
+    ◉  307e33f70413 br:{test_branch} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=second"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  8c1bd3e7de60 br:{} dsc:
+    ◉  468d1ab20fb3 br:{test_branch} dsc: second
+    ◉  307e33f70413 br:{} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+
+    // Now disable advance branches for "test_branch" and "second_branch", which
+    // we will use later. Disabling always takes precedence over enabling.
+    test_env.add_config(
+        r#"[experimental-advance-branches]
+    enabled-branches = ["test_branch", "second_branch"]
+    disabled-branches = ["test_branch"]
+    "#,
+    );
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=third"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  5888a83948dd br:{} dsc:
+    ◉  50e9c28e6d85 br:{} dsc: third
+    ◉  468d1ab20fb3 br:{test_branch} dsc: second
+    ◉  307e33f70413 br:{} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+
+    // If we create a new branch at @- and move test_branch there as well. When
+    // we commit, only "second_branch" will advance since "test_branch" is disabled.
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "second_branch", "-r", "@-"],
+    );
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "set", "test_branch", "-r", "@-"],
+    );
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  5888a83948dd br:{} dsc:
+    ◉  50e9c28e6d85 br:{second_branch test_branch} dsc: third
+    ◉  468d1ab20fb3 br:{} dsc: second
+    ◉  307e33f70413 br:{} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=fourth"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  666d42aedca7 br:{} dsc:
+    ◉  f23aa63eeb99 br:{second_branch} dsc: fourth
+    ◉  50e9c28e6d85 br:{test_branch} dsc: third
+    ◉  468d1ab20fb3 br:{} dsc: second
+    ◉  307e33f70413 br:{} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+}
+
+// If multiple eligible branches point to @-, all of them will be advanced.
+#[test]
+fn test_advance_branches_multiple_branches() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    set_advance_branches(&test_env, &workspace_path, true);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@-", "first_branch"],
+    );
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@-", "second_branch"],
+    );
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  230dd059e1b0 br:{} dsc:
+    ◉  000000000000 br:{first_branch second_branch} dsc:
+    "###);
+
+    // Both branches are eligible and both will advance.
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  f307e5d9f90b br:{} dsc:
+    ◉  0fca5c9228e6 br:{first_branch second_branch} dsc: first
+    ◉  000000000000 br:{} dsc:
+    "###);
+}

--- a/cli/tests/test_advance_branches.rs
+++ b/cli/tests/test_advance_branches.rs
@@ -35,7 +35,7 @@ fn set_advance_branches(test_env: &TestEnvironment, enabled: bool) {
     } else {
         test_env.add_config(
             r#"[experimental-advance-branches]
-        enabled-branches = [""]
+        enabled-branches = []
         "#,
         );
     }
@@ -51,8 +51,15 @@ fn commit_cmd(env: &TestEnvironment, workspace_path: &Path, commit_message: &str
     env.jj_cmd_ok(workspace_path, &["commit", "-m", commit_message]);
 }
 
+// Implements CommitFn using the `jj describe` and `jj new`.
+fn describe_new_cmd(env: &TestEnvironment, workspace_path: &Path, commit_message: &str) {
+    env.jj_cmd_ok(workspace_path, &["describe", "-m", commit_message]);
+    env.jj_cmd_ok(workspace_path, &["new"]);
+}
+
 // Check that enabling and disabling advance-branches works as expected.
 #[test_case(commit_cmd ; "commit")]
+#[test_case(describe_new_cmd; "new")]
 fn test_advance_branches_enabled(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -100,6 +107,7 @@ fn test_advance_branches_enabled(make_commit: CommitFn) {
 // Check that only a branch pointing to @- advances. Branches pointing to @ are
 // not advanced.
 #[test_case(commit_cmd ; "commit")]
+#[test_case(describe_new_cmd; "new")]
 fn test_advance_branches_at_minus(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -141,6 +149,7 @@ fn test_advance_branches_at_minus(make_commit: CommitFn) {
 // Test that per-branch overrides invert the behavior of
 // experimental-advance-branches.enabled.
 #[test_case(commit_cmd ; "commit")]
+#[test_case(describe_new_cmd; "new")]
 fn test_advance_branches_overrides(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -251,6 +260,7 @@ fn test_advance_branches_overrides(make_commit: CommitFn) {
 
 // If multiple eligible branches point to @-, all of them will be advanced.
 #[test_case(commit_cmd ; "commit")]
+#[test_case(describe_new_cmd; "new")]
 fn test_advance_branches_multiple_branches(make_commit: CommitFn) {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -283,4 +293,156 @@ fn test_advance_branches_multiple_branches(make_commit: CommitFn) {
     ◉  branches{} desc:
     "###);
     }
+}
+
+// Call `jj new` on an interior commit and see that the branch pointing to its
+// parent's parent is advanced.
+#[test]
+fn test_new_advance_branches_interior() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    set_advance_branches(&test_env, true);
+
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    ◉  branches{} desc:
+    "###);
+
+    // Create a gap in the commits for us to insert our new commit with --before.
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@---", "test_branch"],
+    );
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    ◉  branches{} desc: third
+    ◉  branches{} desc: second
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
+    "###);
+
+    test_env.jj_cmd_ok(&workspace_path, &["new", "-r", "@--"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    │ ◉  branches{} desc: third
+    ├─╯
+    ◉  branches{test_branch} desc: second
+    ◉  branches{} desc: first
+    ◉  branches{} desc:
+    "###);
+}
+
+// If the `--before` flag is passed to `jj new`, branches are not advanced.
+#[test]
+fn test_new_advance_branches_before() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    set_advance_branches(&test_env, true);
+
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    ◉  branches{} desc:
+    "###);
+
+    // Create a gap in the commits for us to insert our new commit with --before.
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "first"]);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "second"]);
+    test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "third"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@---", "test_branch"],
+    );
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    ◉  branches{} desc: third
+    ◉  branches{} desc: second
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
+    "###);
+
+    test_env.jj_cmd_ok(&workspace_path, &["new", "--before", "-r", "@-"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    ◉  branches{} desc: third
+    @  branches{} desc:
+    ◉  branches{} desc: second
+    ◉  branches{test_branch} desc: first
+    ◉  branches{} desc:
+    "###);
+}
+
+// If the `--after` flag is passed to `jj new`, branches are not advanced.
+#[test]
+fn test_new_advance_branches_after() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    set_advance_branches(&test_env, true);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "-r", "@-", "test_branch"],
+    );
+
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    ◉  branches{test_branch} desc:
+    "###);
+
+    test_env.jj_cmd_ok(&workspace_path, &["describe", "-m", "first"]);
+    test_env.jj_cmd_ok(&workspace_path, &["new", "--after"]);
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc:
+    ◉  branches{} desc: first
+    ◉  branches{test_branch} desc:
+    "###);
+}
+
+#[test]
+fn test_new_advance_branches_merge_children() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let workspace_path = test_env.env_root().join("repo");
+
+    set_advance_branches(&test_env, true);
+    test_env.jj_cmd_ok(&workspace_path, &["desc", "-m", "0"]);
+    test_env.jj_cmd_ok(&workspace_path, &["new", "-m", "1"]);
+    test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m", "2"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["branch", "create", "test_branch", "-r", "description(0)"],
+    );
+
+    // Check the initial state of the repo.
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @  branches{} desc: 2
+    │ ◉  branches{} desc: 1
+    ├─╯
+    ◉  branches{test_branch} desc: 0
+    ◉  branches{} desc:
+    "###);
+
+    // The branch won't advance because `jj  new` had multiple targets.
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["new", "description(1)", "description(2)"],
+    );
+    insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
+    @    branches{} desc:
+    ├─╮
+    │ ◉  branches{} desc: 2
+    ◉ │  branches{} desc: 1
+    ├─╯
+    ◉  branches{test_branch} desc: 0
+    ◉  branches{} desc:
+    "###);
 }

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -123,6 +123,16 @@ impl View {
             .map(|(name, target)| (name.as_ref(), target))
     }
 
+    /// Iterates local branches `(name, target)` in lexicographical order where
+    /// the target adds `commit_id`.
+    pub fn local_branches_for_commit<'a: 'b, 'b>(
+        &'a self,
+        commit_id: &'b CommitId,
+    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + 'b {
+        self.local_branches()
+            .filter(|(_, target)| target.added_ids().contains(commit_id))
+    }
+
     /// Iterates local branch `(name, target)`s matching the given pattern.
     /// Entries are sorted by `name`.
     pub fn local_branches_matching<'a: 'b, 'b>(


### PR DESCRIPTION
This is an *experimental* feature that allows users to configure branches which will automatically advance when a new commit is created with `jj commit` or `jj new`. This feature may change or be removed in the future.

## Setup
This behavior can be enabled by default for all branches by setting
the following in the `config.toml`:

```
[experimental-advance-branches]
enabled-branches = ["glob:*"]
```

Specific branches can also be disabled:
```
[experimental-advance-branches]
enabled-branches = ["glob:*"]
disabled-branches = ["main", "glob:push-*"]
```

Branches that match a disabled pattern will not be advanced, even if they also
match an enabled pattern.

## How it works

- When `jj commit` and `jj new` are run, they target a specific revision, the "target revision". For `jj commit` this is always `@`, and for `jj new` the user specifies the target.
- When `jj commit` or `jj new` is run, jj will look at the parents of the target revision and advance any eligible branches pointing to them to the target revision (not the new commit). Branches are eligible to advance if the feature is enabled globally and the branch is not in the overrides list, or vice versa.
- Eligible branches will be advanced and will point to `@-` after `jj commit` or `jj new` completes.
- `jj new` only advances branches if the target is a single revision and the `--after` and `--before` are not used.

The result is that the branches move forward automatically as new commits are added. This is useful if you are committing linearly and don't want to move the branch pointer manually. Users familiar with Git may find that this feature mimics Git's behavior where branches move automatically as commits are added.

## Misc
An earlier version of this PR also included a feature for colocated Git repos:

> This feature also includes a convenience for colocated git repos. When the working commit is changed in a colocated repo and there is an advance-branches eligible branch pointing to its first parent, the Git HEAD is set to the branch ref instead of being detached at the parent commit id. This applies any time the working commit is changed, not just when `jj commit` is run.

I decided to split that feature into a separate PR, which I will mail after this PR is submitted.