### PR TITLE
Support extending revset functionality with custom functions and programmatic filters

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -967,12 +967,12 @@ impl WorkspaceCommandHelper {
             workspace_id: self.workspace_id(),
             workspace_root: self.workspace.workspace_root(),
         };
-        RevsetParseContext {
-            aliases_map: &self.revset_aliases_map,
-            user_email: self.settings.user_email(),
-            extensions: &self.revset_extensions,
-            workspace: Some(workspace_context),
-        }
+        RevsetParseContext::new(
+            &self.revset_aliases_map,
+            self.settings.user_email(),
+            &self.revset_extensions,
+            Some(workspace_context),
+        )
     }
 
     pub fn id_prefix_context(&self) -> Result<&IdPrefixContext, CommandError> {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -54,8 +54,9 @@ use jj_lib::repo::{
 };
 use jj_lib::repo_path::{FsPathParseError, RepoPath, RepoPathBuf};
 use jj_lib::revset::{
-    RevsetAliasesMap, RevsetExpression, RevsetExtensions, RevsetFilterPredicate, RevsetIteratorExt,
-    RevsetModifier, RevsetParseContext, RevsetWorkspaceContext, SymbolResolverExtension,
+    RevsetAliasesMap, RevsetExpression, RevsetExtensions, RevsetFilterPredicate, RevsetFunction,
+    RevsetIteratorExt, RevsetModifier, RevsetParseContext, RevsetWorkspaceContext,
+    SymbolResolverExtension,
 };
 use jj_lib::rewrite::restore_tree;
 use jj_lib::settings::{ConfigResultExt as _, UserSettings};
@@ -2744,6 +2745,15 @@ impl CliRunner {
         symbol_resolver: Box<dyn SymbolResolverExtension>,
     ) -> Self {
         self.revset_extensions.add_symbol_resolver(symbol_resolver);
+        self
+    }
+
+    pub fn add_revset_function_extension(
+        mut self,
+        name: &'static str,
+        func: RevsetFunction,
+    ) -> Self {
+        self.revset_extensions.add_custom_function(name, func);
         self
     }
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -489,7 +489,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert("mine", |language, _build_ctx, self_property, function| {
         template_parser::expect_no_arguments(function)?;
-        let user_email = language.revset_parse_context.user_email.clone();
+        let user_email = language.revset_parse_context.user_email().clone();
         let out_property = self_property.map(move |commit| commit.author().email == user_email);
         Ok(L::wrap_boolean(out_property))
     });
@@ -687,7 +687,7 @@ fn evaluate_revset_expression<'repo>(
 ) -> Result<Box<dyn Revset + 'repo>, TemplateParseError> {
     let symbol_resolver = revset_util::default_symbol_resolver(
         language.repo,
-        language.revset_parse_context.extensions.symbol_resolvers(),
+        language.revset_parse_context.symbol_resolvers(),
         language.id_prefix_context,
     );
     let revset =

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -489,7 +489,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert("mine", |language, _build_ctx, self_property, function| {
         template_parser::expect_no_arguments(function)?;
-        let user_email = language.revset_parse_context.user_email().clone();
+        let user_email = language.revset_parse_context.user_email().to_owned();
         let out_property = self_property.map(move |commit| commit.author().email == user_email);
         Ok(L::wrap_boolean(out_property))
     });

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -176,7 +176,7 @@ pub fn parse_immutable_expression(
     context: &RevsetParseContext,
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
     let (params, immutable_heads_str) = context
-        .aliases_map
+        .aliases_map()
         .get_function(BUILTIN_IMMUTABLE_HEADS)
         .unwrap();
     assert!(

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -32,7 +32,7 @@ use crate::matchers::{Matcher, Visit};
 use crate::repo_path::RepoPath;
 use crate::revset::{
     ResolvedExpression, ResolvedPredicateExpression, Revset, RevsetEvaluationError,
-    RevsetFilterPredicate, GENERATION_RANGE_FULL,
+    RevsetFilterExtensionWrapper, RevsetFilterPredicate, GENERATION_RANGE_FULL,
 };
 use crate::revset_graph::RevsetGraphEdge;
 use crate::rewrite;
@@ -1050,6 +1050,14 @@ fn build_predicate_fn(
             let commit = store.get_commit(&entry.commit_id()).unwrap();
             commit.has_conflict().unwrap()
         }),
+        RevsetFilterPredicate::Extension(RevsetFilterExtensionWrapper(ext)) => {
+            let ext = ext.clone();
+            box_pure_predicate_fn(move |index, pos| {
+                let entry = index.entry_by_pos(pos);
+                let commit = store.get_commit(&entry.commit_id()).unwrap();
+                ext.matches_commit(&commit)
+            })
+        }
     }
 }
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2656,10 +2656,38 @@ impl RevsetExtensions {
 /// Information needed to parse revset expression.
 #[derive(Clone)]
 pub struct RevsetParseContext<'a> {
-    pub aliases_map: &'a RevsetAliasesMap,
-    pub user_email: String,
-    pub extensions: &'a RevsetExtensions,
-    pub workspace: Option<RevsetWorkspaceContext<'a>>,
+    aliases_map: &'a RevsetAliasesMap,
+    user_email: String,
+    extensions: &'a RevsetExtensions,
+    workspace: Option<RevsetWorkspaceContext<'a>>,
+}
+
+impl<'a> RevsetParseContext<'a> {
+    pub fn new(
+        aliases_map: &'a RevsetAliasesMap,
+        user_email: String,
+        extensions: &'a RevsetExtensions,
+        workspace: Option<RevsetWorkspaceContext<'a>>,
+    ) -> Self {
+        Self {
+            aliases_map,
+            user_email,
+            extensions,
+            workspace,
+        }
+    }
+
+    pub fn aliases_map(&self) -> &'a RevsetAliasesMap {
+        self.aliases_map
+    }
+
+    pub fn user_email(&self) -> &String {
+        &self.user_email
+    }
+
+    pub fn symbol_resolvers(&self) -> &[impl AsRef<dyn SymbolResolverExtension>] {
+        self.extensions.symbol_resolvers()
+    }
 }
 
 /// Workspace information needed to parse revset expression.
