### PR TITLE
cli: improve, document, and bugfix `snapshot.max-new-file-size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rebase the children of the revision being split if they had other parents
   (i.e. if the child was a merge).
 
+* The `snapshot.max-new-file-size` option can now handle raw integer literals,
+  interpreted as a number of bytes, where previously it could only handle string
+  literals. This means that `snapshot.max-new-file-size="1"` and
+  `snapshot.max-new-file-size=1` are now equivalent.
 
 ## [0.16.0] - 2024-04-03
 

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -296,11 +296,41 @@ impl From<OpsetEvaluationError> for CommandError {
 impl From<SnapshotError> for CommandError {
     fn from(err: SnapshotError) -> Self {
         match err {
-            SnapshotError::NewFileTooLarge { .. } => {
-                user_error_with_message("Failed to snapshot the working copy", err).hinted(
-                    r#"Increase the value of the `snapshot.max-new-file-size` config option if you
-want this file to be snapshotted. Otherwise add it to your `.gitignore` file."#,
-                )
+            SnapshotError::NewFileTooLarge {
+                path,
+                size,
+                max_size,
+            } => {
+                // if the size difference is < 1KiB, then show exact bytes.
+                // otherwise, show in human-readable form; this avoids weird cases
+                // where a file is 400 bytes too large but the error says something
+                // like '1.0MiB, maximum size allowed is ~1.0MiB'
+                let size_diff = size.0 - max_size.0;
+                let err_str = if size_diff <= 1024 {
+                    format!(
+                        "it is {} bytes too large; the maximum size allowed is {} bytes ({}).",
+                        size_diff, max_size.0, max_size,
+                    )
+                } else {
+                    format!("it is {}; the maximum size allowed is ~{}.", size, max_size,)
+                };
+
+                user_error(format!(
+                    "Failed to snapshot the working copy\nThe file '{}' is too large to be \
+                     snapshotted: {}",
+                    path.display(),
+                    err_str,
+                ))
+                .hinted(format!(
+                    "This is to prevent large files from being added on accident. You can fix \
+                     this error by:
+  - Adding the file to `.gitignore`
+  - Run `jj config set --repo snapshot.max-new-file-size {}`
+    This will increase the maximum file size allowed for new files, in this repository only.
+  - Run `jj --config-toml 'snapshot.max-new-file-size={}' st`
+    This will increase the maximum file size allowed for new files, for this command only.",
+                    size.0, size.0
+                ))
             }
             err => internal_error_with_message("Failed to snapshot the working copy", err),
         }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -20,7 +20,7 @@ fn test_snapshot_large_file() {
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.add_config(r#"snapshot.max-new-file-size = "10""#);
+    test_env.add_config(r#"snapshot.max-new-file-size = 10"#);
     std::fs::write(repo_path.join("large"), "a lot of text").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["files"]);
     insta::assert_snapshot!(stderr, @r###"

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -25,8 +25,12 @@ fn test_snapshot_large_file() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["files"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: Failed to snapshot the working copy
-    Caused by: New file $TEST_ENV/repo/large of size ~13.0B exceeds snapshot.max-new-file-size (10.0B)
-    Hint: Increase the value of the `snapshot.max-new-file-size` config option if you
-    want this file to be snapshotted. Otherwise add it to your `.gitignore` file.
+    The file '$TEST_ENV/repo/large' is too large to be snapshotted: it is 3 bytes too large; the maximum size allowed is 10 bytes (10.0B).
+    Hint: This is to prevent large files from being added on accident. You can fix this error by:
+      - Adding the file to `.gitignore`
+      - Run `jj config set --repo snapshot.max-new-file-size 13`
+        This will increase the maximum file size allowed for new files, in this repository only.
+      - Run `jj --config-toml 'snapshot.max-new-file-size=13' st`
+        This will increase the maximum file size allowed for new files, for this command only.
     "###);
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -730,6 +730,29 @@ executable on your system](https://facebook.github.io/watchman/docs/install).
 You can check whether Watchman is enabled and whether it is installed correctly
 using `jj debug watchman status`.
 
+## Snapshot settings
+
+### Maximum size for new files
+
+By default, as an anti-footgun measure, `jj` will refuse to add new files to the
+snapshot that are larger than a certain size; the default is 1MiB. This can be
+changed by setting `snapshot.max-new-file-size` to a different value. For
+example:
+
+```toml
+snapshot.max-new-file-size = "10MiB"
+# the following is equivalent
+snapshot.max-new-file-size = 10485760
+```
+
+The value can be specified using a human readable string with typical suffixes;
+`B`, `MiB`, `GB`, etc. By default, if no suffix is provided, or the value is a
+raw integer literal, the value is interpreted as if it were specified in bytes.
+
+Files that already exist in the working copy are not subject to this limit.
+
+Setting this value to zero will disable the limit entirely.
+
 ## Ways to specify `jj` config: details
 
 ### User config file


### PR DESCRIPTION
Motivated by the discussion in [#3439](https://github.com/martinvonz/jj/discussions/3439).

See the (detailed, as usual) commit message for `cli: allow snapshot.max-new-file-size to be a raw u64` in particular.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
