### PR TITLE
Expose diff format options to describe-like commands

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -22,6 +22,7 @@ use crate::command_error::{user_error, CommandError};
 use crate::description_util::{
     description_template_for_commit, edit_description, join_message_paragraphs,
 };
+use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
 /// Update the description and create a new change on top.
@@ -40,6 +41,8 @@ pub(crate) struct CommitArgs {
     /// Put these paths in the first commit
     #[arg(value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
+    #[command(flatten)]
+    diff_format: DiffFormatArgs,
 }
 
 #[instrument(skip_all)]
@@ -94,6 +97,7 @@ new working-copy commit.
         commit.description(),
         &base_tree,
         &middle_tree,
+        &args.diff_format,
     )?;
 
     let description = if !args.message_paragraphs.is_empty() {

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -22,6 +22,7 @@ use crate::command_error::CommandError;
 use crate::description_util::{
     description_template_for_describe, edit_description, join_message_paragraphs,
 };
+use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
 /// Update the change description or other metadata
@@ -58,6 +59,8 @@ pub(crate) struct DescribeArgs {
     /// $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj describe --reset-author
     #[arg(long)]
     reset_author: bool,
+    #[command(flatten)]
+    diff_format: DiffFormatArgs,
 }
 
 #[instrument(skip_all)]
@@ -78,8 +81,13 @@ pub(crate) fn cmd_describe(
     } else if args.no_edit {
         commit.description().to_owned()
     } else {
-        let template =
-            description_template_for_describe(ui, command.settings(), &workspace_command, &commit)?;
+        let template = description_template_for_describe(
+            ui,
+            command.settings(),
+            &workspace_command,
+            &commit,
+            &args.diff_format,
+        )?;
         edit_description(workspace_command.repo(), &template, command.settings())?
     };
     if description == *commit.description() && !args.reset_author {

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -25,6 +25,7 @@ use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
 use crate::commands::rebase::rebase_descendants;
 use crate::description_util::{description_template_for_commit, edit_description};
+use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
 /// Split a revision in two
@@ -57,6 +58,8 @@ pub(crate) struct SplitArgs {
     /// Put these paths in the first commit
     #[arg(value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
+    #[command(flatten)]
+    diff_format: DiffFormatArgs,
 }
 
 #[instrument(skip_all)]
@@ -119,6 +122,7 @@ the operation will be aborted.
         commit.description(),
         &base_tree,
         &selected_tree,
+        &args.diff_format,
     )?;
     let first_description = edit_description(tx.base_repo(), &first_template, command.settings())?;
     let first_commit = tx
@@ -155,6 +159,7 @@ the operation will be aborted.
             commit.description(),
             second_base_tree,
             &second_tree,
+            &args.diff_format,
         )?;
         edit_description(tx.base_repo(), &second_template, command.settings())?
     };

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -7,7 +7,7 @@ use jj_lib::settings::UserSettings;
 
 use crate::cli_util::{edit_temp_file, WorkspaceCommandHelper};
 use crate::command_error::CommandError;
-use crate::diff_util::{self, DiffFormat};
+use crate::diff_util::{self, diff_formats_for_describe, DiffFormatArgs};
 use crate::formatter::PlainTextFormatter;
 use crate::text_util;
 use crate::ui::Ui;
@@ -95,6 +95,7 @@ pub fn description_template_for_describe(
     settings: &UserSettings,
     workspace_command: &WorkspaceCommandHelper,
     commit: &Commit,
+    diff_format: &DiffFormatArgs,
 ) -> Result<String, CommandError> {
     let mut diff_summary_bytes = Vec::new();
     diff_util::show_patch(
@@ -103,7 +104,7 @@ pub fn description_template_for_describe(
         workspace_command,
         commit,
         &EverythingMatcher,
-        &[DiffFormat::Summary],
+        &diff_formats_for_describe(settings, diff_format)?,
     )?;
     let description = if commit.description().is_empty() {
         settings.default_description()
@@ -117,6 +118,7 @@ pub fn description_template_for_describe(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn description_template_for_commit(
     ui: &Ui,
     settings: &UserSettings,
@@ -125,6 +127,7 @@ pub fn description_template_for_commit(
     overall_commit_description: &str,
     from_tree: &MergedTree,
     to_tree: &MergedTree,
+    diff_format: &DiffFormatArgs,
 ) -> Result<String, CommandError> {
     let mut diff_summary_bytes = Vec::new();
     diff_util::show_diff(
@@ -134,7 +137,7 @@ pub fn description_template_for_commit(
         from_tree,
         to_tree,
         &EverythingMatcher,
-        &[DiffFormat::Summary],
+        &diff_formats_for_describe(settings, diff_format)?,
     )?;
     let mut template_chunks = Vec::new();
     if !intro.is_empty() {

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -120,6 +120,19 @@ pub fn diff_formats_for_log(
     Ok(formats)
 }
 
+/// Returns a list of requested diff formats for describe-like commands, which
+/// will never be empty.
+pub fn diff_formats_for_describe(
+    settings: &UserSettings,
+    args: &DiffFormatArgs,
+) -> Result<Vec<DiffFormat>, config::ConfigError> {
+    let mut formats = diff_formats_from_args(settings, args)?;
+    if formats.is_empty() {
+        formats.push(DiffFormat::Summary);
+    }
+    Ok(formats)
+}
+
 fn diff_formats_from_args(
     settings: &UserSettings,
     args: &DiffFormatArgs,


### PR DESCRIPTION
Description taken from the commit message:
> This implements some more powerful version of `git commit --verbose`, which lets the user get more context in the editor buffer they use to write a commit message.
> 
> We default to `DiffFormat::Summary`, which was the previously hardcoded value.

As a next step, what would you think about making those settings configurable from the config file? I personally have
```toml
[commit]
	verbose = true
```
in my git config file and would like to be able to do the same with `jj`.

Long term, it might be worth introducing a sigil like Git's `# ------------------------ >8 ------------------------`, to get rid of the `JJ: ` prefixes for diffs if it helps with editor syntax highlighting (I'm not sure).

I have added no tests because this just changes some plumbing, but let me know if you want me to add some (some pointers would be appreciated, I'm not familiar with the crates used for testing like `insta`).

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
