### PR TITLE
config: migrate "config get"/"set" to TOML-based name argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj config list` now uses multi-line strings and single-quoted strings in the
   output when appropriate.
 
+* `jj config get`/`list`/`set` now parse `name` argument as [TOML
+  key](https://toml.io/en/v1.0.0#keys). Quote meta characters as needed.
+  Example: `jj config get "revset-aliases.'trunk()'"`
+
 ### Deprecations
 
 - Attempting to alias a built-in command now gives a warning, rather than being silently ignored.

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -116,14 +116,14 @@ pub(crate) struct ConfigListArgs {
 #[command(verbatim_doc_comment)]
 pub(crate) struct ConfigGetArgs {
     #[arg(required = true)]
-    name: String,
+    name: ConfigNamePathBuf,
 }
 
 /// Update config file to set the given option to a given value.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct ConfigSetArgs {
     #[arg(required = true)]
-    name: String,
+    name: ConfigNamePathBuf,
     #[arg(required = true)]
     value: String,
     #[command(flatten)]
@@ -277,10 +277,10 @@ pub(crate) fn cmd_config_get(
     command: &CommandHelper,
     args: &ConfigGetArgs,
 ) -> Result<(), CommandError> {
-    let value = command
-        .settings()
-        .config()
-        .get_string(&args.name)
+    let value = args
+        .name
+        .lookup_value(command.settings().config())
+        .and_then(|value| value.into_string())
         .map_err(|err| match err {
             config::ConfigError::Type {
                 origin,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -115,7 +115,7 @@ You will probably also want to make the `gh-pages` branch immutable (and thereby
 hidden from the default `jj log` output) by running the following in your repo:
 
 ```shell
-jj config set --repo "revset-aliases.immutable_heads()" 'remote_branches(exact:"main") | remote_branches(exact:"gh-pages")'
+jj config set --repo "revset-aliases.'immutable_heads()'" 'remote_branches(exact:"main") | remote_branches(exact:"gh-pages")'
 ```
 
 ### Summary


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
