### PR TITLE
template: add contained_in method to commit object in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj rebase -r` now accepts `--insert-after` and `--insert-before` options to
   customize the location of the rebased revisions.
 
+* Commit objects in templates now have a `containted_in(revset: String) -> Boolean` method.
+
 ### Fixed bugs
 
 * Revsets now support `\`-escapes in string literal.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -91,6 +91,7 @@ This type cannot be printed. The following methods are defined.
 * `hidden() -> Boolean`: True if the commit is not visible (a.k.a. abandoned).
 * `immutable() -> Boolean`: True if the commit is included in [the set of
   immutable commits](config.md#set-of-immutable-commits).
+* `contained_in(revset: String) -> Boolean`: True if the commit is included in [the provided revset](revsets.md).
 * `conflict() -> Boolean`: True if the commit contains merge conflicts.
 * `empty() -> Boolean`: True if the commit modifies no files.
 * `root() -> Boolean`: True if the commit is the root commit.


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Adds a new method to commit objects in templates to check whether they're contained within a given revset

Use cases:
- distinct coloring for commits that are local/on remote branches (`label(if(self.contained_in(::remote_branches()), "remote"), builtin_change_id_with_hidden_and_divergent_info)`)
- different node symbols for heads
- distinct styling for merge commits
- ...?

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
