### PR TITLE
Rewrite rebasing in `jj split` using `transform_descendants()`

### DIFF
--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -286,7 +286,7 @@ fn rebase_branch(
 }
 
 /// Rebases `old_commits` onto `new_parents`.
-pub fn rebase_descendants(
+fn rebase_descendants(
     tx: &mut WorkspaceCommandTransaction,
     settings: &UserSettings,
     new_parents: Vec<Commit>,

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -346,8 +346,8 @@ fn test_split_siblings_no_descendants() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--siblings", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    First part: qpvuntsm?? 8d2b7558 TESTED=TODO
-    Second part: zsuskuln acd41528 (no description set)
+    First part: qpvuntsm 8d2b7558 TESTED=TODO
+    Second part: zsuskuln acd41528 test_branch | (no description set)
     Working copy now at: zsuskuln acd41528 test_branch | (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files


### PR DESCRIPTION
This is following on the rewrite for `parallelize`.

- https://github.com/martinvonz/jj/pull/3521

Since rebase_descendants from rebase.rs is no longer used outside of that file, it can be made private again.