### PR TITLE
cli: enrich the error about required template value with a hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Commands producing diffs now accept a `--context` flag for the number of
   lines of context to show.
 
+* `jj` commands with the `-T`/`--template` option now provide a hint containing
+  defined template names when no argument is given, assisting the user in making
+  a selection.
+
 ### Fixed bugs
 
 * On Windows, symlinks in the repo are now supported when Developer Mode is enabled.

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -561,6 +561,10 @@ impl TemplateAliasesMap {
         Self::default()
     }
 
+    pub fn symbol_names(&self) -> impl Iterator<Item = &str> {
+        self.symbol_aliases.keys().map(|s| s.as_str())
+    }
+
     /// Adds new substitution rule `decl = defn`.
     ///
     /// Returns error if `decl` is invalid. The `defn` part isn't checked. A bad

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -29,6 +29,32 @@ fn test_log_with_empty_revision() {
 }
 
 #[test]
+fn test_log_with_no_template() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &["log", "-T"]);
+    insta::assert_snapshot!(stderr, @r###"
+    error: a value is required for '--template <TEMPLATE>' but none was supplied
+
+    For more information, try '--help'.
+    Hint: The following template aliases are defined:
+    - builtin_change_id_with_hidden_and_divergent_info
+    - builtin_log_comfortable
+    - builtin_log_compact
+    - builtin_log_detailed
+    - builtin_log_oneline
+    - builtin_op_log_comfortable
+    - builtin_op_log_compact
+    - commit_summary_separator
+    - description_placeholder
+    - email_placeholder
+    - name_placeholder
+    "###);
+}
+
+#[test]
 fn test_log_with_or_without_diff() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -235,3 +235,29 @@ fn test_obslog_squash() {
          (empty) second
     "###);
 }
+
+#[test]
+fn test_obslog_with_no_template() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &["obslog", "-T"]);
+    insta::assert_snapshot!(stderr, @r###"
+    error: a value is required for '--template <TEMPLATE>' but none was supplied
+
+    For more information, try '--help'.
+    Hint: The following template aliases are defined:
+    - builtin_change_id_with_hidden_and_divergent_info
+    - builtin_log_comfortable
+    - builtin_log_compact
+    - builtin_log_detailed
+    - builtin_log_oneline
+    - builtin_op_log_comfortable
+    - builtin_op_log_compact
+    - commit_summary_separator
+    - description_placeholder
+    - email_placeholder
+    - name_placeholder
+    "###);
+}

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -94,6 +94,32 @@ fn test_op_log() {
 }
 
 #[test]
+fn test_op_log_with_no_template() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &["op", "log", "-T"]);
+    insta::assert_snapshot!(stderr, @r###"
+    error: a value is required for '--template <TEMPLATE>' but none was supplied
+
+    For more information, try '--help'.
+    Hint: The following template aliases are defined:
+    - builtin_change_id_with_hidden_and_divergent_info
+    - builtin_log_comfortable
+    - builtin_log_compact
+    - builtin_log_detailed
+    - builtin_log_oneline
+    - builtin_op_log_comfortable
+    - builtin_op_log_compact
+    - commit_summary_separator
+    - description_placeholder
+    - email_placeholder
+    - name_placeholder
+    "###);
+}
+
+#[test]
 fn test_op_log_limit() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -49,6 +49,32 @@ fn test_show_with_template() {
 }
 
 #[test]
+fn test_show_with_no_template() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &["show", "-T"]);
+    insta::assert_snapshot!(stderr, @r###"
+    error: a value is required for '--template <TEMPLATE>' but none was supplied
+
+    For more information, try '--help'.
+    Hint: The following template aliases are defined:
+    - builtin_change_id_with_hidden_and_divergent_info
+    - builtin_log_comfortable
+    - builtin_log_compact
+    - builtin_log_detailed
+    - builtin_log_oneline
+    - builtin_op_log_comfortable
+    - builtin_op_log_compact
+    - commit_summary_separator
+    - description_placeholder
+    - email_placeholder
+    - name_placeholder
+    "###);
+}
+
+#[test]
 fn test_show_relative_timestamps() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);


### PR DESCRIPTION
This is another implementation variant to improve discoverability of template-aliases (#3175)

If accepted, supersedes the solution implemented in #3189 PR. Thanks to @yuja for the suggestion.

Several `jj` commands accept `--template <TEMPLATE>` argument. When the argument is empty, `jj` will show the list of defined symbol names.

```
λ jj log -T
error: a value is required for '--template <TEMPLATE>' but none was supplied

For more information, try '--help'.

The following symbol names are defined:
- builtin_change_id_with_hidden_and_divergent_info
- builtin_log_comfortable
- builtin_log_compact
- builtin_log_detailed
- builtin_log_oneline
- builtin_op_log_comfortable
- builtin_op_log_compact
- commit_summary_separator
- description_placeholder
- email_placeholder
- name_placeholder
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
