### PR TITLE
revset: backport `\`-escape parsing from templater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed bugs
 
+* Revsets now support `\`-escapes in string literal.
+
+
 ## [0.16.0] - 2024-04-03
 
 ### Deprecations

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -19,10 +19,10 @@
 
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
-escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
-literal_char = @{ !("\"" | "\\") ~ ANY }
-raw_literal = @{ literal_char+ }
-literal = { "\"" ~ (raw_literal | escape)* ~ "\"" }
+string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
+string_content_char = @{ !("\"" | "\\") ~ ANY }
+string_content = @{ string_content_char+ }
+string_literal = { "\"" ~ (string_content | string_escape)* ~ "\"" }
 
 integer_literal = {
   ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
@@ -58,7 +58,7 @@ primary = _{
   | function
   | lambda
   | identifier
-  | literal
+  | string_literal
   | integer_literal
 }
 

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -22,9 +22,9 @@ whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
-string_literal = { "\"" ~ (string_content | string_escape)* ~ "\"" }
+string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }
 
-integer_literal = {
+integer_literal = @{
   ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
   | "0"
 }

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -32,10 +32,10 @@ impl Rule {
         match self {
             Rule::EOI => None,
             Rule::whitespace => None,
-            Rule::escape => None,
-            Rule::literal_char => None,
-            Rule::raw_literal => None,
-            Rule::literal => None,
+            Rule::string_escape => None,
+            Rule::string_content_char => None,
+            Rule::string_content => None,
+            Rule::string_literal => None,
             Rule::integer_literal => None,
             Rule::identifier => None,
             Rule::concat_op => Some("++"),
@@ -315,14 +315,14 @@ fn parse_identifier_name(pair: Pair<Rule>) -> TemplateParseResult<&str> {
 }
 
 fn parse_string_literal(pair: Pair<Rule>) -> String {
-    assert_eq!(pair.as_rule(), Rule::literal);
+    assert_eq!(pair.as_rule(), Rule::string_literal);
     let mut result = String::new();
     for part in pair.into_inner() {
         match part.as_rule() {
-            Rule::raw_literal => {
+            Rule::string_content => {
                 result.push_str(part.as_str());
             }
-            Rule::escape => match &part.as_str()[1..] {
+            Rule::string_escape => match &part.as_str()[1..] {
                 "\"" => result.push('"'),
                 "\\" => result.push('\\'),
                 "t" => result.push('\t'),
@@ -396,7 +396,7 @@ fn parse_term_node(pair: Pair<Rule>) -> TemplateParseResult<ExpressionNode> {
     let expr = inner.next().unwrap();
     let span = expr.as_span();
     let primary = match expr.as_rule() {
-        Rule::literal => {
+        Rule::string_literal => {
             let text = parse_string_literal(expr);
             ExpressionNode::new(ExpressionKind::String(text), span)
         }

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -1,0 +1,52 @@
+// Copyright 2020-2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Domain-specific language helpers.
+
+use pest::iterators::Pairs;
+use pest::RuleType;
+
+/// Helper to parse string literal.
+#[derive(Debug)]
+pub struct StringLiteralParser<R> {
+    /// String content part.
+    pub content_rule: R,
+    /// Escape sequence part including backslash character.
+    pub escape_rule: R,
+}
+
+impl<R: RuleType> StringLiteralParser<R> {
+    /// Parses the given string literal `pairs` into string.
+    pub fn parse(&self, pairs: Pairs<R>) -> String {
+        let mut result = String::new();
+        for part in pairs {
+            if part.as_rule() == self.content_rule {
+                result.push_str(part.as_str());
+            } else if part.as_rule() == self.escape_rule {
+                match &part.as_str()[1..] {
+                    "\"" => result.push('"'),
+                    "\\" => result.push('\\'),
+                    "t" => result.push('\t'),
+                    "r" => result.push('\r'),
+                    "n" => result.push('\n'),
+                    "0" => result.push('\0'),
+                    char => panic!("invalid escape: \\{char:?}"),
+                }
+            } else {
+                panic!("unexpected part of string: {part:?}");
+            }
+        }
+        result
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,7 @@ pub mod dag_walk;
 pub mod default_index;
 pub mod default_submodule_store;
 pub mod diff;
+pub mod dsl_util;
 pub mod extensions_map;
 pub mod file_util;
 pub mod files;

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
+
 identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
 identifier = @{
   identifier_part ~ ("." | "-" | "+" ) ~ identifier
@@ -26,8 +28,6 @@ string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }
-
-whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 at_op = { "@" }
 pattern_kind_op = { ":" }

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -19,9 +19,9 @@ identifier = @{
 }
 symbol = {
   identifier
-  | literal_string
+  | string_literal
 }
-literal_string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+string_literal = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 at_op = { "@" }
@@ -67,7 +67,7 @@ formal_parameters = {
   | ""
 }
 
-// TODO: change rhs to literal_string to require quoting? #2101
+// TODO: change rhs to string_literal to require quoting? #2101
 string_pattern = { identifier ~ pattern_kind_op ~ symbol }
 
 primary = {

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -16,8 +16,7 @@ whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
 identifier = @{
-  identifier_part ~ ("." | "-" | "+" ) ~ identifier
-  | identifier_part
+  identifier_part ~ (("." | "-" | "+") ~ identifier_part)*
 }
 symbol = {
   identifier

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -21,7 +21,12 @@ symbol = {
   identifier
   | string_literal
 }
-string_literal = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+
+string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
+string_content_char = @{ !("\"" | "\\") ~ ANY }
+string_content = @{ string_content_char+ }
+string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }
+
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 at_op = { "@" }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -100,6 +100,7 @@ impl Rule {
     fn to_symbol(self) -> Option<&'static str> {
         match self {
             Rule::EOI => None,
+            Rule::whitespace => None,
             Rule::identifier_part => None,
             Rule::identifier => None,
             Rule::symbol => None,
@@ -107,7 +108,6 @@ impl Rule {
             Rule::string_content_char => None,
             Rule::string_content => None,
             Rule::string_literal => None,
-            Rule::whitespace => None,
             Rule::at_op => Some("@"),
             Rule::pattern_kind_op => Some(":"),
             Rule::parents_op => Some("-"),

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1028,12 +1028,12 @@ fn parse_primary_rule(
         // is considered an indecomposable unit, and no alias substitution would be made.
         Rule::symbol if pairs.peek().is_none() => parse_symbol_rule(first.into_inner(), state),
         Rule::symbol => {
-            let name = parse_symbol_rule_as_literal(first.into_inner())?;
+            let name = parse_symbol_rule_as_literal(first.into_inner());
             assert_eq!(pairs.next().unwrap().as_rule(), Rule::at_op);
             if let Some(second) = pairs.next() {
                 // infix "<name>@<remote>"
                 assert_eq!(second.as_rule(), Rule::symbol);
-                let remote = parse_symbol_rule_as_literal(second.into_inner())?;
+                let remote = parse_symbol_rule_as_literal(second.into_inner());
                 Ok(RevsetExpression::remote_symbol(name, remote))
             } else {
                 // postfix "<workspace_id>@"
@@ -1064,7 +1064,7 @@ fn parse_string_pattern_rule(
     assert_eq!(rhs.as_rule(), Rule::symbol);
     if state.allow_string_pattern {
         let kind = lhs.as_str().to_owned();
-        let value = parse_symbol_rule_as_literal(rhs.into_inner())?;
+        let value = parse_symbol_rule_as_literal(rhs.into_inner());
         Ok(Rc::new(RevsetExpression::StringPattern { kind, value }))
     } else {
         Err(RevsetParseError::with_span(
@@ -1109,11 +1109,11 @@ fn parse_symbol_rule(
 }
 
 /// Parses part of compound symbol to string without alias substitution.
-fn parse_symbol_rule_as_literal(mut pairs: Pairs<Rule>) -> Result<String, RevsetParseError> {
+fn parse_symbol_rule_as_literal(mut pairs: Pairs<Rule>) -> String {
     let first = pairs.next().unwrap();
     match first.as_rule() {
-        Rule::identifier => Ok(first.as_str().to_owned()),
-        Rule::string_literal => Ok(STRING_LITERAL_PARSER.parse(first.into_inner())),
+        Rule::identifier => first.as_str().to_owned(),
+        Rule::string_literal => STRING_LITERAL_PARSER.parse(first.into_inner()),
         _ => {
             panic!("unexpected symbol parse rule: {:?}", first.as_str());
         }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -97,7 +97,7 @@ impl Rule {
             Rule::identifier_part => None,
             Rule::identifier => None,
             Rule::symbol => None,
-            Rule::literal_string => None,
+            Rule::string_literal => None,
             Rule::whitespace => None,
             Rule::at_op => Some("@"),
             Rule::pattern_kind_op => Some(":"),
@@ -1090,7 +1090,7 @@ fn parse_symbol_rule(
                 Ok(RevsetExpression::symbol(name.to_owned()))
             }
         }
-        Rule::literal_string => parse_string_literal(first).map(RevsetExpression::symbol),
+        Rule::string_literal => parse_string_literal(first).map(RevsetExpression::symbol),
         _ => {
             panic!("unexpected symbol parse rule: {:?}", first.as_str());
         }
@@ -1102,7 +1102,7 @@ fn parse_symbol_rule_as_literal(mut pairs: Pairs<Rule>) -> Result<String, Revset
     let first = pairs.next().unwrap();
     match first.as_rule() {
         Rule::identifier => Ok(first.as_str().to_owned()),
-        Rule::literal_string => parse_string_literal(first),
+        Rule::string_literal => parse_string_literal(first),
         _ => {
             panic!("unexpected symbol parse rule: {:?}", first.as_str());
         }
@@ -1111,7 +1111,7 @@ fn parse_symbol_rule_as_literal(mut pairs: Pairs<Rule>) -> Result<String, Revset
 
 // TODO: Add support for \-escape syntax
 fn parse_string_literal(pair: Pair<Rule>) -> Result<String, RevsetParseError> {
-    assert_eq!(pair.as_rule(), Rule::literal_string);
+    assert_eq!(pair.as_rule(), Rule::string_literal);
     Ok(pair
         .as_str()
         .strip_prefix('"')


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