@@ -2696,13 +2724,13 @@ mod tests {
         for (decl, defn) in aliases {
             aliases_map.insert(decl, defn).unwrap();
         }
-        let extensions: RevsetExtensions = Default::default();
-        let context = RevsetParseContext {
-            aliases_map: &aliases_map,
-            user_email: "test.user@example.com".to_string(),
-            extensions: &extensions,
-            workspace: None,
-        };
+        let extensions = RevsetExtensions::default();
+        let context = RevsetParseContext::new(
+            &aliases_map,
+            "test.user@example.com".to_string(),
+            &extensions,
+            None,
+        );
         // Map error to comparable object
         super::parse(revset_str, &context).map_err(|e| e.kind)
     }
@@ -2722,13 +2750,13 @@ mod tests {
         for (decl, defn) in aliases {
             aliases_map.insert(decl, defn).unwrap();
         }
-        let extensions: RevsetExtensions = Default::default();
-        let context = RevsetParseContext {
-            aliases_map: &aliases_map,
-            user_email: "test.user@example.com".to_string(),
-            extensions: &extensions,
-            workspace: Some(workspace_ctx),
-        };
+        let extensions = RevsetExtensions::default();
+        let context = RevsetParseContext::new(
+            &aliases_map,
+            "test.user@example.com".to_string(),
+            &extensions,
+            Some(workspace_ctx),
+        );
         // Map error to comparable object
         super::parse(revset_str, &context).map_err(|e| e.kind)
     }
@@ -2747,13 +2775,13 @@ mod tests {
         for (decl, defn) in aliases {
             aliases_map.insert(decl, defn).unwrap();
         }
-        let extensions: RevsetExtensions = Default::default();
-        let context = RevsetParseContext {
-            aliases_map: &aliases_map,
-            user_email: "test.user@example.com".to_string(),
-            extensions: &extensions,
-            workspace: None,
-        };
+        let extensions = RevsetExtensions::default();
+        let context = RevsetParseContext::new(
+            &aliases_map,
+            "test.user@example.com".to_string(),
+            &extensions,
+            None,
+        );
         // Map error to comparable object
         super::parse_with_modifier(revset_str, &context).map_err(|e| e.kind)
     }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -805,7 +805,7 @@ impl fmt::Display for RevsetAliasId<'_> {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct ParseState<'a> {
+pub struct ParseState<'a> {
     aliases_map: &'a RevsetAliasesMap,
     aliases_expanding: &'a [RevsetAliasId<'a>],
     locals: &'a HashMap<&'a str, Rc<RevsetExpression>>,
