### PR TITLE
templater: add `.len()` method, make `.substr()` byte-index based

### DIFF
--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -26,17 +26,18 @@ fn test_log_parents() {
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@", "@-"]);
 
-    let template = r#"commit_id ++ "\nP: " ++ parents.map(|c| c.commit_id()) ++ "\n""#;
+    let template =
+        r#"commit_id ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|c| c.commit_id()) ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @    c067170d4ca1bc6162b64f7550617ec809647f84
-    ├─╮  P: 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ├─╮  P: 2 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◉ │  4db490c88528133d579540b6900b8098f0c17701
-    ├─╯  P: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ├─╯  P: 1 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    │  P: 0000000000000000000000000000000000000000
+    │  P: 1 0000000000000000000000000000000000000000
     ◉  0000000000000000000000000000000000000000
-       P:
+       P: 0
     "###);
 
     let template = r#"parents.map(|c| c.commit_id().shortest(4))"#;

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -105,6 +105,7 @@ No methods are defined.
 A list can be implicitly converted to `Boolean`. The following methods are
 defined.
 
+* `.len() -> Integer`: Number of elements in the list.
 * `.join(separator: Template) -> Template`: Concatenate elements with
   the given `separator`.
 * `.map(|item| expression) -> ListTemplate`: Apply template `expression`
@@ -164,6 +165,7 @@ The following methods are defined.
 A string can be implicitly converted to `Boolean`. The following methods are
 defined.
 
+* `.len() -> Integer`: Length in UTF-8 bytes.
 * `.contains(needle: Template) -> Boolean`
 * `.first_line() -> String`
 * `.lines() -> List<String>`: Split into lines excluding newline characters.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -173,7 +173,9 @@ defined.
 * `.ends_with(needle: Template) -> Boolean`
 * `.remove_prefix(needle: Template) -> String`: Removes the passed prefix, if present
 * `.remove_suffix(needle: Template) -> String`: Removes the passed suffix, if present
-* `.substr(start: Integer, end: Integer) -> String`: Extract substring. Negative values count from the end.
+* `.substr(start: Integer, end: Integer) -> String`: Extract substring. The
+  `start`/`end` indices should be specified in UTF-8 bytes. Negative values
+  count from the end of the string.
 
 #### String literals
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
