### PR TITLE
`jj config list`: escape keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When the working copy commit becomes immutable, a new one is automatically created on top of it 
 to avoid letting the user edit the immutable one.
 
+* `jj config list` now properly escapes TOML keys (#1322).
+
 ## [0.17.1] - 2024-05-07
 
 ### Fixed bugs

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -170,6 +170,10 @@ pub(crate) fn cmd_config(
     }
 }
 
+fn toml_escape_key(key: String) -> String {
+    toml_edit::Key::from(key).to_string()
+}
+
 // AnnotatedValue will be cloned internally in the templater. If the cloning
 // cost matters, wrap it with Rc.
 fn config_template_language() -> GenericTemplateLanguage<'static, AnnotatedValue> {
@@ -177,7 +181,8 @@ fn config_template_language() -> GenericTemplateLanguage<'static, AnnotatedValue
     let mut language = L::new();
     // "name" instead of "path" to avoid confusion with the source file path
     language.add_keyword("name", |self_property| {
-        let out_property = self_property.map(|annotated| annotated.path.join("."));
+        let out_property = self_property
+            .map(|annotated| annotated.path.into_iter().map(toml_escape_key).join("."));
         Ok(L::wrap_string(out_property))
     });
     language.add_keyword("value", |self_property| {

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -67,6 +67,7 @@ fn test_config_list_table() {
     x = true
     y.foo = "abc"
     y.bar = 123
+    "z"."with space"."function()" = 5
     "#,
     );
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "test-table"]);
@@ -76,6 +77,7 @@ fn test_config_list_table() {
     test-table.x=true
     test-table.y.bar=123
     test-table.y.foo="abc"
+    test-table.z."with space"."function()"=5
     "###);
 }
 


### PR DESCRIPTION
Fixes #1322. There may be more places where keys need escaping, I'm not completely sure.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
