### PR TITLE
revset: extend lifetime of graph iterator (for API consistency)

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -136,7 +136,7 @@ pub(crate) fn cmd_log(
             for (commit_id, edges) in iter.take(args.limit.unwrap_or(usize::MAX)) {
                 // The graph is keyed by (CommitId, is_synthetic)
                 let mut graphlog_edges = vec![];
-                // TODO: Should we update RevsetGraphIterator to yield this flag instead of all
+                // TODO: Should we update revset.iter_graph() to yield this flag instead of all
                 // the missing edges since we don't care about where they point here
                 // anyway?
                 let mut has_missing = false;

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -20,7 +20,7 @@ mod mutable;
 mod readonly;
 mod rev_walk;
 pub mod revset_engine;
-pub mod revset_graph_iterator;
+mod revset_graph_iterator;
 mod store;
 
 pub use self::composite::{AsCompositeIndex, CompositeIndex, IndexLevelStats, IndexStats};

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -105,8 +105,15 @@ impl<I: AsCompositeIndex> RevsetImpl<I> {
         self.inner.positions().attach(self.index.as_composite())
     }
 
-    pub fn iter_graph_impl(&self) -> RevsetGraphIterator<'_, '_> {
-        RevsetGraphIterator::new(self.index.as_composite(), Box::new(self.entries()))
+    pub fn iter_graph_impl(
+        &self,
+        skip_transitive_edges: bool,
+    ) -> impl Iterator<Item = (CommitId, Vec<RevsetGraphEdge>)> + '_ {
+        RevsetGraphIterator::new(
+            self.index.as_composite(),
+            Box::new(self.entries()),
+            skip_transitive_edges,
+        )
     }
 }
 
@@ -147,7 +154,8 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
     }
 
     fn iter_graph(&self) -> Box<dyn Iterator<Item = (CommitId, Vec<RevsetGraphEdge>)> + '_> {
-        Box::new(self.iter_graph_impl())
+        let skip_transitive_edges = true;
+        Box::new(self.iter_graph_impl(skip_transitive_edges))
     }
 
     fn is_empty(&self) -> bool {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2410,7 +2410,9 @@ pub trait Revset: fmt::Debug {
     where
         Self: 'a;
 
-    fn iter_graph(&self) -> Box<dyn Iterator<Item = (CommitId, Vec<RevsetGraphEdge>)> + '_>;
+    fn iter_graph<'a>(&self) -> Box<dyn Iterator<Item = (CommitId, Vec<RevsetGraphEdge>)> + 'a>
+    where
+        Self: 'a;
 
     fn is_empty(&self) -> bool;
 

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -73,10 +73,7 @@ fn test_graph_iterator_linearized(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_d]);
-    let commits = revset
-        .iter_graph_impl()
-        .set_skip_transitive_edges(skip_transitive_edges)
-        .collect_vec();
+    let commits = revset.iter_graph_impl(skip_transitive_edges).collect_vec();
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].0, *commit_d.id());
     assert_eq!(commits[1].0, *commit_a.id());
@@ -113,10 +110,7 @@ fn test_graph_iterator_virtual_octopus(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_b, &commit_c, &commit_f]);
-    let commits = revset
-        .iter_graph_impl()
-        .set_skip_transitive_edges(skip_transitive_edges)
-        .collect_vec();
+    let commits = revset.iter_graph_impl(skip_transitive_edges).collect_vec();
     assert_eq!(commits.len(), 4);
     assert_eq!(commits[0].0, *commit_f.id());
     assert_eq!(commits[1].0, *commit_c.id());
@@ -164,10 +158,7 @@ fn test_graph_iterator_simple_fork(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_c, &commit_e]);
-    let commits = revset
-        .iter_graph_impl()
-        .set_skip_transitive_edges(skip_transitive_edges)
-        .collect_vec();
+    let commits = revset.iter_graph_impl(skip_transitive_edges).collect_vec();
     assert_eq!(commits.len(), 3);
     assert_eq!(commits[0].0, *commit_e.id());
     assert_eq!(commits[1].0, *commit_c.id());
@@ -205,10 +196,7 @@ fn test_graph_iterator_multiple_missing(skip_transitive_edges: bool) {
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_b, &commit_f]);
-    let commits = revset
-        .iter_graph_impl()
-        .set_skip_transitive_edges(skip_transitive_edges)
-        .collect_vec();
+    let commits = revset.iter_graph_impl(skip_transitive_edges).collect_vec();
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].0, *commit_f.id());
     assert_eq!(commits[1].0, *commit_b.id());
@@ -249,10 +237,7 @@ fn test_graph_iterator_edge_to_ancestor(skip_transitive_edges: bool) {
     let repo = tx.commit("test");
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_c, &commit_d, &commit_f]);
-    let commits = revset
-        .iter_graph_impl()
-        .set_skip_transitive_edges(skip_transitive_edges)
-        .collect_vec();
+    let commits = revset.iter_graph_impl(skip_transitive_edges).collect_vec();
     assert_eq!(commits.len(), 3);
     assert_eq!(commits[0].0, *commit_f.id());
     assert_eq!(commits[1].0, *commit_d.id());
@@ -308,10 +293,7 @@ fn test_graph_iterator_edge_escapes_from_(skip_transitive_edges: bool) {
         repo.as_ref(),
         &[&commit_a, &commit_d, &commit_g, &commit_h, &commit_j],
     );
-    let commits = revset
-        .iter_graph_impl()
-        .set_skip_transitive_edges(skip_transitive_edges)
-        .collect_vec();
+    let commits = revset.iter_graph_impl(skip_transitive_edges).collect_vec();
     assert_eq!(commits.len(), 5);
     assert_eq!(commits[0].0, *commit_j.id());
     assert_eq!(commits[1].0, *commit_h.id());


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
