### PR TITLE
cli: avoid snapshotting the working in a few debug commands

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -175,7 +175,7 @@ fn cmd_debug_working_copy(
     command: &CommandHelper,
     _args: &DebugWorkingCopyArgs,
 ) -> Result<(), CommandError> {
-    let workspace_command = command.workspace_helper(ui)?;
+    let workspace_command = command.workspace_helper_no_snapshot(ui)?;
     let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
     writeln!(ui.stdout(), "Current operation: {:?}", wc.operation_id())?;
     writeln!(ui.stdout(), "Current tree: {:?}", wc.tree_id()?)?;
@@ -300,7 +300,7 @@ fn cmd_debug_tree(
     command: &CommandHelper,
     args: &DebugTreeArgs,
 ) -> Result<(), CommandError> {
-    let workspace_command = command.workspace_helper(ui)?;
+    let workspace_command = command.workspace_helper_no_snapshot(ui)?;
     let tree = if let Some(tree_id_hex) = &args.id {
         let tree_id =
             TreeId::try_from_hex(tree_id_hex).map_err(|_| user_error("Invalid tree id"))?;
@@ -334,7 +334,7 @@ fn cmd_debug_watchman(
 ) -> Result<(), CommandError> {
     use jj_lib::local_working_copy::LockedLocalWorkingCopy;
 
-    let mut workspace_command = command.workspace_helper(ui)?;
+    let mut workspace_command = command.workspace_helper_no_snapshot(ui)?;
     let repo = workspace_command.repo().clone();
     match subcommand {
         DebugWatchmanSubcommand::QueryClock => {


### PR DESCRIPTION
Debug commands are sometimes used in repos that are broken in some ways, and sometimes they simply want to display the state before snapshotting (`jj debug workingcopy`).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
