### PR TITLE
cli: remove last use of resolve_multiple_nonempty_revsets() from cmd_run()

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1620,21 +1620,6 @@ pub fn resolve_all_revs(
     }
 }
 
-pub fn resolve_multiple_nonempty_revsets(
-    revision_args: &[RevisionArg],
-    workspace_command: &WorkspaceCommandHelper,
-) -> Result<IndexSet<Commit>, CommandError> {
-    let mut acc = IndexSet::new();
-    for revset in revision_args {
-        let revisions = workspace_command.resolve_revset(revset)?;
-        if revisions.is_empty() {
-            return Err(user_error("Empty revision set"));
-        }
-        acc.extend(revisions);
-    }
-    Ok(acc)
-}
-
 pub fn resolve_multiple_nonempty_revsets_default_single(
     workspace_command: &WorkspaceCommandHelper,
     revisions: &[RevisionArg],

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -14,7 +14,11 @@
 
 //! This file contains the internal implementation of `run`.
 
-use crate::cli_util::{resolve_multiple_nonempty_revsets, CommandHelper, RevisionArg};
+use itertools::Itertools as _;
+use jj_lib::repo::Repo as _;
+use jj_lib::revset::RevsetIteratorExt as _;
+
+use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
 
@@ -48,7 +52,12 @@ pub struct RunArgs {
 
 pub fn cmd_run(ui: &mut Ui, command: &CommandHelper, args: &RunArgs) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let _resolved_commits = resolve_multiple_nonempty_revsets(&args.revisions, &workspace_command)?;
+    let _resolved_commits: Vec<_> = {
+        let repo = workspace_command.repo();
+        let expression = workspace_command.parse_union_revsets(&args.revisions)?;
+        let revset = workspace_command.evaluate_revset(expression)?;
+        revset.iter().commits(repo.store()).try_collect()?
+    };
     // Jobs are resolved in this order:
     // 1. Commandline argument iff > 0.
     // 2. the amount of cores available.


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
