### PR TITLE
Clean up the UnpublishedOperation struct

### DIFF
--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -147,12 +147,6 @@ pub fn create_op_metadata(
     }
 }
 
-struct NewRepoData {
-    operation: Operation,
-    view: View,
-    index: Box<dyn ReadonlyIndex>,
-}
-
 /// An Operation which has been written to the operation store but not
 /// published. The repo can be loaded at an unpublished Operation, but the
 /// Operation will not be visible in the op log if the repo is loaded at head.
@@ -162,7 +156,7 @@ struct NewRepoData {
 #[must_use = "Either publish() or leave_unpublished() must be called to finish the operation."]
 pub struct UnpublishedOperation {
     repo_loader: RepoLoader,
-    data: NewRepoData,
+    repo: Arc<ReadonlyRepo>,
 }
 
 impl UnpublishedOperation {
@@ -172,34 +166,23 @@ impl UnpublishedOperation {
         view: View,
         index: Box<dyn ReadonlyIndex>,
     ) -> Self {
-        UnpublishedOperation {
-            repo_loader,
-            data: NewRepoData {
-                operation,
-                view,
-                index,
-            },
-        }
+        let repo = repo_loader.create_from(operation, view, index);
+        UnpublishedOperation { repo_loader, repo }
     }
 
     pub fn operation(&self) -> &Operation {
-        &self.data.operation
+        self.repo.operation()
     }
 
     pub fn publish(self) -> Arc<ReadonlyRepo> {
-        let data = self.data;
-        {
-            let _lock = self.repo_loader.op_heads_store().lock();
-            self.repo_loader
-                .op_heads_store()
-                .update_op_heads(data.operation.parent_ids(), data.operation.id());
-        }
+        let _lock = self.repo_loader.op_heads_store().lock();
         self.repo_loader
-            .create_from(data.operation, data.view, data.index)
+            .op_heads_store()
+            .update_op_heads(self.operation().parent_ids(), self.operation().id());
+        self.repo
     }
 
     pub fn leave_unpublished(self) -> Arc<ReadonlyRepo> {
-        self.repo_loader
-            .create_from(self.data.operation, self.data.view, self.data.index)
+        self.repo
     }
 }


### PR DESCRIPTION
This PR makes a few minor refactoring changes to `UnpublishedOperation`. The behavior is left unchanged.

Happy to split this into separate PRs if that's easier, but these three commits together complete the cleanup.