### PR TITLE
`jj git push`: safety checks when pushing branch sideways, similar to `git push --force-with-lease`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed bugs
 
+* Previously, `jj git push` only made sure that the branch is in the expected
+  location on the remote server when pushing a branch forward (as opposed to
+  sideways or backwards). Now, `jj git push` makes a safety check in all cases
+  and fails whenever `jj git fetch` would have introduced a conflict.
+
+  In other words, previously branches that moved sideways or backward were
+  pushed similarly to Git's `git push --force`; now they have protections
+  similar to `git push --force-with-lease` (though not identical to it, to match
+  the behavior of `jj git fetch`). Note also that because of the way `jj git
+  fetch` works, `jj` does not suffer from the same problems as Git's `git push
+  --force-with-lease` in situations when `git fetch` is run in the background.
+
 * When the working copy commit becomes immutable, a new one is automatically created on top of it 
 to avoid letting the user edit the immutable one.
 

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -1015,11 +1015,6 @@ fn cmd_git_push(
     })
     .map_err(|err| match err {
         GitPushError::InternalGitError(err) => map_git_error(err),
-        GitPushError::NotFastForward => user_error_with_hint(
-            "The push conflicts with changes made on the remote (it is not fast-forwardable).",
-            "Try fetching from the remote, then make the branch point to where you want it to be, \
-             and push again.",
-        ),
         GitPushError::RefInUnexpectedLocation(refs) => user_error_with_hint(
             format!(
                 "Refusing to push a branch that unexpectedly moved on the remote. Affected refs: \

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -899,6 +899,10 @@ fn cmd_git_push(
     }
 
     let mut new_heads = vec![];
+    // Short-term TODO: `force_pushed_branches` no longer has an effect on how
+    // branches are actually pushed. Messages about "Moving" vs "Forcing"
+    // branches are now misleading. Change this logic so that we print whether
+    // the branch moved forward, backward, or sideways.
     let mut force_pushed_branches = hashset! {};
     for (branch_name, update) in &branch_updates {
         if let Some(new_target) = &update.new_target {
@@ -1001,10 +1005,7 @@ fn cmd_git_push(
         return Ok(());
     }
 
-    let targets = GitBranchPushTargets {
-        branch_updates,
-        force_pushed_branches,
-    };
+    let targets = GitBranchPushTargets { branch_updates };
     let mut writer = GitSidebandProgressMessageWriter::new(ui);
     let mut sideband_progress_callback = |progress_message: &[u8]| {
         _ = writer.write(ui, progress_message);

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -1019,6 +1019,15 @@ fn cmd_git_push(
             "Try fetching from the remote, then make the branch point to where you want it to be, \
              and push again.",
         ),
+        GitPushError::RefInUnexpectedLocation(refs) => user_error_with_hint(
+            format!(
+                "Refusing to push a branch that unexpectedly moved on the remote. Affected refs: \
+                 {}",
+                refs.join(", ")
+            ),
+            "Try fetching from the remote, then make the branch point to where you want it to be, \
+             and push again.",
+        ),
         _ => user_error(err),
     })?;
     writer.flush(ui)?;

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1223,9 +1223,6 @@ pub enum GitPushError {
         name = REMOTE_NAME_FOR_LOCAL_GIT_REPO
     )]
     RemoteReservedForLocalGitRepo,
-    // Short-term TODO: Delete this; it should never trigger
-    #[error("Push is not fast-forwardable")]
-    NotFastForward,
     #[error("Refs in unexpected location: {0:?}")]
     RefInUnexpectedLocation(Vec<String>),
     #[error("Remote rejected the update of some refs (do you have permission to push to {0:?}?)")]
@@ -1422,14 +1419,7 @@ fn push_refs(
             Ok(())
         });
         push_options.remote_callbacks(callbacks);
-        remote
-            .push(refspecs, Some(&mut push_options))
-            .map_err(|err| match (err.class(), err.code()) {
-                (git2::ErrorClass::Reference, git2::ErrorCode::NotFastForward) => {
-                    GitPushError::NotFastForward
-                }
-                _ => GitPushError::InternalGitError(err),
-            })
+        remote.push(refspecs, Some(&mut push_options))
     };
     if !failed_push_negotiations.is_empty() {
         // If the push negotiation returned an error, `remote.push` would not

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2838,6 +2838,7 @@ fn test_push_updates_success() {
         &[GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
             force: false,
+            expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
         git::RemoteCallbacks::default(),
@@ -2874,6 +2875,7 @@ fn test_push_updates_no_such_remote() {
         &[GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
             force: false,
+            expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
         git::RemoteCallbacks::default(),
@@ -2892,6 +2894,7 @@ fn test_push_updates_invalid_remote() {
         &[GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
             force: false,
+            expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
         git::RemoteCallbacks::default(),

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2589,7 +2589,6 @@ fn test_push_branches_success() {
                 new_target: Some(setup.child_of_main_commit.id().clone()),
             },
         )],
-        force_pushed_branches: hashset! {},
     };
     let result = git::push_branches(
         tx.mut_repo(),
@@ -2659,7 +2658,6 @@ fn test_push_branches_deletion() {
                 new_target: None,
             },
         )],
-        force_pushed_branches: hashset! {},
     };
     let result = git::push_branches(
         tx.mut_repo(),
@@ -2717,7 +2715,6 @@ fn test_push_branches_mixed_deletion_and_addition() {
                 },
             ),
         ],
-        force_pushed_branches: hashset! {},
     };
     let result = git::push_branches(
         tx.mut_repo(),
@@ -2777,7 +2774,6 @@ fn test_push_branches_not_fast_forward() {
                 new_target: Some(setup.sideways_commit.id().clone()),
             },
         )],
-        force_pushed_branches: hashset! {},
     };
     let result = git::push_branches(
         tx.mut_repo(),
@@ -2786,7 +2782,9 @@ fn test_push_branches_not_fast_forward() {
         &targets,
         git::RemoteCallbacks::default(),
     );
-    assert_eq!(result, Err(GitPushError::NotFastForward));
+    // Short-term TODO: This test is now equivalent to the following one, and
+    // will be removed in a follow-up commit.
+    assert_eq!(result, Ok(()));
 }
 
 #[test]
@@ -2804,9 +2802,6 @@ fn test_push_branches_not_fast_forward_with_force() {
                 new_target: Some(setup.sideways_commit.id().clone()),
             },
         )],
-        force_pushed_branches: hashset! {
-            "main".to_owned(),
-        },
     };
     let result = git::push_branches(
         tx.mut_repo(),
@@ -2850,7 +2845,6 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote() {
     let attempt_push_expecting_sideways = |target: Option<CommitId>| {
         let targets = [GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
-            force: true,
             expected_current_target: Some(setup.sideways_commit.id().clone()),
             new_target: target,
         }];
@@ -2918,7 +2912,6 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote() {
     let attempt_push_expecting_parent = |target: Option<CommitId>| {
         let targets = [GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
-            force: true,
             expected_current_target: Some(setup.parent_of_main_commit.id().clone()),
             new_target: target,
         }];
@@ -2977,7 +2970,6 @@ fn test_push_updates_unexpectedly_exists_on_remote() {
     let attempt_push_expecting_absence = |target: Option<CommitId>| {
         let targets = [GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
-            force: true,
             expected_current_target: None,
             new_target: target,
         }];
@@ -3014,7 +3006,6 @@ fn test_push_updates_success() {
         "origin",
         &[GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
-            force: false,
             expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
@@ -3052,7 +3043,6 @@ fn test_push_updates_no_such_remote() {
         "invalid-remote",
         &[GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
-            force: false,
             expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
@@ -3072,7 +3062,6 @@ fn test_push_updates_invalid_remote() {
         "http://invalid-remote",
         &[GitRefUpdate {
             qualified_name: "refs/heads/main".to_string(),
-            force: false,
             expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2782,34 +2782,6 @@ fn test_push_branches_not_fast_forward() {
         &targets,
         git::RemoteCallbacks::default(),
     );
-    // Short-term TODO: This test is now equivalent to the following one, and
-    // will be removed in a follow-up commit.
-    assert_eq!(result, Ok(()));
-}
-
-#[test]
-fn test_push_branches_not_fast_forward_with_force() {
-    let settings = testutils::user_settings();
-    let temp_dir = testutils::new_temp_dir();
-    let setup = set_up_push_repos(&settings, &temp_dir);
-    let mut tx = setup.jj_repo.start_transaction(&settings);
-
-    let targets = GitBranchPushTargets {
-        branch_updates: vec![(
-            "main".to_owned(),
-            BranchPushUpdate {
-                old_target: Some(setup.main_commit.id().clone()),
-                new_target: Some(setup.sideways_commit.id().clone()),
-            },
-        )],
-    };
-    let result = git::push_branches(
-        tx.mut_repo(),
-        &get_git_repo(&setup.jj_repo),
-        "origin",
-        &targets,
-        git::RemoteCallbacks::default(),
-    );
     assert_eq!(result, Ok(()));
 
     // Check that the ref got updated in the source repo

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -89,10 +89,27 @@ fn test_merge_ref_targets() {
         target4
     );
 
-    // Both added same target
+    // Both moved sideways ("A - B + A" - type conflict)
+    assert_eq!(
+        merge_ref_targets(index, &target4, &target3, &target4),
+        target4
+    );
+
+    // Both added same target ("A - B + A" - type conflict)
     assert_eq!(
         merge_ref_targets(index, &target3, RefTarget::absent_ref(), &target3),
         target3
+    );
+
+    // Both removed ("A - B + A" - type conflict)
+    assert_eq!(
+        merge_ref_targets(
+            index,
+            RefTarget::absent_ref(),
+            &target3,
+            RefTarget::absent_ref()
+        ),
+        RefTarget::absent()
     );
 
     // Left added target, right added descendant target


### PR DESCRIPTION
Previously, `jj git push` only made sure that the branch is in the expected
  location on the remote server when pushing a branch forward (as opposed to
  sideways or backwards). Now, `jj git push` makes a safety check in all cases
  and fails whenever `jj git fetch` would have introduced a conflict.

In other words, previously branches that moved sideways or backward were
  pushed similarly to Git's `git push --force`; now they have protections
  similar to `git push --force-with-lease` (though not identical to it, to match
  the behavior of `jj git fetch`). Note also that because of the way `jj git
  fetch` works, `jj` does not suffer from the same problems as Git's `git push
  --force-with-lease` in situations when `git fetch` is run in the background.

-------------------------

There are a few TODOs that may be added later (in this or separate PRs):

- [ ] Document this behavior in `jj help git push`, possibly elsewhere.
- [x] Adjustments to user-facing UI
- [ ] Additional tests

See TODOs in the code for more details. It's possible I forgot some, but it's probably time for others to look at the general form of this PR in any case.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
