### PR TITLE
Add template aliases with node symbol configs

### DIFF
--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -88,10 +88,8 @@
 "op_log current_operation user" = "yellow"                    # No bright yellow, see comment above
 "op_log current_operation time" = "bright cyan"
 
-"node" = { bold = true }
 "node elided" = { fg = "bright black" }
-"node working_copy" = { fg = "green" }
-"node current_operation" = { fg = "green" }
-"node immutable" = { fg = "bright cyan" }
-"node conflict" = { fg = "red" }
-"node normal" = { bold = false }
+"node working_copy" = { fg = "green", bold = true }
+"node current_operation" = { fg = "green", bold = true }
+"node immutable" = { fg = "bright cyan", bold = true }
+"node conflict" = { fg = "red", bold = true }

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -87,3 +87,11 @@
 "op_log current_operation id" = "bright blue"
 "op_log current_operation user" = "yellow"                    # No bright yellow, see comment above
 "op_log current_operation time" = "bright cyan"
+
+"node" = { bold = true }
+"node elided" = { fg = "bright black" }
+"node working_copy" = { fg = "green" }
+"node current_operation" = { fg = "green" }
+"node immutable" = { fg = "bright cyan" }
+"node conflict" = { fg = "red" }
+"node normal" = { bold = false }

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -165,3 +165,66 @@ if(hidden,
   )
 )
 '''
+
+'label_log_node(content)' = '''
+label("node",
+  coalesce(
+    if(!self, label("elided", content)),
+    if(immutable, label("immutable", content)),
+    if(conflict, label("conflict", content)),
+    if(current_working_copy, label("working_copy", content)),
+    label("normal", content),
+  )
+)
+'''
+
+'label_op_log_node(content)' = '''
+label("node",
+  coalesce(
+    if(current_operation, label("current_operation", content)),
+    label("normal", content),
+  )
+)
+'''
+
+builtin_log_node = '''
+label_log_node(
+  coalesce(
+    if(!self, "~"),
+    if(current_working_copy, "@"),
+    if(immutable, "◆"),
+    if(conflict, "×"),
+    "○",
+  )
+)
+'''
+
+builtin_log_node_ascii = '''
+label_log_node(
+  coalesce(
+    if(!self, "~"),
+    if(current_working_copy, "@"),
+    if(immutable, "#"),
+    if(conflict, "x"),
+    "o",
+  )
+)
+'''
+
+builtin_op_log_node = '''
+label_op_log_node(
+  coalesce(
+    if(current_operation, "@"),
+    "○",
+  )
+)
+'''
+
+builtin_op_log_node_ascii = '''
+label_op_log_node(
+  coalesce(
+    if(current_operation, "@"),
+    "o",
+  )
+)
+'''

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -166,64 +166,63 @@ if(hidden,
 )
 '''
 
-'label_log_node(content)' = '''
-label("node",
-  coalesce(
-    if(!self, label("elided", content)),
-    if(immutable, label("immutable", content)),
-    if(conflict, label("conflict", content)),
-    if(current_working_copy, label("working_copy", content)),
-    label("normal", content),
-  )
-)
-'''
-
-'label_op_log_node(content)' = '''
-label("node",
-  coalesce(
-    if(current_operation, label("current_operation", content)),
-    label("normal", content),
-  )
-)
-'''
-
 builtin_log_node = '''
-label_log_node(
+label("node", 
   coalesce(
-    if(!self, "~"),
-    if(current_working_copy, "@"),
-    if(immutable, "◆"),
-    if(conflict, "×"),
-    "○",
+    if(!self, label("elided", "~")),
+    label(
+      separate(" ",
+        if(current_working_copy, "working_copy"),
+        if(immutable, "immutable"),
+        if(conflict, "conflict"),
+      ),
+      coalesce(
+        if(!self, "~"),
+        if(current_working_copy, "@"),
+        if(immutable, "◆"),
+        if(conflict, "×"),
+        "○",
+      )
+    )
   )
 )
 '''
 
 builtin_log_node_ascii = '''
-label_log_node(
+label("node", 
   coalesce(
-    if(!self, "~"),
-    if(current_working_copy, "@"),
-    if(immutable, "#"),
-    if(conflict, "x"),
-    "o",
+    if(!self, label("elided", "~")),
+    label(
+      separate(" ",
+        if(current_working_copy, "working_copy"),
+        if(immutable, "immutable"),
+        if(conflict, "conflict"),
+      ),
+      coalesce(
+        if(!self, "~"),
+        if(current_working_copy, "@"),
+        if(immutable, "#"),
+        if(conflict, "x"),
+        "o",
+      )
+    )
   )
 )
 '''
 
 builtin_op_log_node = '''
-label_op_log_node(
+label("node",
   coalesce(
-    if(current_operation, "@"),
+    if(current_operation, label("current_operation", "@")),
     "○",
   )
 )
 '''
 
 builtin_op_log_node_ascii = '''
-label_op_log_node(
+label("node",
   coalesce(
-    if(current_operation, "@"),
+    if(current_operation, label("current_operation", "@")),
     "o",
   )
 )

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -44,9 +44,13 @@ fn test_log_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_node
+    - builtin_log_node_ascii
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_op_log_node
+    - builtin_op_log_node_ascii
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -279,9 +279,13 @@ fn test_obslog_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_node
+    - builtin_log_node_ascii
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_op_log_node
+    - builtin_op_log_node_ascii
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -140,9 +140,13 @@ fn test_op_log_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_node
+    - builtin_log_node_ascii
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_op_log_node
+    - builtin_op_log_node_ascii
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -64,9 +64,13 @@ fn test_show_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_node
+    - builtin_log_node_ascii
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_op_log_node
+    - builtin_op_log_node_ascii
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -111,7 +111,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword "builtin" doesn't exist
-    Hint: Did you mean "builtin_change_id_with_hidden_and_divergent_info", "builtin_log_comfortable", "builtin_log_compact", "builtin_log_detailed", "builtin_log_oneline", "builtin_op_log_comfortable", "builtin_op_log_compact"?
+    Hint: Did you mean "builtin_change_id_with_hidden_and_divergent_info", "builtin_log_comfortable", "builtin_log_compact", "builtin_log_detailed", "builtin_log_node", "builtin_log_node_ascii", "builtin_log_oneline", "builtin_op_log_comfortable", "builtin_op_log_compact", "builtin_op_log_node", "builtin_op_log_node_ascii"?
     "###);
 }
 


### PR DESCRIPTION
Possible future defaults, for opt-in testing.

Considering we'll keep these in the configs for now I'll use the split setup I use in my own config where labeling and symbols are separate, which grants you some goodies like the working change symbol changing color on a conflicted commit.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
