### PR TITLE
Simplify `DescendantRebaser`

### DIFF
--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -540,13 +540,6 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         }
         let old_parent_ids = old_commit.parent_ids();
         let new_parent_ids = self.new_parents(old_parent_ids);
-        if self.mut_repo.abandoned.contains(&old_commit_id) {
-            // Update the `new_parents` map so descendants are rebased correctly.
-            self.mut_repo
-                .parent_mapping
-                .insert(old_commit_id.clone(), new_parent_ids.clone());
-            return Ok(());
-        }
         if new_parent_ids == old_parent_ids {
             // The commit is already in place.
             return Ok(());

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -522,11 +522,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         Ok(())
     }
 
-    pub fn rebase_all(&mut self) -> Result<(), TreeMergeError> {
-        while let Some(old_commit) = self.to_visit.pop() {
-            self.rebase_one(old_commit)?;
-        }
-        self.update_all_references()?;
+    fn update_heads(&mut self) {
         let mut view = self.mut_repo.view().store_view().clone();
         for commit_id in &self.heads_to_remove {
             view.head_ids.remove(commit_id);
@@ -537,6 +533,15 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
         self.heads_to_remove.clear();
         self.heads_to_add.clear();
         self.mut_repo.set_view(view);
+    }
+
+    pub fn rebase_all(&mut self) -> Result<(), TreeMergeError> {
+        while let Some(old_commit) = self.to_visit.pop() {
+            self.rebase_one(old_commit)?;
+        }
+        self.update_all_references()?;
+        self.update_heads();
+
         Ok(())
     }
 }


### PR DESCRIPTION
This makes the `rebase_one()` step of `DescendantRebaser` simpler and safer. References are now updated after all commits have been rebased.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
