### PR TITLE
templater: don't define TemplateLanguage::Context statically

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -244,7 +244,7 @@ impl CommandHelper {
     /// This function also loads template aliases from the settings. Use
     /// `WorkspaceCommandHelper::parse_template()` if you've already
     /// instantiated the workspace helper.
-    pub fn parse_template<'a, C: Clone + 'a, L: TemplateLanguage<'a, Context = ()> + ?Sized>(
+    pub fn parse_template<'a, C: Clone + 'a, L: TemplateLanguage<'a> + ?Sized>(
         &self,
         ui: &Ui,
         language: &L,
@@ -899,7 +899,7 @@ Set which revision the branch points to with `jj branch set {branch_name} -r <RE
     ///
     /// `wrap_self` specifies the type of the top-level property, which should
     /// be one of the `L::wrap_*()` functions.
-    pub fn parse_template<'a, C: Clone + 'a, L: TemplateLanguage<'a, Context = ()> + ?Sized>(
+    pub fn parse_template<'a, C: Clone + 'a, L: TemplateLanguage<'a> + ?Sized>(
         &self,
         language: &L,
         template_text: &str,

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -22,6 +22,7 @@ use tracing::instrument;
 
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Abandon a revision

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -32,6 +32,7 @@ use crate::cli_util::{
 };
 use crate::command_error::{user_error, user_error_with_hint, CommandError};
 use crate::formatter::Formatter;
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Manage branches.

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -185,23 +185,24 @@ pub(crate) fn cmd_config(
 }
 
 fn config_template_language() -> GenericTemplateLanguage<'static, AnnotatedValue> {
+    type L = GenericTemplateLanguage<'static, AnnotatedValue>;
     fn prop_fn<R, F: Fn(&AnnotatedValue) -> R>(f: F) -> TemplatePropertyFn<F> {
         TemplatePropertyFn(f)
     }
     let mut language = GenericTemplateLanguage::new();
     // "name" instead of "path" to avoid confusion with the source file path
-    language.add_keyword("name", |language| {
+    language.add_keyword("name", |_language| {
         let property = prop_fn(|annotated| Ok(annotated.path.join(".")));
-        Ok(language.wrap_string(property))
+        Ok(L::wrap_string(property))
     });
-    language.add_keyword("value", |language| {
+    language.add_keyword("value", |_language| {
         // TODO: would be nice if we can provide raw dynamically-typed value
         let property = prop_fn(|annotated| Ok(serialize_config_value(&annotated.value)));
-        Ok(language.wrap_string(property))
+        Ok(L::wrap_string(property))
     });
-    language.add_keyword("overridden", |language| {
+    language.add_keyword("overridden", |_language| {
         let property = prop_fn(|annotated| Ok(annotated.is_overridden));
-        Ok(language.wrap_boolean(property))
+        Ok(L::wrap_boolean(property))
     });
     language
 }

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -191,16 +191,16 @@ fn config_template_language() -> GenericTemplateLanguage<'static, AnnotatedValue
     }
     let mut language = GenericTemplateLanguage::new();
     // "name" instead of "path" to avoid confusion with the source file path
-    language.add_keyword("name", |_language| {
+    language.add_keyword("name", || {
         let property = prop_fn(|annotated| Ok(annotated.path.join(".")));
         Ok(L::wrap_string(property))
     });
-    language.add_keyword("value", |_language| {
+    language.add_keyword("value", || {
         // TODO: would be nice if we can provide raw dynamically-typed value
         let property = prop_fn(|annotated| Ok(serialize_config_value(&annotated.value)));
         Ok(L::wrap_string(property))
     });
-    language.add_keyword("overridden", |_language| {
+    language.add_keyword("overridden", || {
         let property = prop_fn(|annotated| Ok(annotated.is_overridden));
         Ok(L::wrap_boolean(property))
     });

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -26,7 +26,7 @@ use crate::command_error::{user_error, CommandError};
 use crate::config::{AnnotatedValue, ConfigSource};
 use crate::generic_templater::GenericTemplateLanguage;
 use crate::template_builder::TemplateLanguage as _;
-use crate::templater::TemplateFunction;
+use crate::templater::{Template as _, TemplateFunction};
 use crate::ui::Ui;
 
 #[derive(clap::Args, Clone, Debug)]
@@ -225,7 +225,7 @@ pub(crate) fn cmd_config_list(
                 .config()
                 .get_string("templates.config_list")?,
         };
-        command.parse_template(ui, &language, &text)?
+        command.parse_template(ui, &language, &text, GenericTemplateLanguage::wrap_self)?
     };
 
     ui.request_pager();

--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -21,6 +21,7 @@ use jj_lib::revset::{RevsetExpression, RevsetIteratorExt};
 
 use crate::cli_util::{short_commit_hash, CommandHelper, WorkspaceCommandHelper};
 use crate::command_error::{user_error, CommandError};
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Move the working-copy commit to the child revision

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -27,7 +27,7 @@ use crate::cli_util::{format_template, short_operation_hash, CommandHelper, LogC
 use crate::command_error::{user_error, user_error_with_hint, CommandError};
 use crate::graphlog::{get_graphlog, Edge};
 use crate::operation_templater::OperationTemplateLanguage;
-use crate::templater::Template;
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Commands for working with the operation log
@@ -171,9 +171,18 @@ fn cmd_op_log(
             Some(value) => value.to_owned(),
             None => command.settings().config().get_string("templates.op_log")?,
         };
-        template = command.parse_template(ui, &language, &text)?;
-        op_node_template =
-            command.parse_template(ui, &language, &command.settings().op_node_template())?;
+        template = command.parse_template(
+            ui,
+            &language,
+            &text,
+            OperationTemplateLanguage::wrap_operation,
+        )?;
+        op_node_template = command.parse_template(
+            ui,
+            &language,
+            &command.settings().op_node_template(),
+            OperationTemplateLanguage::wrap_operation,
+        )?;
     }
 
     ui.request_pager();

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -18,6 +18,7 @@ use tracing::instrument;
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
 use crate::diff_util::{self, DiffFormatArgs};
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Show commit description and changes in a revision

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -22,6 +22,7 @@ use super::resolve;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::diff_util;
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Show high-level repo status

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -33,6 +33,7 @@ use crate::cli_util::{
     RevisionArg, WorkingCopyFreshness, WorkspaceCommandHelper,
 };
 use crate::command_error::{internal_error_with_message, user_error, CommandError};
+use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Commands for working with workspaces

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -96,7 +96,6 @@ impl<'repo> CommitTemplateLanguage<'repo> {
 }
 
 impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
-    type Context = ();
     type Property = CommitTemplatePropertyKind<'repo>;
 
     template_builder::impl_core_wrap_property_fns!('repo, CommitTemplatePropertyKind::Core);
@@ -185,54 +184,54 @@ impl<'repo> CommitTemplateLanguage<'repo> {
     }
 
     pub fn wrap_commit(
-        property: impl TemplateProperty<(), Output = Commit> + 'repo,
+        property: impl TemplateProperty<Output = Commit> + 'repo,
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::Commit(Box::new(property))
     }
 
     pub fn wrap_commit_list(
-        property: impl TemplateProperty<(), Output = Vec<Commit>> + 'repo,
+        property: impl TemplateProperty<Output = Vec<Commit>> + 'repo,
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::CommitList(Box::new(property))
     }
 
     pub fn wrap_ref_name(
-        property: impl TemplateProperty<(), Output = RefName> + 'repo,
+        property: impl TemplateProperty<Output = RefName> + 'repo,
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::RefName(Box::new(property))
     }
 
     pub fn wrap_ref_name_list(
-        property: impl TemplateProperty<(), Output = Vec<RefName>> + 'repo,
+        property: impl TemplateProperty<Output = Vec<RefName>> + 'repo,
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::RefNameList(Box::new(property))
     }
 
     pub fn wrap_commit_or_change_id(
-        property: impl TemplateProperty<(), Output = CommitOrChangeId> + 'repo,
+        property: impl TemplateProperty<Output = CommitOrChangeId> + 'repo,
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::CommitOrChangeId(Box::new(property))
     }
 
     pub fn wrap_shortest_id_prefix(
-        property: impl TemplateProperty<(), Output = ShortestIdPrefix> + 'repo,
+        property: impl TemplateProperty<Output = ShortestIdPrefix> + 'repo,
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::ShortestIdPrefix(Box::new(property))
     }
 }
 
 pub enum CommitTemplatePropertyKind<'repo> {
-    Core(CoreTemplatePropertyKind<'repo, ()>),
-    Commit(Box<dyn TemplateProperty<(), Output = Commit> + 'repo>),
-    CommitList(Box<dyn TemplateProperty<(), Output = Vec<Commit>> + 'repo>),
-    RefName(Box<dyn TemplateProperty<(), Output = RefName> + 'repo>),
-    RefNameList(Box<dyn TemplateProperty<(), Output = Vec<RefName>> + 'repo>),
-    CommitOrChangeId(Box<dyn TemplateProperty<(), Output = CommitOrChangeId> + 'repo>),
-    ShortestIdPrefix(Box<dyn TemplateProperty<(), Output = ShortestIdPrefix> + 'repo>),
+    Core(CoreTemplatePropertyKind<'repo>),
+    Commit(Box<dyn TemplateProperty<Output = Commit> + 'repo>),
+    CommitList(Box<dyn TemplateProperty<Output = Vec<Commit>> + 'repo>),
+    RefName(Box<dyn TemplateProperty<Output = RefName> + 'repo>),
+    RefNameList(Box<dyn TemplateProperty<Output = Vec<RefName>> + 'repo>),
+    CommitOrChangeId(Box<dyn TemplateProperty<Output = CommitOrChangeId> + 'repo>),
+    ShortestIdPrefix(Box<dyn TemplateProperty<Output = ShortestIdPrefix> + 'repo>),
 }
 
-impl<'repo> IntoTemplateProperty<'repo, ()> for CommitTemplatePropertyKind<'repo> {
-    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<(), Output = bool> + 'repo>> {
+impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
+    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<Output = bool> + 'repo>> {
         match self {
             CommitTemplatePropertyKind::Core(property) => property.try_into_boolean(),
             CommitTemplatePropertyKind::Commit(_) => None,
@@ -252,14 +251,14 @@ impl<'repo> IntoTemplateProperty<'repo, ()> for CommitTemplatePropertyKind<'repo
         }
     }
 
-    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<(), Output = i64> + 'repo>> {
+    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<Output = i64> + 'repo>> {
         match self {
             CommitTemplatePropertyKind::Core(property) => property.try_into_integer(),
             _ => None,
         }
     }
 
-    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<(), Output = String> + 'repo>> {
+    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<Output = String> + 'repo>> {
         match self {
             CommitTemplatePropertyKind::Core(property) => property.try_into_plain_text(),
             _ => {

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -58,14 +58,14 @@ impl<'a, C> GenericTemplateLanguage<'a, C> {
     /// by `TemplatePropertyFn`.
     ///
     /// ```ignore
-    /// language.add_keyword("name", |_language| {
+    /// language.add_keyword("name", || {
     ///     let property = TemplatePropertyFn(|v: &C| Ok(v.to_string()));
     ///     Ok(GenericTemplateLanguage::wrap_string(property))
     /// });
     /// ```
     pub fn add_keyword<F>(&mut self, name: &'static str, build: F)
     where
-        F: Fn(&Self) -> TemplateParseResult<GenericTemplatePropertyKind<'a, C>> + 'a,
+        F: Fn() -> TemplateParseResult<GenericTemplatePropertyKind<'a, C>> + 'a,
     {
         self.build_fn_table.keywords.insert(name, Box::new(build));
     }
@@ -108,7 +108,7 @@ impl<'a, C: 'a> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
                 let build = template_parser::lookup_method("Self", table, function)?;
                 // For simplicity, only 0-ary method is supported.
                 template_parser::expect_no_arguments(function)?;
-                build(self)
+                build()
             }
         }
     }
