### PR TITLE
Support extensions of the SymbolResolver in revset evaluation

### DIFF
--- a/cli/examples/custom-commit-templater/main.rs
+++ b/cli/examples/custom-commit-templater/main.rs
@@ -49,17 +49,12 @@ fn num_char_in_id(commit: Commit, ch_match: char) -> i64 {
     count
 }
 
+#[derive(Default)]
 struct MostDigitsInId {
     count: OnceCell<i64>,
 }
 
 impl MostDigitsInId {
-    fn new() -> Self {
-        Self {
-            count: OnceCell::new(),
-        }
-    }
-
     fn count(&self, repo: &dyn Repo) -> i64 {
         *self.count.get_or_init(|| {
             RevsetExpression::all()
@@ -125,7 +120,7 @@ impl CommitTemplateLanguageExtension for HexCounter {
     }
 
     fn build_cache_extensions(&self, extensions: &mut ExtensionsMap) {
-        extensions.insert(MostDigitsInId::new());
+        extensions.insert(MostDigitsInId::default());
     }
 }
 

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -496,7 +496,8 @@ impl From<RevsetResolutionError> for CommandError {
             | RevsetResolutionError::WorkspaceMissingWorkingCopy { .. }
             | RevsetResolutionError::AmbiguousCommitIdPrefix(_)
             | RevsetResolutionError::AmbiguousChangeIdPrefix(_)
-            | RevsetResolutionError::StoreError(_) => None,
+            | RevsetResolutionError::StoreError(_)
+            | RevsetResolutionError::Other(_) => None,
         };
         let mut cmd_err = user_error(err);
         cmd_err.extend_hints(hint);

--- a/cli/src/commands/bench.rs
+++ b/cli/src/commands/bench.rs
@@ -23,7 +23,7 @@ use criterion::measurement::Measurement;
 use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
 use jj_lib::object_id::HexPrefix;
 use jj_lib::repo::Repo;
-use jj_lib::revset::{self, DefaultSymbolResolver, RevsetExpression};
+use jj_lib::revset::{self, DefaultSymbolResolver, RevsetExpression, SymbolResolverExtension};
 
 use crate::cli_util::{CommandHelper, RevisionArg, WorkspaceCommandHelper};
 use crate::command_error::CommandError;
@@ -210,7 +210,8 @@ fn bench_revset<M: Measurement>(
     let routine = |workspace_command: &WorkspaceCommandHelper, expression: Rc<RevsetExpression>| {
         // Evaluate the expression without parsing/evaluating short-prefixes.
         let repo = workspace_command.repo().as_ref();
-        let symbol_resolver = DefaultSymbolResolver::new(repo);
+        let symbol_resolver =
+            DefaultSymbolResolver::new(repo, &([] as [Box<dyn SymbolResolverExtension>; 0]));
         let resolved = expression
             .resolve_user_expression(repo, &symbol_resolver)
             .unwrap();

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -181,8 +181,11 @@ fn cmd_debug_revset(
     writeln!(ui.stdout(), "{expression:#?}")?;
     writeln!(ui.stdout())?;
 
-    let symbol_resolver =
-        revset_util::default_symbol_resolver(repo, workspace_command.id_prefix_context()?);
+    let symbol_resolver = revset_util::default_symbol_resolver(
+        repo,
+        command.revset_extensions().symbol_resolvers(),
+        workspace_command.id_prefix_context()?,
+    );
     let expression = expression.resolve_user_expression(repo, &symbol_resolver)?;
     writeln!(ui.stdout(), "-- Resolved:")?;
     writeln!(ui.stdout(), "{expression:#?}")?;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -678,7 +678,11 @@ fn evaluate_immutable_revset<'repo>(
         .map_err(|err| {
             TemplateParseError::expression("Failed to parse revset", span).with_source(err)
         })?;
-    let symbol_resolver = revset_util::default_symbol_resolver(repo, language.id_prefix_context);
+    let symbol_resolver = revset_util::default_symbol_resolver(
+        repo,
+        language.revset_parse_context.extensions.symbol_resolvers(),
+        language.id_prefix_context,
+    );
     let revset = revset_util::evaluate(repo, &symbol_resolver, expression).map_err(|err| {
         TemplateParseError::expression("Failed to evaluate revset", span).with_source(err)
     })?;

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -159,13 +159,7 @@ pub fn default_symbol_resolver<'a>(
     repo: &'a dyn Repo,
     id_prefix_context: &'a IdPrefixContext,
 ) -> DefaultSymbolResolver<'a> {
-    let commit_id_resolver: revset::PrefixResolver<CommitId> =
-        Box::new(|repo, prefix| id_prefix_context.resolve_commit_prefix(repo, prefix));
-    let change_id_resolver: revset::PrefixResolver<Vec<CommitId>> =
-        Box::new(|repo, prefix| id_prefix_context.resolve_change_prefix(repo, prefix));
-    DefaultSymbolResolver::new(repo)
-        .with_commit_id_resolver(commit_id_resolver)
-        .with_change_id_resolver(change_id_resolver)
+    DefaultSymbolResolver::new(repo).with_id_prefix_context(id_prefix_context)
 }
 
 /// Parses user-configured expression defining the immutable set.

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -62,6 +62,8 @@ pub enum RevsetResolutionError {
     AmbiguousChangeIdPrefix(String),
     #[error("Unexpected error from store")]
     StoreError(#[source] BackendError),
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Error occurred during revset evaluation.
@@ -2283,7 +2285,8 @@ fn resolve_symbols(
                         | RevsetResolutionError::EmptyString
                         | RevsetResolutionError::AmbiguousCommitIdPrefix(_)
                         | RevsetResolutionError::AmbiguousChangeIdPrefix(_)
-                        | RevsetResolutionError::StoreError(_) => Err(err),
+                        | RevsetResolutionError::StoreError(_)
+                        | RevsetResolutionError::Other(_) => Err(err),
                     })
                     .map(Some) // Always rewrite subtree
             }


### PR DESCRIPTION
This also sets up some container types for other types of revset extensions, plumbed through CliRunner.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
