### PR TITLE
cli: support filtering by paths in `status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * New command `jj parallelize` that rebases a set of revisions into siblings.
 
+* `jj status` now supports filtering by paths. For example, `jj status .` will
+  only list changed files that are descendants of the current directory.
+
 ### Fixed bugs
 
 ## [0.16.0] - 2024-04-03

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1779,7 +1779,11 @@ This includes:
 
 * Conflicted branches (see https://github.com/martinvonz/jj/blob/main/docs/branches.md)
 
-**Usage:** `jj status`
+**Usage:** `jj status [PATHS]...`
+
+###### **Arguments:**
+
+* `<PATHS>` — Restrict the status display to these paths
 
 
 

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -62,3 +62,22 @@ fn test_status_ignored_gitignore() {
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     "###);
 }
+
+#[test]
+fn test_status_filtered() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file_1"), "file_1").unwrap();
+    std::fs::write(repo_path.join("file_2"), "file_2").unwrap();
+
+    // The output filtered to file_1 should not list the addition of file_2.
+    let stdout = test_env.jj_cmd_success(&repo_path, &["status", "file_1"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy changes:
+    A file_1
+    Working copy : qpvuntsm abcaaacd (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    "###);
+}


### PR DESCRIPTION
I often work in multiple subtrees of a monorepo at once, and want to list modified files only in the current subtree, as supported by `git status .` or `hg status .`.

Example (applied to this change itself):

![image](https://github.com/martinvonz/jj/assets/26806/9a9727ee-691c-432c-84fa-8f42371b5696)

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
