### PR TITLE
Fix grammar for message when only one commit is abandoned after Git import

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -207,7 +207,12 @@ pub fn print_git_import_stats(
         }
     }
 
-    if !stats.abandoned_commits.is_empty() {
+    if stats.abandoned_commits.len() == 1 {
+        writeln!(
+            ui.stderr(),
+            "Abandoned 1 commit that is no longer reachable."
+        )?;
+    } else if !stats.abandoned_commits.is_empty() {
         writeln!(
             ui.stderr(),
             "Abandoned {} commits that are no longer reachable.",

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -811,7 +811,7 @@ fn test_branch_track_untrack() {
     branch: feature2@origin [updated] untracked
     branch: feature3@origin [new] tracked
     branch: main@origin     [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: sptzoqmo 7b33f629 commit 1

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -301,7 +301,7 @@ fn test_git_colocated_rebase_on_import() {
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Reset the working copy parent to the new Git HEAD.
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     Done importing changes from the underlying Git repo.
     "###);
 }
@@ -356,7 +356,7 @@ fn test_git_colocated_branches() {
     ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     Done importing changes from the underlying Git repo.

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -722,7 +722,7 @@ fn test_git_fetch_some_of_many_branches() {
     insta::assert_snapshot!(stderr, @r###"
     branch: a1@origin [updated] tracked
     branch: b@origin  [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  01d115196c39 descr_for_b b?? b@origin
@@ -760,7 +760,7 @@ fn test_git_fetch_some_of_many_branches() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     branch: a2@origin [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  31c7d94b1f29 descr_for_a2 a2
@@ -1124,7 +1124,7 @@ fn test_git_fetch_removed_branch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     branch: a2@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b
@@ -1204,7 +1204,7 @@ fn test_git_fetch_removed_parent_branch() {
     insta::assert_snapshot!(stderr, @r###"
     branch: a1@origin     [deleted] untracked
     branch: trunk1@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ◉  c7d4bdcbc215 descr_for_b b


### PR DESCRIPTION
Before:

- "Abandoned 1 commits that are no longer reachable."

After:

- "Abandoned 1 commit that is no longer reachable."