### PR TITLE
Rename the "AMOUNT" argument for `jj prev` and `jj next` to OFFSET

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -53,10 +53,10 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]
 pub(crate) struct NextArgs {
-    /// How many revisions to move forward. By default advances to the next
-    /// child.
+    /// How many revisions to move forward. Advances to the next child by
+    /// default.
     #[arg(default_value = "1")]
-    amount: u64,
+    offset: u64,
     /// Instead of creating a new working-copy commit on top of the target
     /// commit (like `jj new`), edit the target commit directly (like `jj
     /// edit`).
@@ -102,7 +102,7 @@ pub(crate) fn cmd_next(
     args: &NextArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let amount = args.amount;
+    let offset = args.offset;
     let current_wc_id = workspace_command
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
@@ -123,7 +123,7 @@ pub(crate) fn cmd_next(
             _ => return Err(user_error("Cannot run `jj next` on a merge commit")),
         }
     };
-    let descendant_expression = RevsetExpression::commit(start_id.clone()).descendants_at(amount);
+    let descendant_expression = RevsetExpression::commit(start_id.clone()).descendants_at(offset);
     let target_expression = if edit {
         descendant_expression
     } else {
@@ -139,8 +139,8 @@ pub(crate) fn cmd_next(
         [] => {
             // We found no descendant.
             return Err(user_error(format!(
-                "No descendant found {amount} commit{} forward",
-                if amount > 1 { "s" } else { "" }
+                "No descendant found {offset} commit{} forward",
+                if offset > 1 { "s" } else { "" }
             )));
         }
         commits => choose_commit(ui, &workspace_command, "next", commits)?,

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -53,9 +53,9 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]
 pub(crate) struct PrevArgs {
-    /// How many revisions to move backward. By default moves to the parent.
+    /// How many revisions to move backward. Moves to the parent by default.
     #[arg(default_value = "1")]
-    amount: u64,
+    offset: u64,
     /// Edit the parent directly, instead of moving the working-copy commit.
     #[arg(long)]
     edit: bool,
@@ -67,7 +67,7 @@ pub(crate) fn cmd_prev(
     args: &PrevArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let amount = args.amount;
+    let offset = args.offset;
     let current_wc_id = workspace_command
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
@@ -86,7 +86,7 @@ pub(crate) fn cmd_prev(
             _ => return Err(user_error("Cannot run `jj prev` on a merge commit")),
         }
     };
-    let ancestor_expression = RevsetExpression::commit(start_id.clone()).ancestors_at(amount);
+    let ancestor_expression = RevsetExpression::commit(start_id.clone()).ancestors_at(offset);
     let target_revset = if edit {
         ancestor_expression
     } else {
@@ -106,8 +106,8 @@ pub(crate) fn cmd_prev(
         [target] => target,
         [] => {
             return Err(user_error(format!(
-                "No ancestor found {amount} commit{} back",
-                if amount > 1 { "s" } else { "" }
+                "No ancestor found {offset} commit{} back",
+                if offset > 1 { "s" } else { "" }
             )))
         }
         commits => choose_commit(ui, &workspace_command, "prev", commits)?,

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1172,11 +1172,11 @@ If your working-copy commit already has visible children, then `--edit` is
 implied.
 ```
 
-**Usage:** `jj next [OPTIONS] [AMOUNT]`
+**Usage:** `jj next [OPTIONS] [OFFSET]`
 
 ###### **Arguments:**
 
-* `<AMOUNT>` — How many revisions to move forward. By default advances to the next child
+* `<OFFSET>` — How many revisions to move forward. Advances to the next child by default
 
   Default value: `1`
 
@@ -1376,11 +1376,11 @@ If your working-copy commit already has visible children, then `--edit` is
 implied.
 ```
 
-**Usage:** `jj prev [OPTIONS] [AMOUNT]`
+**Usage:** `jj prev [OPTIONS] [OFFSET]`
 
 ###### **Arguments:**
 
-* `<AMOUNT>` — How many revisions to move backward. By default moves to the parent
+* `<OFFSET>` — How many revisions to move backward. Moves to the parent by default
 
   Default value: `1`
 


### PR DESCRIPTION
Offset is a more descriptive noun for this argument. This commit also tweaks the help message for the argument.

This isn't an option/flag, so this change should be transparent to users.
