### PR TITLE
remove repeated "exit status" from SSH signing error, use default formatting in merge tools

### DIFF
--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -116,7 +116,7 @@ pub enum ExternalToolError {
         #[source]
         source: std::io::Error,
     },
-    #[error("{}", format_tool_aborted(.exit_status))]
+    #[error("Tool exited with {exit_status} (run with --debug to see the exact invocation)")]
     ToolAborted { exit_status: ExitStatus },
     #[error("I/O error")]
     Io(#[source] std::io::Error),
@@ -331,24 +331,12 @@ pub fn generate_diff(
     if !exit_status.success() {
         writeln!(
             ui.warning_default(),
-            "{}",
-            format_tool_aborted(&exit_status)
+            "Tool exited with {exit_status} (run with --debug to see the exact invocation)",
         )
         .ok();
     }
     copy_result.map_err(ExternalToolError::Io)?;
     Ok(())
-}
-
-fn format_tool_aborted(exit_status: &ExitStatus) -> String {
-    let code = exit_status
-        .code()
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| "<unknown>".to_string());
-    format!(
-        "Tool exited with a non-zero code (run with --debug to see the exact invocation). Exit \
-         code: {code}."
-    )
 }
 
 #[cfg(test)]

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -895,8 +895,8 @@ fn test_diff_external_tool() {
 
     diff
     "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: Tool exited with a non-zero code (run with --debug to see the exact invocation). Exit code: 1.
+    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
+    Warning: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     "###);
 
     // --tool=:builtin shouldn't be ignored

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -89,9 +89,10 @@ fn test_diffedit() {
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
-    insta::assert_snapshot!(&test_env.jj_cmd_failure(&repo_path, &["diffedit"]), @r###"
+    let stderr = &test_env.jj_cmd_failure(&repo_path, &["diffedit"]);
+    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
     Error: Failed to edit diff
-    Caused by: Tool exited with a non-zero code (run with --debug to see the exact invocation). Exit code: 1.
+    Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -435,9 +436,10 @@ fn test_diffedit_old_restore_interactive_tests() {
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
-    insta::assert_snapshot!(&test_env.jj_cmd_failure(&repo_path, &["diffedit", "--from", "@-"]), @r###"
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit", "--from", "@-"]);
+    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
     Error: Failed to edit diff
-    Caused by: Tool exited with a non-zero code (run with --debug to see the exact invocation). Exit code: 1.
+    Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -33,7 +33,7 @@ pub struct SshBackend {
 
 #[derive(Debug, Error)]
 pub enum SshError {
-    #[error("SSH sign failed with exit status {exit_status}:\n{stderr}")]
+    #[error("SSH sign failed with {exit_status}:\n{stderr}")]
     Command {
         exit_status: ExitStatus,
         stderr: String,


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
