### PR TITLE
index_store: add more scope to write_index()

### DIFF
--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -359,14 +359,14 @@ impl IndexStore for DefaultIndexStore {
     fn write_index(
         &self,
         index: Box<dyn MutableIndex>,
-        op_id: &OperationId,
+        op: &Operation,
     ) -> Result<Box<dyn ReadonlyIndex>, IndexWriteError> {
         let index = index
             .into_any()
             .downcast::<DefaultMutableIndex>()
             .expect("index to merge in must be a DefaultMutableIndex");
         let index_segment = self
-            .save_mutable_index(*index, op_id)
+            .save_mutable_index(*index, op.id())
             .map_err(|err| IndexWriteError(err.into()))?;
         Ok(Box::new(DefaultReadonlyIndex::from_segment(index_segment)))
     }

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -23,7 +23,6 @@ use thiserror::Error;
 use crate::backend::{ChangeId, CommitId};
 use crate::commit::Commit;
 use crate::object_id::{HexPrefix, PrefixResolution};
-use crate::op_store::OperationId;
 use crate::operation::Operation;
 use crate::revset::{ResolvedExpression, Revset, RevsetEvaluationError};
 use crate::store::Store;
@@ -67,7 +66,7 @@ pub trait IndexStore: Send + Sync + Debug {
     fn write_index(
         &self,
         index: Box<dyn MutableIndex>,
-        op_id: &OperationId,
+        op: &Operation,
     ) -> Result<Box<dyn ReadonlyIndex>, IndexWriteError>;
 }
 

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -131,7 +131,7 @@ impl Transaction {
 
         let index = base_repo
             .index_store()
-            .write_index(mut_index, operation.id())
+            .write_index(mut_index, &operation)
             .unwrap();
         UnpublishedOperation::new(&base_repo.loader(), operation, view, index)
     }


### PR DESCRIPTION
This is more consistent with the other method and it makes some extension operations easier, by giving access to the OpStore and other relevant context for custom index extensions.
