### PR TITLE
cli: add better error message when immutable_heads() cannot be resolved

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -962,10 +962,18 @@ impl WorkspaceCommandHelper {
                 .map(|commit| commit.id().clone())
                 .collect(),
         );
-        let immutable = revset_util::parse_immutable_expression(&self.revset_parse_context())?;
+        let immutable = revset_util::parse_immutable_expression(&self.revset_parse_context())
+            .map_err(|e| {
+                config_error_with_message("Invalid `revset-aliases.immutable_heads()`", e)
+            })?;
         let mut expression = self.attach_revset_evaluator(immutable)?;
         expression.intersect_with(&to_rewrite_revset);
-        if let Some(commit_id) = expression.evaluate_to_commit_ids()?.next() {
+
+        let mut commit_id_iter = expression.evaluate_to_commit_ids().map_err(|e| {
+            config_error_with_message("Invalid `revset-aliases.immutable_heads()`", e)
+        })?;
+
+        if let Some(commit_id) = commit_id_iter.next() {
             let error = if &commit_id == self.repo().store().root_commit_id() {
                 user_error(format!(
                     "The root commit {} is immutable",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,7 +114,7 @@ You will probably also want to make the `gh-pages` branch immutable (and thereby
 hidden from the default `jj log` output) by running the following in your repo:
 
 ```shell
-jj config set --repo "revset-aliases.immutable_heads()" "main@origin | gh-pages@origin"
+jj config set --repo "revset-aliases.immutable_heads()" 'remote_branches(exact:"main") | remote_branches(exact:"gh-pages")'
 ```
 
 ### Summary


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->
Fixes #3415 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
