### PR TITLE
templater: migrate global functions to table-based lookup

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -112,7 +112,8 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
         build_ctx: &BuildContext<Self::Property>,
         function: &FunctionCallNode,
     ) -> TemplateParseResult<Self::Property> {
-        template_builder::build_global_function(self, build_ctx, function)
+        let table = &self.build_fn_table.core;
+        table.build_function(self, build_ctx, function)
     }
 
     fn build_method(

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -107,6 +107,14 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
         self.wrap_commit(TemplatePropertyFn(|commit: &Commit| Ok(commit.clone())))
     }
 
+    fn build_function(
+        &self,
+        build_ctx: &BuildContext<Self::Property>,
+        function: &FunctionCallNode,
+    ) -> TemplateParseResult<Self::Property> {
+        template_builder::build_global_function(self, build_ctx, function)
+    }
+
     fn build_method(
         &self,
         build_ctx: &BuildContext<Self::Property>,

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -88,7 +88,8 @@ impl<'a, C: 'a> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
         build_ctx: &BuildContext<Self::Property>,
         function: &FunctionCallNode,
     ) -> TemplateParseResult<Self::Property> {
-        template_builder::build_global_function(self, build_ctx, function)
+        let table = &self.build_fn_table.core;
+        table.build_function(self, build_ctx, function)
     }
 
     fn build_method(

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -83,6 +83,14 @@ impl<'a, C: 'a> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
         GenericTemplatePropertyKind::Self_
     }
 
+    fn build_function(
+        &self,
+        build_ctx: &BuildContext<Self::Property>,
+        function: &FunctionCallNode,
+    ) -> TemplateParseResult<Self::Property> {
+        template_builder::build_global_function(self, build_ctx, function)
+    }
+
     fn build_method(
         &self,
         build_ctx: &BuildContext<Self::Property>,

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -64,7 +64,8 @@ impl TemplateLanguage<'static> for OperationTemplateLanguage {
         build_ctx: &BuildContext<Self::Property>,
         function: &FunctionCallNode,
     ) -> TemplateParseResult<Self::Property> {
-        template_builder::build_global_function(self, build_ctx, function)
+        let table = &self.build_fn_table.core;
+        table.build_function(self, build_ctx, function)
     }
 
     fn build_method(

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -59,6 +59,14 @@ impl TemplateLanguage<'static> for OperationTemplateLanguage {
         self.wrap_operation(TemplatePropertyFn(|op: &Operation| Ok(op.clone())))
     }
 
+    fn build_function(
+        &self,
+        build_ctx: &BuildContext<Self::Property>,
+        function: &FunctionCallNode,
+    ) -> TemplateParseResult<Self::Property> {
+        template_builder::build_global_function(self, build_ctx, function)
+    }
+
     fn build_method(
         &self,
         build_ctx: &BuildContext<Self::Property>,

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -73,6 +73,13 @@ pub trait TemplateLanguage<'a> {
     /// clones the `Context` object.
     fn build_self(&self) -> Self::Property;
 
+    /// Translates the given global `function` call to a property.
+    fn build_function(
+        &self,
+        build_ctx: &BuildContext<Self::Property>,
+        function: &FunctionCallNode,
+    ) -> TemplateParseResult<Self::Property>;
+
     fn build_method(
         &self,
         build_ctx: &BuildContext<Self::Property>,
@@ -891,7 +898,7 @@ where
     Ok(language.wrap_list_template(Box::new(list_template)))
 }
 
-fn build_global_function<'a, L: TemplateLanguage<'a> + ?Sized>(
+pub fn build_global_function<'a, L: TemplateLanguage<'a> + ?Sized>(
     language: &L,
     build_ctx: &BuildContext<L::Property>,
     function: &FunctionCallNode,
@@ -1033,7 +1040,7 @@ pub fn build_expression<'a, L: TemplateLanguage<'a> + ?Sized>(
             Ok(Expression::unlabeled(property))
         }
         ExpressionKind::FunctionCall(function) => {
-            let property = build_global_function(language, build_ctx, function)?;
+            let property = language.build_function(build_ctx, function)?;
             Ok(Expression::unlabeled(property))
         }
         ExpressionKind::MethodCall(method) => {

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -262,10 +262,7 @@ pub struct CoreTemplateBuildFnTable<'a, L: TemplateLanguage<'a> + ?Sized> {
     // TODO: add global functions table?
 }
 
-pub fn merge_fn_map<'a, L: TemplateLanguage<'a> + ?Sized, T>(
-    base: &mut TemplateBuildMethodFnMap<'a, L, T>,
-    extension: TemplateBuildMethodFnMap<'a, L, T>,
-) {
+pub fn merge_fn_map<'s, F>(base: &mut HashMap<&'s str, F>, extension: HashMap<&'s str, F>) {
     for (name, function) in extension {
         if base.insert(name, function).is_some() {
             panic!("Conflicting template definitions for '{name}' function");

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -38,7 +38,7 @@ fn test_templater_parse_error() {
     [template-aliases]
     'conflicting' = ''
     'shorted()' = ''
-    'cap(x)' = 'x'
+    'socat(x)' = 'x'
     'format_id(id)' = 'id.sort()'
     "###,
     );
@@ -60,14 +60,14 @@ fn test_templater_parse_error() {
       = Method "shorter" doesn't exist for type "CommitOrChangeId"
     Hint: Did you mean "short", "shortest"?
     "###);
-    insta::assert_snapshot!(render_err(r#"cat()"#), @r###"
+    insta::assert_snapshot!(render_err(r#"oncat()"#), @r###"
     Error: Failed to parse template:  --> 1:1
       |
-    1 | cat()
-      | ^-^
+    1 | oncat()
+      | ^---^
       |
-      = Function "cat" doesn't exist
-    Hint: Did you mean "cap"?
+      = Function "oncat" doesn't exist
+    Hint: Did you mean "concat", "socat"?
     "###);
     insta::assert_snapshot!(render_err(r#""".lines().map(|s| se)"#), @r###"
     Error: Failed to parse template:  --> 1:20


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
