### PR TITLE
release: remove .git directory to get a clean `jj version` output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+    - name: Delete .git directory
+      run: rm -rf .git
     - name: Install packages (Ubuntu)
       if: matrix.os == 'ubuntu-20.04'
       run: |


### PR DESCRIPTION
Fixes #3629
