### PR TITLE
templater: migrate core methods to table lookup, add typo hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "scm-record",
  "serde",
  "slab",
+ "strsim",
  "tempfile",
  "test-case",
  "testutils",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -63,6 +63,7 @@ rpassword = { workspace = true }
 scm-record = { workspace = true }
 serde = { workspace = true }
 slab = { workspace = true }
+strsim = { workspace = true }
 tempfile = { workspace = true }
 textwrap = { workspace = true }
 thiserror = { workspace = true }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -405,9 +405,10 @@ impl From<RevsetEvaluationError> for CommandError {
 
 impl From<RevsetParseError> for CommandError {
     fn from(err: RevsetParseError) -> Self {
-        let message = iter::successors(Some(&err), |e| e.origin()).join("\n");
-        // Only for the top-level error as we can't attach hint to inner errors
-        let hint = match err.kind() {
+        let err_chain = iter::successors(Some(&err), |e| e.origin());
+        let message = err_chain.clone().join("\n");
+        // Only for the bottom error, which is usually the root cause
+        let hint = match err_chain.last().unwrap().kind() {
             RevsetParseErrorKind::NotPrefixOperator {
                 op: _,
                 similar_op,

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -68,7 +68,7 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
         match property {
             CommitTemplatePropertyKind::Core(property) => {
                 let table = &self.build_fn_table.core;
-                template_builder::build_core_method(self, table, build_ctx, property, function)
+                table.build_method(self, build_ctx, property, function)
             }
             CommitTemplatePropertyKind::Commit(property) => {
                 let table = &self.build_fn_table.commit_methods;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -804,4 +804,5 @@ pub fn parse<'repo>(
     };
     let node = template_parser::parse(template_text, aliases_map)?;
     template_builder::build(&language, &node)
+        .map_err(|err| err.extend_alias_candidates(aliases_map))
 }

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -255,4 +255,5 @@ pub fn parse(
     };
     let node = template_parser::parse(template_text, aliases_map)?;
     template_builder::build(&language, &node)
+        .map_err(|err| err.extend_alias_candidates(aliases_map))
 }

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -56,7 +56,7 @@ impl TemplateLanguage<'static> for OperationTemplateLanguage {
         match property {
             OperationTemplatePropertyKind::Core(property) => {
                 let table = &self.build_fn_table.core;
-                template_builder::build_core_method(self, table, build_ctx, property, function)
+                table.build_method(self, build_ctx, property, function)
             }
             OperationTemplatePropertyKind::Operation(property) => {
                 let table = &self.build_fn_table.operation_methods;

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -21,8 +21,8 @@ use jj_lib::operation::Operation;
 
 use crate::formatter::Formatter;
 use crate::template_builder::{
-    self, BuildContext, CoreTemplatePropertyKind, IntoTemplateProperty, TemplateBuildMethodFnMap,
-    TemplateLanguage,
+    self, BuildContext, CoreTemplateBuildFnTable, CoreTemplatePropertyKind, IntoTemplateProperty,
+    TemplateBuildMethodFnMap, TemplateLanguage,
 };
 use crate::template_parser::{self, FunctionCallNode, TemplateAliasesMap, TemplateParseResult};
 use crate::templater::{
@@ -55,7 +55,8 @@ impl TemplateLanguage<'static> for OperationTemplateLanguage {
     ) -> TemplateParseResult<Self::Property> {
         match property {
             OperationTemplatePropertyKind::Core(property) => {
-                template_builder::build_core_method(self, build_ctx, property, function)
+                let table = &self.build_fn_table.core;
+                template_builder::build_core_method(self, table, build_ctx, property, function)
             }
             OperationTemplatePropertyKind::Operation(property) => {
                 let table = &self.build_fn_table.operation_methods;
@@ -134,7 +135,7 @@ type OperationTemplateBuildMethodFnMap<T> =
 
 /// Symbol table of methods available in the operation template.
 struct OperationTemplateBuildFnTable {
-    // TODO: add core methods/functions table
+    core: CoreTemplateBuildFnTable<'static, OperationTemplateLanguage>,
     operation_methods: OperationTemplateBuildMethodFnMap<Operation>,
     operation_id_methods: OperationTemplateBuildMethodFnMap<OperationId>,
 }
@@ -143,6 +144,7 @@ impl OperationTemplateBuildFnTable {
     /// Creates new symbol table containing the builtin methods.
     fn builtin() -> Self {
         OperationTemplateBuildFnTable {
+            core: CoreTemplateBuildFnTable::builtin(),
             operation_methods: builtin_operation_methods(),
             operation_id_methods: builtin_operation_id_methods(),
         }

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -228,6 +228,7 @@ fn test_function_name_hint() {
     'branches(x)' = 'x' # override builtin function
     'my_author(x)' = 'author(x)' # similar name to builtin function
     'author_sym' = 'x' # not a function alias
+    'my_branches' = 'branch()' # typo in alias
     "###,
     );
 
@@ -251,6 +252,22 @@ fn test_function_name_hint() {
       |
       = Revset function "author_" doesn't exist
     Hint: Did you mean "author", "my_author"?
+    "###);
+
+    insta::assert_snapshot!(evaluate_err("my_branches"), @r###"
+    Error: Failed to parse revset:  --> 1:1
+      |
+    1 | my_branches
+      | ^---------^
+      |
+      = Alias "my_branches" cannot be expanded
+     --> 1:1
+      |
+    1 | branch()
+      | ^----^
+      |
+      = Revset function "branch" doesn't exist
+    Hint: Did you mean "branches"?
     "###);
 }
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
