### PR TITLE
cli: rename --all to --all-remotes in branch list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj branch list` now allows combining `-r` and `-a` options.
 
+* `--all` is now named `--all-remotes` for `jj branch list`
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -98,16 +98,16 @@ pub struct BranchDeleteArgs {
 pub struct BranchListArgs {
     /// Show all tracking and non-tracking remote branches including the ones
     /// whose targets are synchronized with the local branches.
-    #[arg(long, short, conflicts_with_all = ["names", "tracked"])]
-    all: bool,
+    #[arg(long, short, alias = "all", conflicts_with_all = ["names", "tracked"])]
+    all_remotes: bool,
 
     /// Show remote tracked branches only. Omits local Git-tracking branches by
     /// default.
-    #[arg(long, short, conflicts_with_all = ["all"])]
+    #[arg(long, short, conflicts_with_all = ["all_remotes"])]
     tracked: bool,
 
     /// Show conflicted branches only.
-    #[arg(long, short, conflicts_with_all = ["all"])]
+    #[arg(long, short, conflicts_with_all = ["all_remotes"])]
     conflicted: bool,
 
     /// Show branches whose local name matches
@@ -711,7 +711,7 @@ fn cmd_branch_list(
         for &(remote, remote_ref) in &tracking_remote_refs {
             let synced = remote_ref.target == *branch_target.local_target;
 
-            if !args.all && !args.tracked && synced {
+            if !args.all_remotes && !args.tracked && synced {
                 continue;
             }
             write!(formatter, "  ")?;
@@ -772,7 +772,7 @@ fn cmd_branch_list(
             }
         }
 
-        if args.all {
+        if args.all_remotes {
             for &(remote, remote_ref) in &untracked_remote_refs {
                 write!(formatter.labeled("branch"), "{name}@{remote}")?;
                 print_branch_target(formatter, &remote_ref.target)?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -297,7 +297,7 @@ For information about branches, see https://github.com/martinvonz/jj/blob/main/d
 
 ###### **Options:**
 
-* `-a`, `--all` — Show all tracking and non-tracking remote branches including the ones whose targets are synchronized with the local branches
+* `-a`, `--all-remotes` — Show all tracking and non-tracking remote branches including the ones whose targets are synchronized with the local branches
 
   Possible values: `true`, `false`
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -414,7 +414,7 @@ fn test_branch_delete_export() {
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
 
     test_env.jj_cmd_ok(&repo_path, &["branch", "delete", "foo"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     foo (deleted)
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
@@ -422,7 +422,7 @@ fn test_branch_delete_export() {
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     "###);
 }
@@ -435,7 +435,7 @@ fn test_branch_forget_export() {
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "foo"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
     "###);
@@ -449,7 +449,7 @@ fn test_branch_forget_export() {
     insta::assert_snapshot!(stderr, @"");
     // Forgetting a branch deletes local and remote-tracking branches including
     // the corresponding git-tracking branch.
-    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @"");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r=foo", "--no-graph"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -463,7 +463,7 @@ fn test_branch_forget_export() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @"");
 }
 
@@ -1021,7 +1021,7 @@ fn test_branch_list() {
     "###);
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&local_path, &["branch", "list", "--all"]), @r###"
+        test_env.jj_cmd_success(&local_path, &["branch", "list", "--all-remotes"]), @r###"
     local-only: wqnwkozp 4e887f78 (empty) local-only
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
@@ -1128,9 +1128,9 @@ fn test_branch_list_filtered() {
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
 
-    // Select branches by name, combined with --all
+    // Select branches by name, combined with --all-remotes
     test_env.jj_cmd_ok(&local_path, &["git", "export"]);
-    insta::assert_snapshot!(query(&["--all", "-rbranches(remote-rewrite)"]), @r###"
+    insta::assert_snapshot!(query(&["--all-remotes", "-rbranches(remote-rewrite)"]), @r###"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
@@ -1301,7 +1301,7 @@ fn test_branch_list_tracked() {
     );
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&local_path, &["branch", "list", "--all"]), @r###"
+        test_env.jj_cmd_success(&local_path, &["branch", "list", "--all-remotes"]), @r###"
     local-only: nmzmmopx e1da745b (empty) local-only
       @git: nmzmmopx e1da745b (empty) local-only
     remote-delete (deleted)
@@ -1402,5 +1402,5 @@ fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -365,5 +365,5 @@ fn test_git_clone_remote_default_branch() {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -376,7 +376,7 @@ fn test_git_colocated_branch_forget() {
     ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
     ◉  0000000000000000000000000000000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
@@ -387,7 +387,7 @@ fn test_git_colocated_branch_forget() {
     insta::assert_snapshot!(stderr, @"");
     // A forgotten branch is deleted in the git repo. For a detailed demo explaining
     // this, see `test_branch_forget_export` in `test_branch_command.rs`.
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @"");
 }
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -50,7 +50,7 @@ fn add_git_remote(test_env: &TestEnvironment, repo_path: &Path, remote: &str) {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }
 
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
@@ -282,7 +282,7 @@ fn test_git_fetch_from_remote_named_git() {
     "###);
 
     // Implicit import shouldn't fail because of the remote ref.
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--all"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
 
@@ -296,7 +296,7 @@ fn test_git_fetch_from_remote_named_git() {
 
     // The remote can be renamed, and the ref can be imported.
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--all"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     git: mrylzrtu 76fc7466 message
       @bar: mrylzrtu 76fc7466 message

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -253,7 +253,7 @@ fn test_git_import_move_export_with_default_undo() {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }
 
 fn get_git_repo_refs(git_repo: &git2::Repository) -> Vec<(String, CommitId)> {

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -58,7 +58,7 @@ fn init_git_repo_with_opts(
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }
 
 fn read_git_target(workspace_root: &Path) -> String {

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -50,7 +50,7 @@ fn set_up() -> (TestEnvironment, PathBuf) {
 fn test_git_push_nothing() {
     let (test_env, workspace_root) = set_up();
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 45a3aa29 (empty) description 1
       @origin: lzmmnrxq 45a3aa29 (empty) description 1
@@ -80,7 +80,7 @@ fn test_git_push_current_branch() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "my-branch"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
       @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq hidden 45a3aa29 (empty) description 1
@@ -104,7 +104,7 @@ fn test_git_push_current_branch() {
       Move branch branch2 from 8476341eb395 to 10ee3363b259
       Add branch my-branch to 10ee3363b259
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
       @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq hidden 45a3aa29 (empty) description 1
@@ -256,7 +256,7 @@ fn test_git_push_locally_created_and_rewritten() {
     // Rewrite it and push again, which would fail if the pushed branch weren't
     // set to "tracking"
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-mlocal 2"]);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: lzmmnrxq 45a3aa29 (empty) description 1
       @origin: lzmmnrxq 45a3aa29 (empty) description 1
@@ -283,7 +283,7 @@ fn test_git_push_multiple() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "my-branch"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1 (deleted)
       @origin: lzmmnrxq 45a3aa29 (empty) description 1
@@ -369,7 +369,7 @@ fn test_git_push_multiple() {
       Force branch branch2 from 8476341eb395 to 15dcdaa4f12f
       Add branch my-branch to 15dcdaa4f12f
     "###);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch2: yqosqzyt 15dcdaa4 (empty) foo
       @origin: yqosqzyt 15dcdaa4 (empty) foo
@@ -757,7 +757,7 @@ fn test_git_push_conflicting_branches() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "branch2"]);
     test_env.jj_cmd_ok(&workspace_root, &["git", "fetch"]);
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]), @r###"
+        test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]), @r###"
     branch1: lzmmnrxq 45a3aa29 (empty) description 1
       @origin: lzmmnrxq 45a3aa29 (empty) description 1
     branch2 (conflicted):
@@ -837,7 +837,7 @@ fn test_git_push_tracked_vs_all() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "delete", "branch2"]);
     test_env.jj_cmd_ok(&workspace_root, &["branch", "untrack", "branch1@origin"]);
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "branch3"]);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: vruxwmqv a25f24af (empty) moved branch1
     branch1@origin: lzmmnrxq 45a3aa29 (empty) description 1
@@ -859,7 +859,7 @@ fn test_git_push_tracked_vs_all() {
 
     // Untrack the last remaining tracked branch.
     test_env.jj_cmd_ok(&workspace_root, &["branch", "untrack", "branch2@origin"]);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all"]);
+    let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
     branch1: vruxwmqv a25f24af (empty) moved branch1
     branch1@origin: lzmmnrxq 45a3aa29 (empty) description 1

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -57,7 +57,7 @@ fn init_git_repo_with_opts(
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }
 
 fn read_git_target(workspace_root: &Path) -> String {

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -388,5 +388,5 @@ fn test_branch_track_untrack_undo() {
 }
 
 fn get_branch_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
-    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all"])
+    test_env.jj_cmd_success(repo_path, &["branch", "list", "--all-remotes"])
 }


### PR DESCRIPTION
A follow up to #3406 

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
