### PR TITLE
Make `jj squash <path>` not rewrite unmatched commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   literals. This means that `snapshot.max-new-file-size="1"` and
   `snapshot.max-new-file-size=1` are now equivalent.
 
+* `jj squash <path>` is now a no-op if the path argument didn't match any paths
+  (it used to create new commits with bumped timestamp).
+  [#3334](https://github.com/martinvonz/jj/issues/3334)
+
 ## [0.16.0] - 2024-04-03
 
 ### Deprecations

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -297,7 +297,11 @@ from the source will be moved into the destination.
         }
     };
     let mut predecessors = vec![destination.id().clone()];
-    predecessors.extend(sources.iter().map(|source| source.id().clone()));
+    predecessors.extend(
+        source_commits
+            .iter()
+            .map(|source| source.commit.id().clone()),
+    );
     tx.mut_repo()
         .rewrite_commit(settings, &rewritten_destination)
         .set_tree_id(destination_tree.id().clone())

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -345,16 +345,14 @@ fn test_move_partial() {
     a
     "###);
 
-    // If we specify only a non-existent file, then the move still succeeds and
-    // creates unchanged commits.
+    // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["move", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Working copy now at: vruxwmqv b670567d d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Nothing changed.
     "###);
 }
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -241,15 +241,12 @@ fn test_squash_partial() {
     b
     "###);
 
-    // If we specify only a non-existent file, then the squash still succeeds and
-    // creates unchanged commits.
+    // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Rebased 2 descendant commits
-    Working copy now at: mzvwutvl 5e297967 c | (no description set)
-    Parent commit      : kkmpptxz ac258609 b | (no description set)
+    Nothing changed.
     "###);
 
     // We get a warning if we pass a positional argument that looks like a revset
@@ -257,9 +254,7 @@ fn test_squash_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "b"]);
     insta::assert_snapshot!(stderr, @r###"
     Warning: The argument "b" is being interpreted as a path. To specify a revset, pass -r "b" instead.
-    Rebased 1 descendant commits
-    Working copy now at: mzvwutvl 1c4e5596 c | (no description set)
-    Parent commit      : kkmpptxz 16cc94b4 b | (no description set)
+    Nothing changed.
     "###);
     insta::assert_snapshot!(stdout, @"");
 }
@@ -570,15 +565,13 @@ fn test_squash_from_to_partial() {
     a
     "###);
 
-    // If we specify only a non-existent file, then the move still succeeds and
-    // creates unchanged commits.
+    // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv b670567d d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Nothing changed.
     "###);
 }
 
@@ -692,12 +685,11 @@ fn test_squash_from_multiple() {
     f
     "###);
 
-    // Empty squash shouldn't crash (could be noop)
+    // Empty squash shouldn't crash
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from=none()"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: xznxytkn 68d54010 (empty) (no description set)
-    Parent commit      : yostqsxw b7bc1dda e f | (no description set)
+    Nothing changed.
     "###);
 }
 
@@ -893,7 +885,6 @@ fn test_squash_from_multiple_partial_no_op() {
     "###);
 
     // Source commits that didn't match the paths are not rewritten
-    // TODO: Comit c should be unchanged
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["squash", "--from=@-+ ~ @", "--into=@", "-m=d", "b"],
@@ -906,7 +897,7 @@ fn test_squash_from_multiple_partial_no_op() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  9227d0d780fa d
-    │ ◉  8907be4aab96 c
+    │ ◉  5ad3ca4090a7 c
     ├─╯
     ◉  3df52ee1f8a9 a
     ◉  000000000000
@@ -932,7 +923,6 @@ fn test_squash_from_multiple_partial_no_op() {
     "###);
 
     // If no source commits match the paths, then the whole operation is a no-op
-    // TODO: All commits should be unchanged
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -940,14 +930,13 @@ fn test_squash_from_multiple_partial_no_op() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: mzvwutvl 17f5bc7a d
-    Parent commit      : qpvuntsm 3df52ee1 a
+    Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  17f5bc7ab82a d
-    │ ◉  6eba26a0b46d c
+    @  09441f0a6266 d
+    │ ◉  5ad3ca4090a7 c
     ├─╯
-    │ ◉  88c573358ed5 b
+    │ ◉  285201979c90 b
     ├─╯
     ◉  3df52ee1f8a9 a
     ◉  000000000000

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -910,16 +910,13 @@ fn test_squash_from_multiple_partial_no_op() {
             r#"separate(" ", commit_id.short(), description)"#,
         ],
     );
-    // TODO: Commit c should not be a predecessor
     insta::assert_snapshot!(stdout, @r###"
-    @      9227d0d780fa d
-    ├─┬─╮
-    ◉ │ │  09441f0a6266 d
-    ◉ │ │  cba0f0aa472b d
-      ◉ │  285201979c90 b
-      ◉ │  81187418277d b
-        ◉  5ad3ca4090a7 c
-        ◉  7cfbaf71a279 c
+    @    9227d0d780fa d
+    ├─╮
+    ◉ │  09441f0a6266 d
+    ◉ │  cba0f0aa472b d
+      ◉  285201979c90 b
+      ◉  81187418277d b
     "###);
 
     // If no source commits match the paths, then the whole operation is a no-op

--- a/lib/tests/test_rewrite_transform.rs
+++ b/lib/tests/test_rewrite_transform.rs
@@ -50,11 +50,7 @@ fn test_transform_descendants_sync() {
         .transform_descendants(&settings, vec![commit_b.id().clone()], |mut rewriter| {
             rewriter.replace_parent(commit_a.id(), [commit_g.id()]);
             if *rewriter.old_commit() == commit_c {
-                let old_id = rewriter.old_commit().id().clone();
-                let new_parent_ids = rewriter.new_parents().to_vec();
-                rewriter
-                    .mut_repo()
-                    .record_abandoned_commit_with_parents(old_id, new_parent_ids);
+                rewriter.abandon();
             } else {
                 let old_commit_id = rewriter.old_commit().id().clone();
                 let new_commit = rewriter.rebase(&settings)?.write()?;


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
