### PR TITLE
Add a --use-destination-message option to `jj squash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Operation objects in templates now have a `snapshot() -> Boolean` method that
   evaluates to true if the operation was a snapshot created by a non-mutating
   command (e.g. `jj log`).
+ 
+* `jj squash` now accepts a `--use-destination-message/-u` option that uses the
+  description of the destination for the new squashed revision and discards the
+  descriptions of the source revisions.
 
 * You can check whether Watchman fsmonitor is enabled or installed with the new
   `jj debug watchman status` command.

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -16,7 +16,7 @@ use clap::ArgGroup;
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;
 
-use super::squash::move_diff;
+use super::squash::{move_diff, SquashedDescription};
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
@@ -97,7 +97,7 @@ pub(crate) fn cmd_move(
         &destination,
         matcher.as_ref(),
         &diff_selector,
-        None,
+        SquashedDescription::Combine,
         false,
         &args.paths,
     )?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1770,6 +1770,10 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 * `--from <FROM>` — Revision(s) to squash from (default: @)
 * `--into <INTO>` — Revision to squash into (default: @)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
+* `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
+
+  Possible values: `true`, `false`
+
 * `-i`, `--interactive` — Interactively choose which parts to squash
 
   Possible values: `true`, `false`


### PR DESCRIPTION
If `-d/--drop-message` is passed to `jj squash`, the descriptions of the commits being squashed are dropped and the message of the destination commit is used.

This is useful since I often find myself squashing a commit with a non-empty placeholder name such as "WIP: do something" or even "SQUASH: some change". Without this option `jj squash` always opens the diff editor and I need to navigate to the bottom of the description to remove the placeholder description. This is annoying and error-prone, and sometimes I accidentally leave something from the message that I wanted to discard.

I'm not tied to the name `--drop-message`, but I think that whatever name we use should have a short version as well. I also considered `--abandon-message/-a`, which might be better since it avoids ambiguity about whether `-d` means destination.