### PR TITLE
commit_templater: make git_head return Option<RefName> instead of Vec<_>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* The `git_head` template keyword now returns an optional value instead of a
+  list of 0 or 1 element.
+
 ### New features
 
 * Config now supports rgb hex colors (in the form `#rrggbb`) wherever existing color names are supported.

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -55,6 +55,14 @@ impl<T: Template + ?Sized> Template for Box<T> {
     }
 }
 
+// All optional printable types should be printable, and it's unlikely to
+// implement different formatting per type.
+impl<T: Template> Template for Option<T> {
+    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+        self.as_ref().map_or(Ok(()), |t| t.format(formatter))
+    }
+}
+
 impl Template for Signature {
     fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
         write!(formatter.labeled("name"), "{}", self.name)?;

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -494,6 +494,20 @@ fn test_log_git_head() {
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=initial"]);
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
+
+    let template = r#"
+    separate(", ",
+      if(git_head, "name: " ++ git_head.name()),
+      "remote: " ++ git_head.remote(),
+    ) ++ "\n"
+    "#;
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  remote: <Error: No RefName available>
+    ◉  name: HEAD, remote: git
+    ◉  remote: <Error: No RefName available>
+    "###);
+
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
     @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -81,7 +81,7 @@ This type cannot be printed. The following methods are defined.
 * `remote_branches() -> List<RefName>`: All remote branches pointing to the commit.
 * `tags() -> List<RefName>`
 * `git_refs() -> List<RefName>`
-* `git_head() -> List<RefName>`
+* `git_head() -> Option<RefName>`
 * `divergent() -> Boolean`: True if the commit's change id corresponds to multiple
   visible commits.
 * `hidden() -> Boolean`: True if the commit is not visible (a.k.a. abandoned).


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
