### PR TITLE
templater: turn logical `&&` and `||` into short-circuiting operators

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -31,8 +31,8 @@ The following operators are supported.
 * `x.f()`: Method call.
 * `-x`: Negate integer value.
 * `!x`: Logical not.
-* `x && y`: Logical and.
-* `x || y`: Logical or.
+* `x && y`: Logical and, short-circuiting.
+* `x || y`: Logical or, short-circuiting.
 * `x ++ y`: Concatenate `x` and `y` templates.
 
 ## Global functions


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
