### PR TITLE
docs (direct website push): make "nightly" the preferred alias for "prerelease"

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -3,8 +3,8 @@
     "version": "prerelease",
     "title": "prerelease",
     "aliases": [
-      "main",
-      "nightly"
+      "nightly",
+      "main"
     ]
   },
   {


### PR DESCRIPTION
This follows up on https://github.com/martinvonz/jj/pull/3723.

As shown in the screenshot of that PR (or as can currently be seen live at <https://martinvonz.github.io/jj/prerelease/> or its aliases <https://martinvonz.github.io/jj/nightly/>, <https://martinvonz.github.io/jj/main/>), currently the "prerelease" version is also labeled as "main". This may confuse people on whether it's preferred to the version labelled "latest".

This commit changes the label to "nightly" instead of "main".

