### PR TITLE
conflicts: label closing delimeter with e.g. "Conflict 2 of 3 ends"

### DIFF
--- a/cli/tests/test_cat_command.rs
+++ b/cli/tests/test_cat_command.rs
@@ -95,7 +95,7 @@ fn test_cat() {
     +a
     +++++++ Contents of side #2
     c
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 }
 

--- a/cli/tests/test_chmod_command.rs
+++ b/cli/tests/test_chmod_command.rs
@@ -77,7 +77,7 @@ fn test_chmod_regular_conflict() {
     +x
     +++++++ Contents of side #2
     n
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     // Test chmodding a conflict
@@ -96,7 +96,7 @@ fn test_chmod_regular_conflict() {
     +x
     +++++++ Contents of side #2
     n
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     test_env.jj_cmd_ok(&repo_path, &["chmod", "n", "file"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
@@ -113,7 +113,7 @@ fn test_chmod_regular_conflict() {
     +x
     +++++++ Contents of side #2
     n
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     // Unmatched paths should generate warnings
@@ -206,7 +206,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     a
     %%%%%%% Changes from base to side #2
     -base
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["chmod", "x", "file", "-r=file_deletion"]);
@@ -239,6 +239,6 @@ fn test_chmod_file_dir_deletion_conflicts() {
     a
     %%%%%%% Changes from base to side #2
     -base
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 }

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -402,7 +402,7 @@ fn test_diffedit_merge() {
     +c
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 }
 

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -159,7 +159,7 @@ fn test_interdiff_conflicting() {
     -+abc
     -+++++++ Contents of side #2
     -bar
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +def
     "###);
 }

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -65,7 +65,7 @@ fn test_obslog_with_or_without_diff() {
     │     4     : +++++++ Contents of side #2
     │     5     : foo
     │     6     : bar
-    │     7     : >>>>>>>
+    │     7     : >>>>>>> Conflict 1 of 1 ends
     ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
     ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
@@ -117,7 +117,7 @@ fn test_obslog_with_or_without_diff() {
     -+++++++ Contents of side #2
     -foo
     -bar
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +resolved
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     my description

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -75,7 +75,7 @@ fn test_resolution() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     let editor_script = test_env.set_up_fake_editor();
@@ -110,7 +110,7 @@ fn test_resolution() {
     -+a
     -+++++++ Contents of side #2
     -b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +resolution
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
@@ -150,7 +150,7 @@ fn test_resolution() {
     -+a
     -+++++++ Contents of side #2
     -b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +resolution
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]),
@@ -184,7 +184,7 @@ fn test_resolution() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
     @r###"
@@ -199,7 +199,7 @@ fn test_resolution() {
     -+a
     -+++++++ Contents of side #2
     -b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +resolution
     "###);
 
@@ -259,7 +259,7 @@ fn test_resolution() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     // Note the "Modified" below
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
@@ -277,7 +277,7 @@ fn test_resolution() {
      +++++++ Contents of side #2
     -b
     +conflict
-     >>>>>>>
+     >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -334,13 +334,14 @@ fn test_resolution() {
     -+a
     -+++++++ Contents of side #2
     -b
+    ->>>>>>> Conflict 1 of 1 ends
     +<<<<<<<
     +%%%%%%%
     +-some
     ++fake
     ++++++++
     +conflict
-     >>>>>>>
+    +>>>>>>>
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -407,7 +408,7 @@ fn test_normal_conflict_input_files() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "base", "base\n");
@@ -447,7 +448,7 @@ fn test_baseless_conflict_input_files() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "base", "");
@@ -518,7 +519,7 @@ fn test_edit_delete_conflict_input_files() {
     a
     %%%%%%% Changes from base to side #2
     -base
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "base", "base\n");
@@ -691,7 +692,7 @@ fn test_multiple_conflicts() {
     +first a
     +++++++ Contents of side #2
     first b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("another_file")).unwrap()
@@ -702,7 +703,7 @@ fn test_multiple_conflicts() {
     +second a
     +++++++ Contents of side #2
     second b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -751,7 +752,7 @@ fn test_multiple_conflicts() {
     -+second a
     -+++++++ Contents of side #2
     -second b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +resolution another_file
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -790,7 +791,7 @@ fn test_multiple_conflicts() {
     -+second a
     -+++++++ Contents of side #2
     -second b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +first resolution for auto-chosen file
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -817,7 +818,7 @@ fn test_multiple_conflicts() {
     -+second a
     -+++++++ Contents of side #2
     -second b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +first resolution for auto-chosen file
     diff --git a/this_file_has_a_very_long_name_to_test_padding b/this_file_has_a_very_long_name_to_test_padding
     index 0000000000...f8c72adf17 100644
@@ -830,7 +831,7 @@ fn test_multiple_conflicts() {
     -+first a
     -+++++++ Contents of side #2
     -first b
-    ->>>>>>>
+    ->>>>>>> Conflict 1 of 1 ends
     +second resolution for auto-chosen file
     "###);
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -177,7 +177,7 @@ fn test_restore_conflicted_merge() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     // Overwrite the file...
@@ -191,7 +191,7 @@ fn test_restore_conflicted_merge() {
        4     : +a
        5     : +++++++ Contents of side #2
        6     : b
-       7     : >>>>>>>
+       7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
     "###);
 
@@ -216,7 +216,7 @@ fn test_restore_conflicted_merge() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
     insta::assert_snapshot!(stdout, @"");
@@ -232,7 +232,7 @@ fn test_restore_conflicted_merge() {
        4     : +a
        5     : +++++++ Contents of side #2
        6     : b
-       7     : >>>>>>>
+       7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
     "###);
 
@@ -257,7 +257,7 @@ fn test_restore_conflicted_merge() {
     +a
     +++++++ Contents of side #2
     b
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 }
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -658,7 +658,7 @@ fn test_squash_from_multiple() {
     +b
     +++++++ Contents of side #3
     c
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
 
     // Squash a few commits up an down
@@ -795,7 +795,7 @@ fn test_squash_from_multiple_partial() {
     +b
     +++++++ Contents of side #3
     c
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###);
     // The unselected change from the sources have not been applied to the
     // destination

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -290,7 +290,9 @@ pub fn materialize_merge_result(
                         output.write_all(&slice.0)?;
                     }
                     output.write_all(CONFLICT_END_LINE)?;
-                    output.write_all(b"\n")?;
+                    output.write_all(
+                        format!(" Conflict {conflict_index} of {num_conflicts} ends\n").as_bytes(),
+                    )?;
                 }
             }
         }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -85,7 +85,7 @@ fn test_materialize_conflict_basic() {
     %%%%%%% Changes from base to side #2
     -line 3
     +right 3.1
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
     "###
@@ -109,7 +109,7 @@ fn test_materialize_conflict_basic() {
     left 3.1
     left 3.2
     left 3.3
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
     "###
@@ -185,7 +185,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     %%%%%%% Changes from base #2 to side #3
     -line 2 base
     +line 2 c.1
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 3
     "###
     );
@@ -209,7 +209,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     line 2 a.1
     line 2 a.2
     line 2 a.3
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 3
     "###
     );
@@ -233,7 +233,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     -line 2 base
     +line 2 b.1
     +line 2 b.2
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 3
     "###
     );
@@ -296,7 +296,7 @@ fn test_materialize_parse_roundtrip() {
     -line 1
     +line 1 right
      line 2
-    >>>>>>>
+    >>>>>>> Conflict 1 of 2 ends
     line 3
     <<<<<<< Conflict 2 of 2
     %%%%%%% Changes from base to side #1
@@ -306,7 +306,7 @@ fn test_materialize_parse_roundtrip() {
     +++++++ Contents of side #2
     line 4 right
     line 5 right
-    >>>>>>>
+    >>>>>>> Conflict 2 of 2 ends
     "###
     );
 
@@ -390,7 +390,7 @@ fn test_materialize_conflict_modify_delete() {
     modified
     %%%%%%% Changes from base to side #2
     -line 3
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
     "###
@@ -409,7 +409,7 @@ fn test_materialize_conflict_modify_delete() {
     -line 3
     +++++++ Contents of side #2
     modified
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
     "###
@@ -430,7 +430,7 @@ fn test_materialize_conflict_modify_delete() {
      line 4
      line 5
     +++++++ Contents of side #2
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###
     );
 }
@@ -485,7 +485,7 @@ fn test_materialize_conflict_two_forward_diffs() {
      C
     ------- Contents of base #3
     E
-    >>>>>>>
+    >>>>>>> Conflict 1 of 1 ends
     "###
     );
 }


### PR DESCRIPTION
This follows up on https://github.com/martinvonz/jj/pull/3459 and adds a label to the closing delimeter of each conflict, e.g.  "Conflict 1 of 3 ends".

I didn't initially put any label at the ending delimeter since the
starting delimeter is already marked with "Conflict 1 of 3". However,
I'm realizing that when I resolve conflicts, I usually go from top to
bottom and removing the first delimeter is the very first thing I do. It
is when I get to the *end* of the conflict that I wonder whether there
are any more conflicts left in the file.

# Checklist

- [x] I have added tests to cover my changes
