### PR TITLE
next/prev: make first line of help text consistent

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -23,8 +23,7 @@ use crate::cli_util::{short_commit_hash, CommandHelper, WorkspaceCommandHelper};
 use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
 
-/// Move the current working copy commit to the next child revision in the
-/// repository.
+/// Move the working-copy commit to the child revision
 ///
 /// The command moves you to the next child in a linear fashion.
 ///

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -21,7 +21,7 @@ use crate::command_error::{user_error, CommandError};
 use crate::commands::next::choose_commit;
 use crate::ui::Ui;
 
-/// Move the working copy commit to the parent of the current revision.
+/// Move the working-copy commit to the parent revision
 ///
 ///
 /// The command moves you to the parent in a linear fashion.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -121,11 +121,10 @@ To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/d
 * `log` — Show revision history
 * `move` — Move changes from one revision into another
 * `new` — Create a new, empty change and (by default) edit it in the working copy
-* `next` — Move the current working copy commit to the next child revision in the
-repository.
+* `next` — Move the working-copy commit to the child revision
 * `obslog` — Show how a change has evolved
 * `operation` — Commands for working with the operation log
-* `prev` — Move the working copy commit to the parent of the current revision.
+* `prev` — Move the working-copy commit to the parent revision
 * `rebase` — Move revisions to different parent(s)
 * `resolve` — Resolve a conflicted file with an external merge tool
 * `restore` — Restore paths from another revision
@@ -1142,8 +1141,7 @@ For more information, see https://github.com/martinvonz/jj/blob/main/docs/workin
 
 ## `jj next`
 
-Move the current working copy commit to the next child revision in the
-repository.
+Move the working-copy commit to the child revision
 
 The command moves you to the next child in a linear fashion.
 
@@ -1346,7 +1344,7 @@ This restores the repo to the state at the specified operation, effectively undo
 
 ## `jj prev`
 
-Move the working copy commit to the parent of the current revision.
+Move the working-copy commit to the parent revision
 
 
 The command moves you to the parent in a linear fashion.


### PR DESCRIPTION
This drops the trailing period for consistency with other commands, and rephrases them a bit for consistency between each other.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
