### PR TITLE
templater: Add operation.snapshot() boolean and default template hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The default template alias `builtin_op_log_root(op_id: OperationId)` was replaced by `format_root_operation(root: Operation)`.
 
+* The default template alias `builtin_log_root(change_id: ChangeId, commit_id: CommitId)` was replaced by `format_root_commit(root: Commit)`.
+
 ### New features
 
 * The list of conflicted paths is printed whenever the working copy changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* The default template alias `builtin_op_log_root(op_id: OperationId)` was replaced by `format_root_operation(root: Operation)`.
+
 ### New features
 
 * The list of conflicted paths is printed whenever the working copy changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * File path arguments now support [file pattern
   syntax](docs/filesets.md#file-patterns).
 
+* Operation objects in templates now have a `snapshot() -> Boolean` method that
+  evaluates to true if the operation was a snapshot created by a non-mutating
+  command (e.g. `jj log`).
+
 ### Fixed bugs
 
 * Revsets now support `\`-escapes in string literal.
@@ -231,7 +235,7 @@ No code changes (fixing Rust `Cargo.toml` stuff).
   When symlink support is unavailable, they will be materialized as regular files in the
   working copy (instead of resulting in a crash).
   [#2](https://github.com/martinvonz/jj/issues/2)
-  
+
 * On Windows, the `:builtin` pager is now used by default, rather than being
   disabled entirely.
 
@@ -278,7 +282,7 @@ Thanks to the people who made this release happen!
   copy commit on top of a single specified revision, i.e. with one parent.
   `merge` creates a new working copy commit on top of *at least* two specified
   revisions, i.e. with two or more parents.
-  
+
   The only difference between these commands and `jj new`, which *also* creates
   a new working copy commit, is that `new` can create a working copy commit on
   top of any arbitrary number of revisions, so it can handle both the previous
@@ -435,7 +439,7 @@ Thanks to the people who made this release happen!
 
 * `jj branch set` no longer creates a new branch. Use `jj branch create`
   instead.
-  
+
 * `jj init --git` in an existing Git repository now errors and exits rather than
   creating a second Git store.
 
@@ -599,8 +603,8 @@ Thanks to the people who made this release happen!
 
 ### New features
 
-* The `ancestors()` revset function now takes an optional `depth` argument 
-  to limit the depth of the ancestor set. For example, use `jj log -r 
+* The `ancestors()` revset function now takes an optional `depth` argument
+  to limit the depth of the ancestor set. For example, use `jj log -r
   'ancestors(@, 5)` to view the last 5 commits.
 
 * Support for the Watchman filesystem monitor is now bundled by default. Set
@@ -765,13 +769,13 @@ Thanks to the people who made this release happen!
   respectively.
 
 * `jj log` timestamp format now accepts `.utc()` to convert a timestamp to UTC.
- 
+
 * templates now support additional string methods `.starts_with(x)`, `.ends_with(x)`
   `.remove_prefix(x)`, `.remove_suffix(x)`, and `.substr(start, end)`.
 
 * `jj next` and `jj prev` are added, these allow you to traverse the history
   in a linear style. For people coming from Sapling and `git-branchles`
-  see [#2126](https://github.com/martinvonz/jj/issues/2126) for 
+  see [#2126](https://github.com/martinvonz/jj/issues/2126) for
   further pending improvements.
 
 * `jj diff --stat` has been implemented. It shows a histogram of the changes,

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -42,7 +42,7 @@ show = 'builtin_log_detailed'
 [template-aliases]
 builtin_log_oneline = '''
 if(root,
-  builtin_log_root(change_id, commit_id),
+  format_root_commit(self),
   label(if(current_working_copy, "working_copy"),
     concat(
       separate(" ",
@@ -64,7 +64,7 @@ if(root,
 '''
 builtin_log_compact = '''
 if(root,
-  builtin_log_root(change_id, commit_id),
+  format_root_commit(self),
   label(if(current_working_copy, "working_copy"),
     concat(
       separate(" ",
@@ -87,7 +87,7 @@ if(root,
 )
 '''
 builtin_log_comfortable = 'builtin_log_compact ++ "\n"'
-'builtin_log_detailed' = '''
+builtin_log_detailed = '''
 concat(
   "Commit ID: " ++ commit_id ++ "\n",
   "Change ID: " ++ change_id ++ "\n",
@@ -112,15 +112,6 @@ label(if(current_operation, "current_operation"),
 '''
 builtin_op_log_comfortable = 'builtin_op_log_compact ++ "\n"'
 
-'builtin_log_root(change_id, commit_id)' = '''
-separate(" ",
-  format_short_change_id(change_id),
-  label("root", "root()"),
-  format_short_commit_id(commit_id),
-  branches
-) ++ "\n"
-'''
-
 
 description_placeholder = '''
   label(if(empty, "empty ") ++ "description placeholder", "(no description set)")'''
@@ -141,6 +132,15 @@ commit_summary_separator = 'label("separator", " | ")'
 'format_time_range(time_range)' = '''
   time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp.local().format("%Y-%m-%d %H:%M:%S")'
+
+'format_root_commit(root)' = '''
+separate(" ",
+  format_short_change_id(root.change_id()),
+  label("root", "root()"),
+  format_short_commit_id(root.commit_id()),
+  root.branches()
+) ++ "\n"
+'''
 
 'format_operation(op)' = '''
   concat(

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -102,18 +102,11 @@ concat(
 '''
 
 builtin_op_log_compact = '''
-if(root,
-  builtin_op_log_root(id),
-  label(if(current_operation, "current_operation"),
-    concat(
-      separate(" ",
-        id.short(),
-        user,
-        format_time_range(time),
-      ) ++ "\n",
-      description.first_line() ++ "\n",
-      if(tags, tags ++ "\n"),
-    ),
+label(if(current_operation, "current_operation"),
+  coalesce(
+    if(snapshot, format_snapshot_operation(self)),
+    if(root, format_root_operation(self)),
+    format_operation(self),
   )
 )
 '''
@@ -125,13 +118,6 @@ separate(" ",
   label("root", "root()"),
   format_short_commit_id(commit_id),
   branches
-) ++ "\n"
-'''
-
-'builtin_op_log_root(op_id)' = '''
-separate(" ",
-  op_id.short(),
-  label("root", "root()"),
 ) ++ "\n"
 '''
 
@@ -156,12 +142,22 @@ commit_summary_separator = 'label("separator", " | ")'
   time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp.local().format("%Y-%m-%d %H:%M:%S")'
 
+'format_operation(op)' = '''
+  concat(
+    separate(" ", op.id().short(), op.user(), format_time_range(op.time())), "\n",
+    op.description().first_line(), "\n",
+    if(op.tags(), op.tags() ++ "\n"),
+  )
+'''
+'format_snapshot_operation(op)' = 'format_operation(op)'
+'format_root_operation(root)' = 'separate(" ", root.id().short(), label("root", "root()")) ++ "\n"'
+
 # We have "hidden" override "divergent", since a hidden revision does not cause
 # change id conflicts and is not affected by such conflicts; you have to use the
 # commit id to refer to a hidden revision regardless.
 builtin_change_id_with_hidden_and_divergent_info = '''
 if(hidden,
-  label("hidden", 
+  label("hidden",
     format_short_change_id(change_id) ++ " hidden"
   ),
   label(if(divergent, "divergent"),

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -249,6 +249,14 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
         });
         Ok(L::wrap_string(out_property))
     });
+    map.insert(
+        "snapshot",
+        |_language, _build_ctx, self_property, function| {
+            template_parser::expect_no_arguments(function)?;
+            let out_property = self_property.map(|op| op.metadata().is_snapshot);
+            Ok(L::wrap_boolean(out_property))
+        },
+    );
     map.insert("time", |_language, _build_ctx, self_property, function| {
         template_parser::expect_no_arguments(function)?;
         let out_property = self_property.map(|op| TimestampRange {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -133,7 +133,8 @@ This type cannot be printed. The following methods are defined.
 * `tags() -> String`
 * `time() -> TimestampRange`
 * `user() -> String`
-* `root() -> Boolean`: True if the commit is the root commit.
+* `snapshot() -> Boolean`: True if the operation is a snapshot operation.
+* `root() -> Boolean`: True if the operation is the root operation.
 
 ### OperationId type
 


### PR DESCRIPTION
I think that ideally there will be elided nodes for consecutive snapshots in the log, and the full oplog as it's shown now will require something like an `--all` flag.
But I looked at how `jj log` does elision and it went just a bit over my head atm :upside_down_face: 

Also I wrote those hooks to use the implicit `self` since passing everything as args, especially when there's a possibility more things will be added (like `snapshot`) is unwieldy.

When I added `builtin_log_root(change_id, commit_id)` I just did not realize I could do that 🤷

And also those are hooks, not builtins, so the builtin_ name is bad, it's more consistent for them to be one of the format_ functions - see the comment about maybe having some sort of `deprecated` templater function that'll make jj emit warnings about hooks being changed?.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
