### PR TITLE
cli: indent commits summary in single revset resolution hint

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -800,11 +800,12 @@ impl WorkspaceCommandHelper {
                     let mut output = Vec::new();
                     let mut formatter = PlainTextFormatter::new(&mut output);
                     for commit in &commits {
+                        write!(formatter, "  ")?;
                         template.format(commit, &mut formatter).unwrap();
                         writeln!(formatter).unwrap();
                     }
                     if elided {
-                        writeln!(formatter, "...").unwrap();
+                        writeln!(formatter, "  ...").unwrap();
                     }
                     output.pop(); // drop last newline
                     String::from_utf8(output).expect("template output should be utf-8 bytes")

--- a/cli/tests/test_checkout.rs
+++ b/cli/tests/test_checkout.rs
@@ -70,12 +70,12 @@ fn test_checkout_not_single_rev() {
     warning: `jj checkout` will be removed in a future version, and this will be a hard error
     Error: Revset "root()..@" resolved to more than one revision
     Hint: The revset "root()..@" resolved to these revisions:
-    royxmykx 2f859371 (empty) (no description set)
-    mzvwutvl 5c1afd8b (empty) fifth
-    zsuskuln 009f88bf (empty) fourth
-    kkmpptxz 3fa8931e (empty) third
-    rlvkpnrz 5c52832c (empty) second
-    ...
+      royxmykx 2f859371 (empty) (no description set)
+      mzvwutvl 5c1afd8b (empty) fifth
+      zsuskuln 009f88bf (empty) fourth
+      kkmpptxz 3fa8931e (empty) third
+      rlvkpnrz 5c52832c (empty) second
+      ...
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "root()..@-"]);
@@ -84,11 +84,11 @@ fn test_checkout_not_single_rev() {
     warning: `jj checkout` will be removed in a future version, and this will be a hard error
     Error: Revset "root()..@-" resolved to more than one revision
     Hint: The revset "root()..@-" resolved to these revisions:
-    mzvwutvl 5c1afd8b (empty) fifth
-    zsuskuln 009f88bf (empty) fourth
-    kkmpptxz 3fa8931e (empty) third
-    rlvkpnrz 5c52832c (empty) second
-    qpvuntsm 69542c19 (empty) first
+      mzvwutvl 5c1afd8b (empty) fifth
+      zsuskuln 009f88bf (empty) fourth
+      kkmpptxz 3fa8931e (empty) third
+      rlvkpnrz 5c52832c (empty) second
+      qpvuntsm 69542c19 (empty) first
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "@-|@--"]);
@@ -97,8 +97,8 @@ fn test_checkout_not_single_rev() {
     warning: `jj checkout` will be removed in a future version, and this will be a hard error
     Error: Revset "@-|@--" resolved to more than one revision
     Hint: The revset "@-|@--" resolved to these revisions:
-    mzvwutvl 5c1afd8b (empty) fifth
-    zsuskuln 009f88bf (empty) fourth
+      mzvwutvl 5c1afd8b (empty) fifth
+      zsuskuln 009f88bf (empty) fourth
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "none()"]);

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -495,8 +495,8 @@ fn test_new_conflicting_branches() {
     Error: Revset "foo" resolved to more than one revision
     Hint: Branch foo resolved to multiple revisions because it's conflicted.
     It resolved to these revisions:
-    kkmpptxz 66c6502d foo?? | (empty) two
-    qpvuntsm a9330854 foo?? | (empty) one
+      kkmpptxz 66c6502d foo?? | (empty) two
+      qpvuntsm a9330854 foo?? | (empty) one
     Hint: Set which revision the branch points to with `jj branch set foo -r <REVISION>`.
     "###);
 }
@@ -517,8 +517,8 @@ fn test_new_conflicting_change_ids() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "qpvuntsm" resolved to more than one revision
     Hint: The revset "qpvuntsm" resolved to these revisions:
-    qpvuntsm?? d2ae6806 (empty) two
-    qpvuntsm?? a9330854 (empty) one
+      qpvuntsm?? d2ae6806 (empty) two
+      qpvuntsm?? a9330854 (empty) one
     Hint: Some of these commits have the same change id. Abandon one of them with `jj abandon -r <REVISION>`.
     "###);
 }

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -167,8 +167,8 @@ fn test_rebase_branch() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "e|d" resolved to more than one revision
     Hint: The revset "e|d" resolved to these revisions:
-    znkkpsqq e52756c8 e | e
-    vruxwmqv 514fa6b2 d | d
+      znkkpsqq e52756c8 e | e
+      vruxwmqv 514fa6b2 d | d
     Hint: Prefix the expression with 'all:' to allow any number of revisions (i.e. 'all:e|d').
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b=all:e|d", "-d=b"]);
@@ -478,8 +478,8 @@ fn test_rebase_multiple_destinations() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|c" resolved to more than one revision
     Hint: The revset "b|c" resolved to these revisions:
-    royxmykx fe2e8e8b c | c
-    zsuskuln d370aee1 b | b
+      royxmykx fe2e8e8b c | c
+      zsuskuln d370aee1 b | b
     Hint: Prefix the expression with 'all:' to allow any number of revisions (i.e. 'all:b|c').
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
@@ -614,8 +614,8 @@ fn test_rebase_with_descendants() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "b|d" resolved to more than one revision
     Hint: The revset "b|d" resolved to these revisions:
-    vruxwmqv df54a9fd d | d
-    zsuskuln d370aee1 b | b
+      vruxwmqv df54a9fd d | d
+      zsuskuln d370aee1 b | b
     Hint: Prefix the expression with 'all:' to allow any number of revisions (i.e. 'all:b|d').
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=all:b|d", "-d=a"]);


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
