### PR TITLE
cli: allow colors in form '#rrggbb'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Config now supports rgb hex colors (in the form `#rrggbb`) wherever existing color names are supported.
+
 * `ui.default-command` now accepts multiple string arguments, for more complex
   default `jj` commands.
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -162,7 +162,7 @@
             "type": "object",
             "description": "Mapping from jj formatter labels to colors",
             "definitions": {
-                "colors": {
+                "colorNames": {
                     "enum": [
                         "default",
                         "black",
@@ -182,6 +182,20 @@
                         "bright cyan",
                         "bright white"
                     ]
+                },
+                "hexColor": {
+                    "type": "string",
+                    "pattern": "^#[0-9a-fA-F]{6}$"
+                },
+                "colors": {
+                  "oneOf": [
+                    {
+                        "$ref": "#/properties/colors/definitions/colorNames"
+                    },
+                    {
+                        "$ref": "#/properties/colors/definitions/hexColor"
+                    }
+                  ]
                 },
                 "basicFormatterLabels": {
                     "enum": [

--- a/docs/config.md
+++ b/docs/config.md
@@ -113,12 +113,18 @@ All of them but "default" come in a bright version too, e.g. "bright red". The
 "default" color can be used to override a color defined by a parent style
 (explained below).
 
-If you use a string value for a color, as in the example above, it will be used
+You can also use a 6-digit hex code for more control over the exact color used:
+
+```toml
+colors.change_id = "#ff1525"
+```
+
+If you use a string value for a color, as in the examples above, it will be used
 for the foreground color. You can also set the background color, or make the
 text bold or underlined. For that, you need to use a table:
 
 ```toml
-colors.commit_id = { fg = "green", bg = "red", bold = true, underline = true }
+colors.commit_id = { fg = "green", bg = "#ff1525", bold = true, underline = true }
 ```
 
 The key names are called "labels". The above used `commit_id` as label. You can


### PR DESCRIPTION
I made this change partly to scratch a very minor personal itch, but mainly as a first step to get my head around the codebase, build process, etc. TBH I was surprised how easy it was to support this (being English the hardest part was writing color vs colour!). Given how little complexity it adds to the code, I'd hope it would be considered.

That said, all new features are overhead, and I will not be offended if this is unwanted. I've enjoyed getting it working and learnt a lot, which was my main goal.

Thanks everyone for all the work on jujutsu. I'm really enjoying using it.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
