### PR TITLE
Fix an issue where `jj prev` could not create a new revision on top of `@-`

### DIFF
--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -67,7 +67,6 @@ pub(crate) fn cmd_prev(
     args: &PrevArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let offset = args.offset;
     let current_wc_id = workspace_command
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
@@ -78,25 +77,7 @@ pub(crate) fn cmd_prev(
             .heads()
             .contains(current_wc_id);
     let current_wc = workspace_command.repo().store().get_commit(current_wc_id)?;
-    let start_id = if edit {
-        current_wc_id
-    } else {
-        match current_wc.parent_ids() {
-            [parent_id] => parent_id,
-            _ => return Err(user_error("Cannot run `jj prev` on a merge commit")),
-        }
-    };
-    let ancestor_expression = RevsetExpression::commit(start_id.clone()).ancestors_at(offset);
-    let target_revset = if edit {
-        ancestor_expression
-    } else {
-        // Jujutsu will always create a new commit for prev, even where Mercurial cannot
-        // and fails. The decision and all discussion around it are available
-        // here: https://github.com/martinvonz/jj/pull/1200#discussion_r1298623933
-        //
-        // If users ever request erroring out, add `.ancestors()` to the revset below.
-        ancestor_expression.minus(&RevsetExpression::commit(current_wc_id.clone()))
-    };
+    let target_revset = RevsetExpression::commit(current_wc_id.clone()).ancestors_at(args.offset);
     let targets: Vec<_> = target_revset
         .evaluate_programmatic(workspace_command.repo().as_ref())?
         .iter()
@@ -105,13 +86,11 @@ pub(crate) fn cmd_prev(
     let target = match targets.as_slice() {
         [target] => target,
         [] => {
-            return Err(user_error(format!(
-                "No ancestor found {offset} commit{} back",
-                if offset > 1 { "s" } else { "" }
-            )))
+            return Err(user_error("No ancestor found at requested offset."));
         }
         commits => choose_commit(ui, &workspace_command, "prev", commits)?,
     };
+
     // Generate a short commit hash, to make it readable in the op log.
     let current_short = short_commit_hash(current_wc.id());
     let target_short = short_commit_hash(target.id());

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -87,8 +87,8 @@ fn test_prev_simple() {
     // move backwards.
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: royxmykx 5647d685 (empty) (no description set)
-    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    Working copy now at: royxmykx f039cf03 (empty) (no description set)
+    Parent commit      : kkmpptxz 3fa8931e (empty) third
     "###);
 }
 
@@ -112,8 +112,8 @@ fn test_prev_non_discardable_working_copy() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: royxmykx f04d8595 (empty) (no description set)
-    Parent commit      : qpvuntsm 69542c19 (empty) first
+    Working copy now at: royxmykx 5647d685 (empty) (no description set)
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
     "###);
 }
 
@@ -139,8 +139,8 @@ fn test_prev_multiple_without_root() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv bcea672c (empty) (no description set)
-    Parent commit      : qpvuntsm 69542c19 (empty) first
+    Working copy now at: vruxwmqv 6c3e8d2a (empty) (no description set)
+    Parent commit      : rlvkpnrz 5c52832c (empty) second
     "###);
 }
 
@@ -257,35 +257,6 @@ fn test_next_choose_branching_child() {
 }
 
 #[test]
-fn test_prev_fails_on_merge_commit() {
-    let test_env = TestEnvironment::default();
-    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
-    let repo_path = test_env.env_root().join("repo");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "c", "left"]);
-    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
-    test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
-    test_env.jj_cmd_ok(&repo_path, &["branch", "c", "right"]);
-    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
-    test_env.jj_cmd_ok(&repo_path, &["new", "left", "right"]);
-
-    // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @    yqosqzytrlsw
-    ├─╮
-    │ ◉  zsuskulnrvyr right second
-    ◉ │  qpvuntsmwlqt left first
-    ├─╯
-    ◉  zzzzzzzzzzzz
-    "###);
-
-    // Try to advance the working copy commit.
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["prev"]);
-    insta::assert_snapshot!(stderr,@r###"
-    Error: Cannot run `jj prev` on a merge commit
-    "###);
-}
-
-#[test]
 fn test_prev_prompts_on_multiple_parents() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
@@ -297,12 +268,11 @@ fn test_prev_prompts_on_multiple_parents() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     // Create a merge commit, which has two parents.
     test_env.jj_cmd_ok(&repo_path, &["new", "all:@--+"]);
-    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "merge"]);
+    test_env.jj_cmd_ok(&repo_path, &["desc", "-m", "merge"]);
 
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  vruxwmqvtpmx
-    ◉      yqosqzytrlsw merge
+    @      yqosqzytrlsw merge
     ├─┬─╮
     │ │ ◉  qpvuntsmwlqt first
     │ ◉ │  kkmpptxzrspx second
@@ -329,7 +299,7 @@ fn test_prev_prompts_on_multiple_parents() {
 }
 
 #[test]
-fn test_prev_onto_root_fails() {
+fn test_prev_beyond_root_fails() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
@@ -346,9 +316,9 @@ fn test_prev_onto_root_fails() {
     ◉  zzzzzzzzzzzz
     "###);
     // The root commit is before "first", which is 5 commits back.
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "5"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "6"]);
     insta::assert_snapshot!(stderr,@r###"
-    Error: No ancestor found 5 commits back
+    Error: No ancestor found at requested offset.
     "###);
 }
 


### PR DESCRIPTION
Before this change, `jj prev` does this:
```
jj log -T 'separate(" ",change_id.short(), description)'
@  umspkqwnpqvx add file2
◉  nprzlkrnkpuu add file1
◉  zzzzzzzzzzzz
jj prev
jj log -T 'separate(" ",change_id.short(),description)'
@  otzuvlqzsrxt
│ ◉  umspkqwnpqvx add file2
│ ◉  nprzlkrnkpuu add file1
├─╯
◉  zzzzzzzzzzzz
```

After, it does this:
```
jj log -T 'separate(" ",change_id.short(), description)'
@  okxltnqrlpsr
│ ◉  umspkqwnpqvx add file2
├─╯
◉  nprzlkrnkpuu add file1
◉  zzzzzzzzzzzz
```

And `jj prev 2` does this:
```
jj log -T 'separate(" ",change_id.short(),description)'
@  otzuvlqzsrxt
│ ◉  umspkqwnpqvx add file2
│ ◉  nprzlkrnkpuu add file1
├─╯
◉  zzzzzzzzzzzz
```

Without this change it is impossible to create a new commit on `@-` using `jj
prev`. After this change it is still possible to create a new commit on top of
`@--` (the previous default behavior) specifying an offset of 2.

There is more discussion about this change in
https://github.com/martinvonz/jj/issues/3426.

This commit also allows `jj prev` to run when `@` is a merge commit. Previously
it refused to do this.