### PR TITLE
cli(duplicate, abandon): allow multiple `-r` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj branch list` now supports a `--conflicted/-c` option to show only conflicted branches.
 
+* `jj duplicate` and `jj abandon` can now take more than a single `-r` argument,
+  for consistency with other commands.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -41,8 +41,8 @@ pub(crate) struct AbandonArgs {
     #[arg(long, short)]
     summary: bool,
     /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true)]
-    unused_revision: bool,
+    #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
+    unused_revision: u8,
 }
 
 #[instrument(skip_all)]

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -31,8 +31,8 @@ pub(crate) struct DuplicateArgs {
     #[arg(default_value = "@")]
     revisions: Vec<RevisionArg>,
     /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true)]
-    unused_revision: bool,
+    #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
+    unused_revision: u8,
 }
 
 #[instrument(skip_all)]

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -45,8 +45,8 @@ pub(crate) struct NewArgs {
     #[arg(default_value = "@")]
     pub(crate) revisions: Vec<RevisionArg>,
     /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true, overrides_with = "unused_revision")]
-    unused_revision: bool,
+    #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
+    unused_revision: u8,
     /// The change description to use
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -189,9 +189,6 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 * `-r` — Ignored (but lets you pass `-r` for consistency with other commands)
 
-  Possible values: `true`, `false`
-
-
 
 
 ## `jj backout`
@@ -703,9 +700,6 @@ Create a new change with the same content as an existing one
 
 * `-r` — Ignored (but lets you pass `-r` for consistency with other commands)
 
-  Possible values: `true`, `false`
-
-
 
 
 ## `jj edit`
@@ -1118,9 +1112,6 @@ For more information, see https://github.com/martinvonz/jj/blob/main/docs/workin
 ###### **Options:**
 
 * `-r` — Ignored (but lets you pass `-r` for consistency with other commands)
-
-  Possible values: `true`, `false`
-
 * `-m`, `--message <MESSAGE>` — The change description to use
 * `-L`, `--allow-large-revsets` — Deprecated. Please prefix the revset with `all:` instead
 


### PR DESCRIPTION
Commands like `new`, `duplicate`, and `abandon` can take multiple revset arguments which results in their collective union. They take the revisions directly as arguments. But for consistency with many other commands, they can also take the `-r` argument, which is a no-op. However, due to the flag being specified as a `bool`, the `-r` option can only be specified once, so e.g. `abandon -r x -r y` often fails. I normally use `-r` for consistency and muscle memory, so this bites me often.

Instead, use `clap::ArgAction::Count` in order to allow `-r` to be specified multiple times. It remains unused, of course.

With this change, all the following invocations are equivalent. Before this change, the second example would fail due to  giving `-r` multiple times.

    jj abandon x y
    jj abandon -r x -r y
    jj abandon -r 'x | y'

Note: `jj new` already supported this exact case actually, but it used an awkward trick where it used `.overrides_with()` in order to override *itself* so it could be specified multiple times. I believe this is a bit clearer.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
