### PR TITLE
 cli: move revset::optimize() invocation from parse() to evaluate()

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -67,7 +67,7 @@ use jj_lib::working_copy::{
 use jj_lib::workspace::{
     default_working_copy_factories, LockedWorkspace, Workspace, WorkspaceLoadError, WorkspaceLoader,
 };
-use jj_lib::{dag_walk, file_util, git, op_heads_store, op_walk};
+use jj_lib::{dag_walk, file_util, git, op_heads_store, op_walk, revset};
 use once_cell::unsync::OnceCell;
 use tracing::instrument;
 use tracing_chrome::ChromeLayerBuilder;
@@ -823,7 +823,7 @@ Set which revision the branch points to with `jj branch set {branch_name} -r <RE
         &self,
         revision_str: &str,
     ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
-        revset_util::parse(revision_str, &self.revset_parse_context())
+        revset::parse(revision_str, &self.revset_parse_context())
     }
 
     pub fn evaluate_revset<'repo>(
@@ -860,7 +860,7 @@ Set which revision the branch points to with `jj branch set {branch_name} -r <RE
                 let disambiguation_revset = self.parse_revset(&revset_string).map_err(|err| {
                     CommandError::ConfigError(format!("Invalid `revsets.short-prefixes`: {err}"))
                 })?;
-                context = context.disambiguate_within(disambiguation_revset);
+                context = context.disambiguate_within(revset::optimize(disambiguation_revset));
             }
             Ok(context)
         })

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -934,10 +934,8 @@ Set which revision the branch points to with `jj branch set {branch_name} -r <RE
                 .map(|commit| commit.id().clone())
                 .collect(),
         );
-        let immutable_revset = revset_util::parse_immutable_expression(
-            self.repo().as_ref(),
-            &self.revset_parse_context(),
-        )?;
+        let immutable_revset =
+            revset_util::parse_immutable_expression(&self.revset_parse_context())?;
         let revset = self.evaluate_revset(to_rewrite_revset.intersection(&immutable_revset))?;
         if let Some(commit) = revset.iter().commits(self.repo().store()).next() {
             let commit = commit?;

--- a/cli/src/commands/bench.rs
+++ b/cli/src/commands/bench.rs
@@ -23,7 +23,7 @@ use criterion::measurement::Measurement;
 use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
 use jj_lib::object_id::HexPrefix;
 use jj_lib::repo::Repo;
-use jj_lib::revset::{DefaultSymbolResolver, RevsetExpression};
+use jj_lib::revset::{self, DefaultSymbolResolver, RevsetExpression};
 
 use crate::cli_util::{CommandHelper, WorkspaceCommandHelper};
 use crate::command_error::CommandError;
@@ -204,7 +204,7 @@ fn bench_revset<M: Measurement>(
     revset: &str,
 ) -> Result<(), CommandError> {
     writeln!(ui.stderr(), "----------Testing revset: {revset}----------")?;
-    let expression = workspace_command.parse_revset(revset)?;
+    let expression = revset::optimize(workspace_command.parse_revset(revset)?);
     // Time both evaluation and iteration.
     let routine = |workspace_command: &WorkspaceCommandHelper, expression: Rc<RevsetExpression>| {
         // Evaluate the expression without parsing/evaluating short-prefixes.

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -625,7 +625,6 @@ fn cmd_branch_list(
             // Intersects with the set of local branch targets to minimize the lookup space.
             let revset_expression = RevsetExpression::branches(StringPattern::everything())
                 .intersection(&filter_expression);
-            let revset_expression = revset::optimize(revset_expression);
             let revset = workspace_command.evaluate_revset(revset_expression)?;
             let filtered_targets: HashSet<CommitId> = revset.iter().collect();
             branch_names.extend(

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -96,7 +96,7 @@ pub(crate) fn cmd_log(
                 RevsetFilterPredicate::File(Some(repo_paths)),
             ));
         }
-        revset::optimize(expression)
+        expression
     };
     let repo = workspace_command.repo();
     let wc_commit_id = workspace_command.get_wc_commit_id();

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -619,7 +619,7 @@ fn evaluate_immutable_revset<'repo>(
     // Alternatively, a negated (i.e. visible mutable) set could be computed.
     // It's usually smaller than the immutable set. The revset engine can also
     // optimize "::<recent_heads>" query to use bitset-based implementation.
-    let expression = revset_util::parse_immutable_expression(repo, &language.revset_parse_context)
+    let expression = revset_util::parse_immutable_expression(&language.revset_parse_context)
         .map_err(|err| {
             TemplateParseError::unexpected_expression(revset_util::format_parse_error(&err), span)
         })?;

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -118,7 +118,6 @@ pub fn default_symbol_resolver<'a>(
 
 /// Parses user-configured expression defining the immutable set.
 pub fn parse_immutable_expression(
-    repo: &dyn Repo,
     context: &RevsetParseContext,
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
     let (params, immutable_heads_str) = context
@@ -132,9 +131,7 @@ pub fn parse_immutable_expression(
     let immutable_heads_revset = parse(immutable_heads_str, context)?;
     Ok(immutable_heads_revset
         .ancestors()
-        .union(&RevsetExpression::commit(
-            repo.store().root_commit_id().clone(),
-        )))
+        .union(&RevsetExpression::root()))
 }
 
 pub fn format_parse_error(err: &RevsetParseError) -> String {

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -80,20 +80,12 @@ pub fn load_revset_aliases(
     Ok(aliases_map)
 }
 
-pub fn parse(
-    revision_str: &str,
-    context: &RevsetParseContext,
-) -> Result<Rc<RevsetExpression>, RevsetParseError> {
-    let expression = revset::parse(revision_str, context)?;
-    Ok(revset::optimize(expression))
-}
-
 pub fn evaluate<'a>(
     repo: &'a dyn Repo,
     symbol_resolver: &DefaultSymbolResolver,
     expression: Rc<RevsetExpression>,
 ) -> Result<Box<dyn Revset + 'a>, UserRevsetEvaluationError> {
-    let resolved = expression
+    let resolved = revset::optimize(expression)
         .resolve_user_expression(repo, symbol_resolver)
         .map_err(UserRevsetEvaluationError::Resolution)?;
     resolved
@@ -128,7 +120,7 @@ pub fn parse_immutable_expression(
         params.is_empty(),
         "invalid declaration should have been rejected by load_revset_aliases()"
     );
-    let immutable_heads_revset = parse(immutable_heads_str, context)?;
+    let immutable_heads_revset = revset::parse(immutable_heads_str, context)?;
     Ok(immutable_heads_revset
         .ancestors()
         .union(&RevsetExpression::root()))


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
