### PR TITLE
templater: remove unused context parameter from `Template<C>`

### DIFF
--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -22,7 +22,6 @@ use tracing::instrument;
 
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Abandon a revision

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -32,7 +32,6 @@ use crate::cli_util::{
 };
 use crate::command_error::{user_error, user_error_with_hint, CommandError};
 use crate::formatter::Formatter;
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Manage branches.

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -26,7 +26,7 @@ use crate::command_error::{config_error, user_error, CommandError};
 use crate::config::{AnnotatedValue, ConfigSource};
 use crate::generic_templater::GenericTemplateLanguage;
 use crate::template_builder::TemplateLanguage as _;
-use crate::templater::{Template as _, TemplatePropertyExt as _};
+use crate::templater::TemplatePropertyExt as _;
 use crate::ui::Ui;
 
 #[derive(clap::Args, Clone, Debug)]

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -26,7 +26,6 @@ use crate::command_error::CommandError;
 use crate::commit_templater::CommitTemplateLanguage;
 use crate::diff_util::{self, DiffFormatArgs};
 use crate::graphlog::{get_graphlog, Edge};
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Show revision history

--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -21,7 +21,6 @@ use jj_lib::revset::{RevsetExpression, RevsetIteratorExt};
 
 use crate::cli_util::{short_commit_hash, CommandHelper, WorkspaceCommandHelper};
 use crate::command_error::{user_error, CommandError};
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Move the working-copy commit to the child revision

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -26,7 +26,6 @@ use crate::commit_templater::CommitTemplateLanguage;
 use crate::diff_util::{self, DiffFormat, DiffFormatArgs};
 use crate::formatter::Formatter;
 use crate::graphlog::{get_graphlog, Edge};
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Show how a change has evolved

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -27,7 +27,6 @@ use crate::cli_util::{format_template, short_operation_hash, CommandHelper, LogC
 use crate::command_error::{user_error, user_error_with_hint, CommandError};
 use crate::graphlog::{get_graphlog, Edge};
 use crate::operation_templater::OperationTemplateLanguage;
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Commands for working with the operation log

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -18,7 +18,6 @@ use tracing::instrument;
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
 use crate::diff_util::{self, DiffFormatArgs};
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Show commit description and changes in a revision

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -22,7 +22,6 @@ use super::resolve;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::diff_util;
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Show high-level repo status

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -33,7 +33,6 @@ use crate::cli_util::{
     RevisionArg, WorkingCopyFreshness, WorkspaceCommandHelper,
 };
 use crate::command_error::{internal_error_with_message, user_error, CommandError};
-use crate::templater::Template as _;
 use crate::ui::Ui;
 
 /// Commands for working with workspaces

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -283,7 +283,7 @@ impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
         }
     }
 
-    fn try_into_template(self) -> Option<Box<dyn Template<()> + 'repo>> {
+    fn try_into_template(self) -> Option<Box<dyn Template + 'repo>> {
         match self {
             CommitTemplatePropertyKind::Core(property) => property.try_into_template(),
             CommitTemplatePropertyKind::Commit(_) => None,
@@ -651,8 +651,8 @@ impl RefName {
     }
 }
 
-impl Template<()> for RefName {
-    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
+impl Template for RefName {
+    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
         write!(formatter.labeled("name"), "{}", self.name)?;
         if let Some(remote) = &self.remote {
             write!(formatter, "@")?;
@@ -669,9 +669,9 @@ impl Template<()> for RefName {
     }
 }
 
-impl Template<()> for Vec<RefName> {
-    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
-        templater::format_joined(&(), formatter, self, " ")
+impl Template for Vec<RefName> {
+    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+        templater::format_joined(formatter, self, " ")
     }
 }
 
@@ -823,8 +823,8 @@ impl CommitOrChangeId {
     }
 }
 
-impl Template<()> for CommitOrChangeId {
-    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
+impl Template for CommitOrChangeId {
+    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
         write!(formatter, "{}", self.hex())
     }
 }
@@ -865,8 +865,8 @@ pub struct ShortestIdPrefix {
     pub rest: String,
 }
 
-impl Template<()> for ShortestIdPrefix {
-    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
+impl Template for ShortestIdPrefix {
+    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
         write!(formatter.labeled("prefix"), "{}", self.prefix)?;
         write!(formatter.labeled("rest"), "{}", self.rest)?;
         Ok(())

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -145,7 +145,7 @@ impl<'a, C: 'a> IntoTemplateProperty<'a> for GenericTemplatePropertyKind<'a, C> 
         }
     }
 
-    fn try_into_template(self) -> Option<Box<dyn Template<()> + 'a>> {
+    fn try_into_template(self) -> Option<Box<dyn Template + 'a>> {
         match self {
             GenericTemplatePropertyKind::Core(property) => property.try_into_template(),
             GenericTemplatePropertyKind::Self_(_) => None,

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -160,7 +160,7 @@ impl IntoTemplateProperty<'static> for OperationTemplatePropertyKind {
         }
     }
 
