### PR TITLE
Make URLs in docs hyperlinks

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2075,6 +2075,7 @@ impl fmt::Display for RemoteBranchNamePattern {
 /// Jujutsu (An experimental VCS)
 ///
 /// To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/docs/tutorial.md.
+#[allow(rustdoc::bare_urls)]
 #[derive(clap::Parser, Clone, Debug)]
 #[command(name = "jj")]
 pub struct Args {

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -63,7 +63,7 @@ impl FromStr for FsmonitorKind {
 }
 
 /// Filesystem monitor integration using Watchman
-/// (https://facebook.github.io/watchman/). Requires `watchman` to already be
+/// (<https://facebook.github.io/watchman/>). Requires `watchman` to already be
 /// installed on the system.
 #[cfg(feature = "watchman")]
 pub mod watchman {


### PR DESCRIPTION
`cargo doc` complains that two URLs aren't actually links:

```
warning: this URL is not a hyperlink
  --> lib/src/fsmonitor.rs:66:6
   |
66 | /// (https://facebook.github.io/watchman/). Requires `watchman` to already be
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://facebook.github.io/watchman/>`
   |
   = note: bare URLs are not automatically turned into clickable links
   = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: `jj-lib` (lib doc) generated 1 warning (run `cargo fix --lib -p jj-lib` to apply 1 suggestion)
 Documenting jj-cli v0.14.0 (/Users/emesterhazy/oss/github.com/martinvonz/jj/cli)
 Documenting testutils v0.14.0 (/Users/emesterhazy/oss/github.com/martinvonz/jj/lib/testutils)
warning: this URL is not a hyperlink
    --> cli/src/cli_util.rs:2077:41
     |
2077 | /// To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/docs/tutorial.md.
     |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/martinvonz/jj/blob/main/docs/tutorial.md.>`
     |
     = note: bare URLs are not automatically turned into clickable links
     = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: `jj-cli` (lib doc) generated 1 warning (run `cargo fix --lib -p jj-cli` to apply 1 suggestion)
```

This commit fixes the warnings by making the watchman URL a hyperlink and by disabling the lint for the jj-cli error. Disabling the link is the right thing to do because the comment is captured by clap and printed when `jj --help` runs and any markdown formatting like `<>` is passed through.