### PR TITLE
Shiny default graph symbols, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `templates.log_node`
   * `templates.op_log_node`
 
+* A default configuration for `templates.log_node` is now provided which, out of
+  the box, uses visually distinct nodes with distinct colors, for ease of
+  reading.
+
+  Please see [the documentation](https://martinvonz.github.io/jj/v0.16.0/config/#node-style) 
+  for `templates.log_node` for the default symbols, and an example of how to
+  re-configure this behavior and provide your own symbols.
+
 * `jj log` now includes synthetic nodes in the graph where some revisions were
   elided.
 

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -92,5 +92,5 @@
 "node elided" = { fg = "bright black" }
 "node working_copy" = { fg = "green" }
 "node immutable" = { fg = "bright cyan" }
-"node wip" = { fg = "yellow" }
+"node conflict" = { fg = "red" }
 "node normal" = { bold = false }

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -87,3 +87,10 @@
 "op_log current_operation id" = "bright blue"
 "op_log current_operation user" = "yellow"                    # No bright yellow, see comment above
 "op_log current_operation time" = "bright cyan"
+
+"node" = { bold = true }
+"node elided" = { fg = "bright black" }
+"node working_copy" = { fg = "green" }
+"node immutable" = { fg = "bright cyan" }
+"node wip" = { fg = "yellow" }
+"node normal" = { bold = false }

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -39,6 +39,19 @@ log = 'builtin_log_compact'
 op_log = 'builtin_op_log_compact'
 show = 'builtin_log_detailed'
 
+op_log_node = 'if(current_operation, "@", "◉")'
+
+log_node = '''
+label("node",
+  coalesce(
+    if(!self, label("elided", "⇋")),
+    if(current_working_copy, label("working_copy", "@")),
+    if(immutable, label("immutable", "◆")),
+    label("normal", "○")
+  )
+)
+'''
+
 [template-aliases]
 builtin_log_oneline = '''
 if(root,

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -39,19 +39,6 @@ log = 'builtin_log_compact'
 op_log = 'builtin_op_log_compact'
 show = 'builtin_log_detailed'
 
-op_log_node = 'if(current_operation, "@", "◉")'
-
-log_node = '''
-label("node",
-  coalesce(
-    if(!self, label("elided", "⇋")),
-    if(current_working_copy, label("working_copy", "@")),
-    if(immutable, label("immutable", "◆")),
-    label("normal", "○")
-  )
-)
-'''
-
 [template-aliases]
 builtin_log_oneline = '''
 if(root,

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -43,13 +43,13 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] e
     ├─╮
-    │ ◉  [vru] d
-    │ ◉  [roy] c
-    │ │ ◉  [zsu] b
+    │ ○  [vru] d
+    │ ○  [roy] c
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a
+    ○ │  [rlv] a
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "d"]);
@@ -65,12 +65,12 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] e
     ├─╮
-    │ ◉  [roy] c d
-    │ │ ◉  [zsu] b
+    │ ○  [roy] c d
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a
+    ○ │  [rlv] a
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -84,13 +84,13 @@ fn test_basics() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [nkm]
-    │ ◉  [zsu] b
+    │ ○  [zsu] b
     ├─╯
-    ◉  [rlv] a e??
-    │ ◉  [vru] d e??
-    │ ◉  [roy] c
+    ○  [rlv] a e??
+    │ ○  [vru] d e??
+    │ ○  [roy] c
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -107,10 +107,10 @@ fn test_basics() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [xtn]
-    │ ◉  [zsu] b
+    │ ○  [zsu] b
     ├─╯
-    ◉  [rlv] a e??
-    ◉  [zzz] c d e??
+    ○  [rlv] a e??
+    ◆  [zzz] c d e??
     "###);
 
     // Test abandoning the same commit twice directly
@@ -123,11 +123,11 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] e
     ├─╮
-    │ ◉  [vru] d
-    │ ◉  [roy] c
-    ◉ │  [rlv] a b
+    │ ○  [vru] d
+    │ ○  [roy] c
+    ○ │  [rlv] a b
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     // Test abandoning the same commit twice indirectly
@@ -146,9 +146,9 @@ fn test_basics() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [xlz]
-    │ ◉  [roy] c d e??
+    │ ○  [roy] c d e??
     ├─╯
-    ◉  [zzz] a b e??
+    ◆  [zzz] a b e??
     "###);
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "none()"]);
@@ -177,13 +177,13 @@ fn test_bug_2600() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉    [vru] b
+    ○    [vru] b
     ├─╮
-    │ ◉  [roy] a
+    │ ○  [roy] a
     ├─╯
-    ◉  [zsu] base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -201,12 +201,12 @@ fn test_bug_2600() {
     // should keep "a" as second parent.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉    [vru] b
+    ○    [vru] b
     ├─╮
-    │ ◉  [roy] a
+    │ ○  [roy] a
     ├─╯
-    ◉  [rlv] base nottherootcommit
-    ◉  [zzz]
+    ○  [rlv] base nottherootcommit
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -224,10 +224,10 @@ fn test_bug_2600() {
     // "a".
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉  [vru] b
-    ◉  [zsu] a base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [vru] b
+    ○  [zsu] a base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -245,24 +245,24 @@ fn test_bug_2600() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] c
     ├─╮
-    │ ◉  [roy] a b??
+    │ ○  [roy] a b??
     ├─╯
-    ◉  [zsu] b?? base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] b?? base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ========= Reminder of the setup ===========
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉    [vru] b
+    ○    [vru] b
     ├─╮
-    │ ◉  [roy] a
+    │ ○  [roy] a
     ├─╯
-    ◉  [zsu] base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "a", "b"]);
     insta::assert_snapshot!(stdout, @"");