-    fn try_into_template(self) -> Option<Box<dyn Template<()>>> {
+    fn try_into_template(self) -> Option<Box<dyn Template>> {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.try_into_template(),
             OperationTemplatePropertyKind::Operation(_) => None,
@@ -275,8 +275,8 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
     map
 }
 
-impl Template<()> for OperationId {
-    fn format(&self, _: &(), formatter: &mut dyn Formatter) -> io::Result<()> {
+impl Template for OperationId {
+    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
         write!(formatter, "{}", self.hex())
     }
 }

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -134,11 +134,16 @@ pub enum CoreTemplatePropertyKind<'a> {
     Timestamp(Box<dyn TemplateProperty<Output = Timestamp> + 'a>),
     TimestampRange(Box<dyn TemplateProperty<Output = TimestampRange> + 'a>),
 
-    // TODO: This argument no longer makes sense. Maybe we can migrate these to
-    // TemplateProperty<..>:
-    // Similar to `TemplateProperty<I, Output = Box<dyn Template<()> + 'a>`, but doesn't
-    // capture `I` to produce `Template<()>`. The context `I` would have to be cloned
-    // to convert `Template<I>` to `Template<()>`.
+    // Both TemplateProperty and Template can represent a value to be evaluated
+    // dynamically, which suggests that `Box<dyn Template + 'a>` could be
+    // composed as `Box<dyn TemplateProperty<Output = Box<dyn Template ..`.
+    // However, there's a subtle difference: TemplateProperty is strict on
+    // error, whereas Template is usually lax and prints an error inline. If
+    // `concat(x, y)` were a property returning Template, and if `y` failed to
+    // evaluate, the whole expression would fail. In this example, a partial
+    // evaluation output is more useful. That's one reason why Template isn't
+    // wrapped in a TemplateProperty. Another reason is that the outermost
+    // caller expects a Template, not a TemplateProperty of Template output.
     Template(Box<dyn Template + 'a>),
     ListTemplate(Box<dyn ListTemplate + 'a>),
 }

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -629,22 +629,20 @@ impl<O: Clone> TemplateProperty for PropertyPlaceholder<O> {
 }
 
 /// Adapter that renders compiled `template` with the `placeholder` value set.
-pub struct PlaceholderTemplate<C, T> {
-    template: T,
+pub struct TemplateRenderer<'a, C> {
+    template: Box<dyn Template<()> + 'a>,
     placeholder: PropertyPlaceholder<C>,
 }
 
-impl<C: Clone, T: Template<()>> PlaceholderTemplate<C, T> {
-    pub fn new(template: T, placeholder: PropertyPlaceholder<C>) -> Self {
-        PlaceholderTemplate {
+impl<'a, C: Clone> TemplateRenderer<'a, C> {
+    pub fn new(template: Box<dyn Template<()> + 'a>, placeholder: PropertyPlaceholder<C>) -> Self {
+        TemplateRenderer {
             template,
             placeholder,
         }
     }
-}
 
-impl<C: Clone, T: Template<()>> Template<C> for PlaceholderTemplate<C, T> {
-    fn format(&self, context: &C, formatter: &mut dyn Formatter) -> io::Result<()> {
+    pub fn format(&self, context: &C, formatter: &mut dyn Formatter) -> io::Result<()> {
         self.placeholder
             .with_value(context.clone(), || self.template.format(&(), formatter))
     }


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
