### PR TITLE
Fix empty files can't be selected in builtin diff editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Revsets now support `\`-escapes in string literal.
 
+* The builtin diff editor now allows empty files to be selected during
+  `jj split`.
+
 * Fixed a bug with `jj split` introduced in 0.16.0 that caused it to incorrectly
   rebase the children of the revision being split if they had other parents
   (i.e. if the child was a merge).
+
 
 ## [0.16.0] - 2024-04-03
 


### PR DESCRIPTION
This fixes several issues that made working with empty files difficult using the builtin diff editor.

1. The scm-record library used for the editor expects each file to have at least one section. For empty files this should be a file mode section. jj wasn't rendering this mode section, which prevented empty files from being selected at all.

2. The scm-record library returns `SelectedContents::Absent` if the file has no contents after the diff editor is invoked. This can be because of several reasons: 1) the file is new and empty; 2) the file was empty before and is still empty; 3) the file has been deleted. Perhaps this is a bug in scm-record and it should return `SelectedContents::Unchanged` or `SelectedContents::Present` if the file hasn't been deleted. Until this is patched upstream, we can work around it by disambiguating these cases.

See https://github.com/arxanas/scm-record/issues/26 for the upstream bug.


Fixes #3016