### PR TITLE
docs: Fix FAQ reference to glossary entry for co-located repos

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -181,7 +181,7 @@ We hope to integrate with Gerrit natively in the future.
 [branches_conflicts]: branches.md#conflicts
 
 [change ID]: glossary.md#change-id
-[co-located]: glossary.md#change-id
+[co-located]: glossary.md#co-located-repos
 [commit ID]: glossary.md#commit-id
 [config]: config.md
 


### PR DESCRIPTION
In the FAQ question "How do I integrate Jujutsu with Gerrit?", the link to the glossary entry for "co-located repos" was pointing to the entry for "change-id".