### PR TITLE
cli: colorize commits summary embedded in single revset resolution hint

### DIFF
--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -529,7 +529,7 @@ impl<W: Write> Drop for ColorFormatter<W> {
 /// the destination formatter has already been labeled, the recorded labels
 /// will be stacked on top of the existing labels, and the subsequent data
 /// may be colorized differently.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FormatRecorder {
     data: Vec<u8>,
     label_ops: Vec<(usize, LabelOp)>,

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -429,6 +429,16 @@ fn test_color_ui_messages() {
     [1m[39m<[38;5;1mError: [39mNo commit available>[0m  [38;5;8m(elided revisions)[39m
     [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
+
+    // formatted hint
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["new", ".."]);
+    insta::assert_snapshot!(stderr, @r###"
+    [1m[38;5;1mError: [39mRevset ".." resolved to more than one revision[0m
+    [1m[38;5;6mHint: [0m[39mThe revset ".." resolved to these revisions:[39m
+    [39m  [1m[38;5;5mm[0m[38;5;8mzvwutvl[39m [1m[38;5;4m1[0m[38;5;8m67f90e7[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
+    [39m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
+    [1m[38;5;6mHint: [0m[39mPrefix the expression with 'all:' to allow any number of revisions (i.e. 'all:..').[39m
+    "###);
 }
 
 #[test]


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
