### PR TITLE
completion: add branch name completions for fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj branch track` now show conflicts if there are some.
 
+* Added custom completion of branch names to `jj branch` subcommands for fish.
+
 ### Fixed bugs
 
 * When the working copy commit becomes immutable, a new one is automatically created on top of it 

--- a/cli/src/commands/util.rs
+++ b/cli/src/commands/util.rs
@@ -244,6 +244,29 @@ impl ShellCompletion {
             Self::Zsh => generate(Shell::Zsh, cmd, bin_name, &mut buf),
         }
 
+        // Append custom completions. The main purpose of these is to support
+        // dynamic completions, like branch names. This may be removed in the
+        // future when clap has builtin support for dynamic completions, see:
+        // https://github.com/clap-rs/clap/issues/1232
+        match self {
+            Self::Bash => {}
+            Self::Elvish => {}
+            Self::Fish => buf.write_all(CUSTOM_FISH_COMPLETIONS).unwrap(),
+            Self::Nushell => {}
+            Self::PowerShell => {}
+            Self::Zsh => {}
+        }
+
         buf
     }
 }
+
+static CUSTOM_FISH_COMPLETIONS: &[u8] = r#"
+# dynamic branch name completions
+complete -c jj -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from delete" -f -a "(jj branch list -T 'name ++ \"\n\"')"
+complete -c jj -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from forget" -f -a "(jj branch list -T 'name ++ \"\n\"')"
+complete -c jj -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from rename" -f -a "(jj branch list -T 'name ++ \"\n\"')"
+complete -c jj -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from set" -f -a "(jj branch list -T 'name ++ \"\n\"')"
+complete -c jj -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from track" -f -a "(jj branch list -a -T 'if(remote && !tracked, name ++ \"@\" ++ remote ++ \"\n\")')"
+complete -c jj -n "__fish_seen_subcommand_from branch; and __fish_seen_subcommand_from untrack" -f -a "(jj branch list -a -T 'if(tracked && !\"git\".contains(remote), name ++ \"@\" ++ remote ++ \"\n\")')"
+"#.as_bytes();


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

This is related to #1217, but that issue should probably stay open until someone adds these completions for other shells as well.