### PR TITLE
test: rename `coalesce(x,y)` alias in `test_templater` [NFC]

### DIFF
--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -147,7 +147,7 @@ fn test_templater_alias() {
     'recurse1' = 'recurse2()'
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
-    'coalesce(x, y)' = 'if(x, x, y)'
+    'if_non_null(x, y)' = 'if(x, x, y)'
     "###,
     );
 
@@ -259,19 +259,19 @@ fn test_templater_alias() {
       = Function "identity": Expected 1 arguments
     "###);
 
-    insta::assert_snapshot!(render_err(r#"coalesce(label("x", "not boolean"), "")"#), @r###"
-    Error: Failed to parse template: Alias "coalesce()" cannot be expanded
+    insta::assert_snapshot!(render_err(r#"if_non_null(label("x", "not boolean"), "")"#), @r###"
+    Error: Failed to parse template: Alias "if_non_null()" cannot be expanded
     Caused by:
     1:  --> 1:1
       |
-    1 | coalesce(label("x", "not boolean"), "")
-      | ^-------------------------------------^
+    1 | if_non_null(label("x", "not boolean"), "")
+      | ^----------------------------------------^
       |
-      = Alias "coalesce()" cannot be expanded
-    2:  --> 1:10
+      = Alias "if_non_null()" cannot be expanded
+    2:  --> 1:13
       |
-    1 | coalesce(label("x", "not boolean"), "")
-      |          ^-----------------------^
+    1 | if_non_null(label("x", "not boolean"), "")
+      |             ^-----------------------^
       |
       = Expected expression of type "Boolean"
     "###);


### PR DESCRIPTION
Yuya added `coalesce()` as a built-in function with variable arity in a2a9b7decb586, and we want to use it with more-than-two arguments in the default `log_node` configuration in order to provide better graph node symbols for users.

However, `test_templater` already defined this name as an alias, but with only two parameters; this alias now conflicts with the built-in definition and overrides it, causing the test to fail catastrophically because now the default configuration is considered invalid.

Simply renaming it fixes this without invalidating the actual test case.

---

Note: I pulled this out of #3381 because I realized anyone who now uses `coalesce()` in their `log_node` setting, like I do, can no longer run the tests. So, this should just go in ASAP, in my opinion.