### PR TITLE
cli: Add `prev/next --conflict`, which allows you to jump to the next conflict. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revisions. This means that `jj git push -c xyz -c abc` is now equivalent to
   `jj git push -c 'all:(xyz | abc)'`.
 
+* `jj prev` and `jj next` have gained a `--conflict` flag which moves you
+  to the next conflict in a child commit.
+
 ### Fixed bugs
 
 ## [0.18.0] - 2024-06-05
@@ -93,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commit the new commit will be inserted before/after. Previously, those options
   were global flags and specifying them once would insert the new commit before/
   after all the specified commits.
+
 
 ### Deprecations
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1408,9 +1408,8 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
         // are millions of commits added to the repo, assuming the revset engine can
         // efficiently skip non-conflicting commits. Filter out empty commits mostly so
         // `jj new <conflicted commit>` doesn't result in a message about new conflicts.
-        let conflicts = RevsetExpression::filter(RevsetFilterPredicate::HasConflict).intersection(
-            &RevsetExpression::filter(RevsetFilterPredicate::File(FilesetExpression::all())),
-        );
+        let conflicts = RevsetExpression::filter(RevsetFilterPredicate::HasConflict)
+            .filtered(RevsetFilterPredicate::File(FilesetExpression::all()));
         let removed_conflicts_expr = new_heads.range(&old_heads).intersection(&conflicts);
         let added_conflicts_expr = old_heads.range(&new_heads).intersection(&conflicts);
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -95,8 +95,10 @@ pub(crate) fn cmd_status(
         // Ancestors with conflicts, excluding the current working copy commit.
         let ancestors_conflicts = workspace_command
             .attach_revset_evaluator(
-                RevsetExpression::filter(RevsetFilterPredicate::HasConflict)
-                    .intersection(&wc_revset.parents().ancestors())
+                wc_revset
+                    .parents()
+                    .ancestors()
+                    .filtered(RevsetFilterPredicate::HasConflict)
                     .minus(&revset_util::parse_immutable_expression(
                         &workspace_command.revset_parse_context(),
                     )?),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1163,6 +1163,7 @@ implied.
 ###### **Options:**
 
 * `-e`, `--edit` — Instead of creating a new working-copy commit on top of the target commit (like `jj new`), edit the target commit directly (like `jj edit`)
+* `--conflict` — Jump to the next conflicted descendant
 
 
 
@@ -1399,6 +1400,7 @@ implied.
 ###### **Options:**
 
 * `-e`, `--edit` — Edit the parent directly, instead of moving the working-copy commit
+* `--conflict` — Jump to the previous conflicted ancestor
 
 
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -353,6 +353,13 @@ impl RevsetExpression {
         })
     }
 
+    /// Filter all commits by `predicate` in `self`.
+    pub fn filtered(
+        self: &Rc<RevsetExpression>,
+        predicate: RevsetFilterPredicate,
+    ) -> Rc<RevsetExpression> {
+        self.intersection(&RevsetExpression::filter(predicate))
+    }
     /// Commits that are descendants of `self` and ancestors of `heads`, both
     /// inclusive.
     pub fn dag_range_to(


### PR DESCRIPTION
Tests are complete, although I need help there. 

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
