### PR TITLE
Make `jj prev` and `jj next` work when the working copy is a merge commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * File path arguments now support [file pattern
   syntax](docs/filesets.md#file-patterns).
 
+* `jj prev` now works when the working copy revision is a merge.
+
 * Operation objects in templates now have a `snapshot() -> Boolean` method that
   evaluates to true if the operation was a snapshot created by a non-mutating
   command (e.g. `jj log`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * File path arguments now support [file pattern
   syntax](docs/filesets.md#file-patterns).
 
-* `jj prev` now works when the working copy revision is a merge.
+* `jj prev` and `jj next` now work when the working copy revision is a merge.
 
 * Operation objects in templates now have a `snapshot() -> Boolean` method that
   evaluates to true if the operation was a snapshot created by a non-mutating


### PR DESCRIPTION
Before this commit `jj prev` fails if the current working copy commit is a merge commit. After this commit it will prompt the user to choose the ancestor they want to select.

#2126

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have added tests to cover my changes
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
