### PR TITLE
Teach `jj squash` `--from/--into`, deprecate `jj move`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecations
 
+* `jj move` was deprecated in favor of `jj squash`.
+
 ### Breaking changes
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Graph node symbols are now configurable via `ui.graph.default_node` and `ui.graph.elided_node`.
 
+* `jj squash` now accepts `--from` and `--into` (mutually exclusive with `-r`).
+  It can thereby be for all use cases where `jj move` can be used.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Besides the usual rebase command, there's `jj describe` for editing the
 description (commit message) of an arbitrary commit. There's also `jj diffedit`,
 which lets you edit the changes in a commit without checking it out. To split
 a commit into two, use `jj split`. You can even move part of the changes in a
-commit to any other commit using `jj move`.
+commit to any other commit using `jj squash -i --from X --into Y`.
 
 ## Status
 

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -62,6 +62,14 @@ pub(crate) fn cmd_move(
     command: &CommandHelper,
     args: &MoveArgs,
 ) -> Result<(), CommandError> {
+    writeln!(
+        ui.warning(),
+        "warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent"
+    )?;
+    writeln!(
+        ui.warning(),
+        "warning: `jj move` will be removed in a future version, and this will be a hard error"
+    )?;
     let mut workspace_command = command.workspace_helper(ui)?;
     let source = workspace_command.resolve_single_rev(args.from.as_deref().unwrap_or("@"))?;
     let destination = workspace_command.resolve_single_rev(args.to.as_deref().unwrap_or("@"))?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -133,7 +133,7 @@ repository.
 * `show` — Show commit description and changes in a revision
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
 * `split` — Split a revision in two
-* `squash` — Move changes from a revision into its parent
+* `squash` — Move changes from a revision into another revision
 * `status` — Show high-level repo status
 * `tag` — Manage tags
 * `util` — Infrequently used commands such as for generating shell completions
@@ -1684,9 +1684,13 @@ If the change you split had a description, you will be asked to enter a change d
 
 ## `jj squash`
 
-Move changes from a revision into its parent
+Move changes from a revision into another revision
 
-After moving the changes into the parent, the child revision will have the same content state as before. If that means that the change is now empty compared to its parent, it will be abandoned. Without `--interactive`, the child change will always be empty.
+With the `-r` option, moves the changes from the specified revision to the parent revision. Fails if there are several parent revisions (i.e., the given revision is a merge).
+
+With the `--from` and/or `--into` options, moves changes from/to the given revisions. If either is left out, it defaults to the working-copy commit. For example, `jj squash --into @--` moves changes from the working-copy commit to the grandparent.
+
+If, after moving changes out, the source revision is empty compared to its parent(s), it will be abandoned. Without `--interactive`, the source revision will always be empty.
 
 If the source became empty and both the source and destination had a non-empty description, you will be asked for the combined description. If either was empty, then the other one will be used.
 
@@ -1701,6 +1705,8 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 ###### **Options:**
 
 * `-r`, `--revision <REVISION>` — Revision to squash into its parent (default: @)
+* `--from <FROM>` — Revision to squash from (default: @)
+* `--into <INTO>` — Revision to squash into (default: @)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-i`, `--interactive` — Interactively choose which parts to squash
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -143,12 +143,16 @@ fn test_rewrite_immutable_commands() {
     // move --from
     let stderr = test_env.jj_cmd_failure(&repo_path, &["move", "--from=main"]);
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Error: Commit 3d14df18607e is immutable
     Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // move --to
     let stderr = test_env.jj_cmd_failure(&repo_path, &["move", "--to=main"]);
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Error: Commit 3d14df18607e is immutable
     Hint: Configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -78,6 +78,8 @@ fn test_move() {
     // Errors out if source and destination are the same
     let stderr = test_env.jj_cmd_failure(&repo_path, &["move", "--to", "@"]);
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Error: Source and destination cannot be the same.
     "###);
 
@@ -85,6 +87,8 @@ fn test_move() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Working copy now at: kmkuslsw 1c03e3d3 f | (no description set)
     Parent commit      : znkkpsqq e9515f21 e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
@@ -114,6 +118,8 @@ fn test_move() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Working copy now at: kmkuslsw c8d83075 f | (no description set)
     Parent commit      : znkkpsqq 2c50bfc5 e | (no description set)
     "###);
@@ -140,6 +146,8 @@ fn test_move() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "--from", "e", "--to", "d"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
     Working copy now at: kmkuslsw 2b723b1d f | (no description set)
     Parent commit      : vruxwmqv 4293930d d e | (no description set)
@@ -205,6 +213,8 @@ fn test_move_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Working copy now at: vruxwmqv 71b69e43 d | (no description set)
     Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
@@ -237,6 +247,8 @@ fn test_move_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Working copy now at: vruxwmqv 63f1a6e9 d | (no description set)
     Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
@@ -272,6 +284,8 @@ fn test_move_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Working copy now at: vruxwmqv 17c2e663 d | (no description set)
     Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
@@ -308,6 +322,8 @@ fn test_move_partial() {
         test_env.jj_cmd_ok(&repo_path, &["move", "--from", "c", "--to", "b", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -335,6 +351,8 @@ fn test_move_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
+    warning: `jj move` will be removed in a future version, and this will be a hard error
     Working copy now at: vruxwmqv b670567d d | (no description set)
     Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
     "###);

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -264,6 +264,324 @@ fn test_squash_partial() {
     insta::assert_snapshot!(stdout, @"");
 }
 
+#[test]
+fn test_squash_from_to() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // Create history like this:
+    // F
+    // |
+    // E C
+    // | |
+    // D B
+    // |/
+    // A
+    //
+    // When moving changes between e.g. C and F, we should not get unrelated changes
+    // from B and D.
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "a"]);
+    std::fs::write(repo_path.join("file1"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file3"), "a\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "b"]);
+    std::fs::write(repo_path.join("file3"), "b\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "c"]);
+    std::fs::write(repo_path.join("file1"), "c\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["edit", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "d"]);
+    std::fs::write(repo_path.join("file3"), "d\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "e"]);
+    std::fs::write(repo_path.join("file2"), "e\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "f"]);
+    std::fs::write(repo_path.join("file2"), "f\n").unwrap();
+    // Test the setup
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  0d7353584003 f
+    ◉  e9515f21068c e
+    ◉  bdd835cae844 d
+    │ ◉  caa4d0b23201 c
+    │ ◉  55171e33db26 b
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+
+    // Errors out if source and destination are the same
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--into", "@"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Source and destination cannot be the same
+    "###);
+
+    // Can squash from sibling, which results in the source being abandoned
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: kmkuslsw 5337fca9 f | (no description set)
+    Parent commit      : znkkpsqq e9515f21 e | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  5337fca918e8 f
+    ◉  e9515f21068c e
+    ◉  bdd835cae844 d
+    │ ◉  55171e33db26 b c
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+    // The change from the source has been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    c
+    "###);
+    // File `file2`, which was not changed in source, is unchanged
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2"]);
+    insta::assert_snapshot!(stdout, @r###"
+    f
+    "###);
+
+    // Can squash from ancestor
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "@--"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: kmkuslsw 66ff309f f | (no description set)
+    Parent commit      : znkkpsqq 16f4e7c4 e | (no description set)
+    "###);
+    // The change has been removed from the source (the change pointed to by 'd'
+    // became empty and was abandoned)
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  66ff309f65e8 f
+    ◉  16f4e7c4886f e
+    │ ◉  caa4d0b23201 c
+    │ ◉  55171e33db26 b
+    ├─╯
+    ◉  3db0a2f5b535 a d
+    ◉  000000000000
+    "###);
+    // The change from the source has been applied (the file contents were already
+    // "f", as is typically the case when moving changes from an ancestor)
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2"]);
+    insta::assert_snapshot!(stdout, @r###"
+    f
+    "###);
+
+    // Can squash from descendant
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    let (stdout, stderr) =
+        test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "e", "--into", "d"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Rebased 1 descendant commits
+    Working copy now at: kmkuslsw b4f8051d f | (no description set)
+    Parent commit      : vruxwmqv f74c102f d e | (no description set)
+    "###);
+    // The change has been removed from the source (the change pointed to by 'e'
+    // became empty and was abandoned)
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  b4f8051d8466 f
+    ◉  f74c102ff29a d e
+    │ ◉  caa4d0b23201 c
+    │ ◉  55171e33db26 b
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+    // The change from the source has been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2", "-r", "d"]);
+    insta::assert_snapshot!(stdout, @r###"
+    e
+    "###);
+}
+
+#[test]
+fn test_squash_from_to_partial() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // Create history like this:
+    //   C
+    //   |
+    // D B
+    // |/
+    // A
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "a"]);
+    std::fs::write(repo_path.join("file1"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file3"), "a\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "b"]);
+    std::fs::write(repo_path.join("file3"), "b\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "c"]);
+    std::fs::write(repo_path.join("file1"), "c\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "c\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["edit", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "d"]);
+    std::fs::write(repo_path.join("file3"), "d\n").unwrap();
+    // Test the setup
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  bdd835cae844 d
+    │ ◉  5028db694b6b c
+    │ ◉  55171e33db26 b
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+
+    let edit_script = test_env.set_up_fake_diff_editor();
+
+    // If we don't make any changes in the diff-editor, the whole change is moved
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: vruxwmqv 71b69e43 d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Added 0 files, modified 2 files, removed 0 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  71b69e433fbc d
+    │ ◉  55171e33db26 b c
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+    // The changes from the source has been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    c
+    "###);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2"]);
+    insta::assert_snapshot!(stdout, @r###"
+    c
+    "###);
+    // File `file3`, which was not changed in source, is unchanged
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file3"]);
+    insta::assert_snapshot!(stdout, @r###"
+    d
+    "###);
+
+    // Can squash only part of the change in interactive mode
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    std::fs::write(&edit_script, "reset file2").unwrap();
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: vruxwmqv 63f1a6e9 d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  63f1a6e96edb d
+    │ ◉  d027c6e3e6bc c
+    │ ◉  55171e33db26 b
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+    // The selected change from the source has been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    c
+    "###);
+    // The unselected change from the source has not been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2"]);
+    insta::assert_snapshot!(stdout, @r###"
+    a
+    "###);
+    // File `file3`, which was changed in source's parent, is unchanged
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file3"]);
+    insta::assert_snapshot!(stdout, @r###"
+    d
+    "###);
+
+    // Can squash only part of the change from a sibling in non-interactive mode
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    // Clear the script so we know it won't be used
+    std::fs::write(&edit_script, "").unwrap();
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "file1"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: vruxwmqv 17c2e663 d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    @  17c2e6632cc5 d
+    │ ◉  6a3ae047a03e c
+    │ ◉  55171e33db26 b
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+    // The selected change from the source has been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    c
+    "###);
+    // The unselected change from the source has not been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2"]);
+    insta::assert_snapshot!(stdout, @r###"
+    a
+    "###);
+    // File `file3`, which was changed in source's parent, is unchanged
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file3"]);
+    insta::assert_snapshot!(stdout, @r###"
+    d
+    "###);
+
+    // Can squash only part of the change from a descendant in non-interactive mode
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    // Clear the script so we know it won't be used
+    std::fs::write(&edit_script, "").unwrap();
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &repo_path,
+        &["squash", "--from", "c", "--into", "b", "file1"],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Rebased 1 descendant commits
+    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ◉  21253406d416 c
+    ◉  e1cf08aae711 b
+    │ @  bdd835cae844 d
+    ├─╯
+    ◉  3db0a2f5b535 a
+    ◉  000000000000
+    "###);
+    // The selected change from the source has been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
+    insta::assert_snapshot!(stdout, @r###"
+    c
+    "###);
+    // The unselected change from the source has not been applied
+    let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2", "-r", "b"]);
+    insta::assert_snapshot!(stdout, @r###"
+    a
+    "###);
+
+    // If we specify only a non-existent file, then the move still succeeds and
+    // creates unchanged commits.
+    test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    let (stdout, stderr) =
+        test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "nonexistent"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: vruxwmqv b670567d d | (no description set)
+    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    "###);
+}
+
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     let template = r#"commit_id.short() ++ " " ++ branches"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -122,9 +122,8 @@ try `jj rebase -s all:commit_with_local_changes+ -d main`
 
 An alternative workflow would be to rebase the commit with local changes on
 top of the PR you're working on and then do `jj new commit_with_local_changes`.
-You'll then need to use `jj new --before` to create new commits
-and `jj move --to`
-to move new changes into the correct commits.
+You'll then need to use `jj new --before` to create new commits and
+`jj squash --into` to move new changes into the correct commits.
 
 ### I accidentally changed files in the wrong commit, how do I move the recent changes into another commit?
 

--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -212,7 +212,7 @@ parent.
     </tr>
     <tr>
       <td>Abandon the parent of the working copy, but keep its diff in the working copy</td>
-      <td><code>jj move --from @-</code></td>
+      <td><code>jj squash --from @-</code></td>
       <td><code>git reset --soft HEAD~</code></td>
     </tr>
     <tr>
@@ -275,13 +275,13 @@ parent.
     </tr>
     <tr>
       <td>Move the diff in the working copy into an ancestor</td>
-      <td><code>jj move --to X</code></td>
+      <td><code>jj squash --into X</code></td>
       <td><code>git commit --fixup=X; git rebase -i --autosquash X^</code></td>
     </tr>
     <tr>
       <td>Interactively move part of the diff in an arbitrary change to another
           arbitrary change</td>
-      <td><code>jj move -i --from X --to Y</code></td>
+      <td><code>jj squash -i --from X --into Y</code></td>
       <td>Not supported</td>
     </tr>
     <tr>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -486,6 +486,6 @@ unchanged, `jj diffedit` (typically) results in a different state, which means
 that descendant commits may have conflicts.
 
 Other commands for rewriting contents of existing commits are `jj split`, `jj
-unsquash -i` and `jj move -i`. Now that you've seen how `jj squash -i` and `jj
-diffedit` work, you can hopefully figure out how those work (with the help of
-the instructions in the diff).
+unsquash -i`. Now that you've seen how `jj squash -i` and `jj diffedit` work,
+you can hopefully figure out how those work (with the help of the instructions
+in the diff).


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
