### PR TITLE
diff_util: remove `WorkspaceCommandHelper` dependency

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -86,7 +86,7 @@ use crate::commit_templater::{CommitTemplateLanguage, CommitTemplateLanguageExte
 use crate::config::{
     new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
 };
-use crate::diff_util::DiffWorkspaceContext;
+use crate::diff_util::{DiffFormat, DiffRenderer, DiffWorkspaceContext};
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
 use crate::git_util::{
     is_colocated_git_workspace, print_failed_git_export, print_git_import_stats,
@@ -808,12 +808,13 @@ impl WorkspaceCommandHelper {
         Ok(git_ignores)
     }
 
-    // TODO: make it private
-    pub(crate) fn diff_context(&self) -> DiffWorkspaceContext<'_> {
-        DiffWorkspaceContext {
+    /// Creates textual diff renderer of the specified `formats`.
+    pub fn diff_renderer(&self, formats: Vec<DiffFormat>) -> DiffRenderer<'_> {
+        let workspace_ctx = DiffWorkspaceContext {
             cwd: &self.cwd,
             workspace_root: self.workspace.workspace_root(),
-        }
+        };
+        DiffRenderer::new(self.repo().as_ref(), workspace_ctx, formats)
     }
 
     /// Loads diff editor from the settings.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -86,6 +86,7 @@ use crate::commit_templater::{CommitTemplateLanguage, CommitTemplateLanguageExte
 use crate::config::{
     new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
 };
+use crate::diff_util::DiffWorkspaceContext;
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
 use crate::git_util::{
     is_colocated_git_workspace, print_failed_git_export, print_git_import_stats,
@@ -805,6 +806,14 @@ impl WorkspaceCommandHelper {
             }
         }
         Ok(git_ignores)
+    }
+
+    // TODO: make it private
+    pub(crate) fn diff_context(&self) -> DiffWorkspaceContext<'_> {
+        DiffWorkspaceContext {
+            cwd: &self.cwd,
+            workspace_root: self.workspace.workspace_root(),
+        }
     }
 
     /// Loads diff editor from the settings.

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -36,10 +36,9 @@ use jj_lib::working_copy::{ResetError, SnapshotError, WorkingCopyStateError};
 use jj_lib::workspace::WorkspaceInitError;
 use thiserror::Error;
 
+use crate::diff_util::DiffRenderError;
 use crate::formatter::{FormatRecorder, Formatter};
-use crate::merge_tools::{
-    ConflictResolveError, DiffEditError, DiffGenerateError, MergeToolConfigError,
-};
+use crate::merge_tools::{ConflictResolveError, DiffEditError, MergeToolConfigError};
 use crate::revset_util::UserRevsetEvaluationError;
 use crate::template_parser::{TemplateParseError, TemplateParseErrorKind};
 use crate::ui::Ui;
@@ -361,9 +360,13 @@ impl From<DiffEditError> for CommandError {
     }
 }
 
