### PR TITLE
docs: "bash" is no longer optional for command-line completion

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -175,7 +175,7 @@ depends on your shell.
 ### Bash
 
 ```shell
-source <(jj util completion)  # --bash is the default
+source <(jj util completion bash)
 ```
 
 ### Zsh


### PR DESCRIPTION
While walking through the documentation to try out `jj`, I noticed that when installing the bash completion you get a warning every time a shell opens that `--bash` is no longer support.

I assume that not giving any parameters means it assumes `--bash`, which causes the warning. So I guess there are two solutions:

- Either address the documentation to always add `bash` (which I did here).
- Or make the default be `bash` instead of `--bash`.

As I always like explicit over implicit, I went the first route. But I can fully understand if you think the second route would be better.

Also: first commit+push via `jj` \o/

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
