### PR TITLE
Add short a `-e` alias for `--edit` to prev and next

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -63,7 +63,7 @@ pub(crate) struct NextArgs {
     /// Instead of creating a new working-copy commit on top of the target
     /// commit (like `jj new`), edit the target commit directly (like `jj
     /// edit`).
-    #[arg(long)]
+    #[arg(long, short)]
     edit: bool,
 }
 

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -57,7 +57,7 @@ pub(crate) struct PrevArgs {
     #[arg(default_value = "1")]
     offset: u64,
     /// Edit the parent directly, instead of moving the working-copy commit.
-    #[arg(long)]
+    #[arg(long, short)]
     edit: bool,
 }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1191,7 +1191,7 @@ implied.
 
 ###### **Options:**
 
-* `--edit` — Instead of creating a new working-copy commit on top of the target commit (like `jj new`), edit the target commit directly (like `jj edit`)
+* `-e`, `--edit` — Instead of creating a new working-copy commit on top of the target commit (like `jj new`), edit the target commit directly (like `jj edit`)
 
   Possible values: `true`, `false`
 
@@ -1433,7 +1433,7 @@ implied.
 
 ###### **Options:**
 
-* `--edit` — Edit the parent directly, instead of moving the working-copy commit
+* `-e`, `--edit` — Edit the parent directly, instead of moving the working-copy commit
 
   Possible values: `true`, `false`
 


### PR DESCRIPTION
I'm not sure if this was an intentional omission, but I think it would be useful to have `-e` as a short flag for `--edit`. I don't usually edit commits, but I do use `prev` and `next` with edit to navigate to a commit that I want to squash. Often this is easier than typing `--from` and `--into` plus the change IDs.

If people want to edit commits we shouldn't stand in their way.