### PR TITLE
cli: Split out ascii template versions and migrate config to toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Graph node symbols are now configurable via templates
   * `templates.log_node`
+  * `templates.log_node_ascii`
   * `templates.op_log_node`
+  * `templates.op_log_node_ascii`
 
 * `jj log` now includes synthetic nodes in the graph where some revisions were
   elided.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -39,6 +39,11 @@ log = 'builtin_log_compact'
 op_log = 'builtin_op_log_compact'
 show = 'builtin_log_detailed'
 
+log_node = 'if(self, if(current_working_copy, "@", "◉"), "◌")'
+log_node_ascii = 'if(self, if(current_working_copy, "@", "o"), ".")'
+op_log_node = 'if(current_operation, "@", "◉")'
+op_log_node_ascii = 'if(current_operation, "@", "o")'
+
 [template-aliases]
 builtin_log_oneline = '''
 if(root,

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1460,7 +1460,7 @@ fn test_log_with_custom_symbols() {
         r###"
         ui.log-synthetic-elided-nodes = true
         ui.graph.style = 'ascii'
-        templates.log_node = 'if(self, if(current_working_copy, "$", if(root, "^", "*")), ":")'
+        templates.log_node_ascii = 'if(self, if(current_working_copy, "$", if(root, "^", "*")), ":")'
         "###,
     );
     insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"

--- a/docs/config.md
+++ b/docs/config.md
@@ -234,8 +234,8 @@ ui.graph.style = "square"
 The symbols used to represent commits or operations can be customized via
 templates.
 
-  * `templates.log_node` for commits (with `Option<Commit>` keywords)
-  * `templates.op_log_node` for operations (with `Operation` keywords)
+  * `templates.log_node`/`templates.log_node_ascii` for commits (with `Option<Commit>` keywords)
+  * `templates.op_log_node`/`templates.op_log_node_ascii` for operations (with `Operation` keywords)
 
 For example:
 ```toml

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -243,19 +243,23 @@ impl UserSettings {
     }
 
     pub fn commit_node_template(&self) -> String {
-        self.node_template_for_key(
-            "templates.log_node",
-            r#"if(self, if(current_working_copy, "@", "◉"), "◌")"#,
-            r#"if(self, if(current_working_copy, "@", "o"), ".")"#,
-        )
+        let key = match self.graph_style().as_str() {
+            "ascii" | "ascii-large" => "templates.log_node_ascii",
+            _ => "templates.log_node",
+        };
+        self.config
+            .get_string(key)
+            .expect("Node templates should exist in bundled config!")
     }
 
     pub fn op_node_template(&self) -> String {
-        self.node_template_for_key(
-            "templates.op_log_node",
-            r#"if(current_operation, "@", "◉")"#,
-            r#"if(current_operation, "@", "o")"#,
-        )
+        let key = match self.graph_style().as_str() {
+            "ascii" | "ascii-large" => "templates.op_log_node_ascii",
+            _ => "templates.op_log_node",
+        };
+        self.config
+            .get_string(key)
+            .expect("Node templates should exist in bundled config!")
     }
 
     pub fn max_new_file_size(&self) -> Result<u64, config::ConfigError> {
@@ -279,14 +283,6 @@ impl UserSettings {
 
     pub fn sign_settings(&self) -> SignSettings {
         SignSettings::from_settings(self)
-    }
-
-    fn node_template_for_key(&self, key: &str, fallback: &str, ascii_fallback: &str) -> String {
-        let symbol = self.config.get_string(key);
-        match self.graph_style().as_str() {
-            "ascii" | "ascii-large" => symbol.unwrap_or_else(|_| ascii_fallback.to_owned()),
-            _ => symbol.unwrap_or_else(|_| fallback.to_owned()),
-        }
     }
 }
 


### PR DESCRIPTION
This should hopefully unblock #3381.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
