### PR TITLE
Add the revsets `mutable` and `immutable`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Note, these are cross compiled and currently untested.
   We plan on providing fully tested builds later once our CI system allows it.
 
+* Added new revsets `mutable()` and `immutable()`.
+
 ### Fixed bugs
 
 * When the working copy commit becomes immutable, a new one is automatically created on top of it 

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -18,3 +18,5 @@ latest(
 '''
 
 'immutable_heads()' = 'trunk() | tags()'
+'immutable()' = '::(immutable_heads() | root())'
+'mutable()' = '~immutable()'

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -223,6 +223,16 @@ for a comprehensive list.
 * `immutable_heads()`: Resolves to `trunk() | tags()` by default. See
   [here](config.md#set-of-immutable-commits) for details.
 
+* `immutable()`: The set of commits that `jj` treats as immutable. This is
+  equivalent to `::(immutable_heads() | root())`. Note that modifying this will
+  *not* change whether a commit is immutable. To do that, edit
+  `immutable_heads()`.
+
+* `mutable()`: The set of commits that `jj` treats as mutable. This is
+  equivalent to `~immutable()`. Note that modifying this will
+  *not* change whether a commit is immutable. To do that, edit
+  `immutable_heads()`.
+
 
 ## The `all:` modifier
 


### PR DESCRIPTION
I add them as aliases, since a user may instead choose to define `immutable_heads()`, for example, as `heads(immutable())`, and the define `immutable()` instead.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [NA] I have updated the config schema (cli/src/config-schema.json)
- [NA] I have added tests to cover my changes
