### PR TITLE
Fix link to my tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ developers monitor both channels.
   and the associated [slides][merge-slides].
 
 [krycho]: https://v5.chriskrycho.com/essays/jj-init/
-[klabnik]: https://steveklabnik.github.io/jujutsu-tutorial/introduction.html
+[klabnik]: https://steveklabnik.github.io/jujutsu-tutorial/
 [lwn]: https://lwn.net/Articles/958468/ 
 [merge-talk]: https://www.youtube.com/watch?v=bx_LGilOuE4
 [merge-slides]: https://docs.google.com/presentation/d/1F8j9_UOOSGUN9MvHxPZX_L4bQ9NMcYOp1isn17kTC_M/view 


### PR DESCRIPTION
https://github.com/steveklabnik/jujutsu-tutorial/commit/2d62f22de1677c759afcbe10a098229293e1fe2f reorganized some things, and so this link became broken