### PR TITLE
cli: add `ui.always-allow-large-revsets` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Commit objects in templates now have a `mine() -> Boolean` method analog to the same function in revsets.
   It evaluates to true if the email of the commit author matches the current `user.email`.
 
+* A new config option `ui.always-allow-large-revsets` has been added to
+  allow large revsets expressions in some commands, without the `all:` prefix.
+
 ### Fixed bugs
 
 ## [0.16.0] - 2024-04-03

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -775,7 +775,10 @@ impl WorkspaceCommandHelper {
             let (expression, modifier) = self.parse_revset_with_modifier(revision_arg)?;
             let all = match modifier {
                 Some(RevsetModifier::All) => true,
-                None => false,
+                None => self
+                    .settings
+                    .config()
+                    .get_bool("ui.always-allow-large-revsets")?,
             };
             if all {
                 for commit in expression.evaluate_to_commits()? {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -41,6 +41,11 @@
                     "description": "Whether to allow initializing a repo with the native backend",
                     "default": false
                 },
+                "always-allow-large-revsets": {
+                    "type": "boolean",
+                    "description": "Whether to allow large revsets to be used in all commands without the `all:` modifier",
+                    "default": false
+                },
                 "default-command": {
                     "type": "string",
                     "description": "Default command to run when no explicit command is given",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -5,11 +5,11 @@ amend = ["squash"]
 co = ["checkout"]
 unamend = ["unsquash"]
 
-
 [format]
 tree-level-conflicts = true
 
 [ui]
+always-allow-large-revsets = false
 diff-instructions = true
 paginate = "auto"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -484,9 +484,31 @@ fn test_rebase_multiple_destinations() {
       zsuskuln d370aee1 b | b
     Hint: Prefix the expression with 'all:' to allow any number of revisions (i.e. 'all:b|c').
     "###);
+
+    // try with 'all:' and succeed
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ◉    a
+    ├─╮
+    │ ◉  b
+    @ │  c
+    ├─╯
+    ◉
+    "###);
+
+    // undo and do it again, but with 'ui.always-allow-large-revsets'
+    let (_, _) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
+    let (_, _) = test_env.jj_cmd_ok(
+        &repo_path,
+        &[
+            "rebase",
+            "--config-toml=ui.always-allow-large-revsets=true",
+            "-r=a",
+            "-d=b|c",
+        ],
+    );
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     ◉    a
     ├─╮

--- a/docs/config.md
+++ b/docs/config.md
@@ -326,6 +326,28 @@ Can be customized by the `format_short_signature()` template alias.
 'format_short_signature(signature)' = 'signature.username()'
 ```
 
+### Allow "large" revsets by default
+
+Certain commands (such as `jj rebase`) can take multiple revset arguments, and
+each of these may resolve to one-or-many revisions. By default, `jj` will not
+allow revsets that resolve to more than one revision &mdash; a so-called "large
+revset" &mdash; and will ask you to confirm that you want to proceed by
+prefixing it with the `all:` modifier.
+
+For instance, to add a new parent `abc` to the commit `xyz`, you may use `jj
+rebase`:
+
+```
+jj rebase -r xyz -d "all:xyz-" -d "abc"
+```
+
+`jj` requires the `all:` prefix for the above command. However, you may disable
+this behavior by setting `ui.always-allow-large-revsets` to `true`:
+
+```toml
+ui.always-allow-large-revsets = true
+```
+
 ## Pager
 
 The default pager is can be set via `ui.pager` or the `PAGER` environment


### PR DESCRIPTION
This lets users use "large" revsets in commands such as `jj rebase`, without needing the `all:` modifier.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
