### PR TITLE
nix: fix build on macOS

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -1,4 +1,4 @@
-name: Nix on Linux
+name: nix
 
 on:
   push:
@@ -10,9 +10,14 @@ permissions: read-all
 
 jobs:
   nix:
-    runs-on: ubuntu-latest
-    name: nix-build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15 # NOTE (aseipp): keep in-sync with the build.yml timeout limit
+
+    name: flake check
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -35,11 +35,11 @@
             pkgs.lib.all (re: builtins.match re relPath == null) regexes;
         };
 
-      rust-version = pkgs.rust-bin.stable."1.76.0".default;
+      ourRustVersion = pkgs.rust-bin.stable."1.76.0".default;
 
       ourRustPlatform = pkgs.makeRustPlatform {
-        rustc = rust-version;
-        cargo = rust-version;
+        rustc = ourRustVersion;
+        cargo = ourRustVersion;
       };
 
       # these are needed in both devShell and buildInputs
@@ -137,14 +137,14 @@
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
           # The CI checks against the latest nightly rustfmt, so we should too.
-          # NOTE (aseipp): include this FIRST before the rust-version override
-          # below; otherwise, it will be overridden by the rust-version and
+          # NOTE (aseipp): include this FIRST before the ourRustVersion override
+          # below; otherwise, it will be overridden by the ourRustVersion and
           # we'll get stable rustfmt instead.
           (rust-bin.selectLatestNightlyWith (toolchain: toolchain.rustfmt))
 
           # Using the minimal profile with explicit "clippy" extension to avoid
           # two versions of rustfmt
-          (rust-version.override {
+          (ourRustVersion.override {
             extensions = [
               "rust-src" # for rust-analyzer
               "clippy"


### PR DESCRIPTION
The `jj-proc-macros` crate caused the nix-on-macOS build to regress, due to https://github.com/nextest-rs/nextest/issues/267. Work around this, and add nix-on-macOS to the CI matrix.

Closes #3161.