### PR TITLE
fileset, revset, templater: add support for single-quoted raw string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expressions](docs/filesets.md). Note that filesets are currently experimental,
   but will be enabled by default in a future release.
 
+* Revsets and templates now support single-quoted raw string literals.
+
 * `jj prev` and `jj next` now work when the working copy revision is a merge.
 
 * Operation objects in templates now have a `snapshot() -> Boolean` method that

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -24,6 +24,9 @@ string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }
 
+raw_string_content = @{ (!"'" ~ ANY)* }
+raw_string_literal = ${ "'" ~ raw_string_content ~ "'" }
+
 integer_literal = @{
   ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
   | "0"
@@ -59,6 +62,7 @@ primary = _{
   | lambda
   | identifier
   | string_literal
+  | raw_string_literal
   | integer_literal
 }
 

--- a/docs/filesets.md
+++ b/docs/filesets.md
@@ -13,13 +13,15 @@ ui.allow-filesets = true
 ```
 
 Many `jj` commands accept fileset expressions as positional arguments. File
-names passed to these commands must be quoted if they contain whitespace or meta
-characters. However, as a special case, quotes can be omitted if the expression
-has no operators nor function calls. For example:
+names passed to these commands [must be quoted][string-literals] if they contain
+whitespace or meta characters. However, as a special case, quotes can be omitted
+if the expression has no operators nor function calls. For example:
 
 * `jj diff 'Foo Bar'` (shell quotes are required, but inner quotes are optional)
 * `jj diff '~"Foo Bar"'` (both shell and inner quotes are required)
 * `jj diff '"Foo(1)"'` (both shell and inner quotes are required)
+
+[string-literals]: templates.md#string-literals
 
 ## File patterns
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -29,10 +29,12 @@ A full change ID refers to all visible commits with that change ID (there is
 typically only one visible commit with a given change ID). A unique prefix of
 the full change ID can also be used. It is an error to use a non-unique prefix.
 
-Use double quotes to prevent a symbol from being interpreted as an expression.
-For example, `"x-"` is the symbol `x-`, not the parents of symbol `x`.
-Taking shell quoting into account, you may need to use something like
-`jj log -r '"x-"'`.
+Use [single or double quotes][string-literals] to prevent a symbol from being
+interpreted as an expression. For example, `"x-"` is the symbol `x-`, not the
+parents of symbol `x`. Taking shell quoting into account, you may need to use
+something like `jj log -r '"x-"'`.
+
+[string-literals]: templates.md#string-literals
 
 ### Priority
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -194,11 +194,22 @@ defined.
 
 #### String literals
 
-String literals must be surrounded by double quotes (`"`). The following escape
-sequences starting with a backslash have their usual meaning: `\"`, `\\`, `\n`,
-`\r`, `\t`, `\0`. Other escape sequences are not supported. Any UTF-8 characters
-are allowed inside a string literal, with two exceptions: unescaped `"`-s and
-uses of `\` that don't form a valid escape sequence.
+String literals must be surrounded by single or double quotes (`'` or `"`).
+A double-quoted string literal supports the following escape sequences:
+
+* `\"`: double quote
+* `\\`: backslash
+* `\t`: horizontal tab
+* `\r`: carriage return
+* `\n`: new line
+* `\0`: null
+
+Other escape sequences are not supported. Any UTF-8 characters are allowed
+inside a string literal, with two exceptions: unescaped `"`-s and uses of `\`
+that don't form a valid escape sequence.
+
+A single-quoted string literal has no escape syntax. `'` can't be expressed
+inside a single-quoted string literal.
 
 ### Template type
 

--- a/lib/src/fileset.pest
+++ b/lib/src/fileset.pest
@@ -40,6 +40,9 @@ string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }
 
+raw_string_content = @{ (!"'" ~ ANY)* }
+raw_string_literal = ${ "'" ~ raw_string_content ~ "'" }
+
 pattern_kind_op = { ":" }
 
 negate_op = { "~" }
@@ -57,7 +60,11 @@ function_arguments = {
 }
 
 // TODO: change rhs to string_literal to require quoting? #2101
-string_pattern = { strict_identifier ~ pattern_kind_op ~ (identifier | string_literal) }
+string_pattern = {
+  strict_identifier
+  ~ pattern_kind_op
+  ~ (identifier | string_literal | raw_string_literal)
+}
 bare_string_pattern = { strict_identifier ~ pattern_kind_op ~ bare_string }
 
 primary = {
@@ -66,6 +73,7 @@ primary = {
   | string_pattern
   | identifier
   | string_literal
+  | raw_string_literal
 }
 
 expression = {

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -21,12 +21,16 @@ identifier = @{
 symbol = {
   identifier
   | string_literal
+  | raw_string_literal
 }
 
 string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }
+
+raw_string_content = @{ (!"'" ~ ANY)* }
+raw_string_literal = ${ "'" ~ raw_string_content ~ "'" }
 
 at_op = { "@" }
 pattern_kind_op = { ":" }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1082,10 +1082,10 @@ fn parse_string_pattern_rule(
 
 /// Parses symbol to expression, expands aliases as needed.
 fn parse_symbol_rule(
-    mut pairs: Pairs<Rule>,
+    pairs: Pairs<Rule>,
     state: ParseState,
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
-    let first = pairs.next().unwrap();
+    let first = pairs.peek().unwrap();
     match first.as_rule() {
         Rule::identifier => {
             let name = first.as_str();
@@ -1101,11 +1101,9 @@ fn parse_symbol_rule(
                 Ok(RevsetExpression::symbol(name.to_owned()))
             }
         }
-        Rule::string_literal => Ok(RevsetExpression::symbol(
-            STRING_LITERAL_PARSER.parse(first.into_inner()),
-        )),
         _ => {
-            panic!("unexpected symbol parse rule: {:?}", first.as_str());
+            let text = parse_symbol_rule_as_literal(pairs);
+            Ok(RevsetExpression::symbol(text))
         }
     }
 }


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
