### PR TITLE
docs: disable `main` and `nightly` aliases for `prerelease` version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,6 @@ jobs:
         run: |
           git config user.name 'jj-docs[bot]'
           git config user.email 'jj-docs[bot]@users.noreply.github.io'
-          .github/scripts/docs-build-deploy 'https://martinvonz.github.io/jj' prerelease nightly main --push
+          .github/scripts/docs-build-deploy 'https://martinvonz.github.io/jj' prerelease --push
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"


### PR DESCRIPTION
This is an alternative to https://github.com/martinvonz/jj/pull/3732. I think it's pretty important to show the "latest" alias. I don't know a way to not show any alias for "prerelease" in the version selector without deleting all of them. 

I'll have to then separately delete the directories for the aliases on
the gh-pages branch, so that the URL does not resolve to outdated pages.
