### PR TITLE
cli: make `*Args::tool` fields non-public, except for `DiffFormatArgs`

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -33,7 +33,7 @@ pub(crate) struct CommitArgs {
     interactive: bool,
     /// Specify diff editor to be used (implies --interactive)
     #[arg(long, value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
     /// The change description to use (don't open editor)
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -53,7 +53,7 @@ pub(crate) struct DiffeditArgs {
     to: Option<RevisionArg>,
     /// Specify diff editor to be used
     #[arg(long, value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
 }
 
 #[instrument(skip_all)]

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -52,7 +52,7 @@ pub(crate) struct MoveArgs {
     interactive: bool,
     /// Specify diff editor to be used (implies --interactive)
     #[arg(long, value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
     /// Move only changes to these paths (instead of all paths)
     #[arg(conflicts_with_all = ["interactive", "tool"], value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -57,7 +57,7 @@ pub(crate) struct ResolveArgs {
     quiet: bool,
     /// Specify 3-way merge tool to be used
     #[arg(long, conflicts_with = "list", value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
     /// Restrict to these paths when searching for a conflict to resolve. We
     /// will attempt to resolve the first conflict we can find. You can use
     /// the `--list` argument to find paths to use here.

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -43,7 +43,7 @@ pub(crate) struct SplitArgs {
     interactive: bool,
     /// Specify diff editor to be used (implies --interactive)
     #[arg(long, value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
     /// The revision to split
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -47,7 +47,7 @@ pub(crate) struct SquashArgs {
     interactive: bool,
     /// Specify diff editor to be used (implies --interactive)
     #[arg(long, value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
     /// Move only changes to these paths (instead of all paths)
     #[arg(conflicts_with_all = ["interactive", "tool"], value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -46,7 +46,7 @@ pub(crate) struct UnsquashArgs {
     interactive: bool,
     /// Specify diff editor to be used (implies --interactive)
     #[arg(long, value_name = "NAME")]
-    pub tool: Option<String>,
+    tool: Option<String>,
 }
 
 #[instrument(skip_all)]


### PR DESCRIPTION
Probably just a bad copy&paste.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
