### PR TITLE
graphlog: refactor out node symbols from GraphLog

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -118,8 +118,8 @@ pub(crate) fn cmd_log(
 
         if !args.no_graph {
             let mut graph = get_graphlog(command.settings(), formatter.raw());
-            let default_node_symbol = graph.default_node_symbol().to_owned();
-            let elided_node_symbol = graph.elided_node_symbol().to_owned();
+            let default_node_symbol = command.settings().default_node_symbol();
+            let elided_node_symbol = command.settings().elided_node_symbol();
             let forward_iter = TopoGroupedRevsetGraphIterator::new(revset.iter_graph());
             let iter: Box<dyn Iterator<Item = _>> = if args.reversed {
                 Box::new(ReverseRevsetGraphIterator::new(forward_iter))

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -90,7 +90,7 @@ pub(crate) fn cmd_obslog(
     }
     if !args.no_graph {
         let mut graph = get_graphlog(command.settings(), formatter.raw());
-        let default_node_symbol = graph.default_node_symbol().to_owned();
+        let default_node_symbol = command.settings().default_node_symbol();
         for commit in commits {
             let mut edges = vec![];
             for predecessor in &commit.predecessors() {

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -177,7 +177,7 @@ fn cmd_op_log(
     let iter = op_walk::walk_ancestors(&head_ops).take(args.limit.unwrap_or(usize::MAX));
     if !args.no_graph {
         let mut graph = get_graphlog(command.settings(), formatter.raw());
-        let default_node_symbol = graph.default_node_symbol().to_owned();
+        let default_node_symbol = command.settings().default_node_symbol();
         for op in iter {
             let op = op?;
             let mut edges = vec![];

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -242,19 +242,12 @@ impl UserSettings {
             .unwrap_or_else(|_| "curved".to_string())
     }
 
-    pub fn node_symbols(&self) -> (String, String) {
-        let default_node_symbol = self.config.get_string("ui.graph.default_node");
-        let elided_node_symbol = self.config.get_string("ui.graph.elided_node");
-        match self.graph_style().as_str() {
-            "ascii" | "ascii-large" => (
-                default_node_symbol.unwrap_or("o".to_owned()),
-                elided_node_symbol.unwrap_or(".".to_owned()),
-            ),
-            _ => (
-                default_node_symbol.unwrap_or("◉".to_owned()),
-                elided_node_symbol.unwrap_or("◌".to_owned()),
-            ),
-        }
+    pub fn default_node_symbol(&self) -> String {
+        self.node_symbol_for_key("ui.graph.default_node", "◉", "o")
+    }
+
+    pub fn elided_node_symbol(&self) -> String {
+        self.node_symbol_for_key("ui.graph.elided_node", "◌", ".")
     }
 
     pub fn max_new_file_size(&self) -> Result<u64, config::ConfigError> {
@@ -278,6 +271,14 @@ impl UserSettings {
 
     pub fn sign_settings(&self) -> SignSettings {
         SignSettings::from_settings(self)
+    }
+
+    fn node_symbol_for_key(&self, key: &str, fallback: &str, ascii_fallback: &str) -> String {
+        let symbol = self.config.get_string(key);
+        match self.graph_style().as_str() {
+            "ascii" | "ascii-large" => symbol.unwrap_or_else(|_| ascii_fallback.to_owned()),
+            _ => symbol.unwrap_or_else(|_| fallback.to_owned()),
+        }
     }
 }
 


### PR DESCRIPTION
Now as default and elided node symbols come from the config, the next logical step is to use them directly bypassing GraphLog. Note that commands like `jj op log` and `jj obslog` do not use the elided node symbol at all.


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
