### PR TITLE
Make `jj squash` and `jj move` share more code

### DIFF
--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -76,6 +76,11 @@ pub(crate) fn cmd_move(
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let mut tx = workspace_command.start_transaction();
+    let tx_description = format!(
+        "move changes from {} to {}",
+        source.id().hex(),
+        destination.id().hex()
+    );
     let parent_tree = merge_commit_trees(tx.repo(), &source.parents())?;
     let source_tree = source.tree()?;
     let instructions = format!(
@@ -141,13 +146,6 @@ from the source will be moved into the destination.
         .set_tree_id(new_destination_tree.id().clone())
         .set_description(description)
         .write()?;
-    tx.finish(
-        ui,
-        format!(
-            "move changes from {} to {}",
-            source.id().hex(),
-            destination.id().hex()
-        ),
-    )?;
+    tx.finish(ui, tx_description)?;
     Ok(())
 }

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -78,12 +78,16 @@ pub(crate) fn cmd_move(
         destination.id().hex()
     );
     move_diff(
+        ui,
         &mut tx,
         command.settings(),
         source,
         destination,
         matcher.as_ref(),
         &diff_selector,
+        None,
+        false,
+        &args.paths,
     )?;
     tx.finish(ui, tx_description)?;
     Ok(())

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -13,11 +13,16 @@
 // limitations under the License.
 
 use clap::parser::ValueSource;
+use jj_lib::commit::Commit;
+use jj_lib::matchers::Matcher;
 use jj_lib::object_id::ObjectId;
+use jj_lib::repo::Repo;
 use jj_lib::revset;
+use jj_lib::rewrite::merge_commit_trees;
+use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
-use crate::cli_util::{CommandHelper, RevisionArg};
+use crate::cli_util::{CommandHelper, DiffSelector, RevisionArg, WorkspaceCommandTransaction};
 use crate::command_error::{user_error, CommandError};
 use crate::description_util::{combine_messages, join_message_paragraphs};
 use crate::ui::Ui;
@@ -145,5 +150,77 @@ from the source will be moved into the parent.
             .write()?;
     }
     tx.finish(ui, format!("squash commit {}", commit.id().hex()))?;
