### PR TITLE
working_copy: allow `load_working_copy()` to return error

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -191,12 +191,12 @@ impl WorkingCopyFactory for ConflictsWorkingCopyFactory {
         store: Arc<Store>,
         working_copy_path: PathBuf,
         state_path: PathBuf,
-    ) -> Box<dyn WorkingCopy> {
-        Box::new(ConflictsWorkingCopy::load(
+    ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError> {
+        Ok(Box::new(ConflictsWorkingCopy::load(
             store,
             working_copy_path,
             state_path,
-        ))
+        )))
     }
 }
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1504,6 +1504,7 @@ jj git init --colocate",
             err @ SignInitError::UnknownBackend(_),
         )) => user_error(err),
         WorkspaceLoadError::StoreLoadError(err) => internal_error(err),
+        WorkspaceLoadError::WorkingCopyState(err) => internal_error(err),
         WorkspaceLoadError::NonUnicodePath | WorkspaceLoadError::Path(_) => user_error(err),
     }
 }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1706,8 +1706,12 @@ impl WorkingCopyFactory for LocalWorkingCopyFactory {
         store: Arc<Store>,
         working_copy_path: PathBuf,
         state_path: PathBuf,
-    ) -> Box<dyn WorkingCopy> {
-        Box::new(LocalWorkingCopy::load(store, working_copy_path, state_path))
+    ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError> {
+        Ok(Box::new(LocalWorkingCopy::load(
+            store,
+            working_copy_path,
+            state_path,
+        )))
     }
 }
 

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -81,7 +81,7 @@ pub trait WorkingCopyFactory {
         store: Arc<Store>,
         working_copy_path: PathBuf,
         state_path: PathBuf,
-    ) -> Box<dyn WorkingCopy>;
+    ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError>;
 }
 
 /// A working copy that's being modified.

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -72,6 +72,8 @@ pub enum WorkspaceLoadError {
     #[error("Repo path could not be interpreted as Unicode text")]
     NonUnicodePath,
     #[error(transparent)]
+    WorkingCopyState(#[from] WorkingCopyStateError),
+    #[error(transparent)]
     Path(#[from] PathError),
 }
 
@@ -503,13 +505,14 @@ impl WorkspaceLoader {
         &self,
         store: &Arc<Store>,
         working_copy_factories: &WorkingCopyFactories,
-    ) -> Result<Box<dyn WorkingCopy>, StoreLoadError> {
+    ) -> Result<Box<dyn WorkingCopy>, WorkspaceLoadError> {
         let working_copy_factory = self.get_working_copy_factory(working_copy_factories)?;
-        Ok(working_copy_factory.load_working_copy(
+        let working_copy = working_copy_factory.load_working_copy(
             store.clone(),
             self.workspace_root.to_owned(),
             self.working_copy_state_path.to_owned(),
-        ))
+        )?;
+        Ok(working_copy)
     }
 }
 


### PR DESCRIPTION
It's reasonable for a `WorkingCopy` implementation to want to return an error. `LocalWorkingCopyFactory` doesn't because it loads all data lazily. The VFS-based one at Google wants to be able to return an error, however.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
