### PR TITLE
revset: parse "all:" prefix rule by pest

### DIFF
--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -66,6 +66,18 @@ fn test_syntax_error() {
       = '^' is not a postfix operator
     Hint: Did you mean '-' for parents?
     "###);
+
+    // "jj new" supports "all:" prefix
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "ale:x"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: Failed to parse revset: Modifier "ale" doesn't exist
+    Caused by:  --> 1:1
+      |
+    1 | ale:x
+      | ^-^
+      |
+      = Modifier "ale" doesn't exist
+    "###);
 }
 
 #[test]

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -97,6 +97,10 @@ expression = {
 }
 
 program = _{ SOI ~ whitespace* ~ expression ~ whitespace* ~ EOI }
+program_modifier = { identifier ~ pattern_kind_op ~ !":" }
+program_with_modifier = _{
+  SOI ~ whitespace* ~ (program_modifier ~ whitespace*)? ~ expression ~ whitespace* ~ EOI
+}
 
 alias_declaration_part = _{
   function_name ~ "(" ~ whitespace* ~ formal_parameters ~ whitespace* ~ ")"

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -784,7 +784,21 @@ struct ParseState<'a> {
     allow_string_pattern: bool,
 }
 
-impl ParseState<'_> {
+impl<'a> ParseState<'a> {
+    fn new(
+        context: &'a RevsetParseContext,
+        locals: &'a HashMap<&str, Rc<RevsetExpression>>,
+    ) -> Self {
+        ParseState {
+            aliases_map: context.aliases_map,
+            aliases_expanding: &[],
+            locals,
+            user_email: &context.user_email,
+            workspace_ctx: &context.workspace,
+            allow_string_pattern: false,
+        }
+    }
+
     fn with_alias_expanding<T>(
         self,
         id: RevsetAliasId<'_>,
@@ -1506,14 +1520,8 @@ pub fn parse(
     revset_str: &str,
     context: &RevsetParseContext,
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
-    let state = ParseState {
-        aliases_map: context.aliases_map,
-        aliases_expanding: &[],
-        locals: &HashMap::new(),
-        user_email: &context.user_email,
-        workspace_ctx: &context.workspace,
-        allow_string_pattern: false,
-    };
+    let locals = HashMap::new();
+    let state = ParseState::new(context, &locals);
     parse_program(revset_str, state)
 }
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
