### PR TITLE
cli: move `jj amend/unamend` aliases to config

### DIFF
--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -36,7 +36,6 @@ use crate::ui::Ui;
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 #[derive(clap::Args, Clone, Debug)]
-#[command(visible_alias = "amend")]
 pub(crate) struct SquashArgs {
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -36,7 +36,6 @@ use crate::ui::Ui;
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 #[derive(clap::Args, Clone, Debug)]
-#[command(visible_alias = "unamend")]
 pub(crate) struct UnsquashArgs {
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -1,7 +1,10 @@
 # The code assumes that this table exists, so don't delete it even if you remove
 # all aliases from here.
 [aliases]
+amend = ["squash"]
 co = ["checkout"]
+unamend = ["unsquash"]
+
 
 [format]
 tree-level-conflicts = true

--- a/docs/config.md
+++ b/docs/config.md
@@ -389,7 +389,7 @@ Obviously, you would only set one line, don't copy them all in!
 ## Editing diffs
 
 The `ui.diff-editor` setting affects the tool used for editing diffs (e.g.  `jj
-split`, `jj amend -i`). The default is the special value `:builtin`, which
+split`, `jj squash -i`). The default is the special value `:builtin`, which
 launches a built-in TUI tool (known as [scm-diff-editor]) to edit the diff in
 your terminal.
 


### PR DESCRIPTION
The `amend/unamend` aliases exist for smoothen onboarding for Git/Mercurial users; I don't think we should recommend that users use them, so I think it's fine if users override them as they like. Therefore, I think they belong in the config.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
