### PR TITLE
cli: add --allow-empty-description flag to push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj new`'s `--insert-before` and `--insert-after` options can now be used
   simultaneously.
 
+* `jj git push` now can push commits with empty descriptions with the
+  `--allow-empty-description` flag
+
 ### Fixed bugs
 
 * Previously, `jj git push` only made sure that the branch is in the expected

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -231,6 +231,9 @@ pub struct GitPushArgs {
     /// correspond to missing local branches.
     #[arg(long)]
     deleted: bool,
+    /// Allow pushing commits with empty descriptions
+    #[arg(long)]
+    allow_empty_description: bool,
     /// Push branches pointing to these commits (can be repeated)
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
@@ -959,7 +962,7 @@ fn cmd_git_push(
     {
         let commit = commit?;
         let mut reasons = vec![];
-        if commit.description().is_empty() {
+        if commit.description().is_empty() && !args.allow_empty_description {
             reasons.push("it has no description");
         }
         if commit.author().name.is_empty()

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -976,6 +976,10 @@ Before the command actually moves, creates, or deletes a remote branch, it makes
 
   Possible values: `true`, `false`
 
+* `--allow-empty-description` — Allow pushing commits with empty descriptions
+
+  Possible values: `true`, `false`
+
 * `-r`, `--revisions <REVISIONS>` — Push branches pointing to these commits (can be repeated)
 * `-c`, `--change <CHANGE>` — Push this commit by creating a branch based on its change ID (can be repeated)
 * `--dry-run` — Only display what will change on the remote

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -823,6 +823,16 @@ fn test_git_push_no_description() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Won't push commit 5b36783cd11c since it has no description
     "###);
+    test_env.jj_cmd_ok(
+        &workspace_root,
+        &[
+            "git",
+            "push",
+            "--branch",
+            "my-branch",
+            "--allow-empty-description",
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
This commit adds an optional flag to be able to push commits with an empty description to a remote git repo. While the default behavior is ideal we might need to interact with a repo that has an empty commit description in it. I ran into this issue a few weeks ago pushing commits from an open source repo to an empty repo and had to go back to using git for that push as I would not want to rewrite the history which was many many years long just for that.

This flag allows users an escape hatch for pushing empty descriptions for commits and they're sure that they want that behavior.

This commit adds the flag to the `git push` command and updates the docs for the command. It also adds a new test to make sure that the flag works as intended alongside the old test which makes sure to reject an empty message for a commit.

Closes #2633

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

@martinvonz here's the PR I said I would drop by this week to fix my issue. Thanks for pointing things out. It was quite an easy PR to do and the codebase is well organized. I've also signed the CLA since this is the first time I'm contributing to the repo.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
