### PR TITLE
Render synthetic nodes in `jj log` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Graph node symbols are now configurable via `ui.graph.default_node` and `ui.graph.elided_node`.
 
+* `jj log` now includes synthetic nodes in the graph where some revisions were
+  elided.
+
 * `jj squash` now accepts `--from` and `--into` (mutually exclusive with `-r`).
   It can thereby be for all use cases where `jj move` can be used.
 

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -27,14 +27,18 @@ use crate::diff_util::{self, DiffFormatArgs};
 use crate::graphlog::{get_graphlog, Edge};
 use crate::ui::Ui;
 
-/// Show commit history
+/// Show revision history
+///
+/// Renders a graphical view of the project's history, ordered with children
+/// before parents. By default, the output only includes mutable revisions,
+/// along with some additional revisions for context.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
     /// Which revisions to show. Defaults to the `revsets.log` setting, or
     /// `@ | ancestors(immutable_heads().., 2) | trunk()` if it is not set.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
-    /// Show commits modifying the given paths
+    /// Show revisions modifying the given paths
     #[arg(value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
     /// Show revisions in the opposite order (older revisions first)

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -32,6 +32,9 @@ use crate::ui::Ui;
 /// Renders a graphical view of the project's history, ordered with children
 /// before parents. By default, the output only includes mutable revisions,
 /// along with some additional revisions for context.
+///
+/// Spans of revisions that are not included in the graph per `--revisions` are
+/// rendered as a synthetic node labeled "(elided revisions)".
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
     /// Which revisions to show. Defaults to the `revsets.log` setting, or

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -141,7 +141,7 @@
                 "log-synthetic-elided-nodes": {
                     "type": "boolean",
                     "description": "Whether to render elided parts of the graph as synthetic nodes.",
-                    "default": false
+                    "default": true
                 },
                 "editor": {
                     "type": "string",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -14,7 +14,7 @@ diff-instructions = true
 paginate = "auto"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false
-log-synthetic-elided-nodes = false
+log-synthetic-elided-nodes = true
 
 [snapshot]
 max-new-file-size = "1MiB"

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -118,7 +118,7 @@ To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/d
 * `git` — Commands for working with the underlying Git repo
 * `init` — Create a new repo in the given directory
 * `interdiff` — Compare the changes of two commits
-* `log` — Show commit history
+* `log` — Show revision history
 * `move` — Move changes from one revision into another
 * `new` — Create a new, empty change and (by default) edit it in the working copy
 * `next` — Move the current working copy commit to the next child revision in the
@@ -1010,13 +1010,15 @@ This excludes changes from other commits by temporarily rebasing `--from` onto `
 
 ## `jj log`
 
-Show commit history
+Show revision history
+
+Renders a graphical view of the project's history, ordered with children before parents. By default, the output only includes mutable revisions, along with some additional revisions for context.
 
 **Usage:** `jj log [OPTIONS] [PATHS]...`
 
 ###### **Arguments:**
 
-* `<PATHS>` — Show commits modifying the given paths
+* `<PATHS>` — Show revisions modifying the given paths
 
 ###### **Options:**
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1014,6 +1014,8 @@ Show revision history
 
 Renders a graphical view of the project's history, ordered with children before parents. By default, the output only includes mutable revisions, along with some additional revisions for context.
 
+Spans of revisions that are not included in the graph per `--revisions` are rendered as a synthetic node labeled "(elided revisions)".
+
 **Usage:** `jj log [OPTIONS] [PATHS]...`
 
 ###### **Arguments:**

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1356,6 +1356,7 @@ fn test_elided() {
 
     // Elide some commits from each side of the merge. It's unclear that a revision
     // was skipped on the left side.
+    test_env.add_config("ui.log-synthetic-elided-nodes = false");
     insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
     @    merge
     ├─╮


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
