### PR TITLE
 revset: extend lifetime of `containing_fn()` and iterators

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2401,10 +2401,14 @@ impl VisibilityResolutionContext<'_> {
 
 pub trait Revset: fmt::Debug {
     /// Iterate in topological order with children before parents.
-    fn iter(&self) -> Box<dyn Iterator<Item = CommitId> + '_>;
+    fn iter<'a>(&self) -> Box<dyn Iterator<Item = CommitId> + 'a>
+    where
+        Self: 'a;
 
     /// Iterates commit/change id pairs in topological order.
-    fn commit_change_ids(&self) -> Box<dyn Iterator<Item = (CommitId, ChangeId)> + '_>;
+    fn commit_change_ids<'a>(&self) -> Box<dyn Iterator<Item = (CommitId, ChangeId)> + 'a>
+    where
+        Self: 'a;
 
     fn iter_graph(&self) -> Box<dyn Iterator<Item = (CommitId, Vec<RevsetGraphEdge>)> + '_>;
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2421,7 +2421,9 @@ pub trait Revset: fmt::Debug {
     ///
     /// The implementation may construct and maintain any necessary internal
     /// context to optimize the performance of the check.
-    fn containing_fn(&self) -> Box<dyn Fn(&CommitId) -> bool + '_>;
+    fn containing_fn<'a>(&self) -> Box<dyn Fn(&CommitId) -> bool + 'a>
+    where
+        Self: 'a;
 }
 
 pub trait RevsetIteratorExt<'index, I> {


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