+    Ok(())
+}
+
+pub fn move_diff(
+    tx: &mut WorkspaceCommandTransaction,
+    settings: &UserSettings,
+    source: Commit,
+    mut destination: Commit,
+    matcher: &dyn Matcher,
+    diff_selector: &DiffSelector,
+) -> Result<(), CommandError> {
+    tx.base_workspace_helper()
+        .check_rewritable([&source, &destination])?;
+    let parent_tree = merge_commit_trees(tx.repo(), &source.parents())?;
+    let source_tree = source.tree()?;
+    let instructions = format!(
+        "\
+You are moving changes from: {}
+into commit: {}
+
+The left side of the diff shows the contents of the parent commit. The
+right side initially shows the contents of the commit you're moving
+changes from.
+
+Adjust the right side until the diff shows the changes you want to move
+to the destination. If you don't make any changes, then all the changes
+from the source will be moved into the destination.
+",
+        tx.format_commit_summary(&source),
+        tx.format_commit_summary(&destination)
+    );
+    let new_parent_tree_id =
+        diff_selector.select(&parent_tree, &source_tree, matcher, Some(&instructions))?;
+    if diff_selector.is_interactive() && new_parent_tree_id == parent_tree.id() {
+        return Err(user_error("No changes to move"));
+    }
+    let new_parent_tree = tx.repo().store().get_root_tree(&new_parent_tree_id)?;
+    // Apply the reverse of the selected changes onto the source
+    let new_source_tree = source_tree.merge(&new_parent_tree, &parent_tree)?;
+    let abandon_source = new_source_tree.id() == parent_tree.id();
+    if abandon_source {
+        tx.mut_repo().record_abandoned_commit(source.id().clone());
+    } else {
+        tx.mut_repo()
+            .rewrite_commit(settings, &source)
+            .set_tree_id(new_source_tree.id().clone())
+            .write()?;
+    }
+    if tx.repo().index().is_ancestor(source.id(), destination.id()) {
+        // If we're moving changes to a descendant, first rebase descendants onto the
+        // rewritten source. Otherwise it will likely already have the content
+        // changes we're moving, so applying them will have no effect and the
+        // changes will disappear.
+        let rebase_map = tx.mut_repo().rebase_descendants_return_map(settings)?;
+        let rebased_destination_id = rebase_map.get(destination.id()).unwrap().clone();
+        destination = tx.mut_repo().store().get_commit(&rebased_destination_id)?;
+    }
+    // Apply the selected changes onto the destination
+    let destination_tree = destination.tree()?;
+    let new_destination_tree = destination_tree.merge(&parent_tree, &new_parent_tree)?;
+    let description = combine_messages(
+        tx.base_repo(),
+        &source,
+        &destination,
+        settings,
+        abandon_source,
+    )?;
+    tx.mut_repo()
+        .rewrite_commit(settings, &destination)
+        .set_tree_id(new_destination_tree.id().clone())
+        .set_description(description)
+        .write()?;
     Ok(())
 }

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -66,12 +66,12 @@ pub(crate) fn cmd_squash(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(args.revision.as_deref().unwrap_or("@"))?;
-    workspace_command.check_rewritable([&commit])?;
     let parents = commit.parents();
     if parents.len() != 1 {
         return Err(user_error("Cannot squash merge commits"));
     }
     let parent = &parents[0];
+    workspace_command.check_rewritable([&commit])?;
     workspace_command.check_rewritable(&parents[..1])?;
     let matcher = workspace_command.matcher_from_values(&args.paths)?;
     let diff_selector =

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -220,6 +220,7 @@ from the source will be moved into the destination.
     tx.mut_repo()
         .rewrite_commit(settings, &destination)
         .set_tree_id(new_destination_tree.id().clone())
+        .set_predecessors(vec![destination.id().clone(), source.id().clone()])
         .set_description(description)
         .write()?;
     Ok(())

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1700,9 +1700,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 ###### **Options:**
 
-* `-r`, `--revision <REVISION>`
-
-  Default value: `@`
+* `-r`, `--revision <REVISION>` — Revision to squash into its parent (default: @)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-i`, `--interactive` — Interactively choose which parts to squash
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -207,9 +207,9 @@ fn test_rewrite_immutable_commands() {
     Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // squash
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "-r=main"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "-r=description(b)"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3d14df18607e is immutable
+    Error: Commit c8d4c7ca95d0 is immutable
     Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // unsquash

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -180,7 +180,7 @@ fn test_squash_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 descendant commits
+    Rebased 2 descendant commits
     Working copy now at: mzvwutvl e7a40106 c | (no description set)
     Parent commit      : kkmpptxz 05d95164 b | (no description set)
     "###);
@@ -214,7 +214,7 @@ fn test_squash_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 descendant commits
+    Rebased 2 descendant commits
     Working copy now at: mzvwutvl a911fa1d c | (no description set)
     Parent commit      : kkmpptxz fb73ad17 b | (no description set)
     "###);
@@ -247,7 +247,7 @@ fn test_squash_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 descendant commits
+    Rebased 2 descendant commits
     Working copy now at: mzvwutvl 5e297967 c | (no description set)
     Parent commit      : kkmpptxz ac258609 b | (no description set)
     "###);
@@ -257,6 +257,7 @@ fn test_squash_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "b"]);
     insta::assert_snapshot!(stderr, @r###"
     warning: The argument "b" is being interpreted as a path. To specify a revset, pass -r "b" instead.
+    Rebased 1 descendant commits
     Working copy now at: mzvwutvl 1c4e5596 c | (no description set)
     Parent commit      : kkmpptxz 16cc94b4 b | (no description set)
     "###);


### PR DESCRIPTION
This is prep work for teaching `jj squash --from/--to` and for making it support multiple `--from` revisions (and maybe multiple `-r` revisions)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
