### PR TITLE
Fix the description of the --source arg in the jj rebase --help docs

### DIFF
--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -134,8 +134,8 @@ pub(crate) struct RebaseArgs {
     #[arg(long, short)]
     branch: Vec<RevisionArg>,
 
-    /// Rebase specified revision(s) together their tree of descendants (can be
-    /// repeated)
+    /// Rebase specified revision(s) together with their trees of descendants
+    /// (can be repeated)
     ///
     /// Each specified revision will become a direct child of the destination
     /// revision(s), even if some of the source revisions are descendants

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1482,7 +1482,7 @@ commit. This is true in general; it is not specific to this command.
 ###### **Options:**
 
 * `-b`, `--branch <BRANCH>` — Rebase the whole branch relative to destination's ancestors (can be repeated)
-* `-s`, `--source <SOURCE>` — Rebase specified revision(s) together their tree of descendants (can be repeated)
+* `-s`, `--source <SOURCE>` — Rebase specified revision(s) together with their trees of descendants (can be repeated)
 * `-r`, `--revision <REVISION>` — Rebase only this revision, rebasing descendants onto this revision's parent(s)
 * `-d`, `--destination <DESTINATION>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
 * `--skip-empty` — If true, when rebasing would produce an empty commit, the commit is abandoned. It will not be abandoned if it was already empty before the rebase. Will never skip merge commits with multiple non-empty parents


### PR DESCRIPTION
I think the word "with" is missing and trees should be plural.