### PR TITLE
cli: allow branch list to combine -r and -a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj duplicate` and `jj abandon` can now take more than a single `-r` argument,
   for consistency with other commands.
 
+* `jj branch list` now allows combining `-r` and `-a` options.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -98,7 +98,7 @@ pub struct BranchDeleteArgs {
 pub struct BranchListArgs {
     /// Show all tracking and non-tracking remote branches including the ones
     /// whose targets are synchronized with the local branches.
-    #[arg(long, short, conflicts_with_all = ["names", "revisions", "tracked"])]
+    #[arg(long, short, conflicts_with_all = ["names", "tracked"])]
     all: bool,
 
     /// Show remote tracked branches only. Omits local Git-tracking branches by

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -1128,6 +1128,14 @@ fn test_branch_list_filtered() {
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
 
+    // Select branches by name, combined with --all
+    test_env.jj_cmd_ok(&local_path, &["git", "export"]);
+    insta::assert_snapshot!(query(&["--all", "-rbranches(remote-rewrite)"]), @r###"
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @git: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
+    "###);
+
     // Can select deleted branch by name pattern, but not by revset.
     insta::assert_snapshot!(query(&["remote-delete"]), @r###"
     remote-delete (deleted)


### PR DESCRIPTION
As discussed on discord  [here](https://discord.com/channels/968932220549103686/969291218347524238/1221084605617279016), the change allows `--all` to be used with `-r` when listing branches.

Also discussed was renaming `--all` to `--all-remotes`, but this change is a bit longer and will be followed in a separate PR.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
