### PR TITLE
config: add workaround for config path expression parsing

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -84,7 +84,8 @@ use crate::command_error::{
 };
 use crate::commit_templater::{CommitTemplateLanguage, CommitTemplateLanguageExtension};
 use crate::config::{
-    new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
+    new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigNamePathBuf, ConfigSource,
+    LayeredConfigs,
 };
 use crate::diff_util::{self, DiffFormat, DiffFormatArgs, DiffRenderer, DiffWorkspaceContext};
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
@@ -234,7 +235,7 @@ impl CommandHelper {
 
     pub fn resolved_config_values(
         &self,
-        prefix: &[&str],
+        prefix: &ConfigNamePathBuf,
     ) -> Result<Vec<AnnotatedValue>, crate::config::ConfigError> {
         self.layered_configs.resolved_config_values(prefix)
     }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -710,6 +710,23 @@ fn test_config_get() {
     insta::assert_snapshot!(stdout, @"bar");
 }
 
+#[test]
+fn test_config_path_syntax() {
+    let test_env = TestEnvironment::default();
+
+    let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "list", ""]);
+    insta::assert_snapshot!(stderr, @r###"
+    error: invalid value '' for '[NAME]': TOML parse error at line 1, column 1
+      |
+    1 | 
+      | ^
+    invalid key
+
+
+    For more information, try '--help'.
+    "###);
+}
+
 fn find_stdout_lines(keyname_pattern: &str, stdout: &str) -> String {
     let key_line_re = Regex::new(&format!(r"(?m)^{keyname_pattern}=.*$")).unwrap();
     key_line_re


### PR DESCRIPTION
#1723

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
