### PR TITLE
cli `config list`: serialize values more properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `jj split` will now refuse to split an empty commit.
 
+* `jj config list` now uses multi-line strings and single-quoted strings in the
+  output when appropriate.
+
 ### Deprecations
 
 - Attempting to alias a built-in command now gives a warning, rather than being silently ignored.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2128,26 +2128,6 @@ impl LogContentFormat {
     }
 }
 
-// TODO: Use a proper TOML library to serialize instead.
-pub fn serialize_config_value(value: &config::Value) -> String {
-    match &value.kind {
-        config::ValueKind::Table(table) => format!(
-            "{{{}}}",
-            // TODO: Remove sorting when config crate maintains deterministic ordering.
-            table
-                .iter()
-                .sorted_by_key(|(k, _)| *k)
-                .map(|(k, v)| format!("{k}={}", serialize_config_value(v)))
-                .join(", ")
-        ),
-        config::ValueKind::Array(vals) => {
-            format!("[{}]", vals.iter().map(serialize_config_value).join(", "))
-        }
-        config::ValueKind::String(val) => format!("{val:?}"),
-        _ => value.to_string(),
-    }
-}
-
 pub fn write_config_value_to_file(
     key: &str,
     value_str: &str,

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -334,6 +334,6 @@ fn test_alias_in_repo_config() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    aliases.l=["log", "-r@", "--no-graph", "-T\"user alias\\n\""]
+    aliases.l=["log", "-r@", "--no-graph", '-T"user alias\n"']
     "###);
 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -104,11 +104,13 @@ fn test_config_list_inline_table() {
         x = 1
         [[test-table]]
         y = ["z"]
+        [[test-table]]
+        z."this=key is silly" = ["qq"]
     "#,
     );
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "test-table"]);
     insta::assert_snapshot!(stdout, @r###"
-    test-table=[{x=1}, {y=["z"]}]
+    test-table=[{x=1}, {y=["z"]}, {z={"this=key is silly"=["qq"]}}]
     "###);
 }
 


### PR DESCRIPTION
Follows up on https://github.com/martinvonz/jj/pull/3725.

This also makes `jj config list` output

```
template-aliases.builtin_log_node="""
coalesce(
  if(!self, label(\"elided\", \"~\")),
  label(
    separate(\" \",
      if(current_working_copy, \"working_copy\"),
      if(immutable, \"immutable\"),
      if(conflict, \"conflict\"),
    ),
    coalesce(
      if(current_working_copy, \"@\"),
      if(immutable, \"◆\"),
      if(conflict, \"×\"),
      \"○\",
    )
  )
)
"""
```

instead of

```
template-aliases.builtin_log_node="coalesce(\n  if(!self, label(\"elided\", \"~\")),\n  label(\n    separate(\" \",\n      if(current_working_copy, \"working_copy\"),\n      if(immutable, \"immutable\"),\n      if(conflict, \"conflict\"),\n    ),\n    coalesce(\n      if(current_working_copy, \"@\"),\n      if(immutable, \"◆\"),\n      if(conflict, \"×\"),\n      \"○\",\n    )\n  )\n)\n"
```

`toml_edit` also seems to use single-quoted strings sometimes.