### PR TITLE
Use CommitIteratorExt to replace `.map(|c| c.id().clone())`

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -98,7 +98,7 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
         .resolve_some_revsets_default_single(&args.revisions)?
         .into_iter()
         .collect_vec();
-    let target_ids = target_commits.iter().map(|c| c.id().clone()).collect_vec();
+    let target_ids = target_commits.iter().ids().cloned().collect_vec();
     let mut tx = workspace_command.start_transaction();
     let mut num_rebased;
     let new_commit;
@@ -128,10 +128,10 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
             .commits(tx.repo().store())
             .try_collect()?;
         let merged_tree = merge_commit_trees(tx.repo(), &new_parents_commits)?;
-        let new_parents_commit_id = new_parents_commits.iter().map(|c| c.id().clone()).collect();
+        let new_parents_commit_ids = new_parents_commits.iter().ids().cloned().collect();
         new_commit = tx
             .mut_repo()
-            .new_commit(command.settings(), new_parents_commit_id, merged_tree.id())
+            .new_commit(command.settings(), new_parents_commit_ids, merged_tree.id())
             .set_description(join_message_paragraphs(&args.message_paragraphs))
             .write()?;
         num_rebased = target_ids.len();

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -387,11 +387,7 @@ fn rebase_revision(
             .iter()
             .flat_map(|c| {
                 if c == &old_commit {
-                    old_commit
-                        .parents()
-                        .iter()
-                        .map(|c| c.id().clone())
-                        .collect()
+                    old_commit.parent_ids().to_vec()
                 } else {
                     [c.id().clone()].to_vec()
                 }

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use clap::Subcommand;
 use itertools::Itertools;
+use jj_lib::commit::CommitIteratorExt;
 use jj_lib::file_util;
 use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::{OpStoreError, WorkspaceId};
@@ -209,7 +210,7 @@ fn cmd_workspace_add(
     };
 
     let tree = merge_commit_trees(tx.repo(), &parents)?;
-    let parent_ids = parents.iter().map(|c| c.id().clone()).collect_vec();
+    let parent_ids = parents.iter().ids().cloned().collect_vec();
     let new_wc_commit = tx
         .mut_repo()
         .new_commit(command.settings(), parent_ids, tree.id())


### PR DESCRIPTION
This replaces `.map(|c| c.id().clone())` with `.ids().cloned()`.

This is a minor cleanup to use nicer syntax for getting `CommitId`s from an iterator of commits using the `CommitIteratorExt` trait.