### PR TITLE
commit_templater: support custom cache extensions

### DIFF
--- a/cli/examples/custom-commit-templater/main.rs
+++ b/cli/examples/custom-commit-templater/main.rs
@@ -17,19 +17,24 @@ use jj_cli::commit_templater::{CommitTemplateBuildFnTable, CommitTemplateLanguag
 use jj_cli::template_builder::TemplateLanguage;
 use jj_cli::template_parser::{self, TemplateParseError};
 use jj_cli::templater::{TemplateFunction, TemplatePropertyError};
+use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
+use jj_lib::extensions_map::ExtensionsMap;
 use jj_lib::object_id::ObjectId;
+use jj_lib::repo::Repo;
+use jj_lib::revset::RevsetExpression;
+use once_cell::sync::OnceCell;
 
 struct HexCounter;
 
-fn num_digits_in_id(commit: Commit) -> Result<i64, TemplatePropertyError> {
+fn num_digits_in_id(id: &CommitId) -> i64 {
     let mut count = 0;
-    for ch in commit.id().hex().chars() {
+    for ch in id.hex().chars() {
         if ch.is_ascii_digit() {
             count += 1;
         }
     }
-    Ok(count)
+    count
 }
 
 fn num_char_in_id(commit: Commit, ch_match: char) -> Result<i64, TemplatePropertyError> {
@@ -42,14 +47,57 @@ fn num_char_in_id(commit: Commit, ch_match: char) -> Result<i64, TemplatePropert
     Ok(count)
 }
 
+struct MostDigitsInId {
+    count: OnceCell<i64>,
+}
+
+impl MostDigitsInId {
+    fn new() -> Self {
+        Self {
+            count: OnceCell::new(),
+        }
+    }
+
+    fn count(&self, repo: &dyn Repo) -> i64 {
+        *self.count.get_or_init(|| {
+            RevsetExpression::all()
+                .evaluate_programmatic(repo)
+                .unwrap()
+                .iter()
+                .map(|id| num_digits_in_id(&id))
+                .max()
+                .unwrap_or(0)
+        })
+    }
+}
+
 impl CommitTemplateLanguageExtension for HexCounter {
     fn build_fn_table<'repo>(&self) -> CommitTemplateBuildFnTable<'repo> {
         let mut table = CommitTemplateBuildFnTable::empty();
         table.commit_methods.insert(
+            "has_most_digits",
+            |language, _build_context, property, call| {
+                template_parser::expect_no_arguments(call)?;
+                let most_digits = language
+                    .cache_extension::<MostDigitsInId>()
+                    .unwrap()
+                    .count(language.repo());
+                Ok(
+                    language.wrap_boolean(TemplateFunction::new(property, move |commit| {
+                        Ok(num_digits_in_id(commit.id()) == most_digits)
+                    })),
+                )
+            },
+        );
+        table.commit_methods.insert(
             "num_digits_in_id",
             |language, _build_context, property, call| {
                 template_parser::expect_no_arguments(call)?;
-                Ok(language.wrap_integer(TemplateFunction::new(property, num_digits_in_id)))
+                Ok(
+                    language.wrap_integer(TemplateFunction::new(property, |commit| {
+                        Ok(num_digits_in_id(commit.id()))
+                    })),
+                )
             },
         );
         table.commit_methods.insert(
@@ -77,6 +125,10 @@ impl CommitTemplateLanguageExtension for HexCounter {
         );
 
         table
+    }
+
+    fn build_cache_extensions(&self, extensions: &mut ExtensionsMap) {
+        extensions.insert(MostDigitsInId::new());
     }
 }
 

--- a/lib/src/extensions_map.rs
+++ b/lib/src/extensions_map.rs
@@ -1,0 +1,98 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+/// Type-safe map that stores objects of arbitrary types.
+///
+/// This allows extensions to store and retrieve their own types unknown to
+/// jj_lib safely.
+#[derive(Default)]
+pub struct ExtensionsMap {
+    values: HashMap<TypeId, Box<dyn Any>>,
+}
+
+impl ExtensionsMap {
+    /// Creates an empty ExtensionsMap.
+    pub fn empty() -> Self {
+        Default::default()
+    }
+
+    /// Returns the specified type if it has already been inserted.
+    pub fn get<V: Any>(&self) -> Option<&V> {
+        self.values
+            .get(&TypeId::of::<V>())
+            .map(|v| v.downcast_ref::<V>().unwrap())
+    }
+
+    /// Inserts a new instance of the specified type.
+    ///
+    /// Requires that this type has not been inserted before.
+    pub fn insert<V: Any>(&mut self, value: V) {
+        assert!(self
+            .values
+            .insert(TypeId::of::<V>(), Box::new(value))
+            .is_none());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestTypeA;
+    impl TestTypeA {
+        fn get_a(&self) -> &'static str {
+            "a"
+        }
+    }
+
+    struct TestTypeB;
+    impl TestTypeB {
+        fn get_b(&self) -> &'static str {
+            "b"
+        }
+    }
+
+    #[test]
+    fn test_empty() {
+        let extensions_map = ExtensionsMap::empty();
+        assert!(extensions_map.get::<TestTypeA>().is_none());
+        assert!(extensions_map.get::<TestTypeB>().is_none());
+    }
+
+    #[test]
+    fn test_retrieval() {
+        let mut extensions_map = ExtensionsMap::empty();
+        extensions_map.insert(TestTypeA);
+        extensions_map.insert(TestTypeB);
+        assert_eq!(
+            extensions_map
+                .get::<TestTypeA>()
+                .map(|a| a.get_a())
+                .unwrap_or(""),
+            "a"
+        );
+        assert_eq!(
+            extensions_map
+                .get::<TestTypeB>()
+                .map(|b| b.get_b())
+                .unwrap_or(""),
+            "b"
+        );
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,7 @@ pub mod dag_walk;
 pub mod default_index;
 pub mod default_submodule_store;
 pub mod diff;
+pub mod extensions_map;
 pub mod file_util;
 pub mod files;
 pub mod fmt_util;


### PR DESCRIPTION
This uses OnceMap to support adding data to a shared reference, since CommitTemplateLanguage is not shared mutably

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
