### PR TITLE
cmd `squash`: alias `--to` for the `--into` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj log` now includes synthetic nodes in the graph where some revisions were
   elided.
 
-* `jj squash` now accepts `--from` and `--into` (mutually exclusive with `-r`).
-  It can thereby be for all use cases where `jj move` can be used. The `--from`
-  argument accepts a revset that resolves to more than one revision.
+* `jj squash` now accepts `--from` and `--into` (also aliased as `--to`) if `-r`
+  is not specified. It can now be used for all use cases where `jj move` could
+  previously be used. The `--from` argument accepts a revset that resolves to
+  more than one revision.
 
 * Commit templates now support `immutable` keyword.
 

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -56,7 +56,7 @@ pub(crate) struct SquashArgs {
     #[arg(long, conflicts_with = "revision")]
     from: Option<RevisionArg>,
     /// Revision to squash into (default: @)
-    #[arg(long, conflicts_with = "revision")]
+    #[arg(long, conflicts_with = "revision", visible_alias = "to")]
     into: Option<RevisionArg>,
     /// The description to use for squashed revision (don't open editor)
     #[arg(long = "message", short, value_name = "MESSAGE")]


### PR DESCRIPTION
I keep typing `--to` since I'm used to `jj move` interface. It is also shorter.

Currently, if I type `--to`, clap unhelpfully suggests whether I
meant `--tool`.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
