### PR TITLE
templates: use "+" instead of "#" to denote immutable node in ascii graph

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -196,7 +196,7 @@ coalesce(
     ),
     coalesce(
       if(current_working_copy, "@"),
-      if(immutable, "#"),
+      if(immutable, "+"),
       if(conflict, "x"),
       "o",
     )


### PR DESCRIPTION


Maybe it's personal preference, but the hash sign looks bigger compared to the normal "o" nodes, and is slanted. This makes immutable commits stand out too much. I think "+" is closer to the diamond character used in the unicode template.



# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
