### PR TITLE
cli: update empty revset handling in duplicate and abandon

### DIFF
--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -48,7 +48,8 @@ pub(crate) fn cmd_duplicate(
         revset.iter().collect() // in reverse topological order
     };
     if to_duplicate.is_empty() {
-        return Err(user_error("No revisions to duplicate"));
+        writeln!(ui.stderr(), "No revisions to duplicate.")?;
+        return Ok(());
     }
     if to_duplicate.last() == Some(workspace_command.repo().store().root_commit_id()) {
         return Err(user_error("Cannot duplicate the root commit"));

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -150,6 +150,11 @@ fn test_basics() {
     ├─╯
     ◉  [zzz] a b e??
     "###);
+
+    let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "none()"]);
+    insta::assert_snapshot!(stderr, @r###"
+    No revisions to abandon.
+    "###);
 }
 
 // This behavior illustrates https://github.com/martinvonz/jj/issues/2600.
@@ -263,8 +268,8 @@ fn test_bug_2600() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Abandoned the following commits:
-      royxmykx 98f3b9ba a | a
       vruxwmqv 8c0dced0 b | b
+      royxmykx 98f3b9ba a | a
     Rebased 1 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 84fac1f8 c | c
     Parent commit      : zsuskuln 73c929fc a b base | base

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -52,9 +52,9 @@ fn test_duplicate() {
     Error: Cannot duplicate the root commit
     "###);
 
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "none()"]);
+    let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "none()"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: No revisions to duplicate
+    No revisions to duplicate.
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
