### PR TITLE
templater: evaluate template strictly if it's converted back to string property

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -31,14 +31,13 @@ use jj_lib::revset::{Revset, RevsetParseContext};
 use jj_lib::{git, rewrite};
 use once_cell::unsync::OnceCell;
 
-use crate::formatter::Formatter;
 use crate::template_builder::{
     self, merge_fn_map, BuildContext, CoreTemplateBuildFnTable, CoreTemplatePropertyKind,
     IntoTemplateProperty, TemplateBuildMethodFnMap, TemplateLanguage,
 };
 use crate::template_parser::{self, FunctionCallNode, TemplateParseError, TemplateParseResult};
 use crate::templater::{
-    self, IntoTemplate, PlainTextFormattedProperty, Template, TemplateProperty,
+    self, IntoTemplate, PlainTextFormattedProperty, Template, TemplateFormatter, TemplateProperty,
     TemplatePropertyError, TemplatePropertyExt as _,
 };
 use crate::{revset_util, text_util};
@@ -669,7 +668,7 @@ impl RefName {
 }
 
 impl Template for RefName {
-    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+    fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         write!(formatter.labeled("name"), "{}", self.name)?;
         if let Some(remote) = &self.remote {
             write!(formatter, "@")?;
@@ -687,7 +686,7 @@ impl Template for RefName {
 }
 
 impl Template for Vec<RefName> {
-    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+    fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         templater::format_joined(formatter, self, " ")
     }
 }
@@ -837,7 +836,7 @@ impl CommitOrChangeId {
 }
 
 impl Template for CommitOrChangeId {
-    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+    fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         write!(formatter, "{}", self.hex())
     }
 }
@@ -879,7 +878,7 @@ pub struct ShortestIdPrefix {
 }
 
 impl Template for ShortestIdPrefix {
-    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+    fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         write!(formatter.labeled("prefix"), "{}", self.prefix)?;
         write!(formatter.labeled("rest"), "{}", self.rest)?;
         Ok(())

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -22,15 +22,14 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::OperationId;
 use jj_lib::operation::Operation;
 
-use crate::formatter::Formatter;
 use crate::template_builder::{
     self, merge_fn_map, BuildContext, CoreTemplateBuildFnTable, CoreTemplatePropertyKind,
     IntoTemplateProperty, TemplateBuildMethodFnMap, TemplateLanguage,
 };
 use crate::template_parser::{self, FunctionCallNode, TemplateParseResult};
 use crate::templater::{
-    IntoTemplate, PlainTextFormattedProperty, Template, TemplateProperty, TemplatePropertyExt as _,
-    TimestampRange,
+    IntoTemplate, PlainTextFormattedProperty, Template, TemplateFormatter, TemplateProperty,
+    TemplatePropertyExt as _, TimestampRange,
 };
 
 pub trait OperationTemplateLanguageExtension {
@@ -276,7 +275,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
 }
 
 impl Template for OperationId {
-    fn format(&self, formatter: &mut dyn Formatter) -> io::Result<()> {
+    fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         write!(formatter, "{}", self.hex())
     }
 }

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -620,12 +620,11 @@ impl<O: Clone> TemplateProperty for PropertyPlaceholder<O> {
     type Output = O;
 
     fn extract(&self) -> Result<Self::Output, TemplatePropertyError> {
-        Ok(self
-            .value
-            .borrow()
-            .as_ref()
-            .expect("placeholder value must be set before evaluating template")
-            .clone())
+        if let Some(value) = self.value.borrow().as_ref() {
+            Ok(value.clone())
+        } else {
+            Err(TemplatePropertyError("Placeholder value is not set".into()))
+        }
     }
 }
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