@@ -279,9 +279,9 @@ fn test_bug_2600() {
     // not have two parent pointers to the same commit.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉  [zsu] a b base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] a b base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -305,12 +305,12 @@ fn test_bug_2600_rootcommit_special_case() {
     // Setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [vru] c
-    ◉    [roy] b
+    ○    [roy] b
     ├─╮
-    │ ◉  [zsu] a
+    │ ○  [zsu] a
     ├─╯
-    ◉  [rlv] base
-    ◉  [zzz]
+    ○  [rlv] base
+    ◆  [zzz]
     "###);
 
     // Now, the test

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -167,7 +167,7 @@ fn test_alias_cannot_override_builtin() {
     // Alias should be ignored
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "root()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 }
 
@@ -206,28 +206,28 @@ fn test_alias_global_args_before_and_after() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Can pass global args before
     let stdout = test_env.jj_cmd_success(&repo_path, &["l", "--at-op", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Can pass global args after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "@-", "l"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Test passing global args both before and after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "abc123", "l", "--at-op", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["-R", "../nonexistent", "l", "-R", "."]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -243,7 +243,7 @@ fn test_alias_global_args_in_definition() {
     // The global argument in the alias is respected
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -29,7 +29,7 @@ fn test_branch_multiple_names() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar foo 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -40,8 +40,8 @@ fn test_branch_multiple_names() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar foo 8bb159bc30a9
-    ◉   230dd059e1b0
-    ◉   000000000000
+    ○   230dd059e1b0
+    ◆   000000000000
     "###);
 
     let (stdout, stderr) =
@@ -52,8 +52,8 @@ fn test_branch_multiple_names() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   8bb159bc30a9
-    ◉   230dd059e1b0
-    ◉   000000000000
+    ○   230dd059e1b0
+    ◆   000000000000
     "###);
 }
 
@@ -155,12 +155,12 @@ fn test_branch_move_conflicting() {
     );
     insta::assert_snapshot!(get_log(), @r###"
     @  A1
-    ◉  A0 foo??
-    │ ◉  C0
+    ○  A0 foo??
+    │ ○  C0
     ├─╯
-    │ ◉  B0 foo??
+    │ ○  B0 foo??
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Can't move the branch to C0 since it's sibling.
@@ -178,12 +178,12 @@ fn test_branch_move_conflicting() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log(), @r###"
     @  A1 foo
-    ◉  A0
-    │ ◉  C0
+    ○  A0
+    │ ○  C0
     ├─╯
-    │ ◉  B0
+    │ ○  B0
     ├─╯
-    ◉
+    ◆
     "###);
 }
 
@@ -245,7 +245,7 @@ fn test_branch_forget_glob() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1 foo-3 foo-4 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["branch", "forget", "--glob", "foo-[1-3]"]);
@@ -262,7 +262,7 @@ fn test_branch_forget_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-4 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Forgetting a branch via both explicit name and glob pattern, or with
@@ -277,7 +277,7 @@ fn test_branch_forget_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Malformed glob
@@ -327,7 +327,7 @@ fn test_branch_delete_glob() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1 foo-3 foo-4 6fbf398c2d59
-    ◉   000000000000
+    ◆   000000000000
     "###);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["branch", "delete", "--glob", "foo-[1-3]"]);
@@ -344,7 +344,7 @@ fn test_branch_delete_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1@origin foo-3@origin foo-4 6fbf398c2d59
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // We get an error if none of the globs match live branches. Unlike `jj branch
@@ -367,7 +367,7 @@ fn test_branch_delete_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1@origin foo-3@origin foo-4@origin 6fbf398c2d59
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // The deleted branches are still there
@@ -706,10 +706,10 @@ fn test_branch_track_untrack() {
     main@origin: sptzoqmo 7b33f629 commit 1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1@origin feature2@origin main@origin 7b33f6295eda
+    ◆  feature1@origin feature2@origin main@origin 7b33f6295eda
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Track new branch. Local branch should be created.
@@ -754,10 +754,10 @@ fn test_branch_track_untrack() {
       @origin: sptzoqmo 7b33f629 commit 1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1 feature1@origin feature2@origin main 7b33f6295eda
+    ◆  feature1 feature1@origin feature2@origin main 7b33f6295eda
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Fetch new commit. Only tracking branch "main" should be merged.
@@ -785,12 +785,12 @@ fn test_branch_track_untrack() {
       @origin: mmqqkyyt 40dabdaf commit 2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1@origin feature2@origin main 40dabdaf4abe
-    │ ◉  feature1 7b33f6295eda
+    ◆  feature1@origin feature2@origin main 40dabdaf4abe
+    │ ○  feature1 7b33f6295eda
     ├─╯
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Fetch new commit with auto tracking. Tracking branch "main" and new
@@ -824,12 +824,12 @@ fn test_branch_track_untrack() {
       @origin: wwnpyzpo 3f0f86fa commit 3
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1@origin feature2@origin feature3 main 3f0f86fa0e57
-    │ ◉  feature1 7b33f6295eda
+    ◆  feature1@origin feature2@origin feature3 main 3f0f86fa0e57
+    │ ○  feature1 7b33f6295eda
     ├─╯
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 }
 
@@ -1072,16 +1072,16 @@ fn test_branch_list_filtered() {
             &["log", "-r::(branches() | remote_branches())", "-T", template],
         ),
         @r###"
-    ◉  e31634b64294 remote-rewrite*
+    ○  e31634b64294 remote-rewrite*
     │ @  c7b4c09cd77c local-keep
     ├─╯
-    │ ◉  3e9a5af6ef15 remote-rewrite@origin (hidden)
+    │ ○  3e9a5af6ef15 remote-rewrite@origin (hidden)
     ├─╯
-    │ ◉  dad5f298ca57 remote-delete@origin
+    │ ○  dad5f298ca57 remote-delete@origin
     ├─╯
-    │ ◉  911e912015fb remote-keep
+    │ ○  911e912015fb remote-keep
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // All branches are listed by default.

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -52,7 +52,7 @@ fn test_builtin_alias_trunk_matches_main() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
+    ◆  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -64,7 +64,7 @@ fn test_builtin_alias_trunk_matches_master() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 master 45a3aa29
+    ◆  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 master 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -76,7 +76,7 @@ fn test_builtin_alias_trunk_matches_trunk() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 trunk 45a3aa29
+    ◆  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 trunk 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -91,7 +91,7 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
+    ◆  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -107,7 +107,7 @@ fn test_builtin_alias_trunk_override_alias() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 override-trunk 45a3aa29
+    ◆  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 override-trunk 45a3aa29
     │  (empty) description 1
     ~
     "###);
@@ -119,7 +119,7 @@ fn test_builtin_alias_trunk_no_match() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     "###);
@@ -131,7 +131,7 @@ fn test_builtin_alias_trunk_no_match_only_exact() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     "###);

--- a/cli/tests/test_checkout.rs
+++ b/cli/tests/test_checkout.rs
@@ -36,19 +36,19 @@ fn test_checkout() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  05ce7118568d3007efc9163b055f9cb4a6becfde
-    ◉  5c52832c3483e0ace06d047a806024984f28f1d7 second
-    ◉  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
-    ◉  0000000000000000000000000000000000000000
+    ○  5c52832c3483e0ace06d047a806024984f28f1d7 second
+    ○  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Can provide a description
     test_env.jj_cmd_ok(&repo_path, &["checkout", "@--", "-m", "my message"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1191baaf276e3d0b96b1747e885b3a517be80d6f my message
-    │ ◉  5c52832c3483e0ace06d047a806024984f28f1d7 second
+    │ ○  5c52832c3483e0ace06d047a806024984f28f1d7 second
     ├─╯
-    ◉  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
-    ◉  0000000000000000000000000000000000000000
+    ○  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/cli/tests/test_chmod_command.rs
+++ b/cli/tests/test_chmod_command.rs
@@ -57,11 +57,11 @@ fn test_chmod_regular_conflict() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  n
-    ◉ │  x
+    │ ○  n
+    ○ │  x
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
@@ -162,15 +162,15 @@ fn test_chmod_file_dir_deletion_conflicts() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    file_deletion
     ├─╮
-    │ ◉  deletion
-    │ │ ◉  file_dir
+    │ ○  deletion
+    │ │ ×  file_dir
     ╭───┤
-    │ │ ◉  dir
+    │ │ ○  dir
     │ ├─╯
-    ◉ │  file
+    ○ │  file
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     // The file-dir conflict cannot be chmod-ed

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -26,8 +26,8 @@ fn test_commit_with_description_from_cli() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  b88fb4e51bdd
-    ◉  69542c1984c1 first
-    ◉  000000000000
+    ○  69542c1984c1 first
+    ◆  000000000000
     "###);
 }
 
@@ -45,8 +45,8 @@ fn test_commit_with_editor() {
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  3df78bc2b9b5
-    ◉  30a8c2b3d6eb modified
-    ◉  000000000000
+    ○  30a8c2b3d6eb modified
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
@@ -136,11 +136,11 @@ fn test_commit_with_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  8dc0591d00f7
-    ◉  7e780ba80aeb TESTED=TODO
-    ◉  000000000000
-    "#);
+    ○  7e780ba80aeb TESTED=TODO
+    ◆  000000000000
+    "###);
     assert_eq!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(),
         r#"

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -32,11 +32,11 @@ fn test_log_parents() {
     insta::assert_snapshot!(stdout, @r###"
     @    c067170d4ca1bc6162b64f7550617ec809647f84
     ├─╮  P: 2 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉ │  4db490c88528133d579540b6900b8098f0c17701
+    ○ │  4db490c88528133d579540b6900b8098f0c17701
     ├─╯  P: 1 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  P: 1 0000000000000000000000000000000000000000
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
        P: 0
     "###);
 
@@ -46,7 +46,7 @@ fn test_log_parents() {
         &["log", "-T", template, "-r@", "--color=always"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;4m4[0m[38;5;8mdb4[39m [1m[38;5;4m2[0m[38;5;8m30d[39m
+    [1m[38;5;2m@[0m  [1m[38;5;4m4[0m[38;5;8mdb4[39m [1m[38;5;4m2[0m[38;5;8m30d[39m
     │
     ~
     "###);
@@ -89,8 +89,8 @@ fn test_log_author_timestamp() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 04:05:09.000 +07:00
-    ◉  2001-02-03 04:05:07.000 +07:00
-    ◉  1970-01-01 00:00:00.000 +00:00
+    ○  2001-02-03 04:05:07.000 +07:00
+    ◆  1970-01-01 00:00:00.000 +00:00
     "###);
 }
 
@@ -121,7 +121,7 @@ fn test_log_author_timestamp_utc() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().utc()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-02 21:05:07.000 +00:00
-    ◉  1970-01-01 00:00:00.000 +00:00
+    ◆  1970-01-01 00:00:00.000 +00:00
     "###);
 }
 
@@ -136,13 +136,13 @@ fn test_log_author_timestamp_local() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 08:05:07.000 +11:00
-    ◉  1970-01-01 11:00:00.000 +11:00
+    ◆  1970-01-01 11:00:00.000 +11:00
     "###);
     test_env.add_env_var("TZ", "UTC+10:00");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 08:05:07.000 +11:00
-    ◉  1970-01-01 11:00:00.000 +11:00
+    ◆  1970-01-01 11:00:00.000 +11:00
     "###);
 }
 
@@ -170,8 +170,8 @@ fn test_mine_is_true_when_author_is_user() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  johndoe@example.com
-    ◉  mine
-    ◉  (no email set)
+    ○  mine
+    ◆  (no email set)
     "###);
 }
 
@@ -191,19 +191,19 @@ fn test_log_default() {
     insta::assert_snapshot!(stdout, @r###"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-branch 9de54178
     │  (empty) description 1
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 4291e264
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 4291e264
     │  add a file
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
+    [0m○[0m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
     │  add a file
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     // Color without graph
@@ -311,31 +311,32 @@ fn test_log_builtin_templates_colored() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "my-branch"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
+    [0m○[0m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    [0m○[0m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    [0m○[0m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r###"
-    @  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
+    [1m[38;5;2m@[0m  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
     │  Change ID: [38;5;5mrlvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
     │  Branches: [38;5;5mmy-branch[39m
     │  Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 08:05:08[39m)
@@ -343,14 +344,14 @@ fn test_log_builtin_templates_colored() {
     │
     │  [38;5;2m    (no description set)[39m
     │
-    ◉  Commit ID: [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [0m○[0m  Commit ID: [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     │  Change ID: [38;5;5mqpvuntsmwlqtpsluzzsnyyzlmlwvmlnu[39m
     │  Author: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
     │  Committer: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
     │
     │  [38;5;2m    (no description set)[39m
     │
-    ◉  Commit ID: [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;14m◆[0m  Commit ID: [38;5;4m0000000000000000000000000000000000000000[39m
        Change ID: [38;5;5mzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz[39m
        Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
        Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
@@ -373,7 +374,7 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 7a17d52e
     │  description 1
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Create divergence
@@ -383,11 +384,11 @@ fn test_log_obslog_divergence() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 8979953d
+    ○  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 8979953d
     │  description 2
     │ @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 7a17d52e
     ├─╯  description 1
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -396,11 +397,11 @@ fn test_log_obslog_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m8[0m[38;5;8m979953d[39m
+    [0m○[0m  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m8[0m[38;5;8m979953d[39m
     │  description 2
-    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
+    │ [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     ├─╯  [1mdescription 1[0m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     // Obslog and hidden divergent
@@ -408,20 +409,20 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 7a17d52e
     │  description 1
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 3b68ce25
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 3b68ce25
     │  (no description set)
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
 
     // Colored obslog
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
+    [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
     │  [1mdescription 1[0m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
+    [0m○[0m  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
     │  [38;5;3m(no description set)[39m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    [0m○[0m  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     "###);
 }
@@ -476,43 +477,43 @@ fn test_log_branches() {
     let template = r#"commit_id.short() ++ " " ++ if(branches, branches, "(no branches)")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  fed794e2ba44 branch3?? branch3@origin
-    │ ◉  b1bb3766d584 branch3??
+    ○  fed794e2ba44 branch3?? branch3@origin
+    │ ○  b1bb3766d584 branch3??
     ├─╯
-    │ ◉  21c33875443e branch1*
+    │ ○  21c33875443e branch1*
     ├─╯
     │ @  a5b4d15489cc branch2* new-branch
-    │ ◉  8476341eb395 branch2@origin unchanged
+    │ ○  8476341eb395 branch2@origin unchanged
     ├─╯
-    ◉  000000000000 (no branches)
+    ◆  000000000000 (no branches)
     "###);
 
     let template = r#"branches.map(|b| separate("/", b.remote(), b.name())).join(", ")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  branch3, origin/branch3
-    │ ◉  branch3
+    ○  branch3, origin/branch3
+    │ ○  branch3
     ├─╯
-    │ ◉  branch1
+    │ ○  branch1
     ├─╯
     │ @  branch2, new-branch
-    │ ◉  origin/branch2, unchanged
+    │ ○  origin/branch2, unchanged
     ├─╯
-    ◉
+    ◆
     "###);
 
     let template = r#"separate(" ", "L:", local_branches, "R:", remote_branches)"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  L: branch3?? R: branch3@origin
-    │ ◉  L: branch3?? R:
+    ○  L: branch3?? R: branch3@origin
+    │ ○  L: branch3?? R:
     ├─╯
-    │ ◉  L: branch1* R:
+    │ ○  L: branch1* R:
     ├─╯
     │ @  L: branch2* new-branch R:
-    │ ◉  L: unchanged R: branch2@origin unchanged@origin
+    │ ○  L: unchanged R: branch2@origin unchanged@origin
     ├─╯
-    ◉  L: R:
+    ◆  L: R:
     "###);
 }
 
@@ -535,17 +536,17 @@ fn test_log_git_head() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  remote: <Error: No RefName available>
-    ◉  name: HEAD, remote: git
-    ◉  remote: <Error: No RefName available>
+    ○  name: HEAD, remote: git
+    ◆  remote: <Error: No RefName available>
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    [0m○[0m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 }
 
@@ -570,7 +571,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  Q_pvun test.user@example.com 2001-02-03 08:05:08 6_9542
     │  (empty) first
-    ◉  Z_zzzz root() 0_0000
+    ◆  Z_zzzz root() 0_0000
     "###);
 
     // Customize only the change id
@@ -588,7 +589,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 69542c19
     │  (empty) first
-    ◉  ZZZZZZZZ root() 00000000
+    ◆  ZZZZZZZZ root() 00000000
     "###);
 }
 
@@ -615,11 +616,11 @@ fn test_log_immutable() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r::", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  D
-    │ ◉  C
-    │ ◉  B main [immutable]
-    │ ◉  A [immutable]
+    │ ○  C
+    │ ◆  B main [immutable]
+    │ ◆  A [immutable]
     ├─╯
-    ◉  [immutable]
+    ◆  [immutable]
     "###);
 
     // Suppress error that could be detected earlier

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -33,26 +33,26 @@ fn test_concurrent_operation_divergence() {
     // "op log" doesn't merge the concurrent operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  bd72b691e2a8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  bd72b691e2a8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'message 2' --at-op @-
-    │ ◉  aff16879e85e test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ○  aff16879e85e test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │    args: jj describe -m 'message 1'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  message 2
+    ○  message 2
     │ @  message 1
     ├─╯
-    ◉
+    ◆
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -72,14 +72,14 @@ fn test_concurrent_operations_auto_rebase() {
     @  254fed738276 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 123ed18e4c4c0d77428df41112bc02ffc83fb935
     │  args: jj describe -m initial
-    ◉  1a6e7a5002b6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  1a6e7a5002b6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj describe -m initial
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     let op_id_hex = stdout[3..15].to_string();
 
@@ -92,9 +92,9 @@ fn test_concurrent_operations_auto_rebase() {
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  3f06323826b4a293a9ee6d24cc0e07ad2961b5d5 new child
+    ○  3f06323826b4a293a9ee6d24cc0e07ad2961b5d5 new child
     @  d91437157468ec86bbbc9e6a14a60d3e8d1790ac rewritten
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -127,10 +127,10 @@ fn test_concurrent_operations_wc_modified() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
     @  4eb0610031b7cd148ff9f729a673a3f815033170 new child1
-    │ ◉  4b20e61d23ee7d7c4d5e61e11e97c26e716f9c30 new child2
+    │ ○  4b20e61d23ee7d7c4d5e61e11e97c26e716f9c30 new child2
     ├─╯
-    ◉  52c893bf3cd201e215b23e084e8a871244ca14d5 initial
-    ◉  0000000000000000000000000000000000000000
+    ○  52c893bf3cd201e215b23e084e8a871244ca14d5 initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -150,16 +150,16 @@ fn test_concurrent_operations_wc_modified() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription"]);
     insta::assert_snapshot!(stdout, @r###"
     @  snapshot working copy
-    ◉    resolve concurrent operations
+    ○    resolve concurrent operations
     ├─╮
-    ◉ │  new empty commit
-    │ ◉  new empty commit
+    ○ │  new empty commit
+    │ ○  new empty commit
     ├─╯
-    ◉  describe commit cf911c223d3e24e001fc8264d6dbf0610804fc40
-    ◉  snapshot working copy
-    ◉  add workspace 'default'
-    ◉  initialize repo
-    ◉
+    ○  describe commit cf911c223d3e24e001fc8264d6dbf0610804fc40
+    ○  snapshot working copy
+    ○  add workspace 'default'
+    ○  initialize repo
+    ○
     "###);
 }
 
@@ -187,20 +187,20 @@ fn test_concurrent_snapshot_wc_reloadable() {
     @  072711d601c17a74367ab8654d797d1743063208689cafad1bd43581490b4a4180916964824916c5e10d1ecdbaa0763efe79066554959978af0f7ff4b5ed66f0
     │  commit 323b414dd255b51375d7f4392b7b2641ffe4289f
     │  args: jj commit -m 'new child1'
-    ◉  ab6c5b4e16160c48cabbde43a267ee6991b78668695e744b97e2ae150995458e3ea1d553550e2305028b23af62f74270dc86bd8826b36ad7f1fa7e3986cfdaa3
+    ○  ab6c5b4e16160c48cabbde43a267ee6991b78668695e744b97e2ae150995458e3ea1d553550e2305028b23af62f74270dc86bd8826b36ad7f1fa7e3986cfdaa3
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ◉  6454b2aacf0821685fda129124aecd7a379bdc2da9c3f9b5e0d58da24d1300bf6a09806a572aa7040263fbe57d430aa706d9cea1f3356fe042029e53d9faa991
+    ○  6454b2aacf0821685fda129124aecd7a379bdc2da9c3f9b5e0d58da24d1300bf6a09806a572aa7040263fbe57d430aa706d9cea1f3356fe042029e53d9faa991
     │  commit 3d918700494a9895696e955b85fa05eb0d314cc6
     │  args: jj commit -m initial
-    ◉  8ae097b5e512914cd62b7e13b2ce27ded56ced97005b6e0232438f08b067df1272b06ad428984a6d28496df5ae41aa3522c5b54d7588abf76210922345d94b17
+    ○  8ae097b5e512914cd62b7e13b2ce27ded56ced97005b6e0232438f08b067df1272b06ad428984a6d28496df5ae41aa3522c5b54d7588abf76210922345d94b17
     │  snapshot working copy
     │  args: jj commit -m initial
-    ◉  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
+    ○  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
     │  add workspace 'default'
-    ◉  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
+    ○  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
     │  initialize repo
-    ◉  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
     "###);
     let op_log_lines = op_log_stdout.lines().collect_vec();
@@ -229,11 +229,11 @@ fn test_concurrent_snapshot_wc_reloadable() {
     insta::assert_snapshot!(stdout, @r###"
     @  4011424ea0a210a914f869ea3c47d76931598d1d new child2
     │  A child2
-    ◉  e08863ee7a0df688755d3d3126498afdf4f580ad new child1
+    ○  e08863ee7a0df688755d3d3126498afdf4f580ad new child1
     │  A child1
-    ◉  79989e62f8331e69a803058b57bacc264405cb65 initial
+    ○  79989e62f8331e69a803058b57bacc264405cb65 initial
     │  A base
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -813,12 +813,12 @@ fn test_diff_external_tool() {
     │  --
     │  file2
     │  file3
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 39b5a56f
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 39b5a56f
     │  (no description set)
     │  --
     │  file1
     │  file2
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
        --
     "###);
 

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -41,10 +41,10 @@ fn test_duplicate() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    17a00fc21654   c
     ├─╮
-    │ ◉  d370aee184ba   b
-    ◉ │  2443ea76b0b1   a
+    │ ○  d370aee184ba   b
+    ○ │  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "all()"]);
@@ -63,14 +63,14 @@ fn test_duplicate() {
     Duplicated 2443ea76b0b1 as kpqxywon f5b1e687 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  f5b1e68729d6   a
+    ○  f5b1e68729d6   a
     │ @    17a00fc21654   c
     │ ├─╮
-    │ │ ◉  d370aee184ba   b
+    │ │ ○  d370aee184ba   b
     ├───╯
-    │ ◉  2443ea76b0b1   a
+    │ ○  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -82,14 +82,14 @@ fn test_duplicate() {
     Duplicated 17a00fc21654 as lylxulpl ef3b0f3d c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    ef3b0f3d1046   c
+    ○    ef3b0f3d1046   c
     ├─╮
     │ │ @  17a00fc21654   c
     ╭─┬─╯
-    │ ◉  d370aee184ba   b
-    ◉ │  2443ea76b0b1   a
+    │ ○  d370aee184ba   b
+    ○ │  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -108,12 +108,12 @@ fn test_duplicate_many() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
     ├─╮
-    │ ◉  ebd06dba20ec   d
-    │ ◉  c0cb3a0b73e7   c
-    ◉ │  1394f625cbbd   b
+    │ ○  ebd06dba20ec   d
+    │ ○  c0cb3a0b73e7   c
+    ○ │  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b::"]);
@@ -123,18 +123,18 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as mouksmqu 8348ddce e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    8348ddcec733   e
+    ○    8348ddcec733   e
     ├─╮
-    ◉ │  3b74d9691015   b
+    ○ │  3b74d9691015   b
     │ │ @  921dde6e55c0   e
     │ ╭─┤
-    │ ◉ │  ebd06dba20ec   d
-    │ ◉ │  c0cb3a0b73e7   c
+    │ ○ │  ebd06dba20ec   d
+    │ ○ │  c0cb3a0b73e7   c
     ├─╯ │
-    │   ◉  1394f625cbbd   b
+    │   ○  1394f625cbbd   b
     ├───╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     // Try specifying the same commit twice directly
@@ -145,16 +145,16 @@ fn test_duplicate_many() {
     Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  0276d3d7c24d   b
+    ○  0276d3d7c24d   b
     │ @    921dde6e55c0   e
     │ ├─╮
-    │ │ ◉  ebd06dba20ec   d
-    │ │ ◉  c0cb3a0b73e7   c
+    │ │ ○  ebd06dba20ec   d
+    │ │ ○  c0cb3a0b73e7   c
     ├───╯
-    │ ◉  1394f625cbbd   b
+    │ ○  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     // Try specifying the same commit twice indirectly
@@ -167,20 +167,20 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as ztxkyksq 0f7430f2 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    0f7430f2727a   e
+    ○    0f7430f2727a   e
     ├─╮
-    │ ◉  2181781b4f81   d
-    ◉ │  fa167d18a83a   b
+    │ ○  2181781b4f81   d
+    ○ │  fa167d18a83a   b
     │ │ @    921dde6e55c0   e
     │ │ ├─╮
-    │ │ │ ◉  ebd06dba20ec   d
+    │ │ │ ○  ebd06dba20ec   d
     │ ├───╯
-    │ ◉ │  c0cb3a0b73e7   c
+    │ ○ │  c0cb3a0b73e7   c
     ├─╯ │
-    │   ◉  1394f625cbbd   b
+    │   ○  1394f625cbbd   b
     ├───╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -188,12 +188,12 @@ fn test_duplicate_many() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
     ├─╮
-    │ ◉  ebd06dba20ec   d
-    │ ◉  c0cb3a0b73e7   c
-    ◉ │  1394f625cbbd   b
+    │ ○  ebd06dba20ec   d
+    │ ○  c0cb3a0b73e7   c
+    ○ │  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @"");
@@ -203,20 +203,20 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as urrlptpw 9bd4389f e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    9bd4389f5d47   e
+    ○    9bd4389f5d47   e
     ├─╮
-    │ ◉  d94e4c55a68b   d
+    │ ○  d94e4c55a68b   d
     │ │ @  921dde6e55c0   e
     ╭───┤
-    │ │ ◉  ebd06dba20ec   d
+    │ │ ○  ebd06dba20ec   d
     │ ├─╯
-    │ ◉  c0cb3a0b73e7   c
-    ◉ │  1394f625cbbd   b
+    │ ○  c0cb3a0b73e7   c
+    ○ │  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    │ ◉  c6f7f8c4512e   a
+    ○  2443ea76b0b1   a
+    │ ○  c6f7f8c4512e   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Check for BUG -- makes too many 'a'-s, etc.
@@ -231,22 +231,22 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as mvkzkxrl ee8fe64e e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    ee8fe64ed254   e
+    ○    ee8fe64ed254   e
     ├─╮
-    │ ◉  2f2442db08eb   d
-    │ ◉  df53fa589286   c
-    ◉ │  e13ac0adabdf   b
+    │ ○  2f2442db08eb   d
+    │ ○  df53fa589286   c
+    ○ │  e13ac0adabdf   b
     ├─╯
-    ◉  0fe67a05989e   a
+    ○  0fe67a05989e   a
     │ @    921dde6e55c0   e
     │ ├─╮
-    │ │ ◉  ebd06dba20ec   d
-    │ │ ◉  c0cb3a0b73e7   c
-    │ ◉ │  1394f625cbbd   b
+    │ │ ○  ebd06dba20ec   d
+    │ │ ○  c0cb3a0b73e7   c
+    │ ○ │  1394f625cbbd   b
     │ ├─╯
-    │ ◉  2443ea76b0b1   a
+    │ ○  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -260,7 +260,7 @@ fn test_undo_after_duplicate() {
     create_commit(&test_env, &repo_path, "a", &[]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);
@@ -269,10 +269,10 @@ fn test_undo_after_duplicate() {
     Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  f5cefcbb65a4   a
+    ○  f5cefcbb65a4   a
     │ @  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -280,7 +280,7 @@ fn test_undo_after_duplicate() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -297,9 +297,9 @@ fn test_rebase_duplicates() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
     @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
-    ◉  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
-    ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
-    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
+    ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "c"]);
@@ -313,14 +313,14 @@ fn test_rebase_duplicates() {
     Duplicated 7e4fbf4f2759 as znkkpsqq ce5f4eeb c
     "###);
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
-    ◉  ce5f4eeb69d1   c @ 2001-02-03 04:05:16.000 +07:00
-    │ ◉  0ac2063b1bee   c @ 2001-02-03 04:05:15.000 +07:00
+    ○  ce5f4eeb69d1   c @ 2001-02-03 04:05:16.000 +07:00
+    │ ○  0ac2063b1bee   c @ 2001-02-03 04:05:15.000 +07:00
     ├─╯
     │ @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
     ├─╯
-    ◉  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
-    ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
-    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
+    ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "root()"]);
@@ -334,15 +334,15 @@ fn test_rebase_duplicates() {
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
-    ◉  b86e9f27d085   c @ 2001-02-03 04:05:16.000 +07:00
-    │ ◉  8033590fe04d   c @ 2001-02-03 04:05:17.000 +07:00
+    ○  b86e9f27d085   c @ 2001-02-03 04:05:16.000 +07:00
+    │ ○  8033590fe04d   c @ 2001-02-03 04:05:17.000 +07:00
     ├─╯
     │ @  ed671a3cbf35   c @ 2001-02-03 04:05:18.000 +07:00
     ├─╯
-    ◉  4c6f1569e2a9   b @ 2001-02-03 04:05:18.000 +07:00
-    │ ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ○  4c6f1569e2a9   b @ 2001-02-03 04:05:18.000 +07:00
+    │ ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ├─╯
-    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 }
 

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -47,9 +47,9 @@ fn test_edit() {
     "###);
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  b2f7e9c549aa second
+    ○  b2f7e9c549aa second
     @  f41390a5efbf first
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(read_file(&repo_path.join("file1")), @"0");
@@ -58,9 +58,9 @@ fn test_edit() {
     std::fs::write(repo_path.join("file2"), "0").unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  51d937a3eeb4 second
+    ○  51d937a3eeb4 second
     @  409306de8f44 first
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits onto updated working copy

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -58,8 +58,8 @@ fn test_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  3e9369cd54227eb88455e1834dbc08aad6a16ac4
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
@@ -71,8 +71,8 @@ fn test_git_colocated() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  b26951a9c6f5c270e4d039880208952fd5faae5e
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
@@ -83,9 +83,9 @@ fn test_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  9dbb23ff2ff5e66c43880f1042369d704f7a321e
-    ◉  b26951a9c6f5c270e4d039880208952fd5faae5e HEAD@git
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
-    ◉  0000000000000000000000000000000000000000
+    ○  b26951a9c6f5c270e4d039880208952fd5faae5e HEAD@git
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
@@ -120,7 +120,7 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Stage some change, and check out root. This shouldn't clobber the HEAD.
@@ -139,9 +139,9 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  fcdbbd731496cae17161cd6be9b6cf1f759655a8
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    │ ○  1de814dbef9641cc6c5c80d2689b80778edcce09
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Staged change shouldn't persist.
     checkout_index();
@@ -167,10 +167,10 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  76c60bf0a66dcbe74d74d58c23848d96f9e86e84
-    ◉  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 HEAD@git
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    ○  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 HEAD@git
+    │ ○  1de814dbef9641cc6c5c80d2689b80778edcce09
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Staged change shouldn't persist.
     checkout_index();
@@ -196,12 +196,12 @@ fn test_git_colocated_unborn_branch() {
     assert!(git_repo.head().is_err());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  10dd328bb906e15890e55047740eab2812a3b2f7
-    │ ◉  2c576a57d2e6e8494616629cfdbb8fe5e3fea73b
-    │ ◉  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 master
+    │ ○  2c576a57d2e6e8494616629cfdbb8fe5e3fea73b
+    │ ○  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 master
     ├─╯
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    │ ○  1de814dbef9641cc6c5c80d2689b80778edcce09
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Staged change shouldn't persist.
     checkout_index();
@@ -221,13 +221,13 @@ fn test_git_colocated_unborn_branch() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  cab233704a5c0b21bde070943055f22142fb2043
-    ◉  8f5b263819457712a2937428b9c58a2a84afbb1c HEAD@git
-    │ ◉  2c576a57d2e6e8494616629cfdbb8fe5e3fea73b
-    │ ◉  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 master
+    ○  8f5b263819457712a2937428b9c58a2a84afbb1c HEAD@git
+    │ ○  2c576a57d2e6e8494616629cfdbb8fe5e3fea73b
+    │ ○  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 master
     ├─╯
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    │ ○  1de814dbef9641cc6c5c80d2689b80778edcce09
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -246,7 +246,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "foo"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  438471f3fbf1004298d8fb01eeb13663a051a643 foo
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // The branch gets updated when we modify the working copy, and it should get
@@ -254,7 +254,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca foo
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(git_repo
         .find_reference("refs/heads/foo")
@@ -296,8 +296,8 @@ fn test_git_colocated_rebase_on_import() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
     insta::assert_snapshot!(stdout, @r###"
     @  7f96185cfbe36341d0f9a86ebfaeab67a5922c7e
-    ◉  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master HEAD@git add a file
-    ◉  0000000000000000000000000000000000000000
+    ○  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master HEAD@git add a file
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Reset the working copy parent to the new Git HEAD.
@@ -316,10 +316,10 @@ fn test_git_colocated_branches() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-", "-m", "bar"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  3560559274ab431feea00b7b7e0b9250ecce951f bar
-    │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda foo
+    │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda foo
     ├─╯
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Create a branch in jj. It should be exported to Git even though it points to
@@ -350,10 +350,10 @@ fn test_git_colocated_branches() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
     insta::assert_snapshot!(stdout, @r###"
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
-    │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
+    │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Abandoned 1 commits that are no longer reachable.
@@ -373,8 +373,8 @@ fn test_git_colocated_branch_forget() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "foo"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  65b6b74e08973b88d38404430f119c8c79465250 foo
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["branch", "list", "--all-remotes"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -466,10 +466,10 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  4c04960765ca906d0cb25b15a946be4c0dd71b8e new
-    │ ◉  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
+    │ ○  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
     ├─╯
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -493,12 +493,12 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     test_env.jj_cmd_ok(&clone_path, &["new", "A"]);
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
     @  0335878796213c3a701f1c9c34dcae242bee4131
-    │ ◉  8d4e006fd63547965fbc3a26556a9aa531076d32 C_to_move original C
+    │ ○  8d4e006fd63547965fbc3a26556a9aa531076d32 C_to_move original C
     ├─╯
-    │ ◉  929e298ae9edf969b405a304c75c10457c47d52c B_to_delete B_to_delete
+    │ ○  929e298ae9edf969b405a304c75c10457c47d52c B_to_delete B_to_delete
     ├─╯
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A HEAD@git A
-    ◉  0000000000000000000000000000000000000000
+    ○  a86754f975f953fa25da4265764adc0c62e9ce6b A HEAD@git A
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     test_env.jj_cmd_ok(&origin_path, &["branch", "delete", "B_to_delete"]);
@@ -514,11 +514,11 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     // "original C" and "B_to_delete" are abandoned, as the corresponding branches
     // were deleted or moved on the remote (#864)
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
-    ◉  04fd29df05638156b20044b3b6136b42abcb09ab C_to_move moved C
+    ○  04fd29df05638156b20044b3b6136b42abcb09ab C_to_move moved C
     │ @  0335878796213c3a701f1c9c34dcae242bee4131
     ├─╯
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A HEAD@git A
-    ◉  0000000000000000000000000000000000000000
+    ○  a86754f975f953fa25da4265764adc0c62e9ce6b A HEAD@git A
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -561,8 +561,8 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d6c5e66473426f5ed3a24ecce8ce8b44ff23cf81 feature??
-    ◉  5973d3731aba9dd86c00b4a765fbc4cc13f1e14b HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  5973d3731aba9dd86c00b4a765fbc4cc13f1e14b HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // The working-copy content shouldn't be lost.
@@ -584,10 +584,10 @@ fn test_git_colocated_external_checkout() {
     // Checked out anonymous branch
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f8a23336e41840ed1757ef323402a770427dc89a
-    ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
-    │ ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master A
+    ○  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
+    │ ○  a86754f975f953fa25da4265764adc0c62e9ce6b master A
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Check out another branch by external command
@@ -606,10 +606,10 @@ fn test_git_colocated_external_checkout() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
     @  adadbd65a794e2294962b3c3da9aada09fe1b472
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master HEAD@git A
-    │ ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a B
+    ○  a86754f975f953fa25da4265764adc0c62e9ce6b master HEAD@git A
+    │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Reset the working copy parent to the new Git HEAD.
@@ -626,23 +626,23 @@ fn test_git_colocated_squash_undo() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo 8f71e3b6a3be
-    ◉  qpvuntsmwlqt a86754f975f9 A HEAD@git
-    ◉  zzzzzzzzzzzz 000000000000
+    ○  qpvuntsmwlqt a86754f975f9 A HEAD@git
+    ◆  zzzzzzzzzzzz 000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr f0c12b0396d9
-    ◉  qpvuntsmwlqt 2f376ea1478c A HEAD@git
-    ◉  zzzzzzzzzzzz 000000000000
+    ○  qpvuntsmwlqt 2f376ea1478c A HEAD@git
+    ◆  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo 8f71e3b6a3be
-    ◉  qpvuntsmwlqt a86754f975f9 A HEAD@git
-    ◉  zzzzzzzzzzzz 000000000000
+    ○  qpvuntsmwlqt a86754f975f9 A HEAD@git
+    ◆  zzzzzzzzzzzz 000000000000
     "###);
 }
 
@@ -660,8 +660,8 @@ fn test_git_colocated_undo_head_move() {
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  65b6b74e08973b88d38404430f119c8c79465250
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // HEAD should be unset
@@ -669,7 +669,7 @@ fn test_git_colocated_undo_head_move() {
     assert!(git_repo.head().is_err());
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Create commit on non-root commit
@@ -677,9 +677,9 @@ fn test_git_colocated_undo_head_move() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  69b19f73cf584f162f078fb0d91c55ca39d10bc7
-    ◉  eb08b363bb5ef8ee549314260488980d7bbe8f63 HEAD@git
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ○  eb08b363bb5ef8ee549314260488980d7bbe8f63 HEAD@git
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
@@ -697,8 +697,8 @@ fn test_git_colocated_undo_head_move() {
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  eb08b363bb5ef8ee549314260488980d7bbe8f63
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -786,8 +786,8 @@ fn test_git_colocated_unreachable_commits() {
     test_env.jj_cmd_ok(&workspace_root, &["init", "--git-repo", "."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  66ae47cee4f8c28ee8d7e4f5d9401b03c07e22f2
-    ◉  2ee37513d2b5e549f7478c671a780053614bff19 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  2ee37513d2b5e549f7478c671a780053614bff19 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -449,18 +449,18 @@ fn test_git_fetch_all() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Nothing in our repo before the fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
@@ -482,15 +482,15 @@ fn test_git_fetch_all() {
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // ==== Change both repos ====
@@ -498,14 +498,14 @@ fn test_git_fetch_all() {
     let source_log = create_trunk2_and_rebase_branches(&test_env, &source_git_repo_path);
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
-    ◉  babc49226c14 descr_for_b b
-    │ ◉  91e46b4b2653 descr_for_a2 a2
+    ○  babc49226c14 descr_for_b b
+    │ ○  91e46b4b2653 descr_for_a2 a2
     ├─╯
-    │ ◉  0424f6dfc1ff descr_for_a1 a1
+    │ ○  0424f6dfc1ff descr_for_a1 a1
     ├─╯
     @  8f1f14fbbf42 descr_for_trunk2 trunk2
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
     // Change a branch in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -515,15 +515,15 @@ fn test_git_fetch_all() {
 
     // Our repo before and after fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  061eddbb43ab new_descr_for_b_to_create_conflict b*
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  061eddbb43ab new_descr_for_b_to_create_conflict b*
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: nknoxmzm 359a9a02 descr_for_a1
@@ -560,18 +560,18 @@ fn test_git_fetch_all() {
       @origin: umznmzko 8f1f14fb descr_for_trunk2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  babc49226c14 descr_for_b b?? b@origin
-    │ ◉  91e46b4b2653 descr_for_a2 a2
+    ○  babc49226c14 descr_for_b b?? b@origin
+    │ ○  91e46b4b2653 descr_for_a2 a2
     ├─╯
-    │ ◉  0424f6dfc1ff descr_for_a1 a1
+    │ ○  0424f6dfc1ff descr_for_a1 a1
     ├─╯
-    ◉  8f1f14fbbf42 descr_for_trunk2 trunk2
-    │ ◉  061eddbb43ab new_descr_for_b_to_create_conflict b??
+    ○  8f1f14fbbf42 descr_for_trunk2 trunk2
+    │ ○  061eddbb43ab new_descr_for_b_to_create_conflict b??
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -598,12 +598,12 @@ fn test_git_fetch_some_of_many_branches() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Test an error message
@@ -623,7 +623,7 @@ fn test_git_fetch_some_of_many_branches() {
     // Nothing in our repo before the fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // Fetch one branch...
     let (stdout, stderr) =
@@ -633,11 +633,11 @@ fn test_git_fetch_some_of_many_branches() {
     branch: b@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  c7d4bdcbc215 descr_for_b b
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
@@ -655,15 +655,15 @@ fn test_git_fetch_some_of_many_branches() {
     branch: a2@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  decaa3966c83 descr_for_a2 a2
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  decaa3966c83 descr_for_a2 a2
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    │ ◉  c7d4bdcbc215 descr_for_b b
+    │ ○  c7d4bdcbc215 descr_for_b b
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // Fetching the same branch again
     let (stdout, stderr) =
@@ -673,15 +673,15 @@ fn test_git_fetch_some_of_many_branches() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  decaa3966c83 descr_for_a2 a2
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  decaa3966c83 descr_for_a2 a2
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    │ ◉  c7d4bdcbc215 descr_for_b b
+    │ ○  c7d4bdcbc215 descr_for_b b
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // ==== Change both repos ====
@@ -689,14 +689,14 @@ fn test_git_fetch_some_of_many_branches() {
     let source_log = create_trunk2_and_rebase_branches(&test_env, &source_git_repo_path);
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
-    ◉  01d115196c39 descr_for_b b
-    │ ◉  31c7d94b1f29 descr_for_a2 a2
+    ○  01d115196c39 descr_for_b b
+    │ ○  31c7d94b1f29 descr_for_a2 a2
     ├─╯
-    │ ◉  6df2d34cf0da descr_for_a1 a1
+    │ ○  6df2d34cf0da descr_for_a1 a1
     ├─╯
     @  2bb3ebd2bba3 descr_for_trunk2 trunk2
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
     // Change a branch in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -706,15 +706,15 @@ fn test_git_fetch_some_of_many_branches() {
 
     // Our repo before and after fetch of two branches
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
@@ -727,18 +727,18 @@ fn test_git_fetch_some_of_many_branches() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  01d115196c39 descr_for_b b?? b@origin
-    │ ◉  6df2d34cf0da descr_for_a1 a1
+    ○  01d115196c39 descr_for_b b?? b@origin
+    │ ○  6df2d34cf0da descr_for_a1 a1
     ├─╯
-    ◉  2bb3ebd2bba3 descr_for_trunk2
-    │ ◉  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
+    ○  2bb3ebd2bba3 descr_for_trunk2
+    │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
     ├─╯
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // We left a2 where it was before, let's see how `jj branch list` sees this.
@@ -765,18 +765,18 @@ fn test_git_fetch_some_of_many_branches() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  31c7d94b1f29 descr_for_a2 a2
-    │ ◉  01d115196c39 descr_for_b b?? b@origin
+    ○  31c7d94b1f29 descr_for_a2 a2
+    │ ○  01d115196c39 descr_for_b b?? b@origin
     ├─╯
-    │ ◉  6df2d34cf0da descr_for_a1 a1
+    │ ○  6df2d34cf0da descr_for_a1 a1
     ├─╯
-    ◉  2bb3ebd2bba3 descr_for_trunk2
-    │ ◉  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
+    ○  2bb3ebd2bba3 descr_for_trunk2
+    │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: ypowunwp 6df2d34c descr_for_a1
@@ -815,12 +815,12 @@ fn test_git_fetch_undo() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Fetch 2 branches
@@ -834,13 +834,13 @@ fn test_git_fetch_undo() {
     branch: b@origin  [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
@@ -848,7 +848,7 @@ fn test_git_fetch_undo() {
     // The undo works as expected
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // Now try to fetch just one branch
     let (stdout, stderr) =
@@ -858,11 +858,11 @@ fn test_git_fetch_undo() {
     branch: b@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  c7d4bdcbc215 descr_for_b b
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -890,12 +890,12 @@ fn test_fetch_undo_what() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Initial state we will try to return to after `op restore`. There are no
@@ -910,11 +910,11 @@ fn test_fetch_undo_what() {
     branch: b@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  c7d4bdcbc215 descr_for_b b
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b: vpupmnsl c7d4bdcb descr_for_b
@@ -1069,12 +1069,12 @@ fn test_git_fetch_removed_branch() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Fetch all branches
@@ -1087,15 +1087,15 @@ fn test_git_fetch_removed_branch() {
     branch: trunk1@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Remove a2 branch in origin
@@ -1109,15 +1109,15 @@ fn test_git_fetch_removed_branch() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Fetch branches a2 from origin, and check that it has been removed locally
@@ -1129,13 +1129,13 @@ fn test_git_fetch_removed_branch() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -1161,12 +1161,12 @@ fn test_git_fetch_removed_parent_branch() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Fetch all branches
@@ -1179,15 +1179,15 @@ fn test_git_fetch_removed_parent_branch() {
     branch: trunk1@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Remove all branches in origin.
@@ -1209,13 +1209,13 @@ fn test_git_fetch_removed_parent_branch() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -1276,10 +1276,10 @@ fn test_git_fetch_remote_only_branch() {
     test_env.add_config("git.auto-local-branch = false");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  9f01a0e04879 message feature1 feature2@origin
+    ○  9f01a0e04879 message feature1 feature2@origin
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -137,7 +137,7 @@ fn test_git_init_external(bare: bool) {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @r###"
-        ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+        ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
         │  My commit message
         ~
         "###);
@@ -205,7 +205,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -214,7 +214,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -242,7 +242,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -251,7 +251,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -278,7 +278,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -287,7 +287,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -317,7 +317,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -326,7 +326,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -358,7 +358,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -367,7 +367,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -486,10 +486,10 @@ fn test_git_init_colocated_dirty_working_copy() {
     │  A new-staged-file
     │  M some-file
     │  A unstaged-file
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     │  A some-file
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Git index should be consistent with the working copy parent. With the
@@ -525,14 +525,14 @@ fn test_git_init_external_but_git_dir_exists() {
     // The local ".git" repository is unrelated, so no commits should be imported
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###);
@@ -555,7 +555,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -564,7 +564,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -380,11 +380,11 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @r###"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 branch2 my-branch 15dcdaa4
     │  (empty) foo
-    │ ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
+    │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
     ├─╯  (empty) description 2
-    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
+    │ ○  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
     ├─╯  (empty) description 1
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 }
 
@@ -721,13 +721,13 @@ fn test_git_push_deleted() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 branch2 8476341e
+    ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 branch2 8476341e
     │  (empty) description 2
-    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
+    │ ○  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
     ├─╯  (empty) description 1
     │ @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     ├─╯  (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::assert_snapshot!(stdout, @"");

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -178,7 +178,7 @@ fn test_git_remote_named_git() {
     // @git branch shouldn't be removed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbranches"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  main
+    ○  main
     │
     ~
     "###);

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -125,7 +125,7 @@ fn test_ignore_working_copy() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  438471f3fbf1004298d8fb01eeb13663a051a643
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Modify the file. With --ignore-working-copy, we still get the same commit
@@ -141,7 +141,7 @@ fn test_ignore_working_copy() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -304,30 +304,30 @@ fn test_color_config() {
     // Test that --color=always is respected.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that color is used if it's requested in the config file
     test_env.add_config(r#"ui.color="always""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that --color=never overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=never", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Test that --color=auto overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=auto", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Test that --config-toml 'ui.color="never"' overrides the config.
@@ -343,7 +343,7 @@ fn test_color_config() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // --color overrides --config-toml 'ui.color=...'.
@@ -361,15 +361,15 @@ fn test_color_config() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Test that NO_COLOR does NOT override the request for color in the config file
     test_env.add_env_var("NO_COLOR", "");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that per-repo config overrides the user config.
@@ -381,7 +381,7 @@ fn test_color_config() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -30,11 +30,11 @@ fn test_rewrite_immutable_generic() {
     insta::assert_snapshot!(stdout, @r###"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 78ebd449
     │  c
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main c8d4c7ca
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main c8d4c7ca
     ├─╯  b
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 46a8dc51
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 46a8dc51
     │  a
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Cannot rewrite a commit in the configured set
@@ -116,12 +116,12 @@ fn test_rewrite_immutable_commands() {
     insta::assert_snapshot!(stdout, @r###"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 3f89addf
     │  (empty) (no description set)
-    │ ◉  mzvwutvl test.user@example.com 2001-02-03 08:05:11 main 3d14df18 conflict
+    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:11 main 3d14df18 conflict
     ╭─┤  (empty) merge
     │ │
     │ ~
     │
-    ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c8d4c7ca
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c8d4c7ca
     │  b
     ~
     "###);

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -139,7 +139,7 @@ fn test_init_git_external(bare: bool) {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @r###"
-        ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+        ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
         │  My commit message
         ~
         "###);
@@ -207,7 +207,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -216,7 +216,7 @@ fn test_init_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -246,7 +246,7 @@ fn test_init_git_colocated_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -255,7 +255,7 @@ fn test_init_git_colocated_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -284,7 +284,7 @@ fn test_init_git_colocated_symlink_directory() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -293,7 +293,7 @@ fn test_init_git_colocated_symlink_directory() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -325,7 +325,7 @@ fn test_init_git_colocated_symlink_directory_without_bare_config() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -334,7 +334,7 @@ fn test_init_git_colocated_symlink_directory_without_bare_config() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -368,7 +368,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -377,7 +377,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -477,14 +477,14 @@ fn test_init_git_external_but_git_dir_exists() {
     // The local ".git" repository is unrelated, so no commits should be imported
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###);

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -68,8 +68,8 @@ fn test_log_with_or_without_diff() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
-    ◉  add a file
-    ◉
+    ○  add a file
+    ◆
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p"]);
@@ -78,10 +78,10 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ◉  add a file
+    ○  add a file
     │  Added regular file file1:
     │          1: foo
-    ◉
+    ◆
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--no-graph"]);
@@ -98,11 +98,11 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ◉  add a file
+    ○  add a file
     │  A file1
     │  Added regular file file1:
     │          1: foo
-    ◉
+    ◆
     "###);
 
     // `-s` for summary, `--git` for git diff (which implies `-p`)
@@ -117,7 +117,7 @@ fn test_log_with_or_without_diff() {
     │  @@ -1,1 +1,2 @@
     │   foo
     │  +bar
-    ◉  add a file
+    ○  add a file
     │  A file1
     │  diff --git a/file1 b/file1
     │  new file mode 100644
@@ -126,7 +126,7 @@ fn test_log_with_or_without_diff() {
     │  +++ b/file1
     │  @@ -1,0 +1,1 @@
     │  +foo
-    ◉
+    ◆
     "###);
 
     // `-p` enables default "summary" output, so `-s` is noop
@@ -144,9 +144,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
     │  M file1
-    ◉  add a file
+    ○  add a file
     │  A file1
-    ◉
+    ◆
     "###);
 
     // `-p` enables default "color-words" diff output, so `--color-words` is noop
@@ -159,10 +159,10 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ◉  add a file
+    ○  add a file
     │  Added regular file file1:
     │          1: foo
-    ◉
+    ◆
     "###);
 
     // `--git` enables git diff, so `-p` is noop
@@ -215,9 +215,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
     │  M file1
-    ◉  add a file
+    ○  add a file
     │  A file1
-    ◉
+    ◆
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -502,7 +502,7 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
         @r###"
-    ◉  Change qpvuntsmwlqt initial ba1a30916d29 original
+    ○  Change qpvuntsmwlqt initial ba1a30916d29 original
     │
     ~
     "###
@@ -520,17 +520,17 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4m03[0m[38;5;8mf51310b83e[39m
-    ◉  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7fb1909080[39m
-    ◉  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4me7[0m[38;5;8m15ad5db646[39m
-    ◉  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m38[0m[38;5;8m622e54e2e5[39m
-    ◉  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m0cf[0m[38;5;8m42f60199c[39m
-    ◉  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6015e4e622[39m
-    ◉  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m06[0m[38;5;8mf34d9b1475[39m
-    ◉  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4m1f[0m[38;5;8m99a5e19891[39m
-    ◉  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1f7dee65b4[39m
-    ◉  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4mba1[0m[38;5;8ma30916d29[39m [38;5;5moriginal[39m
-    ◉  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4m03[0m[38;5;8mf51310b83e[39m
+    [0m○[0m  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7fb1909080[39m
+    [0m○[0m  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4me7[0m[38;5;8m15ad5db646[39m
+    [0m○[0m  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m38[0m[38;5;8m622e54e2e5[39m
+    [0m○[0m  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m0cf[0m[38;5;8m42f60199c[39m
+    [0m○[0m  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6015e4e622[39m
+    [0m○[0m  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m06[0m[38;5;8mf34d9b1475[39m
+    [0m○[0m  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4m1f[0m[38;5;8m99a5e19891[39m
+    [0m○[0m  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1f7dee65b4[39m
+    [0m○[0m  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4mba1[0m[38;5;8ma30916d29[39m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
     "###
     );
     let stdout = test_env.jj_cmd_success(
@@ -546,17 +546,17 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4m03[0m[38;5;8mf[39m
-    ◉  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7[39m
-    ◉  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4me7[0m[38;5;8m1[39m
-    ◉  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m38[0m[38;5;8m6[39m
-    ◉  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m0cf[0m
-    ◉  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6[39m
-    ◉  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m06[0m[38;5;8mf[39m
-    ◉  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4m1f[0m[38;5;8m9[39m
-    ◉  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1[39m
-    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
-    ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4m03[0m[38;5;8mf[39m
+    [0m○[0m  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7[39m
+    [0m○[0m  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4me7[0m[38;5;8m1[39m
+    [0m○[0m  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m38[0m[38;5;8m6[39m
+    [0m○[0m  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m0cf[0m
+    [0m○[0m  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6[39m
+    [0m○[0m  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m06[0m[38;5;8mf[39m
+    [0m○[0m  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4m1f[0m[38;5;8m9[39m
+    [0m○[0m  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1[39m
+    [0m○[0m  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
     "###
     );
     let stdout = test_env.jj_cmd_success(
@@ -572,17 +572,17 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4m03[0m
-    ◉  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mf7[0m
-    ◉  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4me7[0m
-    ◉  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m38[0m
-    ◉  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4m0cf[0m
-    ◉  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m9e[0m
-    ◉  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m06[0m
-    ◉  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4m1f[0m
-    ◉  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m7b[0m
-    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
-    ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4m03[0m
+    [0m○[0m  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mf7[0m
+    [0m○[0m  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4me7[0m
+    [0m○[0m  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m38[0m
+    [0m○[0m  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4m0cf[0m
+    [0m○[0m  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m9e[0m
+    [0m○[0m  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m06[0m
+    [0m○[0m  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4m1f[0m
+    [0m○[0m  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m7b[0m
+    [0m○[0m  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
     "###
     );
 }
@@ -618,7 +618,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
         @r###"
     @  Change q[pvuntsmwlqt] initial b[a1a30916d29] original
-    ◉  Change z[zzzzzzzzzzz] 0[00000000000]
+    ◆  Change z[zzzzzzzzzzz] 0[00000000000]
     "###
     );
 
@@ -634,9 +634,9 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-T", prefix_format]),
         @r###"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
-    │ ◉  Change qpv[untsmwlqt] initial ba[1a30916d29] original
+    │ ○  Change qpv[untsmwlqt] initial ba[1a30916d29] original
     ├─╯
-    ◉  Change zzz[zzzzzzzzz] 00[0000000000]
+    ◆  Change zzz[zzzzzzzzz] 00[0000000000]
     "###
     );
     insta::assert_snapshot!(
@@ -665,22 +665,22 @@ fn test_log_short_shortest_length_parameter() {
     insta::assert_snapshot!(
         render(r#"commit_id.short(0) ++ "|" ++ commit_id.shortest(0)"#), @r###"
     @  |2
-    ◉  |0
+    ◆  |0
     "###);
     insta::assert_snapshot!(
         render(r#"commit_id.short(-0) ++ "|" ++ commit_id.shortest(-0)"#), @r###"
     @  |2
-    ◉  |0
+    ◆  |0
     "###);
     insta::assert_snapshot!(
         render(r#"commit_id.short(-100) ++ "|" ++ commit_id.shortest(-100)"#), @r###"
     @  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
-    ◉  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
+    ◆  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
     "###);
     insta::assert_snapshot!(
         render(r#"commit_id.short(100) ++ "|" ++ commit_id.shortest(100)"#), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22|230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000|0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000|0000000000000000000000000000000000000000
     "###);
 }
 
@@ -731,7 +731,7 @@ fn test_log_divergence() {
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
     @  description 1
-    ◉
+    ◆
     "###);
 
     // Create divergence
@@ -741,10 +741,10 @@ fn test_log_divergence() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  description 2 !divergence!
+    ○  description 2 !divergence!
     │ @  description 1 !divergence!
     ├─╯
-    ◉
+    ◆
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -762,8 +762,8 @@ fn test_log_reversed() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉
-    ◉  first
+    ◆
+    ○  first
     @  second
     "###);
 
@@ -792,7 +792,7 @@ fn test_log_filtered_by_path() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     @  second
-    ◉  first
+    ○  first
     │
     ~
     "###);
@@ -808,7 +808,7 @@ fn test_log_filtered_by_path() {
     insta::assert_snapshot!(stdout, @r###"
     @  second
     │  M file1
-    ◉  first
+    ○  first
     │  A file1
     ~
     "###);
@@ -840,7 +840,7 @@ fn test_log_filtered_by_path() {
     @  second
     │  M file1
     │  A file2
-    ◉  first
+    ○  first
     │  A file1
     ~
     "###);
@@ -860,7 +860,7 @@ fn test_log_filtered_by_path() {
     insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
     @  second
     │  M repo/file1
-    ◉  first
+    ○  first
     │  A repo/file1
     ~
     "###);
@@ -905,8 +905,8 @@ fn test_log_limit() {
     insta::assert_snapshot!(stdout, @r###"
     @    d
     ├─╮
-    │ ◉  b
-    ◉ │  c
+    │ ○  b
+    ○ │  c
     ├─╯
     "###);
 
@@ -915,7 +915,7 @@ fn test_log_limit() {
     insta::assert_snapshot!(stdout, @r###"
     @    d
     ├─╮
-    │ ◉  b
+    │ ○  b
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -933,10 +933,10 @@ fn test_log_limit() {
         &["log", "-T", "description", "--limit=3", "--reversed"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    ◉
-    ◉    a
+    ◆
+    ○    a
     ├─╮
-    │ ◉  c
+    │ ○  c
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -960,7 +960,7 @@ fn test_log_limit() {
         &["log", "-T", "description", "--limit=1", "b", "c"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    ◉  c
+    ○  c
     │
     ~
     "###);
@@ -1098,7 +1098,7 @@ fn test_multiple_revsets() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches", "-rfoo"]),
         @r###"
-    ◉  foo
+    ○  foo
     │
     ~
     "###);
@@ -1106,15 +1106,15 @@ fn test_multiple_revsets() {
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches", "-rfoo", "-rbar", "-rbaz"]),
         @r###"
     @  baz
-    ◉  bar
-    ◉  foo
+    ○  bar
+    ○  foo
     │
     ~
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches", "-rfoo", "-rfoo"]),
         @r###"
-    ◉  foo
+    ○  foo
     │
     ~
     "###);
@@ -1145,18 +1145,18 @@ fn test_graph_template_color() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  single line
-    ◉  first line
+    ○  first line
     │  second line
     │  third line
-    ◉
+    ◆
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;2msingle line[0m
-    ◉  [38;5;1mfirst line[39m
+    [1m[38;5;2m@[0m  [1m[38;5;2msingle line[0m
+    [0m○[0m  [38;5;1mfirst line[39m
     │  [38;5;1msecond line[39m
     │  [38;5;1mthird line[39m
-    ◉
+    [1m[38;5;14m◆[0m
     "###);
 }
 
@@ -1184,15 +1184,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─╮
-    │ ◉  side branch
+    │ ○  side branch
     │ │  with
     │ │  long
     │ │  description
-    │ ◉  main branch 2
+    │ ○  main branch 2
     ├─╯
-    ◉  main branch 1
-    ◉  initial
-    ◉
+    ○  main branch 1
+    ○  initial
+    ◆
     "###);
 
     // ASCII style
@@ -1209,7 +1209,7 @@ fn test_graph_styles() {
     |/
     o  main branch 1
     o  initial
-    o
+    #
     "###);
 
     // Large ASCII style
@@ -1228,7 +1228,7 @@ fn test_graph_styles() {
     |/
     o  main branch 1
     o  initial
-    o
+    #
     "###);
 
     // Curved style
@@ -1237,15 +1237,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─╮
-    │ ◉  side branch
+    │ ○  side branch
     │ │  with
     │ │  long
     │ │  description
-    │ ◉  main branch 2
+    │ ○  main branch 2
     ├─╯
-    ◉  main branch 1
-    ◉  initial
-    ◉
+    ○  main branch 1
+    ○  initial
+    ◆
     "###);
 
     // Square style
@@ -1254,15 +1254,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─┐
-    │ ◉  side branch
+    │ ○  side branch
     │ │  with
     │ │  long
     │ │  description
-    │ ◉  main branch 2
+    │ ○  main branch 2
     ├─┘
-    ◉  main branch 1
-    ◉  initial
-    ◉
+    ○  main branch 1
+    ○  initial
+    ◆
     "###);
 }
 
@@ -1313,7 +1313,7 @@ fn test_log_word_wrap() {
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r###"
-    @  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
     │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12m6[38;5;8m8518a7e[39m[0m
     ~  [1m[38;5;10m(empty)[39m merge[0m
     "###);
@@ -1325,18 +1325,18 @@ fn test_log_word_wrap() {
     ├─╮  3 4 5
     │ │  6 7 8
     │ │  9
-    │ ◉  0 1 2
+    │ ○  0 1 2
     │ │  3 4 5
     │ │  6 7 8
     │ │  9
-    │ ◉  0 1 2
+    │ ○  0 1 2
     ├─╯  3 4 5
     │    6 7 8
     │    9
-    ◉  0 1 2 3
+    ○  0 1 2 3
     │  4 5 6 7
     │  8 9
-    ◉  0 1 2 3
+    ◆  0 1 2 3
        4 5 6 7
        8 9
     "###);
@@ -1390,17 +1390,17 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("::"), @r###"
     @    merge
     ├─╮
-    │ ◉  side branch 2
+    │ ○  side branch 2
     │ │
-    │ ◉  side branch 1
+    │ ○  side branch 1
     │ │
-    ◉ │  main branch 2
+    ○ │  main branch 2
     │ │
-    ◉ │  main branch 1
+    ○ │  main branch 1
     ├─╯
-    ◉  initial
+    ○  initial
     │
-    ◉
+    ◆
     "###);
 
     // Elide some commits from each side of the merge. It's unclear that a revision
@@ -1409,11 +1409,11 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
     @    merge
     ├─╮
-    │ ◉  side branch 2
+    │ ○  side branch 2
     │ ╷
-    ◉ ╷  main branch 2
+    ○ ╷  main branch 2
     ├─╯
-    ◉  initial
+    ○  initial
     │
     ~
     "###);
@@ -1421,11 +1421,11 @@ fn test_elided() {
     // Elide shared commits. It's unclear that a revision was skipped on the right
     // side (#1252).
     insta::assert_snapshot!(get_log("@-- | root()"), @r###"
-    ◉  side branch 1
+    ○  side branch 1
     ╷
-    ╷ ◉  main branch 1
+    ╷ ○  main branch 1
     ╭─╯
-    ◉
+    ◆
     "###);
 
     // Now test the same thing with synthetic nodes for elided commits
@@ -1435,14 +1435,14 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
     @    merge
     ├─╮
-    │ ◉  side branch 2
+    │ ○  side branch 2
     │ │
-    │ ◌  (elided revisions)
-    ◉ │  main branch 2
+    │ ~  (elided revisions)
+    ○ │  main branch 2
     │ │
-    ◌ │  (elided revisions)
+    ~ │  (elided revisions)
     ├─╯
-    ◉  initial
+    ○  initial
     │
     ~
     "###);
@@ -1450,14 +1450,14 @@ fn test_elided() {
     // Elide shared commits. To keep the implementation simple, it still gets
     // rendered as two synthetic nodes.
     insta::assert_snapshot!(get_log("@-- | root()"), @r###"
-    ◉  side branch 1
+    ○  side branch 1
     │
-    ◌  (elided revisions)
-    │ ◉  main branch 1
+    ~  (elided revisions)
+    │ ○  main branch 1
     │ │
-    │ ◌  (elided revisions)
+    │ ~  (elided revisions)
     ├─╯
-    ◉
+    ◆
     "###);
 }
 

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -56,13 +56,13 @@ fn test_move() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  0d7353584003 f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    ○  e9515f21068c e
+    ○  bdd835cae844 d
+    │ ○  caa4d0b23201 c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
 
     // Errors out without arguments
@@ -95,12 +95,12 @@ fn test_move() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1c03e3d3c63f f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  55171e33db26 b c
+    ○  e9515f21068c e
+    ○  bdd835cae844 d
+    │ ○  55171e33db26 b c
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -127,12 +127,12 @@ fn test_move() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c8d83075e8c2 f
-    ◉  2c50bfc59c68 e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    ○  2c50bfc59c68 e
+    │ ○  caa4d0b23201 c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a d
-    ◉  000000000000
+    ○  3db0a2f5b535 a d
+    ◆  000000000000
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
@@ -156,12 +156,12 @@ fn test_move() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2b723b1d6033 f
-    ◉  4293930d6333 d e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    ○  4293930d6333 d e
+    │ ○  caa4d0b23201 c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2", "-r", "d"]);
@@ -200,11 +200,11 @@ fn test_move_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bdd835cae844 d
-    │ ◉  5028db694b6b c
-    │ ◉  55171e33db26 b
+    │ ○  5028db694b6b c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
 
     let edit_script = test_env.set_up_fake_diff_editor();
@@ -221,10 +221,10 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  71b69e433fbc d
-    │ ◉  55171e33db26 b c
+    │ ○  55171e33db26 b c
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -255,11 +255,11 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  63f1a6e96edb d
-    │ ◉  d027c6e3e6bc c
-    │ ◉  55171e33db26 b
+    │ ○  d027c6e3e6bc c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -292,11 +292,11 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  17c2e6632cc5 d
-    │ ◉  6a3ae047a03e c
-    │ ◉  55171e33db26 b
+    │ ○  6a3ae047a03e c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -327,12 +327,12 @@ fn test_move_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  21253406d416 c
-    ◉  e1cf08aae711 b
+    ○  21253406d416 c
+    ○  e1cf08aae711 b
     │ @  bdd835cae844 d
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -27,29 +27,29 @@ fn test_new() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
-    ◉  0000000000000000000000000000000000000000
+    ○  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Start a new change off of a specific commit (the root commit in this case).
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "off of root", "root()"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ◉  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    │ ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    │ ○  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
+    │ ○  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // --edit is a no-op
     test_env.jj_cmd_ok(&repo_path, &["new", "--edit", "-m", "yet another commit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  101cbec5cae8049cb9850a906ef3675631ed48fa yet another commit
-    ◉  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ◉  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    │ ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    ○  026537ddb96b801b9cb909985d5443aab44616c1 off of root
+    │ ○  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
+    │ ○  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // --edit cannot be used with --no-edit
@@ -80,10 +80,10 @@ fn test_new_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    0c4e5b9b68ae0cbe7ce3c61042619513d09005bf
     ├─╮
-    │ ◉  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
+    ○ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @"a");
@@ -98,12 +98,12 @@ fn test_new_merge() {
     Created new commit znkkpsqq 200ed1a1 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    200ed1a14c8acf09783dafefe5bebf2ff58f12fd
+    ○    200ed1a14c8acf09783dafefe5bebf2ff58f12fd
     ├─╮
     │ @  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    ○ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Same test with `jj merge`
@@ -112,10 +112,10 @@ fn test_new_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    3a44e52b073cbb5deb11bb8fa0763a369e96427a
     ├─╮
-    │ ◉  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
+    ○ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // `jj merge` with less than two arguments is an error
@@ -161,14 +161,14 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // --insert-after can be repeated (this does not affect the outcome); --after is
@@ -194,18 +194,18 @@ fn test_new_insert_after() {
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉  C
-    │ ◉  F
+    ○  C
+    │ ○  F
     ╭─┤
     @ │    G
     ├───╮
-    │ │ ◉  D
-    ◉ │ │  B
-    ◉ │ │  A
+    │ │ ○  D
+    ○ │ │  B
+    ○ │ │  A
     ├───╯
-    │ ◉  E
+    │ ○  E
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) =
@@ -217,19 +217,19 @@ fn test_new_insert_after() {
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉  C
-    │ ◉  F
+    ○  C
+    │ ○  F
     ╭─┤
-    ◉ │    G
+    ○ │    G
     ├───╮
     │ │ @  H
-    │ │ ◉  D
-    ◉ │ │  B
-    ◉ │ │  A
+    │ │ ○  D
+    ○ │ │  B
+    ○ │ │  A
     ├───╯
-    │ ◉  E
+    │ ○  E
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // --after cannot be used with --before
@@ -252,14 +252,14 @@ fn test_new_insert_after_children() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // Check that inserting G after A and C doesn't try to rebase B (which is
@@ -276,17 +276,17 @@ fn test_new_insert_after_children() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
     ├─╮
-    │ ◉  C
-    │ ◉  B
+    │ ○  C
+    │ ○  B
     ├─╯
-    ◉  A
-    │ ◉    F
+    ○  A
+    │ ○    F
     │ ├─╮
-    │ │ ◉  E
+    │ │ ○  E
     ├───╯
-    │ ◉  D
+    │ ○  D
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 }
 
@@ -299,14 +299,14 @@ fn test_new_insert_before() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) =
@@ -320,18 +320,18 @@ fn test_new_insert_before() {
     Parent commit      : kkmpptxz 6041917c B | (empty) B
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉  F
-    │ ◉  C
+    ○  F
+    │ ○  C
     ├─╯
     @      G
     ├─┬─╮
-    │ │ ◉  B
-    │ │ ◉  A
-    │ ◉ │  D
+    │ │ ○  B
+    │ │ ○  A
+    │ ○ │  D
     │ ├─╯
-    ◉ │  E
+    ○ │  E
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 }
 
@@ -344,14 +344,14 @@ fn test_new_insert_before_root_successors() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) =
@@ -363,17 +363,17 @@ fn test_new_insert_before_root_successors() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉    F
+    ○    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
-    │ │ ◉  C
-    │ │ ◉  B
-    │ │ ◉  A
+    │ ○  E
+    ○ │  D
+    │ │ ○  C
+    │ │ ○  B
+    │ │ ○  A
     ├───╯
     @ │  G
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 }
 
@@ -388,14 +388,14 @@ fn test_new_insert_before_no_loop() {
     insta::assert_snapshot!(stdout, @r###"
     @    7705d353bf5d F
     ├─╮
-    │ ◉  41a89ffcbba2 E
-    ◉ │  c9257eff5bf9 D
+    │ ○  41a89ffcbba2 E
+    ○ │  c9257eff5bf9 D
     ├─╯
-    │ ◉  ec18c57d72d8 C
-    │ ◉  6041917ceeb5 B
-    │ ◉  65b1ef43c737 A
+    │ ○  ec18c57d72d8 C
+    │ ○  6041917ceeb5 B
+    │ ○  65b1ef43c737 A
     ├─╯
-    ◉  000000000000 root
+    ◆  000000000000 root
     "###);
 
     let stderr =
@@ -414,14 +414,14 @@ fn test_new_insert_before_no_root_merge() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let stderr =
@@ -440,14 +440,14 @@ fn test_new_insert_before_root() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let stderr =

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -74,10 +74,10 @@ fn test_prev_simple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
@@ -100,11 +100,11 @@ fn test_prev_multiple_without_root() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt
-    ◉  zsuskulnrvyr fourth
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  zsuskulnrvyr fourth
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "2"]);
@@ -146,12 +146,12 @@ fn test_next_parent_has_multiple_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  mzvwutvlkqwt 4
+    ○  mzvwutvlkqwt 4
     @  zsuskulnrvyr 3
-    │ ◉  kkmpptxzrspx 2
-    │ ◉  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    │ ○  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     // --edit is implied since the working copy isn't a leaf commit.
@@ -163,11 +163,11 @@ fn test_next_parent_has_multiple_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt 4
-    ◉  zsuskulnrvyr 3
-    │ ◉  kkmpptxzrspx 2
-    │ ◉  qpvuntsmwlqt 1
+    ○  zsuskulnrvyr 3
+    │ ○  kkmpptxzrspx 2
+    │ ○  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -187,14 +187,14 @@ fn test_next_with_merge_commit_parent() {
     test_env.jj_cmd_ok(&repo_path, &["prev", "0"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  royxmykxtrkr
-    │ ◉  mzvwutvlkqwt 4
+    │ ○  mzvwutvlkqwt 4
     ├─╯
-    ◉    zsuskulnrvyr 3
+    ○    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
@@ -205,13 +205,13 @@ fn test_next_with_merge_commit_parent() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  vruxwmqvtpmx
-    ◉  mzvwutvlkqwt 4
-    ◉    zsuskulnrvyr 3
+    ○  mzvwutvlkqwt 4
+    ○    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -230,13 +230,13 @@ fn test_next_on_merge_commit() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  mzvwutvlkqwt 4
+    ○  mzvwutvlkqwt 4
     @    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     // --edit is implied since the working copy is not a leaf commit.
@@ -248,12 +248,12 @@ fn test_next_on_merge_commit() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt 4
-    ◉    zsuskulnrvyr 3
+    ○    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -349,10 +349,10 @@ fn test_prev_on_merge_commit() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    royxmykxtrkr
     ├─╮
-    │ ◉  zsuskulnrvyr right second
-    ◉ │  qpvuntsmwlqt left first
+    │ ○  zsuskulnrvyr right second
+    ○ │  qpvuntsmwlqt left first
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
@@ -398,14 +398,14 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    royxmykxtrkr M
     ├─╮
-    │ ◉  mzvwutvlkqwt 1
-    ◉ │    zsuskulnrvyr z
+    │ ○  mzvwutvlkqwt 1
+    ○ │    zsuskulnrvyr z
     ├───╮
-    │ │ ◉  kkmpptxzrspx y
+    │ │ ○  kkmpptxzrspx y
     │ ├─╯
-    ◉ │  qpvuntsmwlqt x
+    ○ │  qpvuntsmwlqt x
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev"], "2\n");
@@ -455,14 +455,14 @@ fn test_prev_prompts_on_multiple_parents() {
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  vruxwmqvtpmx
-    ◉      yqosqzytrlsw merge
+    ○      yqosqzytrlsw merge
     ├─┬─╮
-    │ │ ◉  qpvuntsmwlqt first
-    │ ◉ │  kkmpptxzrspx second
+    │ │ ○  qpvuntsmwlqt first
+    │ ○ │  kkmpptxzrspx second
     │ ├─╯
-    ◉ │  mzvwutvlkqwt third
+    ○ │  mzvwutvlkqwt third
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     // Move @ backwards.
@@ -492,11 +492,11 @@ fn test_prev_beyond_root_fails() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt
-    ◉  zsuskulnrvyr fourth
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  zsuskulnrvyr fourth
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
     // @- is at "fourth", and there is no parent 5 commits behind it.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "5"]);
@@ -520,10 +520,10 @@ fn test_prev_editing() {
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr fourth
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit"]);

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -31,24 +31,24 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
        (empty) my description
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
     │  [1mmy description[0m
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4meb[0m[38;5;8mc23d4b[39m [38;5;1mconflict[39m
+    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4meb[0m[38;5;8mc23d4b[39m [38;5;1mconflict[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m6f[0m[38;5;8mbba7bc[39m
+    [0m○[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m6f[0m[38;5;8mbba7bc[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mea[0m[38;5;8mc0d0da[39m
+    [0m○[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mea[0m[38;5;8mc0d0da[39m
        [38;5;2m(empty)[39m my description
     "###);
 
@@ -66,16 +66,16 @@ fn test_obslog_with_or_without_diff() {
     │     5     : foo
     │     6     : bar
     │     7     : >>>>>>>
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
        (empty) my description
     "###);
 
@@ -84,7 +84,7 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 ebc23d4b conflict
     │  my description
     "###);
 
@@ -196,14 +196,14 @@ fn test_obslog_word_wrap() {
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 69542c19
     │  (empty) first
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
     @  qpvuntsm test.user@example.com
     │  2001-02-03 08:05:08 69542c19
     │  (empty) first
-    ◉  qpvuntsm hidden test.user@example.com
+    ○  qpvuntsm hidden test.user@example.com
        2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
@@ -240,25 +240,25 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉    qpvuntsm test.user@example.com 2001-02-03 08:05:10 27e721a5
+    ○    qpvuntsm test.user@example.com 2001-02-03 08:05:10 27e721a5
     ├─╮  squashed
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 9764e503
+    ○ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 9764e503
     │ │  first
     │ │  Added regular file file1:
     │ │          1: foo
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 69542c19
+    ○ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 69542c19
     │ │  (empty) first
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
       │  (empty) (no description set)
-      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 f09a3889
+      ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 f09a3889
       │  second
       │  Modified regular file file1:
       │     1    1: foo
       │          2: bar
-      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 57996536
+      ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 57996536
          (empty) second
     "###);
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -39,11 +39,11 @@ fn test_op_log() {
     @  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     let op_log_lines = stdout.lines().collect_vec();
     let add_workspace_id = op_log_lines[3].split(' ').nth(2).unwrap();
@@ -51,21 +51,21 @@ fn test_op_log() {
 
     // Can load the repo at a specific operation ID
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, initialize_repo_id), @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, add_workspace_id), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // "@" resolves to the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@"), @r###"
     @  bc8f18aa6f396a93572811632313cbb5625d475d
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // "@-" resolves to the parent of the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@-"), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "@----"]), @r###"
@@ -94,12 +94,44 @@ fn test_op_log() {
 }
 
 #[test]
+fn test_op_log_default_ascii_symbols() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
+
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "op",
+            "log",
+            "--config-toml",
+            concat!(
+                "template-aliases.'format_time_range(x)' = 'x'\n",
+                "ui.graph.style = 'ascii'\n",
+            ),
+        ],
+    );
+    insta::assert_snapshot!(&stdout, @r###"
+    @  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    |  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    |  args: jj describe -m 'description 0'
+    o  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    |  add workspace 'default'
+    o  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    |  initialize repo
+    o  000000000000 root()
+    "###);
+}
+
+#[test]
 fn test_op_log_with_custom_symbols() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
     let repo_path = test_env.env_root().join("repo");
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
 
+    // Custom symbols.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -121,6 +153,31 @@ fn test_op_log_with_custom_symbols() {
     ┝  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
     ┴  000000000000 root()
+    "###);
+
+    // Custom symbols, ascii.
+    let stdout = test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "op",
+            "log",
+            "--config-toml",
+            concat!(
+                "template-aliases.'format_time_range(x)' = 'x'\n",
+                "ui.graph.style = 'ascii'\n",
+                "templates.op_log_node = 'if(current_operation, \"v\", if(root, \"^\", \">\"))'",
+            ),
+        ],
+    );
+    insta::assert_snapshot!(&stdout, @r###"
+    v  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    |  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    |  args: jj describe -m 'description 0'
+    >  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    |  add workspace 'default'
+    >  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    |  initialize repo
+    ^  000000000000 root()
     "###);
 }
 
@@ -209,22 +266,22 @@ fn test_op_log_template() {
 
     insta::assert_snapshot!(render(r#"id ++ "\n""#), @r###"
     @  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
-    ◉  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
-    ◉  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    ○  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
+    ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
                                 time.start(), time.end(), time.duration()) ++ "\n""#), @r###"
     @  b5141 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
-    ◉  9a7d8 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
-    ◉  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
+    ○  9a7d8 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+    ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
     "###);
 
     // Negative length shouldn't cause panic.
     insta::assert_snapshot!(render(r#"id.short(-1) ++ "|""#), @r###"
     @  <Error: out of range integral type conversion attempted>|
-    ◉  <Error: out of range integral type conversion attempted>|
-    ◉  <Error: out of range integral type conversion attempted>|
+    ○  <Error: out of range integral type conversion attempted>|
+    ○  <Error: out of range integral type conversion attempted>|
     "###);
 
     // Test the default template, i.e. with relative start time and duration. We
@@ -241,9 +298,9 @@ fn test_op_log_template() {
     insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r###"
     @  b51416386f26 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com NN years ago, lasted less than a microsecond
+    ○  9a7d829846af test-username@host.example.com NN years ago, lasted less than a microsecond
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 }
 
@@ -311,9 +368,9 @@ fn test_op_log_word_wrap() {
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @r###"
     @  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @r###"
     @  b51416386f26
@@ -321,12 +378,12 @@ fn test_op_log_word_wrap() {
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af
+    ○  9a7d829846af
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 }
 
@@ -362,14 +419,14 @@ fn test_op_abandon_ancestors() {
     @  de138472a722 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit a8ac27b29a157ae7dabc0deb524df68823505730
     │  args: jj commit -m 'commit 2'
-    ◉  652e5aecc9f7 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  652e5aecc9f7 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj commit -m 'commit 1'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Abandon old operations. The working-copy operation id should be updated.
@@ -386,7 +443,7 @@ fn test_op_abandon_ancestors() {
     @  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit a8ac27b29a157ae7dabc0deb524df68823505730
     │  args: jj commit -m 'commit 2'
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Abandon operation range.
@@ -401,10 +458,10 @@ fn test_op_abandon_ancestors() {
     @  70112b4447b6 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit e184d62c9ab118b0f62de91959b857550a9273a5
     │  args: jj commit -m 'commit 5'
-    ◉  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit a8ac27b29a157ae7dabc0deb524df68823505730
     │  args: jj commit -m 'commit 2'
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Can't abandon the current operation.
@@ -435,10 +492,10 @@ fn test_op_abandon_ancestors() {
     @  445e93662d71 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     │  undo operation 70112b4447b65fa811038b2b119fe22e959e3b3194b461a32475f6528c2b684ac6baebc86cce7ad7e0bb92c033852850e561506508ca43e823626f107e81ed76
     │  args: jj undo
-    ◉  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit a8ac27b29a157ae7dabc0deb524df68823505730
     │  args: jj commit -m 'commit 2'
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Abandon empty range.

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -28,28 +28,28 @@ fn test_parallelize_no_descendants() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  b911505e443e 6
-    ◉  2e00cb15c7b6 5
-    ◉  9df3c87db1a2 4
-    ◉  9f5b59fa4622 3
-    ◉  d826910d21fb 2
-    ◉  dc0e5d6135ce 1
-    ◉  000000000000
+    ○  2e00cb15c7b6 5
+    ○  9df3c87db1a2 4
+    ○  9f5b59fa4622 3
+    ○  d826910d21fb 2
+    ○  dc0e5d6135ce 1
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  6c7b60a45eb6 6
-    │ ◉  296f48966777 5
+    │ ○  296f48966777 5
     ├─╯
-    │ ◉  524062469789 4
+    │ ○  524062469789 4
     ├─╯
-    │ ◉  a9334ecaa379 3
+    │ ○  a9334ecaa379 3
     ├─╯
-    │ ◉  3a7b37ebe843 2
+    │ ○  3a7b37ebe843 2
     ├─╯
-    │ ◉  761e67df44b7 1
+    │ ○  761e67df44b7 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -66,12 +66,12 @@ fn test_parallelize_with_descendants_simple() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  b911505e443e 6
-    ◉  2e00cb15c7b6 5
-    ◉  9df3c87db1a2 4
-    ◉  9f5b59fa4622 3
-    ◉  d826910d21fb 2
-    ◉  dc0e5d6135ce 1
-    ◉  000000000000
+    ○  2e00cb15c7b6 5
+    ○  9df3c87db1a2 4
+    ○  9f5b59fa4622 3
+    ○  d826910d21fb 2
+    ○  dc0e5d6135ce 1
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(
@@ -80,16 +80,16 @@ fn test_parallelize_with_descendants_simple() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  f28f986c7134 6
-    ◉        21e9963ac5ff 5
+    ○        21e9963ac5ff 5
     ├─┬─┬─╮
-    │ │ │ ◉  524062469789 4
-    │ │ ◉ │  a9334ecaa379 3
+    │ │ │ ○  524062469789 4
+    │ │ ○ │  a9334ecaa379 3
     │ │ ├─╯
-    │ ◉ │  3a7b37ebe843 2
+    │ ○ │  3a7b37ebe843 2
     │ ├─╯
-    ◉ │  761e67df44b7 1
+    ○ │  761e67df44b7 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -109,31 +109,31 @@ fn test_parallelize_where_interior_has_non_target_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(5)", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  d27ee705f7a9 6
-    ◉  2e00cb15c7b6 5
-    ◉  9df3c87db1a2 4
-    ◉  9f5b59fa4622 3
-    │ ◉  9c8865930f3c 2c
+    ○  2e00cb15c7b6 5
+    ○  9df3c87db1a2 4
+    ○  9f5b59fa4622 3
+    │ ○  9c8865930f3c 2c
     ├─╯
-    ◉  d826910d21fb 2
-    ◉  dc0e5d6135ce 1
-    ◉  000000000000
+    ○  d826910d21fb 2
+    ○  dc0e5d6135ce 1
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "dc0::9df"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9f1bec0d6c46 6
-    ◉        7dd2f5648395 5
+    ○        7dd2f5648395 5
     ├─┬─┬─╮
-    │ │ │ ◉  b8f977c12383 4
-    │ │ ◉ │  7be8374575b9 3
+    │ │ │ ○  b8f977c12383 4
+    │ │ ○ │  7be8374575b9 3
     │ │ ├─╯
-    │ │ │ ◉  679fc870858c 2c
+    │ │ │ ○  679fc870858c 2c
     ╭─┬───╯
-    │ ◉ │  96ce11389312 2
+    │ ○ │  96ce11389312 2
     │ ├─╯
-    ◉ │  2bfe3fe3e472 1
+    ○ │  2bfe3fe3e472 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -150,27 +150,27 @@ fn test_parallelize_where_root_has_non_target_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m=4"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  7636b3f489f4 4
-    ◉  9f5b59fa4622 3
-    ◉  d826910d21fb 2
-    │ ◉  50e2ced81124 1c
+    ○  9f5b59fa4622 3
+    ○  d826910d21fb 2
+    │ ○  50e2ced81124 1c
     ├─╯
-    ◉  dc0e5d6135ce 1
-    ◉  000000000000
+    ○  dc0e5d6135ce 1
+    ◆  000000000000
     "###);
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(3)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    ◉  ad35c9caf4fb 1c
+    ○  ad35c9caf4fb 1c
     │ @    6ee674074e23 4
     ╭─┼─╮
-    │ │ ◉  5bd049136a7c 3
-    │ ◉ │  60f737a5a4a7 2
+    │ │ ○  5bd049136a7c 3
+    │ ○ │  60f737a5a4a7 2
     │ ├─╯
-    ◉ │  79ebcd81a1ee 1
+    ○ │  79ebcd81a1ee 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -193,14 +193,14 @@ fn test_parallelize_with_merge_commit_child() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m", "4"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  90a65779e2ec 4
-    ◉  9f5b59fa4622 3
-    │ ◉  a01c1fad8506 2a-c
+    ○  9f5b59fa4622 3
+    │ ○  a01c1fad8506 2a-c
     ╭─┤
-    │ ◉  1eb902150bb9 a
-    ◉ │  d826910d21fb 2
-    ◉ │  dc0e5d6135ce 1
+    │ ○  1eb902150bb9 a
+    ○ │  d826910d21fb 2
+    ○ │  dc0e5d6135ce 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // After this finishes, child-2a will have three parents: "1", "2", and "a".
@@ -211,16 +211,16 @@ fn test_parallelize_with_merge_commit_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @      5a0dd49510d1 4
     ├─┬─╮
-    │ │ ◉  a9334ecaa379 3
-    │ │ │ ◉  605371712469 2a-c
+    │ │ ○  a9334ecaa379 3
+    │ │ │ ○  605371712469 2a-c
     ╭─┬───┤
-    │ │ │ ◉  1eb902150bb9 a
+    │ │ │ ○  1eb902150bb9 a
     │ │ ├─╯
-    │ ◉ │  3a7b37ebe843 2
+    │ ○ │  3a7b37ebe843 2
     │ ├─╯
-    ◉ │  761e67df44b7 1
+    ○ │  761e67df44b7 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -236,9 +236,9 @@ fn test_parallelize_failure_disconnected_target_commits() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9f5b59fa4622 3
-    ◉  d826910d21fb 2
-    ◉  dc0e5d6135ce 1
-    ◉  000000000000
+    ○  d826910d21fb 2
+    ○  dc0e5d6135ce 1
+    ◆  000000000000
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_failure(
@@ -264,12 +264,12 @@ fn test_parallelize_head_is_a_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    1a8db14a8cf0 merged-head
     ├─╮
-    │ ◉  401e43e9461f b
-    │ ◉  66ea2ab19a70 a
-    ◉ │  d826910d21fb 2
-    ◉ │  dc0e5d6135ce 1
+    │ ○  401e43e9461f b
+    │ ○  66ea2ab19a70 a
+    ○ │  d826910d21fb 2
+    ○ │  dc0e5d6135ce 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_failure(&workspace_path,&["parallelize", "description(1)::"]),
@@ -292,12 +292,12 @@ fn test_parallelize_interior_target_is_a_merge() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  299099c22761 3
-    ◉    0c4da981fc0a 2
+    ○    0c4da981fc0a 2
     ├─╮
-    │ ◉  6d37472c632c a
-    ◉ │  dc0e5d6135ce 1
+    │ ○  6d37472c632c a
+    ○ │  dc0e5d6135ce 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_failure(&workspace_path,&["parallelize", "description(1)::"]),
@@ -321,13 +321,13 @@ fn test_parallelize_root_is_a_merge() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9f66b50aa1f2 3
-    ◉  dd995ce87f21 2
-    ◉    4b4941342e06 1
+    ○  dd995ce87f21 2
+    ○    4b4941342e06 1
     ├─╮
-    │ ◉  4035b23c8f72 x
-    ◉ │  f3ec359cf9ff y
+    │ ○  4035b23c8f72 x
+    ○ │  f3ec359cf9ff y
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(
@@ -337,14 +337,14 @@ fn test_parallelize_root_is_a_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    4e81469adb0d 3
     ├─╮
-    │ ◉    38945baf55f4 2
+    │ ○    38945baf55f4 2
     │ ├─╮
-    ◉ │ │  9b1a1927720c 1
+    ○ │ │  9b1a1927720c 1
     ╰─┬─╮
-      │ ◉  4035b23c8f72 x
-      ◉ │  f3ec359cf9ff y
+      │ ○  4035b23c8f72 x
+      ○ │  f3ec359cf9ff y
       ├─╯
-      ◉  000000000000
+      ◆  000000000000
     "###);
 }
 
@@ -358,20 +358,20 @@ fn test_parallelize_multiple_heads() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  8314addde180 2
-    │ ◉  a915696cf0ad 1
+    │ ○  a915696cf0ad 1
     ├─╯
-    ◉  a56846756248 0
-    ◉  000000000000
+    ○  a56846756248 0
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(0)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  e84481c26195 2
-    │ ◉  2047527ade93 1
+    │ ○  2047527ade93 1
     ├─╯
-    │ ◉  9d0c0750973c 0
+    │ ○  9d0c0750973c 0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -388,10 +388,10 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  8314addde180 2
-    │ ◉  a915696cf0ad 1
+    │ ○  a915696cf0ad 1
     ├─╯
-    ◉  a56846756248 0
-    ◉  000000000000
+    ○  a56846756248 0
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(
@@ -400,10 +400,10 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  49fe9e130d15 2
-    ◉  9d0c0750973c 0
-    │ ◉  2047527ade93 1
+    ○  9d0c0750973c 0
+    │ ○  2047527ade93 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -421,25 +421,25 @@ fn test_parallelize_multiple_roots() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  299099c22761 3
-    ◉    0c4da981fc0a 2
+    ○    0c4da981fc0a 2
     ├─╮
-    │ ◉  6d37472c632c a
-    ◉ │  dc0e5d6135ce 1
+    │ ○  6d37472c632c a
+    ○ │  dc0e5d6135ce 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Succeeds because the roots have the same parents.
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "root().."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  3c90598481cd 3
-    │ ◉  b96aa55582e5 2
+    │ ○  b96aa55582e5 2
     ├─╯
-    │ ◉  3178394e33e7 a
+    │ ○  3178394e33e7 a
     ├─╯
-    │ ◉  1d9a0895e7d6 1
+    │ ○  1d9a0895e7d6 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -457,14 +457,14 @@ fn test_parallelize_failure_multiple_heads_with_different_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=c"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9b5fa4b364d4
-    ◉  7b095ae9b21f c
-    ◉  5164ab888473 b
-    ◉  f16fe8ac5ce9 a
-    │ ◉  9f5b59fa4622 3
-    │ ◉  d826910d21fb 2
-    │ ◉  dc0e5d6135ce 1
+    ○  7b095ae9b21f c
+    ○  5164ab888473 b
+    ○  f16fe8ac5ce9 a
+    │ ○  9f5b59fa4622 3
+    │ ○  d826910d21fb 2
+    │ ○  dc0e5d6135ce 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     insta::assert_snapshot!(
@@ -497,12 +497,12 @@ fn test_parallelize_failure_multiple_roots_with_different_parents() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    1a8db14a8cf0 merged-head
     ├─╮
-    │ ◉  401e43e9461f b
-    │ ◉  66ea2ab19a70 a
-    ◉ │  d826910d21fb 2
-    ◉ │  dc0e5d6135ce 1
+    │ ○  401e43e9461f b
+    │ ○  66ea2ab19a70 a
+    ○ │  d826910d21fb 2
+    ○ │  dc0e5d6135ce 1
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     insta::assert_snapshot!(
@@ -529,19 +529,19 @@ fn test_parallelize_complex_nonlinear_target() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3c", "description(3)"]);
     insta::assert_snapshot!(get_log_output_with_parents(&test_env, &workspace_path), @r###"
     @  b043eb81416c 3c parents: 3
-    │ ◉    48277ee9afe0 4 parents: 3 2 1
+    │ ○    48277ee9afe0 4 parents: 3 2 1
     ╭─┼─╮
-    ◉ │ │  944922f0c69f 3 parents: 0
-    │ │ │ ◉  9d28e8e38435 2c parents: 2
+    ○ │ │  944922f0c69f 3 parents: 0
+    │ │ │ ○  9d28e8e38435 2c parents: 2
     │ ├───╯
-    │ ◉ │  97d7522f40e8 2 parents: 0
+    │ ○ │  97d7522f40e8 2 parents: 0
     ├─╯ │
-    │ ◉ │  6c82c22a5e35 1c parents: 1
+    │ ○ │  6c82c22a5e35 1c parents: 1
     │ ├─╯
-    │ ◉  0c058af014a6 1 parents: 0
+    │ ○  0c058af014a6 1 parents: 0
     ├─╯
-    ◉  745bea8029c1 0 parents:
-    ◉  000000000000 parents:
+    ○  745bea8029c1 0 parents:
+    ◆  000000000000 parents:
     "###);
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
@@ -556,20 +556,20 @@ fn test_parallelize_complex_nonlinear_target() {
     insta::assert_snapshot!(get_log_output_with_parents(&test_env, &workspace_path), @r###"
     @    d193f3b72495 3c parents: 0 3
     ├─╮
-    │ ◉  cb9447869bf0 3 parents:
-    │ │ ◉  80fbafb56917 2c parents: 0 2
+    │ ○  cb9447869bf0 3 parents:
+    │ │ ○  80fbafb56917 2c parents: 0 2
     ╭───┤
-    │ │ ◉  8f4b8ef68676 2 parents:
+    │ │ ○  8f4b8ef68676 2 parents:
     │ ├─╯
-    │ │ ◉  1985e0427139 1c parents: 0 1
+    │ │ ○  1985e0427139 1c parents: 0 1
     ╭───┤
-    │ │ ◉  82918d78c984 1 parents:
+    │ │ ○  82918d78c984 1 parents:
     │ ├─╯
-    ◉ │  cbb4e1692ef4 0 parents:
+    ○ │  cbb4e1692ef4 0 parents:
     ├─╯
-    │ ◉  14ca4df576b3 4 parents:
+    │ ○  14ca4df576b3 4 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###)
 }
 

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -116,13 +116,13 @@ fn test_rebase_branch() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ◉  d
-    │ │ ◉  c
+    │ ○  d
+    │ │ ○  c
     │ ├─╯
-    │ ◉  b
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "e"]);
@@ -131,13 +131,13 @@ fn test_rebase_branch() {
     Rebased 3 commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  d
-    │ ◉  c
+    ○  d
+    │ ○  c
     ├─╯
-    ◉  b
+    ○  b
     @  e
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Test rebasing multiple branches at once
@@ -153,13 +153,13 @@ fn test_rebase_branch() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ◉  d
+    │ ○  d
     ├─╯
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  b
-    ◉  a
-    ◉
+    ○  b
+    ○  a
+    ◆
     "###);
 
     // Same test but with more than one revision per argument
@@ -183,13 +183,13 @@ fn test_rebase_branch() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ◉  d
+    │ ○  d
     ├─╯
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  b
-    ◉  a
-    ◉
+    ○  b
+    ○  a
+    ◆
     "###);
 }
 
@@ -208,13 +208,13 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  d
-    │ ◉  c
-    │ │ ◉  b
+    │ ○  d
+    │ ○  c
+    │ │ ○  b
     ├───╯
-    ◉ │  a
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
@@ -229,12 +229,12 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  d
-    │ ◉  c
-    │ ◉  b
+    │ ○  d
+    │ ○  c
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -250,12 +250,12 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  d
-    │ ◉  c
-    │ ◉  b
+    │ ○  d
+    │ ○  c
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 }
 
@@ -272,12 +272,12 @@ fn test_rebase_single_revision() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Descendants of the rebased commit "b" should be rebased onto parents. First
@@ -295,12 +295,12 @@ fn test_rebase_single_revision() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  b
+    ○  b
     │ @  d
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -316,14 +316,14 @@ fn test_rebase_single_revision() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  c
+    ○  c
     │ @    d
     │ ├─╮
-    │ │ ◉  a
+    │ │ ○  a
     ├───╯
-    │ ◉  b
+    │ ○  b
     ├─╯
-    ◉
+    ◆
     "###);
 }
 
@@ -341,11 +341,11 @@ fn test_rebase_single_revision_merge_parent() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    d
     ├─╮
-    │ ◉  c
-    │ ◉  b
-    ◉ │  a
+    │ ○  c
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Descendants of the rebased commit should be rebased onto parents, and if
@@ -360,13 +360,13 @@ fn test_rebase_single_revision_merge_parent() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  c
+    ○  c
     │ @  d
     ╭─┤
-    ◉ │  a
-    │ ◉  b
+    ○ │  a
+    │ ○  b
     ├─╯
-    ◉
+    ◆
     "###);
 }
 
@@ -384,11 +384,11 @@ fn test_rebase_revision_onto_descendant() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    merge
     ├─╮
-    │ ◉  a
-    ◉ │  b
+    │ ○  a
+    ○ │  b
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -403,13 +403,13 @@ fn test_rebase_revision_onto_descendant() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  base
+    ○  base
     │ @  merge
     ╭─┤
-    ◉ │  a
-    │ ◉  b
+    ○ │  a
+    │ ○  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Now, let's rebase onto the descendant merge
@@ -431,13 +431,13 @@ fn test_rebase_revision_onto_descendant() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  base
+    ○  base
     @    merge
     ├─╮
-    │ ◉  a
-    ◉ │  b
+    │ ○  a
+    ○ │  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     // TODO(ilyagr): These will be good tests for `jj rebase --insert-after` and
@@ -456,11 +456,11 @@ fn test_rebase_multiple_destinations() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    │ ◉  b
+    │ ○  b
     ├─╯
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     let (stdout, stderr) =
@@ -468,12 +468,12 @@ fn test_rebase_multiple_destinations() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    a
+    ○    a
     ├─╮
     │ @  c
-    ◉ │  b
+    ○ │  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b|c"]);
@@ -490,12 +490,12 @@ fn test_rebase_multiple_destinations() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    a
+    ○    a
     ├─╮
-    │ ◉  b
+    │ ○  b
     @ │  c
     ├─╯
-    ◉
+    ◆
     "###);
 
     // undo and do it again, but with 'ui.always-allow-large-revsets'
@@ -510,12 +510,12 @@ fn test_rebase_multiple_destinations() {
         ],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    a
+    ○    a
     ├─╮
-    │ ◉  b
+    │ ○  b
     @ │  c
     ├─╯
-    ◉
+    ◆
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
@@ -554,12 +554,12 @@ fn test_rebase_with_descendants() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
@@ -571,12 +571,12 @@ fn test_rebase_with_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Rebase several subtrees at once.
@@ -591,24 +591,24 @@ fn test_rebase_with_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  a
-    │ ◉  b
+    ○  a
+    │ ○  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // Reminder of the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     // `d` was a descendant of `b`, and both are moved to be direct descendants of
@@ -622,14 +622,14 @@ fn test_rebase_with_descendants() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
+    │ ○  b
     ├─╯
     │ @  d
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Same test as above, but with multiple commits per argument
@@ -651,14 +651,14 @@ fn test_rebase_with_descendants() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
+    │ ○  b
     ├─╯
     │ @  d
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 }
 
@@ -703,12 +703,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     // ===================== rebase -s tests =================
@@ -721,12 +721,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -738,12 +738,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -758,12 +758,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // "base" and "a" as parents as before.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
-    ◉ │  base
+    │ ○  a
+    ○ │  base
     ├─╯
-    ◉
+    ◆
     "###);
 
     // ===================== rebase -b tests =================
@@ -771,12 +771,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "base"]);
@@ -788,12 +788,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -808,10 +808,10 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // which means "b" loses its "base" parent
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉  b
-    ◉  a
-    ◉  base
-    ◉
+    ○  b
+    ○  a
+    ○  base
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -823,12 +823,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     // ===================== rebase -r tests =================
@@ -836,12 +836,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     let (stdout, stderr) =
@@ -865,11 +865,11 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // ◉
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉  b
-    ◉  a
-    │ ◉  base
+    ○  b
+    ○  a
+    │ ○  base
     ├─╯
-    ◉
+    ◆
     "###);
 
     // TODO(#2650) !!!!! The panic here is a BUG !!!
@@ -951,12 +951,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // ◉
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     // This tests the algorithm for rebasing onto descendants. The result should be
@@ -971,24 +971,24 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  base
+    ○  base
     │ @  c
-    │ ◉  b
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ====== Reminder of the setup =========
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "root()"]);
@@ -1002,12 +1002,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // In this case, it is unclear whether the user would always prefer unsimplified
     // ancestry (whether `b` should also be a direct child of the root commit).
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  a
+    ○  a
     │ @  c
-    │ ◉  b
-    │ ◉  base
+    │ ○  b
+    │ ○  base
     ├─╯
-    ◉
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -1029,12 +1029,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // ├─╯
     // ◉
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  b
+    ○  b
     │ @  c
-    │ ◉  a
-    │ ◉  base
+    │ ○  a
+    │ ○  base
     ├─╯
-    ◉
+    ◆
     "###);
 
     // This tests the algorithm for rebasing onto descendants. The result should be
@@ -1049,11 +1049,11 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  b
+    ○  b
     @  c
-    ◉  a
-    ◉  base
-    ◉
+    ○  a
+    ○  base
+    ◆
     "###);
 
     // In this test, the commit with weird ancestry is not rebased (neither directly
@@ -1068,12 +1068,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    │ ◉  b
+    │ ○  b
     ╭─┤
-    ◉ │  a
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 }
 
@@ -1093,12 +1093,12 @@ fn test_rebase_skip_empty() {
     // Test the setup
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
     @  also already empty
-    ◉  already empty
-    ◉  will become empty
-    │ ◉  b
+    ○  already empty
+    ○  will become empty
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=b", "--skip-empty"]);
@@ -1113,10 +1113,10 @@ fn test_rebase_skip_empty() {
     // were kept
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
     @  also already empty
-    ◉  already empty
-    ◉  b
-    ◉  a
-    ◉
+    ○  already empty
+    ○  b
+    ○  a
+    ◆
     "###);
 }
 
@@ -1136,16 +1136,16 @@ fn test_rebase_skip_if_on_destination() {
     // Test the setup
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "a"]);
@@ -1158,16 +1158,16 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) =
@@ -1179,16 +1179,16 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d", "-d", "c"]);
@@ -1199,16 +1199,16 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e", "-d", "c"]);
@@ -1223,17 +1223,17 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  77cb229f
-    │ ◉  e  kmkuslsw  48dd9e3f
+    │ ○  e  kmkuslsw  48dd9e3f
     ├─╯
-    │ ◉  d  znkkpsqq  92438fc9
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 }
 

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -56,11 +56,11 @@ fn test_resolution() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -357,11 +357,11 @@ fn test_normal_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -398,11 +398,11 @@ fn test_baseless_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -469,11 +469,11 @@ fn test_edit_delete_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -512,11 +512,11 @@ fn test_file_vs_dir() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -562,13 +562,13 @@ fn test_description_with_dir_and_deletion() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @      conflict
     ├─┬─╮
-    │ │ ◉  del
-    │ ◉ │  dir
+    │ │ ○  del
+    │ ○ │  dir
     │ ├─╯
-    ◉ │  edit
+    ○ │  edit
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -645,11 +645,11 @@ fn test_multiple_conflicts() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap()

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -162,11 +162,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -345,12 +345,12 @@ fn test_alias() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root() & syntax-error"]);
@@ -479,7 +479,7 @@ fn test_bad_alias_decl() {
     // Invalid declaration should be warned and ignored.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Warning: Failed to load "revset-aliases."bad"":  --> 1:1

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -38,7 +38,7 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  qpvuntsmwlqt false
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
     insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r###"
     Author date:  2001-02-03 04:05:07.000 +07:00
@@ -72,8 +72,8 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
-    ◉  qpvuntsmwlqt false
-    ◉  zzzzzzzzzzzz true
+    ○  qpvuntsmwlqt false
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // The author dates of the new commits should be inherited from the commit being
@@ -111,9 +111,9 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
-    ◉  znkkpsqqskkl true
-    ◉  qpvuntsmwlqt false
-    ◉  zzzzzzzzzzzz true
+    ○  znkkpsqqskkl true
+    ○  qpvuntsmwlqt false
+    ◆  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@--"]);
@@ -139,9 +139,9 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
-    ◉  lylxulplsnyw false
-    ◉  qpvuntsmwlqt true
-    ◉  zzzzzzzzzzzz true
+    ○  lylxulplsnyw false
+    ○  qpvuntsmwlqt true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
@@ -199,8 +199,8 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  kkmpptxzrspx false part 2
-    ◉  qpvuntsmwlqt false part 1
-    ◉  zzzzzzzzzzzz true
+    ○  qpvuntsmwlqt false part 1
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -245,8 +245,8 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     assert!(!test_env.env_root().join("editor2").exists());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  kkmpptxzrspx false test_branch
-    ◉  qpvuntsmwlqt false TESTED=TODO
-    ◉  zzzzzzzzzzzz true
+    ○  qpvuntsmwlqt false TESTED=TODO
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -268,10 +268,10 @@ fn test_split_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ◉  kkmpptxzrspx false a
-    ◉ │  qpvuntsmwlqt true 1
+    │ ○  kkmpptxzrspx false a
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // Set up the editor and do the split.
@@ -285,11 +285,11 @@ fn test_split_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ◉  royxmykxtrkr false Add file2
-    │ ◉  kkmpptxzrspx false Add file1
-    ◉ │  qpvuntsmwlqt true 1
+    │ ○  royxmykxtrkr false Add file2
+    │ ○  kkmpptxzrspx false Add file1
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -310,7 +310,7 @@ fn test_split_siblings_no_descendants() {
     test_env.jj_cmd_ok(&workspace_path, &["branch", "create", "test_branch"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  qpvuntsmwlqt false test_branch
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     let edit_script = test_env.set_up_fake_editor();
@@ -340,9 +340,9 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     assert!(!test_env.env_root().join("editor2").exists());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  zsuskulnrvyr false test_branch
-    │ ◉  qpvuntsmwlqt false TESTED=TODO
+    │ ○  qpvuntsmwlqt false TESTED=TODO
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -411,13 +411,13 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     );
 
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    ◉  kkmpptxzrspx false Add file4
-    ◉    rlvkpnrzqnoo false Add file3
+    ○  kkmpptxzrspx false Add file4
+    ○    rlvkpnrzqnoo false Add file3
     ├─╮
     │ @  yqosqzytrlsw false Add file2
-    ◉ │  qpvuntsmwlqt false Add file1
+    ○ │  qpvuntsmwlqt false Add file1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -439,10 +439,10 @@ fn test_split_siblings_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ◉  kkmpptxzrspx false a
-    ◉ │  qpvuntsmwlqt true 1
+    │ ○  kkmpptxzrspx false a
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // Set up the editor and do the split.
@@ -459,11 +459,11 @@ fn test_split_siblings_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @      zsuskulnrvyr true 2
     ├─┬─╮
-    │ │ ◉  royxmykxtrkr false Add file2
-    │ ◉ │  kkmpptxzrspx false Add file1
+    │ │ ○  royxmykxtrkr false Add file2
+    │ ○ │  kkmpptxzrspx false Add file1
     │ ├─╯
-    ◉ │  qpvuntsmwlqt true 1
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -33,9 +33,9 @@ fn test_squash() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  90fe0a96fc90 c
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  fa5efbdf533c b
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
 
     // Squashes the working copy into the parent by default
@@ -47,9 +47,9 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b9280a9898cb
-    ◉  6ca29c9d2e7c b c
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  6ca29c9d2e7c b c
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -67,8 +67,8 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e87cf8ebc7e1 c
-    ◉  893c93ae2a87 a b
-    ◉  000000000000
+    ○  893c93ae2a87 a b
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -91,12 +91,12 @@ fn test_squash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    c7a11b36d333 e
     ├─╮
-    │ ◉  5658521e0f8b d
-    ◉ │  90fe0a96fc90 c
+    │ ○  5658521e0f8b d
+    ○ │  90fe0a96fc90 c
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  fa5efbdf533c b
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -114,14 +114,14 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  959145c11426
-    ◉    80960125bb96 e
+    ○    80960125bb96 e
     ├─╮
-    │ ◉  5658521e0f8b d
-    ◉ │  90fe0a96fc90 c
+    │ ○  5658521e0f8b d
+    ○ │  90fe0a96fc90 c
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  fa5efbdf533c b
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "e"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -149,9 +149,9 @@ fn test_squash_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d989314f3df0 c
-    ◉  2a2d19a3283f b
-    ◉  47a1e795d146 a
-    ◉  000000000000
+    ○  2a2d19a3283f b
+    ○  47a1e795d146 a
+    ◆  000000000000
     "###);
 
     // If we don't make any changes in the diff-editor, the whole change is moved
@@ -166,8 +166,8 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f03d5ce4a973 c
-    ◉  c9f931cd78af a b
-    ◉  000000000000
+    ○  c9f931cd78af a b
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -186,9 +186,9 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e7a40106bee6 c
-    ◉  05d951646873 b
-    ◉  0c5ddc685260 a
-    ◉  000000000000
+    ○  05d951646873 b
+    ○  0c5ddc685260 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -220,9 +220,9 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a911fa1d0627 c
-    ◉  fb73ad17899f b
-    ◉  70621f4c7a42 a
-    ◉  000000000000
+    ○  fb73ad17899f b
+    ○  70621f4c7a42 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -304,13 +304,13 @@ fn test_squash_from_to() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  0d7353584003 f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    ○  e9515f21068c e
+    ○  bdd835cae844 d
+    │ ○  caa4d0b23201 c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
 
     // Errors out if source and destination are the same
@@ -329,12 +329,12 @@ fn test_squash_from_to() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  5337fca918e8 f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  55171e33db26 b c
+    ○  e9515f21068c e
+    ○  bdd835cae844 d
+    │ ○  55171e33db26 b c
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -359,12 +359,12 @@ fn test_squash_from_to() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  66ff309f65e8 f
-    ◉  16f4e7c4886f e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    ○  16f4e7c4886f e
+    │ ○  caa4d0b23201 c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a d
-    ◉  000000000000
+    ○  3db0a2f5b535 a d
+    ◆  000000000000
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
@@ -387,12 +387,12 @@ fn test_squash_from_to() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b4f8051d8466 f
-    ◉  f74c102ff29a d e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    ○  f74c102ff29a d e
+    │ ○  caa4d0b23201 c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file2", "-r", "d"]);
@@ -431,11 +431,11 @@ fn test_squash_from_to_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bdd835cae844 d
-    │ ◉  5028db694b6b c
-    │ ◉  55171e33db26 b
+    │ ○  5028db694b6b c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
 
     let edit_script = test_env.set_up_fake_diff_editor();
@@ -450,10 +450,10 @@ fn test_squash_from_to_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  71b69e433fbc d
-    │ ◉  55171e33db26 b c
+    │ ○  55171e33db26 b c
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -482,11 +482,11 @@ fn test_squash_from_to_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  63f1a6e96edb d
-    │ ◉  d027c6e3e6bc c
-    │ ◉  55171e33db26 b
+    │ ○  d027c6e3e6bc c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -517,11 +517,11 @@ fn test_squash_from_to_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  17c2e6632cc5 d
-    │ ◉  6a3ae047a03e c
-    │ ◉  55171e33db26 b
+    │ ○  6a3ae047a03e c
+    │ ○  55171e33db26 b
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
@@ -552,12 +552,12 @@ fn test_squash_from_to_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  21253406d416 c
-    ◉  e1cf08aae711 b
+    ○  21253406d416 c
+    ○  e1cf08aae711 b
     │ @  bdd835cae844 d
     ├─╯
-    ◉  3db0a2f5b535 a
-    ◉  000000000000
+    ○  3db0a2f5b535 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
@@ -617,15 +617,15 @@ fn test_squash_from_multiple() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  7c982f87d244 f
-    ◉      90fb23310e1d e
+    ○      90fb23310e1d e
     ├─┬─╮
-    │ │ ◉  512dff087306 b
-    │ ◉ │  5ee503da2262 c
+    │ │ ○  512dff087306 b
+    │ ○ │  5ee503da2262 c
     │ ├─╯
-    ◉ │  cb214cffd91a d
+    ○ │  cb214cffd91a d
     ├─╯
-    ◉  37941ee54ace a
-    ◉  000000000000
+    ○  37941ee54ace a
+    ◆  000000000000
     "###);
 
     // Squash a few commits sideways
@@ -646,12 +646,12 @@ fn test_squash_from_multiple() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  cc9f4cad1a29 f
-    ◉    9f25b62ddffc e
+    ○    9f25b62ddffc e
     ├─╮
-    ◉ │  d54017421f3f d
+    × │  d54017421f3f d
     ├─╯
-    ◉  37941ee54ace a b c
-    ◉  000000000000
+    ○  37941ee54ace a b c
+    ◆  000000000000
     "###);
     // The changes from the sources have been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "-r=d", "file"]);
@@ -679,12 +679,12 @@ fn test_squash_from_multiple() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  59801ce3ff81
-    ◉    b7bc1dda247e e f
+    ○    b7bc1dda247e e f
     ├─╮
-    ◉ │  cb214cffd91a d
+    ○ │  cb214cffd91a d
     ├─╯
-    ◉  37941ee54ace a b c
-    ◉  000000000000
+    ○  37941ee54ace a b c
+    ◆  000000000000
     "###);
     // The changes from the sources have been applied to the destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "-r=e", "file"]);
@@ -743,15 +743,15 @@ fn test_squash_from_multiple_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  5adc4b1fb0f9 f
-    ◉      8ba764396a28 e
+    ○      8ba764396a28 e
     ├─┬─╮
-    │ │ ◉  2a2d19a3283f b
-    │ ◉ │  864a16169cef c
+    │ │ ○  2a2d19a3283f b
+    │ ○ │  864a16169cef c
     │ ├─╯
-    ◉ │  5def0e76dfaf d
+    ○ │  5def0e76dfaf d
     ├─╯
-    ◉  47a1e795d146 a
-    ◉  000000000000
+    ○  47a1e795d146 a
+    ◆  000000000000
     "###);
 
     // Partially squash a few commits sideways
@@ -772,15 +772,15 @@ fn test_squash_from_multiple_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  8aaa79109163 f
-    ◉      5aad25eae5aa e
+    ○      5aad25eae5aa e
     ├─┬─╮
-    │ │ ◉  ba60ddff2d41 b
-    │ ◉ │  8ef5a315bf7d c
+    │ │ ○  ba60ddff2d41 b
+    │ ○ │  8ef5a315bf7d c
     │ ├─╯
-    ◉ │  13468b546ba3 d
+    × │  13468b546ba3 d
     ├─╯
-    ◉  47a1e795d146 a
-    ◉  000000000000
+    ○  47a1e795d146 a
+    ◆  000000000000
     "###);
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "-r=b", "file1"]);
@@ -824,15 +824,15 @@ fn test_squash_from_multiple_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  610a144de39b f
-    ◉      ac27a1361b09 e
+    ○      ac27a1361b09 e
     ├─┬─╮
-    │ │ ◉  0c8eab864a32 b
-    │ ◉ │  ad1776ad0b1b c
+    │ │ ○  0c8eab864a32 b
+    │ ○ │  ad1776ad0b1b c
     │ ├─╯
-    ◉ │  5def0e76dfaf d
+    ○ │  5def0e76dfaf d
     ├─╯
-    ◉  47a1e795d146 a
-    ◉  000000000000
+    ○  47a1e795d146 a
+    ◆  000000000000
     "###);
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "-r=b", "file1"]);

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -147,7 +147,7 @@ fn test_templater_alias() {
     'recurse1' = 'recurse2()'
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
-    'coalesce(x, y)' = 'if(x, x, y)'
+    'if_not_null(x, y)' = 'if(x, x, y)'
     "###,
     );
 
@@ -259,19 +259,19 @@ fn test_templater_alias() {
       = Function "identity": Expected 1 arguments
     "###);
 
-    insta::assert_snapshot!(render_err(r#"coalesce(label("x", "not boolean"), "")"#), @r###"
-    Error: Failed to parse template: Alias "coalesce()" cannot be expanded
+    insta::assert_snapshot!(render_err(r#"if_not_null(label("x", "not boolean"), "")"#), @r###"
+    Error: Failed to parse template: Alias "if_not_null()" cannot be expanded
     Caused by:
     1:  --> 1:1
       |
-    1 | coalesce(label("x", "not boolean"), "")
-      | ^-------------------------------------^
+    1 | if_not_null(label("x", "not boolean"), "")
+      | ^----------------------------------------^
       |
-      = Alias "coalesce()" cannot be expanded
-    2:  --> 1:10
+      = Alias "if_not_null()" cannot be expanded
+    2:  --> 1:13
       |
-    1 | coalesce(label("x", "not boolean"), "")
-      |          ^-----------------------^
+    1 | if_not_null(label("x", "not boolean"), "")
+      |             ^-----------------------^
       |
       = Expected expression of type "Boolean"
     "###);

--- a/cli/tests/test_tree_level_conflicts.rs
+++ b/cli/tests/test_tree_level_conflicts.rs
@@ -41,13 +41,13 @@ fn test_enable_tree_level_conflicts() {
     insta::assert_snapshot!(stdout, @r###"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 f2101bed conflict
     │  (empty) (no description set)
-    ◉    zsuskuln test.user@example.com 2001-02-03 08:05:10 5100e4e1 conflict
+    ×    zsuskuln test.user@example.com 2001-02-03 08:05:10 5100e4e1 conflict
     ├─╮  (empty) merge
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 0b65c8fb
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 0b65c8fb
     │ │  right
-    ◉ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 32003b88
+    ○ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 32003b88
     ├─╯  left
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Enable tree-level conflicts
@@ -58,13 +58,13 @@ fn test_enable_tree_level_conflicts() {
     insta::assert_snapshot!(stdout, @r###"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 51f1748d conflict
     │  (no description set)
-    ◉    zsuskuln test.user@example.com 2001-02-03 08:05:10 5100e4e1 conflict
+    ×    zsuskuln test.user@example.com 2001-02-03 08:05:10 5100e4e1 conflict
     ├─╮  (empty) merge
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 0b65c8fb
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 0b65c8fb
     │ │  right
-    ◉ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 32003b88
+    ○ │  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 32003b88
     ├─╯  left
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     // ...but at least it has no diff
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -31,8 +31,8 @@ fn test_undo_rewrite_with_child() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  child
-    ◉  modified
-    ◉
+    ○  modified
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo", &op_id_hex]);
 
@@ -41,8 +41,8 @@ fn test_undo_rewrite_with_child() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  child
-    ◉  initial
-    ◉
+    ○  initial
+    ◆
     "###);
 }
 

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -33,9 +33,9 @@ fn test_unsquash() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  90fe0a96fc90 c
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  fa5efbdf533c b
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
 
     // Unsquashes into the working copy from its parent by default
@@ -47,8 +47,8 @@ fn test_unsquash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1b10d78f6136 c
-    ◉  90aeefd03044 a b
-    ◉  000000000000
+    ○  90aeefd03044 a b
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -66,8 +66,8 @@ fn test_unsquash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  45b8b3ddc25a c
-    ◉  9146bcc8d996 b
-    ◉  000000000000 a
+    ○  9146bcc8d996 b
+    ◆  000000000000 a
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -90,12 +90,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    1f8f152ff48e e
     ├─╮
-    │ ◉  5658521e0f8b d
-    ◉ │  90fe0a96fc90 c
+    │ ○  5658521e0f8b d
+    ○ │  90fe0a96fc90 c
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  fa5efbdf533c b
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -115,12 +115,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    3217340cb761
     ├─╮
-    │ ◉  5658521e0f8b d e??
-    ◉ │  90fe0a96fc90 c e??
+    │ ○  5658521e0f8b d e??
+    ○ │  90fe0a96fc90 c e??
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
-    ◉  000000000000
+    ○  fa5efbdf533c b
+    ○  90aeefd03044 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -148,9 +148,9 @@ fn test_unsquash_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d989314f3df0 c
-    ◉  2a2d19a3283f b
-    ◉  47a1e795d146 a
-    ◉  000000000000
+    ○  2a2d19a3283f b
+    ○  47a1e795d146 a
+    ◆  000000000000
     "###);
 
     // If we don't make any changes in the diff-editor, the whole change is moved
@@ -165,9 +165,9 @@ fn test_unsquash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  37c961d0d1e2 c
-    ◉  000af22057b9 b
-    ◉  ee67504598b6 a
-    ◉  000000000000
+    ○  000af22057b9 b
+    ○  ee67504598b6 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -185,9 +185,9 @@ fn test_unsquash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a8e8fded1021 c
-    ◉  46cc06672a99 b
-    ◉  47a1e795d146 a
-    ◉  000000000000
+    ○  46cc06672a99 b
+    ○  47a1e795d146 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["print", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -47,18 +47,18 @@ fn test_workspaces_add_second_workspace() {
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  397eac932ad3 second@
+    ○  397eac932ad3 second@
     │ @  e0e6d5672858 default@
     ├─╯
-    ◉  7d308bc9d934
-    ◉  000000000000
+    ○  7d308bc9d934
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  397eac932ad3 second@
-    │ ◉  e0e6d5672858 default@
+    │ ○  e0e6d5672858 default@
     ├─╯
-    ◉  7d308bc9d934
-    ◉  000000000000
+    ○  7d308bc9d934
+    ◆  000000000000
     "###);
 
     // Both workspaces show up when we list them
@@ -117,14 +117,14 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     // The new workspace's working-copy commit shares all parents with the old one.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉    6d4c2b8ab610 second@
+    ○    6d4c2b8ab610 second@
     ├─╮
     │ │ @  21a0ea6d1c86 default@
     ╭─┬─╯
-    │ ◉  09ba8d9dfa21
-    ◉ │  1694f2ddf8ec
+    │ ○  09ba8d9dfa21
+    ○ │  1694f2ddf8ec
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -169,20 +169,20 @@ fn test_workspaces_add_workspace_at_revision() {
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  e6baf9d9cfd0 second@
+    ○  e6baf9d9cfd0 second@
     │ @  2801c219094d default@
-    │ ◉  4ec5df5a189c
+    │ ○  4ec5df5a189c
     ├─╯
-    ◉  e7d7dbb91c5a
-    ◉  000000000000
+    ○  e7d7dbb91c5a
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  e6baf9d9cfd0 second@
-    │ ◉  2801c219094d default@
-    │ ◉  4ec5df5a189c
+    │ ○  2801c219094d default@
+    │ ○  4ec5df5a189c
     ├─╯
-    ◉  e7d7dbb91c5a
-    ◉  000000000000
+    ○  e7d7dbb91c5a
+    ◆  000000000000
     "###);
 }
 
@@ -208,13 +208,13 @@ fn test_workspaces_add_workspace_multiple_revisions() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  5b36783cd11c
-    │ ◉  23881f07b53c
+    │ ○  23881f07b53c
     ├─╯
-    │ ◉  1f6a15f0af2a
+    │ ○  1f6a15f0af2a
     ├─╯
-    │ ◉  e7d7dbb91c5a
+    │ ○  e7d7dbb91c5a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (_, stderr) = test_env.jj_cmd_ok(
@@ -239,16 +239,16 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉      fa8fdc28af12 merge@
+    ○      fa8fdc28af12 merge@
     ├─┬─╮
-    │ │ ◉  e7d7dbb91c5a
-    │ ◉ │  1f6a15f0af2a
+    │ │ ○  e7d7dbb91c5a
+    │ ○ │  1f6a15f0af2a
     │ ├─╯
-    ◉ │  23881f07b53c
+    ○ │  23881f07b53c
     ├─╯
     │ @  5b36783cd11c default@
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -267,11 +267,11 @@ fn test_workspaces_conflicting_edits() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  265af0cdbcc7 secondary@
+    ○  265af0cdbcc7 secondary@
     │ @  351099fa72cf default@
     ├─╯
-    ◉  cf911c223d3e
-    ◉  000000000000
+    ○  cf911c223d3e
+    ◆  000000000000
     "###);
 
     // Make changes in both working copies
@@ -290,10 +290,10 @@ fn test_workspaces_conflicting_edits() {
     // The secondary workspace's working-copy commit was updated
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  fe8f41ed01d6 default@
-    │ ◉  a1896a17282f secondary@
+    │ ○  a1896a17282f secondary@
     ├─╯
-    ◉  c0d4a99ef98a
-    ◉  000000000000
+    ○  c0d4a99ef98a
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -321,25 +321,25 @@ fn test_workspaces_conflicting_edits() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ◉  b0b43f24d501 (divergent)
-    │ ◉  fe8f41ed01d6 default@
+    ×  b0b43f24d501 (divergent)
+    │ ○  fe8f41ed01d6 default@
     ├─╯
     │ @  a1896a17282f secondary@ (divergent)
     ├─╯
-    ◉  c0d4a99ef98a
-    ◉  000000000000
+    ○  c0d4a99ef98a
+    ◆  000000000000
     "###);
     // The stale working copy should have been resolved by the previous command
     let stdout = get_log_output(&test_env, &secondary_path);
     assert!(!stdout.starts_with("The working copy is stale"));
     insta::assert_snapshot!(stdout, @r###"
-    ◉  b0b43f24d501 (divergent)
-    │ ◉  fe8f41ed01d6 default@
+    ×  b0b43f24d501 (divergent)
+    │ ○  fe8f41ed01d6 default@
     ├─╯
     │ @  a1896a17282f secondary@ (divergent)
     ├─╯
-    ◉  c0d4a99ef98a
-    ◉  000000000000
+    ○  c0d4a99ef98a
+    ◆  000000000000
     "###);
 }
 
@@ -357,11 +357,11 @@ fn test_workspaces_updated_by_other() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  265af0cdbcc7 secondary@
+    ○  265af0cdbcc7 secondary@
     │ @  351099fa72cf default@
     ├─╯
-    ◉  cf911c223d3e
-    ◉  000000000000
+    ○  cf911c223d3e
+    ◆  000000000000
     "###);
 
     // Rewrite the check-out commit in one workspace.
@@ -377,10 +377,10 @@ fn test_workspaces_updated_by_other() {
     // The secondary workspace's working-copy commit was updated.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  fe8f41ed01d6 default@
-    │ ◉  a1896a17282f secondary@
+    │ ○  a1896a17282f secondary@
     ├─╯
-    ◉  c0d4a99ef98a
-    ◉  000000000000
+    ○  c0d4a99ef98a
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -398,11 +398,11 @@ fn test_workspaces_updated_by_other() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ◉  fe8f41ed01d6 default@
+    ○  fe8f41ed01d6 default@
     │ @  a1896a17282f secondary@
     ├─╯
-    ◉  c0d4a99ef98a
-    ◉  000000000000
+    ○  c0d4a99ef98a
+    ◆  000000000000
     "###);
 }
 
@@ -456,15 +456,15 @@ fn test_workspaces_current_op_discarded_by_other() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  716b8d737e abandon commit 8ac26d0060e2be7f3fce2b5ebd2eb0c75053666f6cbc41bee50bb6da463868704a0bcf1ed9848761206d77694a71e3c657e5e250245e342779df1b00f0da9009
-    ◉  bb8aec2a1c Create initial working-copy commit in workspace secondary
-    ◉  af6f39b411 add workspace 'secondary'
-    ◉  05c14c7e78 new empty commit
-    ◉  92bb962606 snapshot working copy
-    ◉  553e0ea3a4 new empty commit
-    ◉  b3755a9026 snapshot working copy
-    ◉  17dbb2fe40 add workspace 'default'
-    ◉  cecfee9647 initialize repo
-    ◉  0000000000
+    ○  bb8aec2a1c Create initial working-copy commit in workspace secondary
+    ○  af6f39b411 add workspace 'secondary'
+    ○  05c14c7e78 new empty commit
+    ○  92bb962606 snapshot working copy
+    ○  553e0ea3a4 new empty commit
+    ○  b3755a9026 snapshot working copy
+    ○  17dbb2fe40 add workspace 'default'
+    ○  cecfee9647 initialize repo
+    ○  0000000000
     "###);
 
     // Abandon ops, including the one the secondary workspace is currently on.
@@ -472,11 +472,11 @@ fn test_workspaces_current_op_discarded_by_other() {
     test_env.jj_cmd_ok(&main_path, &["util", "gc", "--expire=now"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  ec4904a30161 secondary@
+    ○  ec4904a30161 secondary@
     │ @  74769415363f default@
     ├─╯
-    ◉  bd711986720f
-    ◉  000000000000
+    ○  bd711986720f
+    ◆  000000000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
@@ -494,12 +494,12 @@ fn test_workspaces_current_op_discarded_by_other() {
     insta::assert_snapshot!(stdout, @"");
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  b93a924213f3 secondary@
-    ◉  ec4904a30161
+    ○  b93a924213f3 secondary@
+    ○  ec4904a30161
     │ @  74769415363f default@
     ├─╯
-    ◉  bd711986720f
-    ◉  000000000000
+    ○  bd711986720f
+    ◆  000000000000
     "###);
 
     // The sparse patterns should remain
@@ -530,7 +530,7 @@ fn test_workspaces_current_op_discarded_by_other() {
     insta::assert_snapshot!(stdout, @r###"
     @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ b93a9242
     │  (no description set)
-    ◉  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 30ee0d1f
+    ○  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 30ee0d1f
        (empty) (no description set)
     "###);
 }
@@ -559,8 +559,8 @@ fn test_workspaces_update_stale_noop() {
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "-Tdescription"]);
     insta::assert_snapshot!(stdout, @r###"
     @  add workspace 'default'
-    ◉  initialize repo
-    ◉
+    ○  initialize repo
+    ○
     "###);
 }
 
@@ -591,11 +591,11 @@ fn test_workspaces_update_stale_snapshot() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  4976dfa88529 secondary@
-    │ ◉  8357b22214ba default@
-    │ ◉  1a769966ed69
+    │ ○  8357b22214ba default@
+    │ ○  1a769966ed69
     ├─╯
-    ◉  b4a6c25e7778
-    ◉  000000000000
+    ○  b4a6c25e7778
+    ◆  000000000000
     "###);
 }
 
@@ -633,11 +633,11 @@ fn test_workspaces_forget() {
     // there's only one workspace. We should show it when the command is not run
     // from that workspace.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  feda1c4e5ffe
-    │ ◉  e949be04e93e
+    ○  feda1c4e5ffe
+    │ ○  e949be04e93e
     ├─╯
-    ◉  123ed18e4c4c
-    ◉  000000000000
+    ○  123ed18e4c4c
+    ◆  000000000000
     "###);
 
     // Revision "@" cannot be used

--- a/docs/config.md
+++ b/docs/config.md
@@ -237,7 +237,25 @@ templates.
   * `templates.log_node` for commits (with `Option<Commit>` keywords)
   * `templates.op_log_node` for operations (with `Operation` keywords)
 
-For example:
+By default, the following graph nodes are shown to the user:
+
+  * The working-copy-commit is the `@` symbol, and is green.
+  * Immutable nodes (as specified by the `immutable_heads()` revset) are
+    represented with blue diamonds `◆`
+  * Mutable commits are represented with ordinary uncolored circles `○`
+  * "Elided nodes" are specified with the "harpoon" symbol `⇋` to show that
+    there are commits between the two nodes that are "cut" out, and not shown.
+  * Commits whose description begins with `wip:` are represented with a yellow
+    `!` symbol.
+
+These symbols are chosen to be visually distinct from one another, with distinct
+colors. However, certain Unicode characters may not render correctly in all
+terminals, or with all monospace fonts. We welcome feedback on the default
+symbols and colors, and we may adjust them in future releases.
+
+Reconfiguring the symbols can be done by setting the `templates.log_node`, like
+the following example:
+
 ```toml
 [templates]
 log_node = '''
@@ -250,6 +268,40 @@ coalesce(
 '''
 op_log_node = 'if(current_operation, "@", "○")'
 ```
+
+If you wish to color the symbols, you can use the `label()` function to mark the
+symbols with a label, and then provide a color for that label. You can also
+provide default colors for every node, using nested `label()` calls. For
+example, to make every node bold by default, except working-copy symbol `@`, and
+also make `@` green at the same time, you can first provide an label name in the
+colors section of your config:
+
+```toml
+[colors]
+"mynode" = { bold = true }
+"mynode wcc" = { fg = "green", bold = false }
+```
+
+Then, you can use nested `label()` calls in the `log_node` template to attach
+the label `"mynode wcc"` to the `@` symbol, like so:
+
+```toml
+label("mynode",
+  if(self,
+    if(current_working_copy, label("wcc", "@"),
+    ...
+  )
+)
+```
+
+A default set of colors for nodes is provided in `colors.toml`, including:
+
+- `"node"`
+- `"node elided"`
+- `"node wcc"`
+- `"node immutable"`
+- `"node wip"`
+- `"node normal"`
 
 ### Wrap log content
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -242,11 +242,13 @@ By default, the following graph nodes are shown to the user:
   * The working-copy-commit is the `@` symbol, and is green.
   * Immutable nodes (as specified by the `immutable_heads()` revset) are
     represented with blue diamonds `◆`
-  * Mutable commits are represented with ordinary uncolored circles `○`
-  * "Elided nodes" are specified with the "harpoon" symbol `⇋` to show that
-    there are commits between the two nodes that are "cut" out, and not shown.
-  * Commits whose description begins with `wip:` are represented with a yellow
-    `!` symbol.
+  * Conflicted commits are represented with red crosses `×`.
+  * Other mutable commits are represented with ordinary uncolored circles `○`
+  * "Elided nodes" are represented with a tilde `~` to reflect the similarity
+    to its usage for graphs with cut roots.
+
+For the ascii style graph colors are the same, while symbols differ due to
+the character set restriction.
 
 These symbols are chosen to be visually distinct from one another, with distinct
 colors. However, certain Unicode characters may not render correctly in all

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -245,16 +245,50 @@ impl UserSettings {
     pub fn commit_node_template(&self) -> String {
         self.node_template_for_key(
             "templates.log_node",
-            r#"if(self, if(current_working_copy, "@", "◉"), "◌")"#,
-            r#"if(self, if(current_working_copy, "@", "o"), ".")"#,
+            r#"
+            label("node",
+              coalesce(
+                if(!self, label("elided", "~")),
+                if(current_working_copy, label("working_copy", "@")),
+                if(immutable, label("immutable", "◆")),
+                if(conflict, label("conflict", "×")),
+                label("normal", "○"),
+              )
+            )
+            "#,
+            r##"
+            label("node",
+              coalesce(
+                if(!self, label("elided", "~")),
+                if(current_working_copy, label("working_copy", "@")),
+                if(immutable, label("immutable", "#")),
+                if(conflict, label("conflict", "x")),
+                label("normal", "o"),
+              )
+            )
+            "##,
         )
     }
 
     pub fn op_node_template(&self) -> String {
         self.node_template_for_key(
             "templates.op_log_node",
-            r#"if(current_operation, "@", "◉")"#,
-            r#"if(current_operation, "@", "o")"#,
+            r#"
+            label("node",
+              coalesce(
+                if(current_operation, label("working_copy", "@")),
+                "○",
+              )
+            )
+            "#,
+            r#"
+            label("node",
+              coalesce(
+                if(current_operation, label("working_copy", "@")),
+                "o",
+              )
+            )
+            "#,
         )
     }
 


### PR DESCRIPTION
I split this into a few commit to keep @thoughtpolice's initial commit intact, put my fixes on top, and shove all the tests into a separate commit to make reviewing hopefully less terrible.

Screenshot showing the new proposed style, both non-ascii and ascii style
![image](https://github.com/martinvonz/jj/assets/15268706/175374b1-cdc2-4ace-a565-e30c92fc8688)

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
