### PR TITLE
cli: add option to list only conflicted branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj git push` now prints messages from the remote.
 
+* `jj branch list` now supports a `--conflicted/-c` option to show only conflicted branches.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -109,6 +109,10 @@ pub struct BranchListArgs {
     #[arg(long, short, conflicts_with_all = ["all"])]
     tracked: bool,
 
+    /// Show conflicted branches only.
+    #[arg(long, short, conflicts_with_all = ["all"])]
+    conflicted: bool,
+
     /// Show branches whose local name matches
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
@@ -673,10 +677,11 @@ fn cmd_branch_list(
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
 
-    let branches_to_list = view.branches().filter(|&(name, _)| {
+    let branches_to_list = view.branches().filter(|(name, target)| {
         branch_names_to_list
             .as_ref()
             .map_or(true, |branch_names| branch_names.contains(name))
+            && (!args.conflicted || target.local_target.has_conflict())
     });
     for (name, branch_target) in branches_to_list {
         let (mut tracking_remote_refs, untracked_remote_refs) = branch_target

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -306,6 +306,10 @@ For information about branches, see https://github.com/martinvonz/jj/blob/main/d
 
   Possible values: `true`, `false`
 
+* `-c`, `--conflicted` — Show conflicted branches only
+
+  Possible values: `true`, `false`
+
 * `-r`, `--revisions <REVISIONS>` — Show branches whose local targets are in the given revisions
 
 


### PR DESCRIPTION
As requested in #1471, I added a new flag for `jj branch list` to only show branches that are conflicted.

Adds a unit test to check for listing only conflicted branches and regenerates the cli output to incorporate the new flag.

Closes #1471

reformat

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
