### PR TITLE
workspace: allow extensions to customize creating the .jj directory

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -34,7 +34,9 @@ use jj_lib::working_copy::{
     CheckoutError, CheckoutStats, LockedWorkingCopy, ResetError, SnapshotError, SnapshotOptions,
     WorkingCopy, WorkingCopyFactory, WorkingCopyStateError,
 };
-use jj_lib::workspace::{default_working_copy_factories, Workspace, WorkspaceInitError};
+use jj_lib::workspace::{
+    create_jj_dir, default_working_copy_factories, Workspace, WorkspaceInitError,
+};
 
 #[derive(clap::Parser, Clone, Debug)]
 enum CustomCommand {
@@ -58,6 +60,7 @@ fn run_custom_command(
             Workspace::init_with_factories(
                 command_helper.settings(),
                 wc_path,
+                create_jj_dir,
                 &backend_initializer,
                 Signer::from_settings(command_helper.settings())
                     .map_err(WorkspaceInitError::SignInit)?,


### PR DESCRIPTION
This is relevant for google's cloud filesystem, where for technical reasons the '.jj' directory always exists and it's not especially feasible to let the client pretend to create it.  Would prefer a non-googler to approve this iff it looks reasonable.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
