### PR TITLE
cli: status: when current change has conflicts, display instructions to resolve them

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1423,47 +1423,63 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
                     "There are still unresolved conflicts in rebased descendants.",
                 )?;
             }
-            let root_conflicts_revset = RevsetExpression::commits(
+
+            self.report_repo_conflicts(
+                fmt.as_mut(),
+                new_repo,
                 added_conflict_commits
                     .iter()
                     .map(|commit| commit.id().clone())
                     .collect(),
-            )
-            .roots()
-            .evaluate_programmatic(new_repo)?;
-
-            let root_conflict_commits: Vec<_> = root_conflicts_revset
-                .iter()
-                .commits(new_repo.store())
-                .try_collect()?;
-            if !root_conflict_commits.is_empty() {
-                fmt.push_label("hint")?;
-                if added_conflict_commits.len() == 1 {
-                    writeln!(fmt, "To resolve the conflicts, start by updating to it:",)?;
-                } else if root_conflict_commits.len() == 1 {
-                    writeln!(
-                        fmt,
-                        "To resolve the conflicts, start by updating to the first one:",
-                    )?;
-                } else {
-                    writeln!(
-                        fmt,
-                        "To resolve the conflicts, start by updating to one of the first ones:",
-                    )?;
-                }
-                for commit in root_conflict_commits {
-                    writeln!(fmt, "  jj new {}", short_change_hash(commit.change_id()))?;
-                }
-                writeln!(
-                    fmt,
-                    r#"Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
-Then run `jj squash` to move the resolution into the conflicted commit."#,
-                )?;
-                fmt.pop_label()?;
-            }
+            )?;
         }
 
+        Ok(())
+    }
+
+    pub fn report_repo_conflicts(
+        &self,
+        fmt: &mut dyn Formatter,
+        repo: &ReadonlyRepo,
+        conflicted_commits: Vec<CommitId>,
+    ) -> Result<(), CommandError> {
+        let only_one_conflicted_commit = conflicted_commits.len() == 1;
+        let root_conflicts_revset = RevsetExpression::commits(conflicted_commits)
+            .roots()
+            .evaluate_programmatic(repo)?;
+
+        let root_conflict_change_ids: Vec<_> = root_conflicts_revset
+            .iter()
+            .commits(repo.store())
+            .map(|maybe_commit| maybe_commit.map(|c| c.change_id().clone()))
+            .try_collect()?;
+
+        if !root_conflict_change_ids.is_empty() {
+            fmt.push_label("hint")?;
+            if only_one_conflicted_commit {
+                writeln!(fmt, "To resolve the conflicts, start by updating to it:",)?;
+            } else if root_conflict_change_ids.len() == 1 {
+                writeln!(
+                    fmt,
+                    "To resolve the conflicts, start by updating to the first one:",
+                )?;
+            } else {
+                writeln!(
+                    fmt,
+                    "To resolve the conflicts, start by updating to one of the first ones:",
+                )?;
+            }
+            for change_id in root_conflict_change_ids {
+                writeln!(fmt, "  jj new {}", short_change_hash(&change_id))?;
+            }
+            writeln!(
+                fmt,
+                r#"Then use `jj resolve`, or edit the conflict markers in the file directly.
+Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Then run `jj squash` to move the resolution into the conflicted commit."#,
+            )?;
+            fmt.pop_label()?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #3108

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Example output (which takes into account my own jj config and PWD so it's a little wonkier than the test, the screen is to show colors):

![Screenshot 2024-03-30 at 20 34 56](https://github.com/martinvonz/jj/assets/7951708/0edef6ec-7992-4d39-9970-0b9c37154293)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

I don't know if this deserves a changelog entry ? It's a small polish thing