### PR TITLE
Move parse_string_pattern in cli to StringPattern::parse in lib

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -58,7 +58,7 @@ use jj_lib::revset::{
 use jj_lib::rewrite::restore_tree;
 use jj_lib::settings::{ConfigResultExt as _, UserSettings};
 use jj_lib::signing::SignInitError;
-use jj_lib::str_util::{StringPattern, StringPatternParseError};
+use jj_lib::str_util::StringPattern;
 use jj_lib::transaction::Transaction;
 use jj_lib::view::View;
 use jj_lib::working_copy::{
@@ -1649,14 +1649,6 @@ pub fn print_trackable_remote_branches(ui: &Ui, view: &View) -> io::Result<()> {
         names = remote_branch_names.join(" "),
     )?;
     Ok(())
-}
-
-pub fn parse_string_pattern(src: &str) -> Result<StringPattern, StringPatternParseError> {
-    if let Some((kind, pat)) = src.split_once(':') {
-        StringPattern::from_str_kind(pat, kind)
-    } else {
-        Ok(StringPattern::exact(src))
-    }
 }
 
 /// Resolves revsets into revisions for use; useful for rebases or operations

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -27,9 +27,7 @@ use jj_lib::revset::{self, RevsetExpression};
 use jj_lib::str_util::StringPattern;
 use jj_lib::view::View;
 
-use crate::cli_util::{
-    parse_string_pattern, CommandHelper, RemoteBranchName, RemoteBranchNamePattern, RevisionArg,
-};
+use crate::cli_util::{CommandHelper, RemoteBranchName, RemoteBranchNamePattern, RevisionArg};
 use crate::command_error::{user_error, user_error_with_hint, CommandError};
 use crate::formatter::Formatter;
 use crate::ui::Ui;
@@ -78,7 +76,7 @@ pub struct BranchDeleteArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
-    #[arg(required_unless_present_any(&["glob"]), value_parser = parse_string_pattern)]
+    #[arg(required_unless_present_any(&["glob"]), value_parser = StringPattern::parse)]
     pub names: Vec<StringPattern>,
 
     /// Deprecated. Please prefix the pattern with `glob:` instead.
@@ -117,7 +115,7 @@ pub struct BranchListArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
-    #[arg(value_parser = parse_string_pattern)]
+    #[arg(value_parser = StringPattern::parse)]
     pub names: Vec<StringPattern>,
 
     /// Show branches whose local targets are in the given revisions.
@@ -140,7 +138,7 @@ pub struct BranchForgetArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
-    #[arg(required_unless_present_any(&["glob"]), value_parser = parse_string_pattern)]
+    #[arg(required_unless_present_any(&["glob"]), value_parser = StringPattern::parse)]
     pub names: Vec<StringPattern>,
 
     /// Deprecated. Please prefix the pattern with `glob:` instead.

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -41,9 +41,8 @@ use jj_lib::workspace::Workspace;
 use maplit::hashset;
 
 use crate::cli_util::{
-    parse_string_pattern, print_trackable_remote_branches, short_change_hash, short_commit_hash,
-    start_repo_transaction, CommandHelper, RevisionArg, WorkspaceCommandHelper,
-    WorkspaceCommandTransaction,
+    print_trackable_remote_branches, short_change_hash, short_commit_hash, start_repo_transaction,
+    CommandHelper, RevisionArg, WorkspaceCommandHelper, WorkspaceCommandTransaction,
 };
 use crate::command_error::{
     user_error, user_error_with_hint, user_error_with_message, CommandError,
@@ -158,7 +157,7 @@ pub struct GitFetchArgs {
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// expand `*` as a glob. The other wildcard characters aren't supported.
-    #[arg(long, short, default_value = "glob:*", value_parser = parse_string_pattern)]
+    #[arg(long, short, default_value = "glob:*", value_parser = StringPattern::parse)]
     branch: Vec<StringPattern>,
     /// The remote to fetch from (only named remotes are supported, can be
     /// repeated)
@@ -203,7 +202,7 @@ pub struct GitPushArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select branches by wildcard pattern. For details, see
     /// https://martinvonz.github.io/jj/latest/revsets#string-patterns.
-    #[arg(long, short, value_parser = parse_string_pattern)]
+    #[arg(long, short, value_parser = StringPattern::parse)]
     branch: Vec<StringPattern>,
     /// Push all branches (including deleted branches)
     #[arg(long)]

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -14,7 +14,7 @@
 
 use jj_lib::str_util::StringPattern;
 
-use crate::cli_util::{parse_string_pattern, CommandHelper};
+use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -33,7 +33,7 @@ pub struct TagListArgs {
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select tags by wildcard pattern. For details, see
     /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
-    #[arg(value_parser = parse_string_pattern)]
+    #[arg(value_parser = StringPattern::parse)]
     pub names: Vec<StringPattern>,
 }
 


### PR DESCRIPTION
This commit moves the parse_string_pattern helper function into the str_util module in jj lib and adds tests for it.

I'd like to reuse this code in a function defined by `UserSettings`, which is part of the jj lib crate and cannot use functions from the cli crate.