### PR TITLE
CommitRewriter::rewrite_parents(): Take `IntoIterator` instead of `&[CommitId]`

### DIFF
--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -181,10 +181,8 @@ the operation will be aborted.
         |mut rewriter| {
             num_rebased += 1;
             if args.siblings {
-                rewriter.replace_parent(
-                    second_commit.id(),
-                    &[first_commit.id().clone(), second_commit.id().clone()],
-                );
+                rewriter
+                    .replace_parent(second_commit.id(), [first_commit.id(), second_commit.id()]);
             }
             // We don't need to do anything special for the non-siblings case
             // since we already marked the original commit as rewritten.

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -153,10 +153,14 @@ impl<'repo> CommitRewriter<'repo> {
 
     /// Update the intended new parents by replacing any occurrence of
     /// `old_parent` by `new_parents`.
-    pub fn replace_parent(&mut self, old_parent: &CommitId, new_parents: &[CommitId]) {
+    pub fn replace_parent<'a>(
+        &mut self,
+        old_parent: &CommitId,
+        new_parents: impl IntoIterator<Item = &'a CommitId>,
+    ) {
         if let Some(i) = self.new_parents.iter().position(|p| p == old_parent) {
             self.new_parents
-                .splice(i..i + 1, new_parents.iter().cloned());
+                .splice(i..i + 1, new_parents.into_iter().cloned());
             let mut unique = HashSet::new();
             self.new_parents.retain(|p| unique.insert(p.clone()));
         }

--- a/lib/tests/test_rewrite_transform.rs
+++ b/lib/tests/test_rewrite_transform.rs
@@ -48,7 +48,7 @@ fn test_transform_descendants_sync() {
     let mut rebased = HashMap::new();
     tx.mut_repo()
         .transform_descendants(&settings, vec![commit_b.id().clone()], |mut rewriter| {
-            rewriter.replace_parent(commit_a.id(), &[commit_g.id().clone()]);
+            rewriter.replace_parent(commit_a.id(), [commit_g.id()]);
             if *rewriter.old_commit() == commit_c {
                 let old_id = rewriter.old_commit().id().clone();
                 let new_parent_ids = rewriter.new_parents().to_vec();
@@ -106,7 +106,7 @@ fn test_transform_descendants_sync_linearize_merge() {
     let mut rebased = HashMap::new();
     tx.mut_repo()
         .transform_descendants(&settings, vec![commit_c.id().clone()], |mut rewriter| {
-            rewriter.replace_parent(commit_a.id(), &[commit_b.id().clone()]);
+            rewriter.replace_parent(commit_a.id(), [commit_b.id()]);
             let old_commit_id = rewriter.old_commit().id().clone();
             let new_commit = rewriter.rebase(&settings)?.write()?;
             rebased.insert(old_commit_id, new_commit);


### PR DESCRIPTION
CommitIds are often manipulated by reference, so this makes the API more flexible for cases where the caller doesn't already have a Vec or array of owned CommitIds.

In many cases, `rewrite_parents()` does not even need to clone the input CommitIds.  This refactor allows the clone to be avoided if it's unnecessary.

There might be other APIs that would benefit from a similar change. In general, it seems like there are a lot of places where we're writing `&[commit_x.id().clone, commit_y.id().clone()]` and similar.

   - [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/flexibility.html#functions-minimize-assumptions-about-parameters-by-using-generics-c-generic)
