### PR TITLE
cli: improve discoverability of template-aliases

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -35,6 +35,7 @@ use jj_lib::working_copy::{ResetError, SnapshotError, WorkingCopyStateError};
 use jj_lib::workspace::WorkspaceInitError;
 use thiserror::Error;
 
+use crate::cli_util::WorkspaceCommandHelper;
 use crate::merge_tools::{
     ConflictResolveError, DiffEditError, DiffGenerateError, MergeToolConfigError,
 };
@@ -74,6 +75,24 @@ impl ErrorWithMessage {
             source: source.into(),
         }
     }
+}
+
+pub fn user_error_missing_template(workspace_command: &WorkspaceCommandHelper) -> CommandError {
+    let mut template_names = workspace_command
+        .template_aliases_map()
+        .symbol_aliases_keys();
+    template_names.sort_unstable();
+    let mut hint = String::new();
+    let padding = "   ";
+    for name in template_names {
+        hint.push('\n');
+        hint.push_str(padding);
+        hint.push_str(name);
+    }
+    user_error_with_hint(
+        String::from("Template is required"),
+        format!("The following template-aliases are defined:{}", hint),
+    )
 }
 
 pub fn user_error(err: impl Into<Box<dyn error::Error + Send + Sync>>) -> CommandError {

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -561,6 +561,10 @@ impl TemplateAliasesMap {
         Self::default()
     }
 
+    pub fn symbol_aliases_keys(&self) -> Vec<&str> {
+        self.symbol_aliases.keys().map(|s| s.as_str()).collect_vec()
+    }
+
     /// Adds new substitution rule `decl = defn`.
     ///
     /// Returns error if `decl` is invalid. The `defn` part isn't checked. A bad

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -179,7 +179,7 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stderr, @r###"
     error: the argument '--git' cannot be used with '--color-words'
 
-    Usage: jj log --template <TEMPLATE> --no-graph --patch --git [PATHS]...
+    Usage: jj log --template [<TEMPLATE>] --no-graph --patch --git [PATHS]...
 
     For more information, try '--help'.
     "###);


### PR DESCRIPTION
This is follow up of #3175. This is a draft. Looking for initial feedback.

When user types `jj log -T` without passing a template name we can list all of them:

```
Error: Template is required
Hint: The following template-aliases are defined:
   builtin_change_id_with_hidden_and_divergent_info
   builtin_log_comfortable
   builtin_log_compact
   builtin_log_detailed
   builtin_log_oneline
   builtin_op_log_comfortable
   builtin_op_log_compact
   commit_summary_separator
   description_placeholder
   email_placeholder
   name_placeholder
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
