### PR TITLE
cli: move `jj co` alias to config file, so it can be overridden

### DIFF
--- a/cli/src/commands/checkout.rs
+++ b/cli/src/commands/checkout.rs
@@ -25,7 +25,6 @@ use crate::ui::Ui;
 /// For more information, see
 /// https://github.com/martinvonz/jj/blob/main/docs/working-copy.md.
 #[derive(clap::Args, Clone, Debug)]
-#[command(visible_aliases = &["co"])]
 pub(crate) struct CheckoutArgs {
     /// The revision to update to
     revision: RevisionArg,

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -1,5 +1,7 @@
+# The code assumes that this table exists, so don't delete it even if you remove
+# all aliases from here.
 [aliases]
-# Placeholder: added by user
+co = ["checkout"]
 
 [format]
 tree-level-conflicts = true


### PR DESCRIPTION
This way users can override `jj co` to mean `jj new` if they want to get rid of the warning.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
