### PR TITLE
github release: replace unsupported `upload-release-asset` actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
         fi
     - name: Upload release archive
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: shogo82148/actions-upload-release-asset@5bd52f05dd8076794da5975d4c0a4f3bce7dd8f5 # v1.7.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -100,7 +100,7 @@ jobs:
           tar czf "$archive" -C "rendered-docs" .
           echo "ASSET=$archive" >> $GITHUB_ENV
       - name: Upload release archive
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+        uses: shogo82148/actions-upload-release-asset@5bd52f05dd8076794da5975d4c0a4f3bce7dd8f5 # v1.7.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
It generates numerous warnings that it will stop working once Node 16 is unsupported. This replaces it by a seemingly equivalent action that somebody is supporting. I tired this change on
https://github.com/ilyagr/diffedit3/, and it seems to work.

I think it would be better to switch to using
https://github.com/shogo82148/actions-upload-release-asset, which is recommended at https://github.com/actions/upload-release-asset, but that would be a slight change to the release process (that action creates a release when a tag is pushed, we'd probably want it to be for tags starting with `v`), so I'll let @martinvonz do that.

Ultimately, Martin, since you do the releases, it's entirely up to you what we do here. For example, you can wait until the next release and experiment with this PR then.
