### PR TITLE
cli: use a different symbol for immutable nodes in log

### DIFF
--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -41,6 +41,8 @@ pub trait GraphLog<K: Clone + Eq + Hash> {
 
     fn elided_node_symbol(&self) -> &str;
 
+    fn immutable_node_symbol(&self) -> &str;
+
     fn width(&self, id: &K, edges: &[Edge<K>]) -> usize;
 }
 
@@ -49,6 +51,7 @@ pub struct SaplingGraphLog<'writer, R> {
     writer: &'writer mut dyn Write,
     default_node_symbol: String,
     elided_node_symbol: String,
+    immutable_node_symbol: String,
 }
 
 impl<K: Clone> From<&Edge<K>> for Ancestor<K> {
@@ -91,6 +94,10 @@ where
         &self.elided_node_symbol
     }
 
+    fn immutable_node_symbol(&self) -> &str {
+        &self.immutable_node_symbol
+    }
+
     fn width(&self, id: &K, edges: &[Edge<K>]) -> usize {
         let parents = edges.iter().map_into().collect();
         let w: u64 = self.renderer.width(Some(id), Some(&parents));
@@ -104,6 +111,7 @@ impl<'writer, R> SaplingGraphLog<'writer, R> {
         formatter: &'writer mut dyn Write,
         default_node_symbol: &str,
         elided_node_symbol: &str,
+        immutable_node_symbol: &str,
     ) -> Box<dyn GraphLog<K> + 'writer>
     where
         K: Clone + Eq + Hash + 'writer,
@@ -114,6 +122,7 @@ impl<'writer, R> SaplingGraphLog<'writer, R> {
             writer: formatter,
             default_node_symbol: default_node_symbol.to_owned(),
             elided_node_symbol: elided_node_symbol.to_owned(),
+            immutable_node_symbol: immutable_node_symbol.to_owned(),
         })
     }
 }
@@ -130,10 +139,13 @@ pub fn get_graphlog<'a, K: Clone + Eq + Hash + 'a>(
             formatter,
             "◉",
             "◌",
+            "◈",
         ),
-        "ascii" => SaplingGraphLog::create(builder.build_ascii(), formatter, "o", "."),
-        "ascii-large" => SaplingGraphLog::create(builder.build_ascii_large(), formatter, "o", "."),
+        "ascii" => SaplingGraphLog::create(builder.build_ascii(), formatter, "o", ".", "x"),
+        "ascii-large" => {
+            SaplingGraphLog::create(builder.build_ascii_large(), formatter, "o", ".", "x")
+        }
         // "curved"
-        _ => SaplingGraphLog::create(builder.build_box_drawing(), formatter, "◉", "◌"),
+        _ => SaplingGraphLog::create(builder.build_box_drawing(), formatter, "◉", "◌", "◈"),
     }
 }


### PR DESCRIPTION
This is a part of #3111. I've introduced a different symbol for immutable nodes. I'm not planning doing configurable node symbols in this PR (mentioned in the issue). And I'm not sure about coloring the commit id differently. I'm open to color suggestions :)

I didn't update tests because there are a lot of them failed and also to avoid opening a massive PR as a draft. I'll update them when the main part of the PR is resolved.

Here are some screenshots with different symbols I've tried:

| `◈` diamond inside (PR) | `✦` four pointed star |
| --- | --- |
| <img width="300" alt="Screenshot 2024-03-06 at 22 26 27" src="https://github.com/martinvonz/jj/assets/3009258/9131e909-e659-406b-89e5-742d3e2c72ba"> | <img width="300" alt="Screenshot 2024-03-06 at 22 28 38" src="https://github.com/martinvonz/jj/assets/3009258/a21036cc-5c9d-45a4-910d-565af4c766f6"> |

| `◆` diamond | `·` middle dot |
| --- | --- |
| <img width="300" alt="Screenshot 2024-03-06 at 22 29 56" src="https://github.com/martinvonz/jj/assets/3009258/25b86877-ffdb-4a85-a78c-4ab6687ea8a0"> | <img width="300" alt="Screenshot 2024-03-06 at 22 31 09" src="https://github.com/martinvonz/jj/assets/3009258/f676e830-7c5b-44ca-a7f3-a08d7091d8df"> |

> Using `jj log -r ..` on the repo with `revset-aliases.immutable_heads()="main@upstream | gh-pages@upstream"` in the config.

While diamond symbols look great, with my vision I'd prefer `✦`  or `·` because they are more distinct than the default node symbol.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