@@ -154,12 +154,8 @@ impl<'a, C: 'a> IntoTemplateProperty<'a, C> for GenericTemplatePropertyKind<'a, 
 ///
 /// Because the `GenericTemplateLanguage` doesn't provide a way to pass around
 /// global resources, the keyword function is allowed to capture resources.
-pub type GenericTemplateBuildKeywordFn<'a, C> = Box<
-    dyn Fn(
-            &GenericTemplateLanguage<'a, C>,
-        ) -> TemplateParseResult<GenericTemplatePropertyKind<'a, C>>
-        + 'a,
->;
+pub type GenericTemplateBuildKeywordFn<'a, C> =
+    Box<dyn Fn() -> TemplateParseResult<GenericTemplatePropertyKind<'a, C>> + 'a>;
 
 /// Table of functions that translate keyword node.
 pub type GenericTemplateBuildKeywordFnMap<'a, C> =

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -66,7 +66,7 @@ impl<'a, C> GenericTemplateLanguage<'a, C> {
     pub fn add_keyword<F>(&mut self, name: &'static str, build: F)
     where
         F: Fn(
-                Box<dyn TemplateProperty<(), Output = C> + 'a>,
+                Box<dyn TemplateProperty<Output = C> + 'a>,
             ) -> TemplateParseResult<GenericTemplatePropertyKind<'a, C>>
             + 'a,
     {
@@ -75,7 +75,6 @@ impl<'a, C> GenericTemplateLanguage<'a, C> {
 }
 
 impl<'a, C: 'a> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
-    type Context = ();
     type Property = GenericTemplatePropertyKind<'a, C>;
 
     template_builder::impl_core_wrap_property_fns!('a, GenericTemplatePropertyKind::Core);
@@ -113,33 +112,33 @@ impl<'a, C: 'a> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
 
 impl<'a, C> GenericTemplateLanguage<'a, C> {
     pub fn wrap_self(
-        property: impl TemplateProperty<(), Output = C> + 'a,
+        property: impl TemplateProperty<Output = C> + 'a,
     ) -> GenericTemplatePropertyKind<'a, C> {
         GenericTemplatePropertyKind::Self_(Box::new(property))
     }
 }
 
 pub enum GenericTemplatePropertyKind<'a, C> {
-    Core(CoreTemplatePropertyKind<'a, ()>),
-    Self_(Box<dyn TemplateProperty<(), Output = C> + 'a>),
+    Core(CoreTemplatePropertyKind<'a>),
+    Self_(Box<dyn TemplateProperty<Output = C> + 'a>),
 }
 
-impl<'a, C: 'a> IntoTemplateProperty<'a, ()> for GenericTemplatePropertyKind<'a, C> {
-    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<(), Output = bool> + 'a>> {
+impl<'a, C: 'a> IntoTemplateProperty<'a> for GenericTemplatePropertyKind<'a, C> {
+    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<Output = bool> + 'a>> {
         match self {
             GenericTemplatePropertyKind::Core(property) => property.try_into_boolean(),
             GenericTemplatePropertyKind::Self_(_) => None,
         }
     }
 
-    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<(), Output = i64> + 'a>> {
+    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<Output = i64> + 'a>> {
         match self {
             GenericTemplatePropertyKind::Core(property) => property.try_into_integer(),
             GenericTemplatePropertyKind::Self_(_) => None,
         }
     }
 
-    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<(), Output = String> + 'a>> {
+    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<Output = String> + 'a>> {
         match self {
             GenericTemplatePropertyKind::Core(property) => property.try_into_plain_text(),
             GenericTemplatePropertyKind::Self_(_) => None,
@@ -161,7 +160,7 @@ impl<'a, C: 'a> IntoTemplateProperty<'a, ()> for GenericTemplatePropertyKind<'a,
 /// global resources, the keyword function is allowed to capture resources.
 pub type GenericTemplateBuildKeywordFn<'a, C> = Box<
     dyn Fn(
-            Box<dyn TemplateProperty<(), Output = C> + 'a>,
+            Box<dyn TemplateProperty<Output = C> + 'a>,
         ) -> TemplateParseResult<GenericTemplatePropertyKind<'a, C>>
         + 'a,
 >;

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -58,9 +58,9 @@ impl<'a, C> GenericTemplateLanguage<'a, C> {
     /// by `TemplatePropertyFn`.
     ///
     /// ```ignore
-    /// language.add_keyword("name", |language| {
+    /// language.add_keyword("name", |_language| {
     ///     let property = TemplatePropertyFn(|v: &C| Ok(v.to_string()));
-    ///     Ok(language.wrap_string(property))
+    ///     Ok(GenericTemplateLanguage::wrap_string(property))
     /// });
     /// ```
     pub fn add_keyword<F>(&mut self, name: &'static str, build: F)

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -72,7 +72,6 @@ impl OperationTemplateLanguage {
 }
 
 impl TemplateLanguage<'static> for OperationTemplateLanguage {
-    type Context = ();
     type Property = OperationTemplatePropertyKind;
 
     template_builder::impl_core_wrap_property_fns!('static, OperationTemplatePropertyKind::Core);
@@ -117,26 +116,26 @@ impl OperationTemplateLanguage {
     }
 
     pub fn wrap_operation(
-        property: impl TemplateProperty<(), Output = Operation> + 'static,
+        property: impl TemplateProperty<Output = Operation> + 'static,
     ) -> OperationTemplatePropertyKind {
         OperationTemplatePropertyKind::Operation(Box::new(property))
     }
 
     pub fn wrap_operation_id(
-        property: impl TemplateProperty<(), Output = OperationId> + 'static,
+        property: impl TemplateProperty<Output = OperationId> + 'static,
     ) -> OperationTemplatePropertyKind {
         OperationTemplatePropertyKind::OperationId(Box::new(property))
     }
 }
 
 pub enum OperationTemplatePropertyKind {
-    Core(CoreTemplatePropertyKind<'static, ()>),
-    Operation(Box<dyn TemplateProperty<(), Output = Operation>>),
-    OperationId(Box<dyn TemplateProperty<(), Output = OperationId>>),
+    Core(CoreTemplatePropertyKind<'static>),
+    Operation(Box<dyn TemplateProperty<Output = Operation>>),
+    OperationId(Box<dyn TemplateProperty<Output = OperationId>>),
 }
 
-impl IntoTemplateProperty<'static, ()> for OperationTemplatePropertyKind {
-    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<(), Output = bool>>> {
+impl IntoTemplateProperty<'static> for OperationTemplatePropertyKind {
+    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<Output = bool>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_boolean(),
             OperationTemplatePropertyKind::Operation(_) => None,
@@ -144,14 +143,14 @@ impl IntoTemplateProperty<'static, ()> for OperationTemplatePropertyKind {
         }
     }
 
-    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<(), Output = i64>>> {
+    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<Output = i64>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_integer(),
             _ => None,
         }
     }
 
-    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<(), Output = String>>> {
+    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<Output = String>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_plain_text(),
             _ => {

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -30,7 +30,7 @@ use crate::template_builder::{
 use crate::template_parser::{self, FunctionCallNode, TemplateParseResult};
 use crate::templater::{
     IntoTemplate, PlainTextFormattedProperty, Template, TemplateFunction, TemplateProperty,
-    TemplatePropertyFn, TimestampRange,
+    TimestampRange,
 };
 
 pub trait OperationTemplateLanguageExtension {
@@ -72,15 +72,10 @@ impl OperationTemplateLanguage {
 }
 
 impl TemplateLanguage<'static> for OperationTemplateLanguage {
-    type Context = Operation;
+    type Context = ();
     type Property = OperationTemplatePropertyKind;
 
     template_builder::impl_core_wrap_property_fns!('static, OperationTemplatePropertyKind::Core);
-
-    fn build_self(&self) -> Self::Property {
-        // Operation object is lightweight (a few Arc + OperationId)
-        Self::wrap_operation(TemplatePropertyFn(|op: &Operation| Ok(op.clone())))
-    }
 
     fn build_function(
         &self,
@@ -122,26 +117,26 @@ impl OperationTemplateLanguage {
     }
 
     pub fn wrap_operation(
-        property: impl TemplateProperty<Operation, Output = Operation> + 'static,
+        property: impl TemplateProperty<(), Output = Operation> + 'static,
     ) -> OperationTemplatePropertyKind {
         OperationTemplatePropertyKind::Operation(Box::new(property))
     }
 
     pub fn wrap_operation_id(
-        property: impl TemplateProperty<Operation, Output = OperationId> + 'static,
+        property: impl TemplateProperty<(), Output = OperationId> + 'static,
     ) -> OperationTemplatePropertyKind {
         OperationTemplatePropertyKind::OperationId(Box::new(property))
     }
 }
 
 pub enum OperationTemplatePropertyKind {
-    Core(CoreTemplatePropertyKind<'static, Operation>),
-    Operation(Box<dyn TemplateProperty<Operation, Output = Operation>>),
-    OperationId(Box<dyn TemplateProperty<Operation, Output = OperationId>>),
+    Core(CoreTemplatePropertyKind<'static, ()>),
+    Operation(Box<dyn TemplateProperty<(), Output = Operation>>),
+    OperationId(Box<dyn TemplateProperty<(), Output = OperationId>>),
 }
 
-impl IntoTemplateProperty<'static, Operation> for OperationTemplatePropertyKind {
-    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<Operation, Output = bool>>> {
+impl IntoTemplateProperty<'static, ()> for OperationTemplatePropertyKind {
+    fn try_into_boolean(self) -> Option<Box<dyn TemplateProperty<(), Output = bool>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_boolean(),
             OperationTemplatePropertyKind::Operation(_) => None,
@@ -149,14 +144,14 @@ impl IntoTemplateProperty<'static, Operation> for OperationTemplatePropertyKind 
         }
     }
 
-    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<Operation, Output = i64>>> {
+    fn try_into_integer(self) -> Option<Box<dyn TemplateProperty<(), Output = i64>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_integer(),
             _ => None,
         }
     }
 
-    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<Operation, Output = String>>> {
+    fn try_into_plain_text(self) -> Option<Box<dyn TemplateProperty<(), Output = String>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_plain_text(),
             _ => {
@@ -166,7 +161,7 @@ impl IntoTemplateProperty<'static, Operation> for OperationTemplatePropertyKind 
         }
     }
 
-    fn try_into_template(self) -> Option<Box<dyn Template<Operation>>> {
+    fn try_into_template(self) -> Option<Box<dyn Template<()>>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_template(),
             OperationTemplatePropertyKind::Operation(_) => None,

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1206,7 +1206,7 @@ mod tests {
         where
             F: Fn() -> TestTemplatePropertyKind + 'static,
         {
-            self.language.add_keyword(name, move || Ok(build()));
+            self.language.add_keyword(name, move |_| Ok(build()));
         }
 
         fn add_alias(&mut self, decl: impl AsRef<str>, defn: impl Into<String>) {

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -617,6 +617,28 @@ impl<C, O: Clone> TemplateProperty<C> for PropertyPlaceholder<O> {
     }
 }
 
+/// Adapter that renders compiled `template` with the `placeholder` value set.
+pub struct PlaceholderTemplate<C, T> {
+    template: T,
+    placeholder: PropertyPlaceholder<C>,
+}
+
+impl<C: Clone, T: Template<()>> PlaceholderTemplate<C, T> {
+    pub fn new(template: T, placeholder: PropertyPlaceholder<C>) -> Self {
+        PlaceholderTemplate {
+            template,
+            placeholder,
+        }
+    }
+}
+
+impl<C: Clone, T: Template<()>> Template<C> for PlaceholderTemplate<C, T> {
+    fn format(&self, context: &C, formatter: &mut dyn Formatter) -> io::Result<()> {
+        self.placeholder
+            .with_value(context.clone(), || self.template.format(&(), formatter))
+    }
+}
+
 pub fn format_joined<C, I, S>(
     context: &C,
     formatter: &mut dyn Formatter,

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -348,20 +348,6 @@ impl<C, O: Clone> TemplateProperty<C> for Literal<O> {
     }
 }
 
-/// Adapter to turn closure into property.
-pub struct TemplatePropertyFn<F>(pub F);
-
-impl<C, O, F> TemplateProperty<C> for TemplatePropertyFn<F>
-where
-    F: Fn(&C) -> Result<O, TemplatePropertyError>,
-{
-    type Output = O;
-
-    fn extract(&self, context: &C) -> Result<Self::Output, TemplatePropertyError> {
-        (self.0)(context)
-    }
-}
-
 /// Adapter to extract context-less template value from property for displaying.
 pub struct FormattablePropertyTemplate<P> {
     property: P,


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
