### PR TITLE
Update the documentation for `jj next`

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -25,31 +25,34 @@ use crate::ui::Ui;
 
 /// Move the working-copy commit to the child revision
 ///
-/// The command moves you to the next child in a linear fashion.
+/// The command creates a new empty working copy revision that is the child of a
+/// descendant `offset` revisions ahead of the parent of the current working
+/// copy.
+///
+/// For example, when the offset is 1:
 ///
 /// ```text
-/// D      D @
-/// |      |/
-/// C @ => C
-/// |/     |
-/// B      B
+/// D        D @
+/// |        |/
+/// C @  =>  C
+/// |/       |
+/// B        B
 /// ```
 ///
-/// If `--edit` is passed, it will move you directly to the child
-/// revision.
+/// If `--edit` is passed, the working copy revision is changed to the child of
+/// the current working copy revision.
 ///
 /// ```text
-/// D    D
-/// |    |
-/// C    C
-/// |    |
-/// B => @
-/// |    |
-/// @    A
-///
+/// D        D
+/// |        |
+/// C        C
+/// |        |
+/// B   =>   @
+/// |        |
+/// @        A
+/// ```
 /// If your working-copy commit already has visible children, then `--edit` is
 /// implied.
-/// ```
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]
 pub(crate) struct NextArgs {

--- a/cli/src/commands/parallelize.rs
+++ b/cli/src/commands/parallelize.rs
@@ -46,7 +46,7 @@ use crate::ui::Ui;
 /// the target revset (not to be confused with the repo root). The children of
 /// the head(s) of the target revset are rebased onto the target revisions.
 ///
-/// The target revset is the union of the REVISIONS arguments and must satisfy
+/// The target revset is the union of the `revisions` arguments and must satisfy
 /// several conditions, otherwise the command will fail.
 ///
 /// 1. The heads of the target revset must have either the same children as the

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -20,35 +20,36 @@ use crate::cli_util::{short_commit_hash, CommandHelper};
 use crate::command_error::{user_error, CommandError};
 use crate::commands::next::choose_commit;
 use crate::ui::Ui;
-
-/// Move the working-copy commit to the parent revision
+/// Change the working copy revision relative to the parent revision
 ///
+/// The command creates a new empty working copy revision that is the child of
+/// an ancestor `offset` revisions behind the parent of the current working
+/// copy.
 ///
-/// The command moves you to the parent in a linear fashion.
+/// For example, when the offset is 1:
 ///
 /// ```text
-/// D @  D
-/// |/   |
-/// A => A @
-/// |    |/
-/// B    B
+/// D @      D
+/// |/       |
+/// A   =>   A @
+/// |        |/
+/// B        B
 /// ```
 ///
-/// If `--edit` is passed, it will move the working copy commit
-/// directly to the parent.
+/// If `--edit` is passed, the working copy revision is changed to the parent of
+/// the current working copy revision.
 ///
 /// ```text
-/// D @  D
-/// |/   |
-/// C => @
-/// |    |
-/// B    B
-/// |    |
-/// A    A
-///
-/// If your working-copy commit already has visible children, then `--edit` is
+/// D @      D
+/// |/       |
+/// C   =>   @
+/// |        |
+/// B        B
+/// |        |
+/// A        A
+/// ```
+/// If the working copy revision already has visible children, then `--edit` is
 /// implied.
-/// ```
 // TODO(#2126): Handle multiple parents, e.g merges.
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1148,31 +1148,34 @@ For more information, see https://github.com/martinvonz/jj/blob/main/docs/workin
 
 Move the working-copy commit to the child revision
 
-The command moves you to the next child in a linear fashion.
+The command creates a new empty working copy revision that is the child of a
+descendant `offset` revisions ahead of the parent of the current working
+copy.
+
+For example, when the offset is 1:
 
 ```text
-D      D @
-|      |/
-C @ => C
-|/     |
-B      B
+D        D @
+|        |/
+C @  =>  C
+|/       |
+B        B
 ```
 
-If `--edit` is passed, it will move you directly to the child
-revision.
+If `--edit` is passed, the working copy revision is changed to the child of
+the current working copy revision.
 
 ```text
-D    D
-|    |
-C    C
-|    |
-B => @
-|    |
-@    A
-
+D        D
+|        |
+C        C
+|        |
+B   =>   @
+|        |
+@        A
+```
 If your working-copy commit already has visible children, then `--edit` is
 implied.
-```
 
 **Usage:** `jj next [OPTIONS] [OFFSET]`
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1366,7 +1366,7 @@ Each of the target revisions is rebased onto the parents of the root(s) of
 the target revset (not to be confused with the repo root). The children of
 the head(s) of the target revset are rebased onto the target revisions.
 
-The target revset is the union of the REVISIONS arguments and must satisfy
+The target revset is the union of the `revisions` arguments and must satisfy
 several conditions, otherwise the command will fail.
 
 1. The heads of the target revset must have either the same children as the

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -128,7 +128,7 @@ To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/d
 * `obslog` — Show how a change has evolved
 * `operation` — Commands for working with the operation log
 * `parallelize` — Parallelize revisions by making them siblings
-* `prev` — Move the working-copy commit to the parent revision
+* `prev` — Change the working copy revision relative to the parent revision
 * `rebase` — Move revisions to different parent(s)
 * `resolve` — Resolve a conflicted file with an external merge tool
 * `restore` — Restore paths from another revision
@@ -1385,34 +1385,36 @@ several conditions, otherwise the command will fail.
 
 ## `jj prev`
 
-Move the working-copy commit to the parent revision
+Change the working copy revision relative to the parent revision
 
+The command creates a new empty working copy revision that is the child of
+an ancestor `offset` revisions behind the parent of the current working
+copy.
 
-The command moves you to the parent in a linear fashion.
+For example, when the offset is 1:
 
 ```text
-D @  D
-|/   |
-A => A @
-|    |/
-B    B
+D @      D
+|/       |
+A   =>   A @
+|        |/
+B        B
 ```
 
-If `--edit` is passed, it will move the working copy commit
-directly to the parent.
+If `--edit` is passed, the working copy revision is changed to the parent of
+the current working copy revision.
 
 ```text
-D @  D
-|/   |
-C => @
-|    |
-B    B
-|    |
-A    A
-
-If your working-copy commit already has visible children, then `--edit` is
+D @      D
+|/       |
+C   =>   @
+|        |
+B        B
+|        |
+A        A
+```
+If the working copy revision already has visible children, then `--edit` is
 implied.
-```
 
 **Usage:** `jj prev [OPTIONS] [OFFSET]`
 


### PR DESCRIPTION
This is to match the recent changes made to the docs for `jj prev`.
