### PR TITLE
templates: add missing "\n" to builtin "root" output

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -125,14 +125,14 @@ separate(" ",
   label("root", "root()"),
   format_short_commit_id(commit_id),
   branches
-)
+) ++ "\n"
 '''
 
 'builtin_op_log_root(op_id)' = '''
 separate(" ",
   op_id.short(),
   label("root", "root()"),
-)
+) ++ "\n"
 '''
 
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -191,7 +191,10 @@ fn test_log_builtin_templates() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
-    let render = |template| test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
+    // Render without graph and append "[EOF]" marker to test line ending
+    let render = |template| {
+        test_env.jj_cmd_success(&repo_path, &["log", "-T", template, "--no-graph"]) + "[EOF]\n"
+    };
 
     test_env.jj_cmd_ok(
         &repo_path,
@@ -204,52 +207,57 @@ fn test_log_builtin_templates() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "my-branch"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    @  rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397 (empty) (no description set)
-    ◉  qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059 (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
+    rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397 (empty) (no description set)
+    qpvuntsm test.user 2001-02-03 04:05:07.000 +07:00 230dd059 (empty) (no description set)
+    zzzzzzzz root() 00000000
+    [EOF]
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    @  rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397
-    │  (empty) (no description set)
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
-    │  (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
+    rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397
+    (empty) (no description set)
+    qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    (empty) (no description set)
+    zzzzzzzz root() 00000000
+    [EOF]
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    @  rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397
-    │  (empty) (no description set)
-    │
-    ◉  qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
-    │  (empty) (no description set)
-    │
-    ◉  zzzzzzzz root() 00000000
+    rlvkpnrz (no email set) 2001-02-03 04:05:08.000 +07:00 my-branch dc315397
+    (empty) (no description set)
+
+    qpvuntsm test.user@example.com 2001-02-03 04:05:07.000 +07:00 230dd059
+    (empty) (no description set)
+
+    zzzzzzzz root() 00000000
+
+    [EOF]
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r###"
-    @  Commit ID: dc31539712c7294d1d712cec63cef4504b94ca74
-    │  Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
-    │  Branches: my-branch
-    │  Author: (no name set) <(no email set)> (2001-02-03 04:05:08.000 +07:00)
-    │  Committer: (no name set) <(no email set)> (2001-02-03 04:05:08.000 +07:00)
-    │
-    │      (no description set)
-    │
-    ◉  Commit ID: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    │  Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
-    │  Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
-    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
-    │
-    │      (no description set)
-    │
-    ◉  Commit ID: 0000000000000000000000000000000000000000
-       Change ID: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
-       Author: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
-       Committer: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+    Commit ID: dc31539712c7294d1d712cec63cef4504b94ca74
+    Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
+    Branches: my-branch
+    Author: (no name set) <(no email set)> (2001-02-03 04:05:08.000 +07:00)
+    Committer: (no name set) <(no email set)> (2001-02-03 04:05:08.000 +07:00)
 
-           (no description set)
+        (no description set)
 
+    Commit ID: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+
+        (no description set)
+
+    Commit ID: 0000000000000000000000000000000000000000
+    Change ID: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    Author: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+    Committer: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+
+        (no description set)
+
+    [EOF]
     "###);
 }
 

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -221,32 +221,39 @@ fn test_op_log_builtin_templates() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
-    let render = |template| test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
+    // Render without graph and append "[EOF]" marker to test line ending
+    let render = |template| {
+        test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template, "--no-graph"])
+            + "[EOF]\n"
+    };
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
 
     insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r###"
-    @  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
-    │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    │  args: jj describe -m 'description 0'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
-    │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
-    │  initialize repo
-    ◉  000000000000 root()
+    52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    args: jj describe -m 'description 0'
+    b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    add workspace 'default'
+    9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    initialize repo
+    000000000000 root()
+    [EOF]
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r###"
-    @  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
-    │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    │  args: jj describe -m 'description 0'
-    │
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
-    │  add workspace 'default'
-    │
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
-    │  initialize repo
-    │
-    ◉  000000000000 root()
+    52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    args: jj describe -m 'description 0'
+
+    b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    add workspace 'default'
+
+    9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    initialize repo
+
+    000000000000 root()
+
+    [EOF]
     "###);
 }
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
