### PR TITLE
cli: Display messages from remote after `jj git push`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Timestamps are now shown in local timezone and without milliseconds and
   timezone offset by default.
 
+* `jj git push` now prints messages from the remote.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -415,7 +415,7 @@ impl Ui {
                 .unwrap_or(false)
     }
 
-    pub fn prompt(&mut self, prompt: &str) -> io::Result<String> {
+    pub fn prompt(&self, prompt: &str) -> io::Result<String> {
         if !Self::can_prompt() {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
@@ -441,7 +441,7 @@ impl Ui {
 
     /// Repeat the given prompt until the input is one of the specified choices.
     pub fn prompt_choice(
-        &mut self,
+        &self,
         prompt: &str,
         choices: &[impl AsRef<str>],
         default: Option<&str>,
@@ -470,7 +470,7 @@ impl Ui {
     }
 
     /// Prompts for a yes-or-no response, with yes = true and no = false.
-    pub fn prompt_yes_no(&mut self, prompt: &str, default: Option<bool>) -> io::Result<bool> {
+    pub fn prompt_yes_no(&self, prompt: &str, default: Option<bool>) -> io::Result<bool> {
         let default_str = match &default {
             Some(true) => "(Yn)",
             Some(false) => "(yN)",
@@ -486,7 +486,7 @@ impl Ui {
         Ok(choice.starts_with(['y', 'Y']))
     }
 
-    pub fn prompt_password(&mut self, prompt: &str) -> io::Result<String> {
+    pub fn prompt_password(&self, prompt: &str) -> io::Result<String> {
         if !io::stdout().is_terminal() {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1362,6 +1362,7 @@ fn push_refs(
 #[allow(clippy::type_complexity)]
 pub struct RemoteCallbacks<'a> {
     pub progress: Option<&'a mut dyn FnMut(&Progress)>,
+    pub sideband_progress: Option<&'a mut dyn FnMut(&[u8])>,
     pub get_ssh_keys: Option<&'a mut dyn FnMut(&str) -> Vec<PathBuf>>,
     pub get_password: Option<&'a mut dyn FnMut(&str, &str) -> Option<String>>,
     pub get_username_password: Option<&'a mut dyn FnMut(&str) -> Option<(String, String)>>,
@@ -1378,6 +1379,12 @@ impl<'a> RemoteCallbacks<'a> {
                     overall: (progress.indexed_objects() + progress.indexed_deltas()) as f32
                         / (progress.total_objects() + progress.total_deltas()) as f32,
                 });
+                true
+            });
+        }
+        if let Some(sideband_progress_cb) = self.sideband_progress {
+            callbacks.sideband_progress(move |data| {
+                sideband_progress_cb(data);
                 true
             });
         }


### PR DESCRIPTION
Closes #3236.

Here's what this looks like pushing this branch:

```
❯ ./target/debug/jj git push -c @-
Creating branch bnjmnt4n/push-zuqnruqlvnyl for revision @-
Branch changes to push to origin:
  Add branch bnjmnt4n/push-zuqnruqlvnyl to 3ffca99209d2
remote:
remote: Create a pull request for 'bnjmnt4n/push-zuqnruqlvnyl' on GitHub by visiting:
remote:      https://github.com/martinvonz/jj/pull/new/bnjmnt4n/push-zuqnruqlvnyl
remote:
```

This is implemented by printing sideband messages from the Git protocol as they arrive. This is aligned as much as possible with Git's implementation: https://github.com/git/git/blob/43072b4ca132437f21975ac6acc6b72dc22fd398/sideband.c#L178.

I didn't write any tests for this, since it would likely involve having to create a custom git backend with the ability to write sideband messages (which is outside my area of expertise).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
