### PR TITLE
fileset: fall back to bare pattern/string if no operator-like character found

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -748,7 +748,7 @@ impl WorkspaceCommandHelper {
         let ctx = self.fileset_parse_context();
         let expressions: Vec<_> = file_args
             .iter()
-            .map(|arg| fileset::parse(arg, &ctx))
+            .map(|arg| fileset::parse_maybe_bare(arg, &ctx))
             .try_collect()?;
         Ok(FilesetExpression::union_all(expressions))
     }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -151,7 +151,7 @@ fn cmd_debug_fileset(
     let workspace_command = command.workspace_helper(ui)?;
     let ctx = workspace_command.fileset_parse_context();
 
-    let expression = fileset::parse(&args.path, &ctx)?;
+    let expression = fileset::parse_maybe_bare(&args.path, &ctx)?;
     writeln!(ui.stdout(), "-- Parsed:")?;
     writeln!(ui.stdout(), "{expression:#?}")?;
     writeln!(ui.stdout())?;

--- a/docs/filesets.md
+++ b/docs/filesets.md
@@ -12,6 +12,15 @@ consists of file patterns, operators, and functions.
 ui.allow-filesets = true
 ```
 
+Many `jj` commands accept fileset expressions as positional arguments. File
+names passed to these commands must be quoted if they contain whitespace or meta
+characters. However, as a special case, quotes can be omitted if the expression
+has no operators nor function calls. For example:
+
+* `jj diff 'Foo Bar'` (shell quotes are required, but inner quotes are optional)
+* `jj diff '~"Foo Bar"'` (both shell and inner quotes are required)
+* `jj diff '"Foo(1)"'` (both shell and inner quotes are required)
+
 ## File patterns
 
 The following patterns are supported:

--- a/lib/src/fileset.pest
+++ b/lib/src/fileset.pest
@@ -27,6 +27,14 @@ strict_identifier = @{
   strict_identifier_part ~ ("-" ~ strict_identifier_part)*
 }
 
+// TODO: accept glob characters?
+// TODO: accept more ASCII meta characters such as "#" and ","?
+bare_string = @{
+  ( ASCII_ALPHANUMERIC
+  | " " | "+" | "-" | "." | "@" | "_" | "/" | "\\"
+  | '\u{80}'..'\u{10ffff}' )+
+}
+
 string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
@@ -50,6 +58,7 @@ function_arguments = {
 
 // TODO: change rhs to string_literal to require quoting? #2101
 string_pattern = { strict_identifier ~ pattern_kind_op ~ (identifier | string_literal) }
+bare_string_pattern = { strict_identifier ~ pattern_kind_op ~ bare_string }
 
 primary = {
   "(" ~ whitespace* ~ expression ~ whitespace* ~ ")"
@@ -65,3 +74,8 @@ expression = {
 }
 
 program = _{ SOI ~ whitespace* ~ expression ~ whitespace* ~ EOI }
+program_or_bare_string = _{
+  SOI ~ ( whitespace* ~ expression ~ whitespace* ~ EOI
+        | bare_string_pattern ~ EOI
+        | bare_string ~ EOI )
+}


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
