### PR TITLE
Fix clippy warnings on windows

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -93,25 +93,28 @@ impl FileState {
     /// re-stat'ed on the next snapshot.
     fn placeholder() -> Self {
         #[cfg(unix)]
-        let executable = false;
+        let file_type = FileType::Normal { executable: false };
         #[cfg(windows)]
-        let executable = ();
+        let file_type = FileType::Normal { executable: () };
         FileState {
-            file_type: FileType::Normal { executable },
+            file_type,
             mtime: MillisSinceEpoch(0),
             size: 0,
         }
     }
 
     fn for_file(executable: bool, size: u64, metadata: &Metadata) -> Self {
+        #[cfg(unix)]
+        let file_type = FileType::Normal { executable };
         #[cfg(windows)]
-        let executable = {
-            // Windows doesn't support executable bit.
-            let _ = executable;
-            ()
+        let file_type = FileType::Normal {
+            executable: {
+                // Windows doesn't support executable bit.
+                let _ = executable; // Avoid unused variable warning.
+            },
         };
         FileState {
-            file_type: FileType::Normal { executable },
+            file_type,
             mtime: mtime_from_metadata(metadata),
             size,
         }


### PR DESCRIPTION
Minor rearrangements to avoid `clippy::unused_unit` and `clippy::let_unit_value` warnings on windows.

# Checklist

_None applicable_
