### PR TITLE
templater: migrate non-core methods to symbol table

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -71,12 +71,9 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                 template_builder::build_core_method(self, build_ctx, property, function)
             }
             CommitTemplatePropertyKind::Commit(property) => {
-                // TODO: add name resolution helper that provides typo hint
-                if let Some(build) = self.build_fn_table.commit_methods.get(function.name) {
-                    build(self, build_ctx, property, function)
-                } else {
-                    Err(TemplateParseError::no_such_method("Commit", function))
-                }
+                let table = &self.build_fn_table.commit_methods;
+                let build = template_parser::lookup_method("Commit", table, function)?;
+                build(self, build_ctx, property, function)
             }
             CommitTemplatePropertyKind::CommitList(property) => {
                 template_builder::build_unformattable_list_method(

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -706,15 +706,12 @@ fn build_commit_or_change_id_method<'repo>(
     self_property: impl TemplateProperty<Commit, Output = CommitOrChangeId> + 'repo,
     function: &FunctionCallNode,
 ) -> TemplateParseResult<CommitTemplatePropertyKind<'repo>> {
-    let parse_optional_integer = |function| -> Result<Option<_>, TemplateParseError> {
-        let ([], [len_node]) = template_parser::expect_arguments(function)?;
-        len_node
-            .map(|node| template_builder::expect_integer_expression(language, build_ctx, node))
-            .transpose()
-    };
     let property = match function.name {
         "short" => {
-            let len_property = parse_optional_integer(function)?;
+            let ([], [len_node]) = template_parser::expect_arguments(function)?;
+            let len_property = len_node
+                .map(|node| template_builder::expect_integer_expression(language, build_ctx, node))
+                .transpose()?;
             language.wrap_string(TemplateFunction::new(
                 (self_property, len_property),
                 |(id, len)| id.short(len.map_or(12, |l| l.try_into().unwrap_or(0))),
@@ -722,7 +719,10 @@ fn build_commit_or_change_id_method<'repo>(
         }
         "shortest" => {
             let id_prefix_context = &language.id_prefix_context;
-            let len_property = parse_optional_integer(function)?;
+            let ([], [len_node]) = template_parser::expect_arguments(function)?;
+            let len_property = len_node
+                .map(|node| template_builder::expect_integer_expression(language, build_ctx, node))
+                .transpose()?;
             language.wrap_shortest_id_prefix(TemplateFunction::new(
                 (self_property, len_property),
                 |(id, len)| {

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -213,6 +213,24 @@ impl<'a, I: 'a> IntoTemplateProperty<'a, I> for CoreTemplatePropertyKind<'a, I> 
     }
 }
 
+/// Function that translates method call node of self type `T`.
+// The lifetime parameter 'a could be replaced with for<'a> to keep the method
+// table away from a certain lifetime. That's technically more correct, but I
+// couldn't find an easy way to expand that to the core template methods, which
+// are defined for L: TemplateLanguage<'a>. That's why the build fn table is
+// bound to a named lifetime, and therefore can't be cached statically.
+pub type TemplateBuildMethodFn<'a, L, T> =
+    fn(
+        &L,
+        &BuildContext<<L as TemplateLanguage<'a>>::Property>,
+        Box<dyn TemplateProperty<<L as TemplateLanguage<'a>>::Context, Output = T> + 'a>,
+        &FunctionCallNode,
+    ) -> TemplateParseResult<<L as TemplateLanguage<'a>>::Property>;
+
+/// Table of functions that translate method call node of self type `T`.
+pub type TemplateBuildMethodFnMap<'a, L, T> =
+    HashMap<&'static str, TemplateBuildMethodFn<'a, L, T>>;
+
 /// Opaque struct that represents a template value.
 pub struct Expression<P> {
     property: P,

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -855,6 +855,20 @@ pub fn expect_lambda_with<'a, 'i, T>(
     }
 }
 
+/// Looks up `table` by the given method name.
+pub fn lookup_method<'a, V>(
+    type_name: impl Into<String>,
+    table: &'a HashMap<&str, V>,
+    function: &FunctionCallNode,
+) -> TemplateParseResult<&'a V> {
+    if let Some(value) = table.get(function.name) {
+        Ok(value)
+    } else {
+        // TODO: provide typo hint
+        Err(TemplateParseError::no_such_method(type_name, function))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
