### PR TITLE
local_working_copy: when all sides of a conflict are executable, mate…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ to avoid letting the user edit the immutable one.
 
 * `jj config list` now properly escapes TOML keys (#1322).
 
+* Files with conflicts are now checked out as executable if all sides of the 
+  conflict are executable.
+
 ## [0.17.1] - 2024-05-07
 
 ### Fixed bugs

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(missing_docs)]
+#![allow(clippy::let_unit_value)]
 
 use std::any::Any;
 use std::collections::HashSet;
@@ -109,7 +110,6 @@ impl FileState {
         let executable = {
             // Windows doesn't support executable bit.
             let _ = executable;
-            ()
         };
         FileState {
             file_type: FileType::Normal { executable },

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -512,6 +512,16 @@ impl MergedTreeValue {
         })
     }
 
+    /// If this merge contains only files or absent entries, returns a merge of
+    /// the files' executable bits.
+    pub fn to_executable_merge(&self) -> Option<Merge<bool>> {
+        self.maybe_map(|term| match term {
+            None => Some(false),
+            Some(TreeValue::File { id: _, executable }) => Some(*executable),
+            _ => None,
+        })
+    }
+
     /// Creates a new merge with the file ids from the given merge. In other
     /// words, only the executable bits from `self` will be preserved.
     pub fn with_new_file_ids(&self, file_ids: &Merge<Option<FileId>>) -> Self {


### PR DESCRIPTION
local_working_copy: when all sides of a conflict are executable, materialise the conflicted file as executable

Fixes #3579 and adds a testcase for an executable conflict treevalue.