### PR TITLE
Adjust visibility of codependent MutableRepo and CommitBuilder functions

### DIFF
--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -32,7 +32,7 @@ pub struct CommitBuilder<'repo> {
 }
 
 impl CommitBuilder<'_> {
-    // Use MutRepo::new_commit() instead
+    /// Only called from [`MutRepo::new_commit`]. Use that function instead.
     pub(crate) fn for_new_commit<'repo>(
         mut_repo: &'repo mut MutableRepo,
         settings: &UserSettings,
@@ -62,7 +62,7 @@ impl CommitBuilder<'_> {
         }
     }
 
-    // Use MutRepo::rewrite_commit() instead
+    /// Only called from [`MutRepo::rewrite_commit`]. Use that function instead.
     pub(crate) fn for_rewrite_from<'repo>(
         mut_repo: &'repo mut MutableRepo,
         settings: &UserSettings,

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -771,11 +771,12 @@ impl MutableRepo {
             && self.view() == &self.base_repo.view)
     }
 
-    pub fn consume(self) -> (Box<dyn MutableIndex>, View) {
+    pub(crate) fn consume(self) -> (Box<dyn MutableIndex>, View) {
         self.view.ensure_clean(|v| self.enforce_view_invariants(v));
         (self.index, self.view.into_inner())
     }
 
+    /// Returns a [`CommitBuilder`] to write new commit to the repo.
     pub fn new_commit(
         &mut self,
         settings: &UserSettings,
@@ -785,6 +786,7 @@ impl MutableRepo {
         CommitBuilder::for_new_commit(self, settings, parents, tree_id)
     }
 
+    /// Returns a [`CommitBuilder`] to rewrite an existing commit in the repo.
     pub fn rewrite_commit(
         &mut self,
         settings: &UserSettings,
@@ -795,7 +797,8 @@ impl MutableRepo {
         // `self.rewritten_commits`
     }
 
-    pub fn write_commit(
+    /// Only called from [`CommitBuilder::write`]. Use that function instead.
+    pub(crate) fn write_commit(
         &mut self,
         commit: backend::Commit,
         sign_with: Option<&mut SigningFn>,


### PR DESCRIPTION
MutableRepo and CommitBuilder both define public (now crate-public) functions which should only be called by each other. This commit adds documentation and restricts visibility of these functions to the jj_lib crate. It might be even better to move CommitBuilder to the same module as MutableRepo so that these co-dependent functions can be private to the module to avoid misuse.
