### PR TITLE
cli: print conflicted paths whenever the working copy is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * new function `working_copies()` for revsets to show the working copy commits of all workspaces.
 
+* The list of conflicted paths is printed whenever the working copy changes.
+  This can be disabled with the `--quiet` option.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -18,8 +18,7 @@ use jj_lib::repo::Repo;
 use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;
 
-use super::resolve;
-use crate::cli_util::CommandHelper;
+use crate::cli_util::{print_conflicted_paths, CommandHelper};
 use crate::command_error::CommandError;
 use crate::diff_util;
 use crate::ui::Ui;
@@ -72,7 +71,7 @@ pub(crate) fn cmd_status(
                 formatter.labeled("conflict"),
                 "There are unresolved conflicts at these paths:"
             )?;
-            resolve::print_conflicted_paths(&conflicts, formatter, &workspace_command)?
+            print_conflicted_paths(&conflicts, formatter, &workspace_command)?
         }
 
         let template = workspace_command.commit_summary_template();

--- a/cli/tests/test_chmod_command.rs
+++ b/cli/tests/test_chmod_command.rs
@@ -234,6 +234,8 @@ fn test_chmod_file_dir_deletion_conflicts() {
     Parent commit      : zsuskuln c51c9c55 file | file
     Parent commit      : royxmykx 6b18b3c1 deletion | deletion
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion and an executable
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout,

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -384,6 +384,8 @@ fn test_diffedit_merge() {
     Working copy now at: yqosqzyt 1de824f2 (conflict) (empty) (no description set)
     Parent commit      : royxmykx b90654a0 (conflict) merge
     Added 0 files, modified 0 files, removed 1 files
+    There are unresolved conflicts at these paths:
+    file2    2-sided conflict
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -43,6 +43,8 @@ fn test_report_conflicts() {
     Working copy now at: zsuskuln 7dc9bf15 (conflict) (empty) (no description set)
     Parent commit      : kkmpptxz 9baab11e (conflict) C
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
@@ -75,6 +77,8 @@ fn test_report_conflicts() {
     Working copy now at: zsuskuln 83074dac (conflict) (empty) (no description set)
     Parent commit      : kkmpptxz 4f0eeaa6 (conflict) C
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict
     "###);
 
     // Resolve one of the conflicts by (mostly) following the instructions
@@ -84,6 +88,8 @@ fn test_report_conflicts() {
     Working copy now at: vruxwmqv 2ec0b4c3 (conflict) (empty) (no description set)
     Parent commit      : rlvkpnrz e93270ab (conflict) B
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     "###);
     std::fs::write(repo_path.join("file"), "resolved\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
@@ -129,6 +135,8 @@ fn test_report_conflicts_with_divergent_commits() {
     Working copy now at: zsuskuln?? cdae4322 (conflict) C2
     Parent commit      : kkmpptxz b76d6a88 (conflict) B
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
@@ -160,6 +168,8 @@ fn test_report_conflicts_with_divergent_commits() {
     Working copy now at: zsuskuln?? 33752e7e (conflict) C2
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     "###);
 
     let (stdout, stderr) =

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -233,7 +233,7 @@ fn test_resolution() {
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    After this operation, some files at this revision still have conflicts:
+    There are unresolved conflicts at these paths:
     file    2-sided conflict
     "###);
     insta::assert_snapshot!(
@@ -704,7 +704,7 @@ fn test_multiple_conflicts() {
     Parent commit      : zsuskuln de7553ef a | a
     Parent commit      : royxmykx f68bc2f0 b | b
     Added 0 files, modified 1 files, removed 0 files
-    After this operation, some files at this revision still have conflicts:
+    There are unresolved conflicts at these paths:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -71,6 +71,8 @@ fn test_restore() {
     Working copy now at: kkmpptxz 761deaef (conflict) (no description set)
     Parent commit      : rlvkpnrz e25100af (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file2    2-sided conflict including 1 deletion
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
     insta::assert_snapshot!(stdout, @"");
@@ -202,6 +204,8 @@ fn test_restore_conflicted_merge() {
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
@@ -241,6 +245,8 @@ fn test_restore_conflicted_merge() {
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This is disabled when the global `--quiet` flag is used, as suggested by https://github.com/martinvonz/jj/pull/975#issuecomment-1371580761.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
