### PR TITLE
cli: parse out redundant "all:" revset modifier

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -14,7 +14,7 @@
 
 use jj_lib::backend::CommitId;
 use jj_lib::repo::Repo;
-use jj_lib::revset::{self, RevsetExpression, RevsetFilterPredicate, RevsetIteratorExt};
+use jj_lib::revset::{RevsetExpression, RevsetFilterPredicate, RevsetIteratorExt};
 use jj_lib::revset_graph::{
     ReverseRevsetGraphIterator, RevsetGraphEdgeType, TopoGroupedRevsetGraphIterator,
 };
@@ -262,7 +262,9 @@ pub(crate) fn cmd_log(
                  working copy commit, pass -r '@' instead."
             )?;
         } else if revset.is_empty()
-            && revset::parse(only_path, &workspace_command.revset_parse_context()).is_ok()
+            && workspace_command
+                .parse_revset(&RevisionArg::from(only_path.to_owned()))
+                .is_ok()
         {
             writeln!(
                 ui.warning_default(),

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -18,7 +18,6 @@ use jj_lib::matchers::Matcher;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
-use jj_lib::revset;
 use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
@@ -234,11 +233,10 @@ from the source will be moved into the destination.
 
         if let [only_path] = path_arg {
             if no_rev_arg
-                && revset::parse(
-                    only_path,
-                    &tx.base_workspace_helper().revset_parse_context(),
-                )
-                .is_ok()
+                && tx
+                    .base_workspace_helper()
+                    .parse_revset(&RevisionArg::from(only_path.to_owned()))
+                    .is_ok()
             {
                 writeln!(
                     ui.warning_default(),

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -28,7 +28,7 @@ use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::{RefTarget, RemoteRef, WorkspaceId};
 use jj_lib::repo::Repo;
-use jj_lib::revset::{self, Revset, RevsetExpression, RevsetParseContext};
+use jj_lib::revset::{self, Revset, RevsetExpression, RevsetModifier, RevsetParseContext};
 use once_cell::unsync::OnceCell;
 
 use crate::template_builder::{
@@ -713,9 +713,11 @@ fn evaluate_user_revset<'repo>(
     span: pest::Span<'_>,
     revset: &str,
 ) -> Result<Box<dyn Revset + 'repo>, TemplateParseError> {
-    let expression = revset::parse(revset, &language.revset_parse_context).map_err(|err| {
-        TemplateParseError::expression("Failed to parse revset", span).with_source(err)
-    })?;
+    let (expression, modifier) =
+        revset::parse_with_modifier(revset, &language.revset_parse_context).map_err(|err| {
+            TemplateParseError::expression("Failed to parse revset", span).with_source(err)
+        })?;
+    let (None | Some(RevsetModifier::All)) = modifier;
 
     evaluate_revset_expression(language, span, expression)
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -454,7 +454,7 @@ fn test_log_bad_short_prefixes() {
     1 | !nval!d
       | ^---
       |
-      = expected <expression>
+      = expected <identifier> or <expression>
     For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
 }


### PR DESCRIPTION
#3654

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