@@ -906,7 +906,7 @@ fn parse_program_with_modifier(
     }
 }
 
-fn parse_expression_rule(
+pub fn parse_expression_rule(
     pairs: Pairs<Rule>,
     state: ParseState,
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
@@ -1172,7 +1172,7 @@ fn all_function_names(aliases_map: &RevsetAliasesMap) -> impl Iterator<Item = &s
     )
 }
 
-type RevsetFunction =
+pub type RevsetFunction =
     fn(&str, Pair<Rule>, ParseState) -> Result<Rc<RevsetExpression>, RevsetParseError>;
 
 static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy::new(|| {
@@ -1372,7 +1372,7 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
 
 type OptionalArg<'i> = Option<Pair<'i, Rule>>;
 
-fn expect_no_arguments(
+pub fn expect_no_arguments(
     function_name: &str,
     arguments_pair: Pair<Rule>,
 ) -> Result<(), RevsetParseError> {
@@ -1380,7 +1380,7 @@ fn expect_no_arguments(
     Ok(())
 }
 
-fn expect_one_argument<'i>(
+pub fn expect_one_argument<'i>(
     function_name: &str,
     arguments_pair: Pair<'i, Rule>,
 ) -> Result<Pair<'i, Rule>, RevsetParseError> {
@@ -1388,7 +1388,7 @@ fn expect_one_argument<'i>(
     Ok(arg)
 }
 
-fn expect_arguments<'i, const N: usize, const M: usize>(
+pub fn expect_arguments<'i, const N: usize, const M: usize>(
     function_name: &str,
     arguments_pair: Pair<'i, Rule>,
 ) -> Result<([Pair<'i, Rule>; N], [OptionalArg<'i>; M]), RevsetParseError> {
@@ -1399,7 +1399,7 @@ fn expect_arguments<'i, const N: usize, const M: usize>(
 ///
 /// `argument_names` is a list of argument names. Unnamed positional arguments
 /// should be padded with `""`.
-fn expect_named_arguments<'i, const N: usize, const M: usize>(
+pub fn expect_named_arguments<'i, const N: usize, const M: usize>(
     function_name: &str,
     argument_names: &[&str],
     arguments_pair: Pair<'i, Rule>,
@@ -1409,7 +1409,7 @@ fn expect_named_arguments<'i, const N: usize, const M: usize>(
     Ok((required.try_into().unwrap(), optional.try_into().unwrap()))
 }
 
-fn expect_named_arguments_vec<'i>(
+pub fn expect_named_arguments_vec<'i>(
     function_name: &str,
     argument_names: &[&str],
     arguments_pair: Pair<'i, Rule>,
@@ -1486,7 +1486,7 @@ fn expect_named_arguments_vec<'i>(
     Ok((required, optional))
 }
 
-fn parse_function_argument_to_file_pattern(
+pub fn parse_function_argument_to_file_pattern(
     name: &str,
     pair: Pair<Rule>,
     state: ParseState,
@@ -1499,7 +1499,7 @@ fn parse_function_argument_to_file_pattern(
     parse_function_argument_as_pattern("file pattern", name, pair, state, parse_pattern)
 }
 
-fn parse_function_argument_to_string_pattern(
+pub fn parse_function_argument_to_string_pattern(
     name: &str,
     pair: Pair<Rule>,
     state: ParseState,
@@ -1543,7 +1543,7 @@ fn parse_function_argument_as_pattern<T, E: Into<Box<dyn error::Error + Send + S
     }
 }
 
-fn parse_function_argument_as_literal<T: FromStr>(
+pub fn parse_function_argument_as_literal<T: FromStr>(
     type_name: &str,
     name: &str,
     pair: Pair<Rule>,


### PR DESCRIPTION
This doesn't support _everything_ an extension might want to do with the revset language, but it covers a large portion of it and for much less internal cost than the previous proposal.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
