### PR TITLE
clippy: remove some unused code beta clippy/rustc compain about

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1176,7 +1176,6 @@ mod tests {
     use super::*;
     use crate::formatter::{self, ColorFormatter};
     use crate::generic_templater::GenericTemplateLanguage;
-    use crate::template_parser::TemplateAliasesMap;
 
     type TestTemplateLanguage = GenericTemplateLanguage<'static, ()>;
     type TestTemplatePropertyKind = <TestTemplateLanguage as TemplateLanguage<'static>>::Property;

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -16,7 +16,6 @@
 
 use std::collections::VecDeque;
 use std::fmt::{Debug, Error, Formatter};
-use std::ops::Range;
 
 use itertools::Itertools;
 
@@ -157,14 +156,6 @@ impl Debug for ContentHunk {
 pub enum MergeResult {
     Resolved(ContentHunk),
     Conflict(Vec<Merge<ContentHunk>>),
-}
-
-/// A region where the base and two sides match.
-#[derive(Debug, PartialEq, Eq, Clone)]
-struct SyncRegion {
-    base: Range<usize>,
-    left: Range<usize>,
-    right: Range<usize>,
 }
 
 pub fn merge(slices: &Merge<&[u8]>) -> MergeResult {


### PR DESCRIPTION
There are still some warnings from (seemingly) clippy bugs. Quoting myself from Discord:

> PSA: the latest beta cargo clippy (from Rust 1.78) has some problems
> that affect jj: https://github.com/rust-lang/rust-clippy/issues/12467
> and https://github.com/rust-lang/rust-clippy/issues/12377.  You could
> disable clippy::assigning_clones and clippy::empty_docs as a workaround.
> VS Code can disable them in rust-analyzer, you can also use
> https://github.com/ericseppanen/cargo-cranky (you can put Cranky.toml in
> the per-user gitignore).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
