### PR TITLE
Don't detatch Git HEAD when advance-branches is enabled for a branch

### DIFF
--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1942,7 +1942,7 @@ fn test_reset_head_to_root() {
         .unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.mut_repo(), &git_repo, &commit2).unwrap();
+    git::reset_head(tx.mut_repo(), &git_repo, &commit2, None).unwrap();
     assert!(git_repo.head().is_ok());
     assert_eq!(
         tx.mut_repo().git_head(),
@@ -1950,7 +1950,7 @@ fn test_reset_head_to_root() {
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.mut_repo(), &git_repo, &commit1).unwrap();
+    git::reset_head(tx.mut_repo(), &git_repo, &commit1, None).unwrap();
     assert!(git_repo.head().is_err());
     assert!(tx.mut_repo().git_head().is_absent());
 
@@ -1958,7 +1958,7 @@ fn test_reset_head_to_root() {
     git_repo
         .reference("refs/jj/root", git_id(&commit1), false, "")
         .unwrap();
-    git::reset_head(tx.mut_repo(), &git_repo, &commit2).unwrap();
+    git::reset_head(tx.mut_repo(), &git_repo, &commit2, None).unwrap();
     assert!(git_repo.head().is_ok());
     assert_eq!(
         tx.mut_repo().git_head(),
@@ -1967,7 +1967,7 @@ fn test_reset_head_to_root() {
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.mut_repo(), &git_repo, &commit1).unwrap();
+    git::reset_head(tx.mut_repo(), &git_repo, &commit1, None).unwrap();
     assert!(git_repo.head().is_err());
     assert!(tx.mut_repo().git_head().is_absent());
     // The placeholder ref should be deleted


### PR DESCRIPTION
When setting the working copy commit, if a single branch points to a parent of the working copy and advance-branches is enabled for that branch, set Git HEAD to the branch instead of detatching at the parent commit.
