### PR TITLE
revset: substitute '~(::x)' to 'x..'

### DIFF
--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -120,10 +120,10 @@ pub fn parse_immutable_expression(
         params.is_empty(),
         "invalid declaration should have been rejected by load_revset_aliases()"
     );
-    let immutable_heads_revset = revset::parse(immutable_heads_str, context)?;
-    Ok(immutable_heads_revset
-        .ancestors()
-        .union(&RevsetExpression::root()))
+    // Negated ancestors expression `~::(<heads> | root())` is slightly easier
+    // to optimize than negated union `~(::<heads> | root())`.
+    let heads = revset::parse(immutable_heads_str, context)?;
+    Ok(heads.union(&RevsetExpression::root()).ancestors())
 }
 
 pub fn format_parse_error(err: &RevsetParseError) -> String {

--- a/cli/testing/bench-revsets-git.txt
+++ b/cli/testing/bench-revsets-git.txt
@@ -15,6 +15,7 @@ v2.39.0..v2.40.0
 v2.39.0::v2.40.0
 # Mostly recent history
 v2.40.0-..
+~(::v2.40.0)
 # Tags and branches
 tags()
 branches()

--- a/cli/testing/bench-revsets-git.txt
+++ b/cli/testing/bench-revsets-git.txt
@@ -13,6 +13,8 @@ v2.40.0
 v2.39.0..v2.40.0
 ::v2.40.0 ~ ::v2.39.0
 v2.39.0::v2.40.0
+# Mostly recent history
+v2.40.0-..
 # Tags and branches
 tags()
 branches()

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2344,7 +2344,7 @@ impl VisibilityResolutionContext<'_> {
         // but if it does, the heads set could be extended to include the commits
         // (and `remote_branches()`) specified in the revset expression. Alternatively,
         // some optimization rules could be removed, but that means `author(_) & x`
-        // would have to test `:visible_heads() & x`.
+        // would have to test `::visible_heads() & x`.
         ResolvedExpression::Ancestors {
             heads: self.resolve_visible_heads().into(),
             generation: GENERATION_RANGE_FULL,

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1279,6 +1279,15 @@ fn test_evaluate_expression_range() {
         ]
     );
 
+    // Range including merge ancestors: commit4-- == root | commit2
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("{}--..{}", commit4.id().hex(), commit3.id().hex())
+        ),
+        vec![commit3.id().clone()]
+    );
+
     // Sibling commits
     assert_eq!(
         resolve_commit_ids(


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
