### PR TITLE
docs: Add missing "jj" to swap rebase example

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -258,7 +258,7 @@ parent.
     </tr>
     <tr>
       <td>Reorder changes from A-B-C-D to A-C-B-D</td>
-      <td><code>jj rebase -r C -d A; rebase -s B -d C</code> (pass change IDs,
+      <td><code>jj rebase -r C -d A; jj rebase -s B -d C</code> (pass change IDs,
           not commit IDs, to not have to look up commit ID of rewritten C)</td>
       <td><code>git rebase -i A</code></td>
     </tr>


### PR DESCRIPTION
`jj rebase -r C -d A; rebase -s B -d C` is missing the second jj.

Although it would be cool if jj had syntax to chain commands like this, so I could write a "swap" alias.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
