### PR TITLE
templater: clean up `build_*_keyword()` functions

### DIFF
--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -154,7 +154,7 @@ fn build_operation_keyword_opt(
         property: impl TemplateProperty<Operation, Output = Operation>,
         f: impl Fn(&OperationMetadata) -> O,
     ) -> impl TemplateProperty<Operation, Output = O> {
-        TemplateFunction::new(property, move |op| f(&op.store_operation().metadata))
+        TemplateFunction::new(property, move |op| f(op.metadata()))
     }
 
     let property = match name {

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -39,7 +39,7 @@ id_type!(pub FileId);
 id_type!(pub SymlinkId);
 id_type!(pub ConflictId);
 
-#[derive(ContentHash, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(ContentHash, Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub struct MillisSinceEpoch(pub i64);
 
 #[derive(ContentHash, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -950,7 +950,7 @@ impl<'index> EvaluationContext<'index> {
         let make_rev_item = |entry: IndexEntry<'_>| {
             let commit = self.store.get_commit(&entry.commit_id()).unwrap();
             Reverse(Item {
-                timestamp: commit.committer().timestamp.timestamp.clone(),
+                timestamp: commit.committer().timestamp.timestamp,
                 pos: entry.position(),
             })
         };

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1876,8 +1876,7 @@ mod tests {
             commit2.committer.timestamp.timestamp
         );
         // The rest of the commit should be the same
-        actual_commit2.committer.timestamp.timestamp =
-            commit2.committer.timestamp.timestamp.clone();
+        actual_commit2.committer.timestamp.timestamp = commit2.committer.timestamp.timestamp;
         assert_eq!(actual_commit2, commit2);
     }
 

--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -129,7 +129,7 @@ where
         return Ok(op_head.clone());
     }
 
-    op_heads.sort_by_key(|op| op.store_operation().metadata.end_time.timestamp.clone());
+    op_heads.sort_by_key(|op| op.metadata().end_time.timestamp.clone());
     let new_op = resolver(op_heads)?;
     let mut old_op_heads = ancestor_op_heads;
     old_op_heads.extend_from_slice(new_op.parent_ids());

--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -129,7 +129,7 @@ where
         return Ok(op_head.clone());
     }
 
-    op_heads.sort_by_key(|op| op.metadata().end_time.timestamp.clone());
+    op_heads.sort_by_key(|op| op.metadata().end_time.timestamp);
     let new_op = resolver(op_heads)?;
     let mut old_op_heads = ancestor_op_heads;
     old_op_heads.extend_from_slice(new_op.parent_ids());

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -191,8 +191,8 @@ struct OperationByEndTime(Operation);
 
 impl Ord for OperationByEndTime {
     fn cmp(&self, other: &Self) -> Ordering {
-        let self_end_time = &self.0.store_operation().metadata.end_time;
-        let other_end_time = &other.0.store_operation().metadata.end_time;
+        let self_end_time = &self.0.metadata().end_time;
+        let other_end_time = &other.0.metadata().end_time;
         self_end_time
             .cmp(other_end_time)
             .then_with(|| self.0.cmp(&other.0)) // to comply with Eq

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -20,7 +20,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::op_store;
-use crate::op_store::{OpStore, OpStoreResult, OperationId, ViewId};
+use crate::op_store::{OpStore, OpStoreResult, OperationId, OperationMetadata, ViewId};
 use crate::view::View;
 
 #[derive(Clone)]
@@ -102,6 +102,10 @@ impl Operation {
     pub fn view(&self) -> OpStoreResult<View> {
         let data = self.op_store.read_view(&self.data.view_id)?;
         Ok(View::new(data))
+    }
+
+    pub fn metadata(&self) -> &OperationMetadata {
+        &self.data.metadata
     }
 
     pub fn store_operation(&self) -> &op_store::Operation {

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -237,16 +237,10 @@ fn test_reparent_range_linear() {
     assert_eq!(stats.rewritten_count, 2);
     assert_eq!(stats.unreachable_count, 1);
     let new_op_d = read_op(&stats.new_head_ids[0]);
-    assert_eq!(
-        new_op_d.store_operation().metadata,
-        repo_d.operation().store_operation().metadata
-    );
+    assert_eq!(new_op_d.metadata(), repo_d.operation().metadata());
     assert_eq!(new_op_d.view_id(), repo_d.operation().view_id());
     let [new_op_c] = op_parents(&new_op_d);
-    assert_eq!(
-        new_op_c.store_operation().metadata,
-        repo_c.operation().store_operation().metadata
-    );
+    assert_eq!(new_op_c.metadata(), repo_c.operation().metadata());
     assert_eq!(new_op_c.view_id(), repo_c.operation().view_id());
     assert_eq!(new_op_c.parent_ids(), slice::from_ref(repo_a.op_id()));
 
@@ -325,10 +319,7 @@ fn test_reparent_range_branchy() {
     assert_eq!(stats.rewritten_count, 3);
     assert_eq!(stats.unreachable_count, 2);
     let new_op_g = read_op(&stats.new_head_ids[0]);
-    assert_eq!(
-        new_op_g.store_operation().metadata,
-        repo_g.operation().store_operation().metadata
-    );
+    assert_eq!(new_op_g.metadata(), repo_g.operation().metadata());
     assert_eq!(new_op_g.view_id(), repo_g.operation().view_id());
     let [new_op_e, new_op_f] = op_parents(&new_op_g);
     assert_eq!(new_op_e.parent_ids(), slice::from_ref(repo_b.op_id()));
@@ -355,10 +346,7 @@ fn test_reparent_range_branchy() {
     assert_eq!(stats.rewritten_count, 5);
     assert_eq!(stats.unreachable_count, 1);
     let new_op_g = read_op(&stats.new_head_ids[0]);
-    assert_eq!(
-        new_op_g.store_operation().metadata,
-        repo_g.operation().store_operation().metadata
-    );
+    assert_eq!(new_op_g.metadata(), repo_g.operation().metadata());
     assert_eq!(new_op_g.view_id(), repo_g.operation().view_id());
     let [new_op_e, new_op_f] = op_parents(&new_op_g);
     let [new_op_d] = op_parents(&new_op_e);
@@ -384,10 +372,7 @@ fn test_reparent_range_branchy() {
     assert_eq!(stats.rewritten_count, 1);
     assert_eq!(stats.unreachable_count, 2);
     let new_op_g = read_op(&stats.new_head_ids[0]);
-    assert_eq!(
-        new_op_g.store_operation().metadata,
-        repo_g.operation().store_operation().metadata
-    );
+    assert_eq!(new_op_g.metadata(), repo_g.operation().metadata());
     assert_eq!(new_op_g.view_id(), repo_g.operation().view_id());
     assert_eq!(new_op_g.parent_ids(), slice::from_ref(repo_d.op_id()));
 
@@ -409,10 +394,7 @@ fn test_reparent_range_branchy() {
     assert_eq!(stats.rewritten_count, 1);
     assert_eq!(stats.unreachable_count, 0);
     let new_op_f = read_op(&stats.new_head_ids[0]);
-    assert_eq!(
-        new_op_f.store_operation().metadata,
-        op_f.store_operation().metadata
-    );
+    assert_eq!(new_op_f.metadata(), op_f.metadata());
     assert_eq!(new_op_f.view_id(), op_f.view_id());
     assert_eq!(new_op_f.parent_ids(), slice::from_ref(repo_d.op_id()));
 }


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
