### PR TITLE
Add default value of revsets.log to config docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -222,6 +222,8 @@ You can configure the revisions `jj log` would show when neither `-r` nor any pa
 revsets.log = "main@origin.."
 ```
 
+The default value for `revsets.log` is `'@ | ancestors(immutable_heads().., 2) | trunk()'`.
+
 ### Graph style
 
 ```toml


### PR DESCRIPTION
I wanted to have a reference point for the built-in revsets, but `jj config get revsets.log` doesn't turn anything up since it has special handling for the legacy config key
`ui.default-revset`. So I had to dig into the source code of jj to get it.

I think it might help others to be able to reason about revsets to have the log default shown in the settings documentation.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated the documentation (README.md, docs/, demos/)
