### PR TITLE
cli: migrate "cat" to matcher API, print symlink target

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -108,7 +108,7 @@ To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/d
 * `abandon` — Abandon a revision
 * `backout` — Apply the reverse of a revision on top of another revision
 * `branch` — Manage branches
-* `cat` — Print contents of a file in a revision
+* `cat` — Print contents of files in a revision
 * `chmod` — Sets or removes the executable bit for paths in the repo
 * `commit` — Update the description and create a new change on top
 * `config` — Manage config options
@@ -384,13 +384,15 @@ A non-tracking remote branch is just a pointer to the last-fetched remote branch
 
 ## `jj cat`
 
-Print contents of a file in a revision
+Print contents of files in a revision
 
-**Usage:** `jj cat [OPTIONS] <PATH>`
+If the given path is a directory, files in the directory will be visited recursively.
+
+**Usage:** `jj cat [OPTIONS] <PATHS>...`
 
 ###### **Arguments:**
 
-* `<PATH>` — The file to print
+* `<PATHS>` — Paths to print
 
 ###### **Options:**
 

--- a/cli/tests/test_cat_command.rs
+++ b/cli/tests/test_cat_command.rs
@@ -58,13 +58,14 @@ fn test_cat() {
     // Error if the path doesn't exist
     let stderr = test_env.jj_cmd_failure(&repo_path, &["cat", "nonexistent"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: No such path
+    Error: No such path: nonexistent
     "###);
 
-    // Error if the path is not a file
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["cat", "dir"]);
+    // TODO: files under the directory will be printed
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["cat", "dir"]);
+    insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Error: Path exists but is not a file
+    Warning: Path exists but is not a file: dir
     "###);
 
     // Can print a conflict


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