-impl From<DiffGenerateError> for CommandError {
-    fn from(err: DiffGenerateError) -> Self {
-        user_error_with_message("Failed to generate diff", err)
+impl From<DiffRenderError> for CommandError {
+    fn from(err: DiffRenderError) -> Self {
+        match err {
+            DiffRenderError::DiffGenerate(_) => user_error(err),
+            DiffRenderError::Backend(err) => err.into(),
+            DiffRenderError::Io(err) => err.into(),
+        }
     }
 }
 

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 
 use crate::cli_util::{print_unmatched_explicit_paths, CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
-use crate::diff_util::{diff_formats_for, DiffFormatArgs};
+use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
 /// Compare file contents between two revisions
@@ -76,8 +76,7 @@ pub(crate) fn cmd_diff(
     }
     let fileset_expression = workspace_command.parse_file_patterns(&args.paths)?;
     let matcher = fileset_expression.to_matcher();
-    let diff_formats = diff_formats_for(command.settings(), &args.format)?;
-    let diff_renderer = workspace_command.diff_renderer(diff_formats);
+    let diff_renderer = workspace_command.diff_renderer_for(&args.format)?;
     ui.request_pager();
     diff_renderer.show_diff(
         ui,

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 
 use crate::cli_util::{print_unmatched_explicit_paths, CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
-use crate::diff_util::{diff_formats_for, show_diff, DiffFormatArgs};
+use crate::diff_util::{diff_formats_for, DiffFormatArgs};
 use crate::ui::Ui;
 
 /// Compare file contents between two revisions
@@ -77,15 +77,14 @@ pub(crate) fn cmd_diff(
     let fileset_expression = workspace_command.parse_file_patterns(&args.paths)?;
     let matcher = fileset_expression.to_matcher();
     let diff_formats = diff_formats_for(command.settings(), &args.format)?;
+    let diff_renderer = workspace_command.diff_renderer(diff_formats);
     ui.request_pager();
-    show_diff(
+    diff_renderer.show_diff(
         ui,
         ui.stdout_formatter().as_mut(),
-        &workspace_command,
         &from_tree,
         &to_tree,
         matcher.as_ref(),
-        &diff_formats,
     )?;
     print_unmatched_explicit_paths(
         ui,

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -59,15 +59,14 @@ pub(crate) fn cmd_interdiff(
         .parse_file_patterns(&args.paths)?
         .to_matcher();
     let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
+    let diff_renderer = workspace_command.diff_renderer(diff_formats);
     ui.request_pager();
-    diff_util::show_diff(
+    diff_renderer.show_diff(
         ui,
         ui.stdout_formatter().as_mut(),
-        &workspace_command,
         &from_tree,
         &to_tree,
         matcher.as_ref(),
-        &diff_formats,
     )?;
     Ok(())
 }

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
-use crate::diff_util::{self, DiffFormatArgs};
+use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
 /// Compare the changes of two commits
@@ -58,8 +58,7 @@ pub(crate) fn cmd_interdiff(
     let matcher = workspace_command
         .parse_file_patterns(&args.paths)?
         .to_matcher();
-    let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
-    let diff_renderer = workspace_command.diff_renderer(diff_formats);
+    let diff_renderer = workspace_command.diff_renderer_for(&args.format)?;
     ui.request_pager();
     diff_renderer.show_diff(
         ui,

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -68,5 +68,6 @@ pub(crate) fn cmd_interdiff(
         &to_tree,
         matcher.as_ref(),
         &diff_formats,
-    )
+    )?;
+    Ok(())
 }

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 use crate::cli_util::{format_template, CommandHelper, LogContentFormat, RevisionArg};
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitTemplateLanguage;
-use crate::diff_util::{self, DiffFormatArgs};
+use crate::diff_util::DiffFormatArgs;
 use crate::graphlog::{get_graphlog, Edge};
 use crate::ui::Ui;
 
@@ -102,10 +102,7 @@ pub(crate) fn cmd_log(
     let revset = revset_expression.evaluate()?;
 
     let store = repo.store();
-    let diff_formats =
-        diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch)?;
-    let diff_renderer =
-        (!diff_formats.is_empty()).then(|| workspace_command.diff_renderer(diff_formats));
+    let diff_renderer = workspace_command.diff_renderer_for_log(&args.diff_format, args.patch)?;
 
     let use_elided_nodes = command
         .settings()

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -181,5 +181,6 @@ fn show_predecessor_patch(
         &tree,
         &EverythingMatcher,
         diff_formats,
-    )
+    )?;
+    Ok(())
 }

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 use crate::cli_util::{format_template, CommandHelper, LogContentFormat, RevisionArg};
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitTemplateLanguage;
-use crate::diff_util::{self, DiffFormatArgs, DiffRenderer};
+use crate::diff_util::{DiffFormatArgs, DiffRenderer};
 use crate::formatter::Formatter;
 use crate::graphlog::{get_graphlog, Edge};
 use crate::ui::Ui;
@@ -71,10 +71,7 @@ pub(crate) fn cmd_obslog(
 
     let start_commit = workspace_command.resolve_single_rev(&args.revision)?;
 
-    let diff_formats =
-        diff_util::diff_formats_for_log(command.settings(), &args.diff_format, args.patch)?;
-    let diff_renderer =
-        (!diff_formats.is_empty()).then(|| workspace_command.diff_renderer(diff_formats));
+    let diff_renderer = workspace_command.diff_renderer_for_log(&args.diff_format, args.patch)?;
     let with_content_format = LogContentFormat::new(ui, command.settings())?;
 
     let template;

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 
 use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
-use crate::diff_util::{self, DiffFormatArgs};
+use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
 /// Show commit description and changes in a revision
@@ -51,8 +51,7 @@ pub(crate) fn cmd_show(
         None => command.settings().config().get_string("templates.show")?,
     };
     let template = workspace_command.parse_commit_template(&template_string)?;
-    let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
-    let diff_renderer = workspace_command.diff_renderer(diff_formats);
+    let diff_renderer = workspace_command.diff_renderer_for(&args.format)?;
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -52,17 +52,11 @@ pub(crate) fn cmd_show(
     };
     let template = workspace_command.parse_commit_template(&template_string)?;
     let diff_formats = diff_util::diff_formats_for(command.settings(), &args.format)?;
+    let diff_renderer = workspace_command.diff_renderer(diff_formats);
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
     template.format(&commit, formatter)?;
-    diff_util::show_patch(
-        ui,
-        formatter,
-        &workspace_command,
-        &commit,
-        &EverythingMatcher,
-        &diff_formats,
-    )?;
+    diff_renderer.show_patch(ui, formatter, &commit, &EverythingMatcher)?;
     Ok(())
 }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -19,6 +19,7 @@ use tracing::instrument;
 
 use crate::cli_util::{print_conflicted_paths, CommandHelper};
 use crate::command_error::CommandError;
+use crate::diff_util::DiffFormat;
 use crate::ui::Ui;
 use crate::{diff_util, revset_util};
 
@@ -64,10 +65,14 @@ pub(crate) fn cmd_status(
             writeln!(formatter, "The working copy is clean")?;
         } else {
             writeln!(formatter, "Working copy changes:")?;
-            diff_util::show_diff_summary(
+            diff_util::show_diff(
+                ui,
                 formatter,
                 &workspace_command,
-                parent_tree.diff_stream(&tree, matcher.as_ref()),
+                &parent_tree,
+                &tree,
+                &matcher,
+                &[DiffFormat::Summary],
             )?;
         }
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -20,8 +20,8 @@ use tracing::instrument;
 use crate::cli_util::{print_conflicted_paths, CommandHelper};
 use crate::command_error::CommandError;
 use crate::diff_util::DiffFormat;
+use crate::revset_util;
 use crate::ui::Ui;
-use crate::{diff_util, revset_util};
 
 /// Show high-level repo status
 ///
@@ -65,15 +65,8 @@ pub(crate) fn cmd_status(
             writeln!(formatter, "The working copy is clean")?;
         } else {
             writeln!(formatter, "Working copy changes:")?;
-            diff_util::show_diff(
-                ui,
-                formatter,
-                &workspace_command,
-                &parent_tree,
-                &tree,
-                &matcher,
-                &[DiffFormat::Summary],
-            )?;
+            let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
+            diff_renderer.show_diff(ui, formatter, &parent_tree, &tree, &matcher)?;
         }
 
         // TODO: Conflicts should also be filtered by the `matcher`. See the related

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -7,7 +7,7 @@ use jj_lib::settings::UserSettings;
 
 use crate::cli_util::{edit_temp_file, WorkspaceCommandHelper};
 use crate::command_error::CommandError;
-use crate::diff_util::{self, DiffFormat};
+use crate::diff_util::DiffFormat;
 use crate::formatter::PlainTextFormatter;
 use crate::text_util;
 use crate::ui::Ui;
@@ -97,13 +97,12 @@ pub fn description_template_for_describe(
     commit: &Commit,
 ) -> Result<String, CommandError> {
     let mut diff_summary_bytes = Vec::new();
-    diff_util::show_patch(
+    let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
+    diff_renderer.show_patch(
         ui,
         &mut PlainTextFormatter::new(&mut diff_summary_bytes),
-        workspace_command,
         commit,
         &EverythingMatcher,
-        &[DiffFormat::Summary],
     )?;
     let description = if commit.description().is_empty() {
         settings.default_description()
@@ -127,14 +126,13 @@ pub fn description_template_for_commit(
     to_tree: &MergedTree,
 ) -> Result<String, CommandError> {
     let mut diff_summary_bytes = Vec::new();
-    diff_util::show_diff(
+    let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
+    diff_renderer.show_diff(
         ui,
         &mut PlainTextFormatter::new(&mut diff_summary_bytes),
-        workspace_command,
         from_tree,
         to_tree,
         &EverythingMatcher,
-        &[DiffFormat::Summary],
     )?;
     let mut template_chunks = Vec::new();
     if !intro.is_empty() {

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -217,7 +217,9 @@ pub fn show_diff(
             }
             DiffFormat::Stat => {
                 let tree_diff = from_tree.diff_stream(to_tree, matcher);
-                show_diff_stat(ui, formatter, workspace_command, tree_diff)?;
+                // TODO: In graph log, graph width should be subtracted
+                let width = usize::from(ui.term_width().unwrap_or(80));
+                show_diff_stat(formatter, workspace_command, tree_diff, width)?;
             }
             DiffFormat::Types => {
                 let tree_diff = from_tree.diff_stream(to_tree, matcher);
@@ -939,10 +941,10 @@ fn get_diff_stat(
 }
 
 pub fn show_diff_stat(
-    ui: &Ui,
     formatter: &mut dyn Formatter,
     workspace_command: &WorkspaceCommandHelper,
     tree_diff: TreeDiffStream,
+    display_width: usize,
 ) -> Result<(), DiffRenderError> {
     let mut stats: Vec<DiffStat> = vec![];
     let mut max_path_width = 0;
@@ -966,8 +968,7 @@ pub fn show_diff_stat(
 
     let number_padding = max_diffs.to_string().len();
     // 4 characters padding for the graph
-    let available_width =
-        usize::from(ui.term_width().unwrap_or(80)).saturating_sub(4 + " | ".len() + number_padding);
+    let available_width = display_width.saturating_sub(4 + " | ".len() + number_padding);
     // Always give at least a tiny bit of room
     let available_width = max(available_width, 5);
     let max_path_width = max_path_width.clamp(3, (0.7 * available_width as f64) as usize);


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
