### PR TITLE
docs: make it clear `ui.` refers to a toml section

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -172,10 +172,11 @@ If `ui.diff.tool` is set, the specified diff command will be called instead of
 the internal diff function.
 
 ```toml
+[ui]
 # Use Difftastic by default
-ui.diff.tool = ["difft", "--color=always", "$left", "$right"]
+diff.tool = ["difft", "--color=always", "$left", "$right"]
 # Use tool named "<name>" (see below)
-ui.diff.tool = "<name>"
+diff.tool = "<name>"
 ```
 
 The external diff tool can also be enabled by `diff --tool <name>` argument.


### PR DESCRIPTION
There was a question on Discord about why using Difftastic wasn't working as the diff tool. The root cause was putting `ui.diff.tool` in the wrong toml section, when the `ui.` component actually refers to the `[ui]` section itself.

This reads kind of weirdly too because _immediately_ after this, the alternative option of using the `merge-tools` section is suggested; except it uses `[merge- tools.<name>]` which makes it immediately clear it's a section on its own.

This simply these two examples more consistent with each other, by using `[ui]` instead of `ui.` to make it clear `ui.` is a top-level section.