### PR TITLE
docs: fix converting a repo into a co-located one

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -173,7 +173,7 @@ echo -n '../../../.git' > .jj/repo/store/git_target
 echo '/*' > .jj/.gitignore
 # Make the Git repository non-bare and set HEAD
 git config --unset core.bare
-jj st
+jj new @-
 ```
 
 We may officially support this in the future. If you try this, we would


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

Personal note:

I started using jj last week and I'm already completely sold. (thank you!) Support for submodules and git-lfs are the only blockers for me right now. Submodules I think I can solve with a colocated repo and maybe even some hacky shell hooks to trigger git commands when jj updates something and ignores the submodules. So I tested the workflow of converting a pure jj repo to colocated - in case I need to add submodules.