### PR TITLE
Make node symbols templatable in the graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ui.default-command` now accepts multiple string arguments, for more complex
   default `jj` commands.
 
-* Graph node symbols are now configurable via `ui.graph.default_node` and `ui.graph.elided_node`.
+* Graph node symbols are now configurable via templates
+  * `templates.log_node`
+  * `templates.op_log_node`
+  * `templates.log_node_elided`
+
 
 * `jj log` now includes synthetic nodes in the graph where some revisions were
   elided.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -122,14 +122,6 @@
                                 "ascii-large"
                             ],
                             "default": "curved"
-                        },
-                        "default_node": {
-                            "type": "string",
-                            "description": "The symbol used as the default symbol for nodes."
-                        },
-                        "elided_node": {
-                            "type": "string",
-                            "description": "The symbol used for elided nodes."
                         }
                     }
                 },

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1409,7 +1409,7 @@ fn test_elided() {
 }
 
 #[test]
-fn test_custom_symbols() {
+fn test_log_with_custom_symbols() {
     // Test that elided commits are shown as synthetic nodes.
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
@@ -1435,11 +1435,11 @@ fn test_custom_symbols() {
     // Simple test with showing default and elided nodes.
     test_env.add_config(concat!(
         "ui.log-synthetic-elided-nodes = true\n",
-        "ui.graph.default_node = '┝'\n",
-        "ui.graph.elided_node = '🮀'",
+        "templates.log_node = 'if(current_working_copy, \"$\", if(root, \"┴\", \"┝\"))'\n",
+        "templates.log_node_elided = '\"🮀\"'",
     ));
-    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
-    @    merge
+    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"
+    $    merge
     ├─╮
     │ ┝  side branch 2
     │ │
@@ -1450,18 +1450,18 @@ fn test_custom_symbols() {
     ├─╯
     ┝  initial
     │
-    ~
+    ┴
     "###);
 
     // Simple test with showing default and elided nodes, ascii style.
     test_env.add_config(concat!(
         "ui.log-synthetic-elided-nodes = true\n",
         "ui.graph.style = 'ascii'\n",
-        "ui.graph.default_node = '*'\n",
-        "ui.graph.elided_node = ':'",
+        "templates.log_node = 'if(current_working_copy, \"$\", if(root, \"^\", \"*\"))'\n",
+        "templates.log_node_elided = '\":\"'",
     ));
-    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
-    @    merge
+    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"
+    $    merge
     |\
     | *  side branch 2
     | |
@@ -1472,6 +1472,6 @@ fn test_custom_symbols() {
     |/
     *  initial
     |
-    ~
+    ^
     "###);
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -94,6 +94,37 @@ fn test_op_log() {
 }
 
 #[test]
+fn test_op_log_with_custom_symbols() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "op",
+            "log",
+            "--config-toml",
+            concat!(
+                "template-aliases.'format_time_range(x)' = 'x'\n",
+                "templates.op_log_node = 'if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
+            ),
+        ],
+    );
+    insta::assert_snapshot!(&stdout, @r###"
+    $  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    │  args: jj describe -m 'description 0'
+    ┝  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │  add workspace 'default'
+    ┝  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │  initialize repo
+    ┴  000000000000 root()
+    "###);
+}
+
+#[test]
 fn test_op_log_with_no_template() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);

--- a/docs/config.md
+++ b/docs/config.md
@@ -229,6 +229,30 @@ revsets.log = "main@origin.."
 ui.graph.style = "square"
 ```
 
+#### Node style
+
+The symbols used to represent commits or operations can be customized via
+templates.
+
+  * `templates.log_node` for commits (with `Commit` keywords)
+  * `templates.op_log_node` for operations (with `Operation` keywords)
+  * `templates.log_node_elided` for elided nodes
+
+For example:
+```toml
+[templates]
+log_node = '''
+  if(current_working_copy, "@",
+    if(root, "┴",
+      if(immutable, "●", "○")
+    )
+  )
+'''
+op_log_node = 'if(current_operation, "@", "○")'
+log_node_elided = '"🮀"'
+
+```
+
 ### Wrap log content
 
 If enabled, `log`/`obslog`/`op log` content will be wrapped based on

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -242,12 +242,24 @@ impl UserSettings {
             .unwrap_or_else(|_| "curved".to_string())
     }
 
-    pub fn default_node_symbol(&self) -> String {
-        self.node_symbol_for_key("ui.graph.default_node", "◉", "o")
+    pub fn commit_node_template(&self) -> String {
+        self.node_template_for_key(
+            "templates.log_node",
+            r#"if(current_working_copy, "@", "◉")"#,
+            r#"if(current_working_copy, "@", "o")"#,
+        )
     }
 
-    pub fn elided_node_symbol(&self) -> String {
-        self.node_symbol_for_key("ui.graph.elided_node", "◌", ".")
+    pub fn op_node_template(&self) -> String {
+        self.node_template_for_key(
+            "templates.op_log_node",
+            r#"if(current_operation, "@", "◉")"#,
+            r#"if(current_operation, "@", "o")"#,
+        )
+    }
+
+    pub fn elided_node_template(&self) -> String {
+        self.node_template_for_key("templates.log_node_elided", r#""◌""#, r#"".""#)
     }
 
     pub fn max_new_file_size(&self) -> Result<u64, config::ConfigError> {
@@ -273,7 +285,7 @@ impl UserSettings {
         SignSettings::from_settings(self)
     }
 
-    fn node_symbol_for_key(&self, key: &str, fallback: &str, ascii_fallback: &str) -> String {
+    fn node_template_for_key(&self, key: &str, fallback: &str, ascii_fallback: &str) -> String {
         let symbol = self.config.get_string(key);
         match self.graph_style().as_str() {
             "ascii" | "ascii-large" => symbol.unwrap_or_else(|_| ascii_fallback.to_owned()),


### PR DESCRIPTION
No-op change styling wise for now. I suspect there will be room for bikeshedding the default style after this.

Hopefully I'm not stepping on @zummenix's toes too much here after the great idea in #3260 to just use a separate template for the elided node. :sweat_smile:

Some stuff is a bit odd still, like what template to even use for the elided node? Commit template for the root it happens to be associated with? Just make it not a template and let it be a string?

Still need to update docs.

Hopefully just dropping the symbol configs I added recently is fine, especially considering there hasn't been a release with them included.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [X] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
