### PR TITLE
docs: say that we support `$GIT_DIR/info/exclude`

### DIFF
--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -57,8 +57,7 @@ control. You can tell Jujutsu to not automatically track certain files by using
 `.gitignore` files (there's no such thing as `.jjignore` yet).
 See https://git-scm.com/docs/gitignore for details about the format.
 `.gitignore` files are supported in any directory in the working copy, as well
-as in `$HOME/.gitignore`. However, `$GIT_DIR/info/exclude` or equivalent way
-(maybe `.jj/gitignore`) of specifying per-clone ignores is not yet supported.
+as in `$HOME/.gitignore` and `$GIT_DIR/info/exclude`.
 
 
 ## Workspaces


### PR DESCRIPTION
We have had support for `GIT_DIR/info/exclude` since 8336c48 (almost exactly two years ago).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
