### PR TITLE
clippy: disable bogus lints for nightly clippy

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -729,6 +729,8 @@ impl RefNamesIndex {
         }
     }
 
+    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+    #[allow(clippy::manual_unwrap_or_default)]
     pub fn get(&self, id: &CommitId) -> &[RefName] {
         if let Some(names) = self.index.get(id) {
             names

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -479,6 +479,8 @@ impl Ui {
                 .unwrap_or(false)
     }
 
+    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+    #[allow(clippy::assigning_clones)]
     pub fn prompt(&self, prompt: &str) -> io::Result<String> {
         if !Self::can_prompt() {
             return Err(io::Error::new(

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -63,6 +63,8 @@ impl CommitBuilder<'_> {
     }
 
     /// Only called from [`MutRepo::rewrite_commit`]. Use that function instead.
+    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+    #[allow(clippy::assigning_clones)]
     pub(crate) fn for_rewrite_from<'repo>(
         mut_repo: &'repo mut MutableRepo,
         settings: &UserSettings,

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -306,6 +306,8 @@ impl Backend for LocalBackend {
     }
 }
 
+#[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+#[allow(clippy::assigning_clones)]
 pub fn commit_to_proto(commit: &Commit) -> crate::protos::local_store::Commit {
     let mut proto = crate::protos::local_store::Commit::default();
     for parent in &commit.parents {

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -615,6 +615,8 @@ impl TreeState {
         Ok(())
     }
 
+    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+    #[allow(clippy::assigning_clones)]
     fn save(&mut self) -> Result<(), TreeStateError> {
         let mut proto: crate::protos::working_copy::TreeState = Default::default();
         match &self.tree_id {

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -223,6 +223,8 @@ impl MutableTable {
         other.segment_add_entries_to(self);
     }
 
+    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+    #[allow(clippy::assigning_clones)]
     fn merge_in(&mut self, other: &Arc<ReadonlyTable>) {
         let mut maybe_own_ancestor = self.parent_file.clone();
         let mut maybe_other_ancestor = Some(other.clone());
@@ -281,6 +283,8 @@ impl MutableTable {
     /// If the MutableTable has more than half the entries of its parent
     /// ReadonlyTable, return MutableTable with the commits from both. This
     /// is done recursively, so the stack of index files has O(log n) files.
+    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
+    #[allow(clippy::assigning_clones)]
     fn maybe_squash_with_ancestors(self) -> MutableTable {
         let mut num_new_entries = self.entries.len();
         let mut files_to_squash = vec![];


### PR DESCRIPTION
I'm experimenting with using nightly inside the Nix build, in order to use the parallel rustc frontend and cranelift, and this really helps avoid bogus/spurious clippy warnings.

I suspect @ilyagr might have opinions on this, since he's tracked a bunch of these regressions along with me.

As an alternative to `#[allow(unknown_lints)]` &mdash; which I am not a huge fan of &mdash; I think we could also wire up a `build.rs` that detects the rustc version and emits `cargo:rustc-cfg=nightly` which would allow us to conditionalize the macro on `#[cfg(nightly)]`. But maybe this is good enough.