### PR TITLE
Nodeenv demo

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -521,6 +521,20 @@ release = ["twine (>=1.13.0)"]
 test = ["autoflake", "black", "isort", "pytest"]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "24.0"
 description = "Core utilities for Python packages"
@@ -822,6 +836,21 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "setuptools"
+version = "70.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
+    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -939,4 +968,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f02779a0d14d18dad4d1c76eb15351c30fc0ebc2d1c171e6b4f837892151632f"
+content-hash = "9d1ef08e10c0b585ae18baf3319b7f4fffd6171afb7803a778f0e1d0ccd66f43"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ mdx-breakless-lists = "^1.0.1"
 mkdocs-redirects = "^1.2.1"
 # Used for the CLI reference
 mkdocs-include-markdown-plugin = "^6.0.4"
+nodeenv = "^1.8.0"


### PR DESCRIPTION
**UPDATE:** I'll likely close this soon. I remembered that https://pre-commit.com/ is likely a better option than `nodeenv`. IIRC, it can install Node+Pretter in a hermetic way, removing the need for a `package.json`. It should be possible to install pre-commit with Poetry or `pipx`.

OTOH, I'm not sure pre-commit currently has a working Prettier plugin. https://github.com/pre-commit/pre-commit/issues/3133

----------------------------

This is a demo of using `nodeenv` to install Prettier for #3757. It may or may not be later fleshed out to a real PR.

Try

```bash
poetry install
poetry run -- nodeenv -p
poetry run -- npm install  # After merging this PR with #3757.
```


If we wanted to use this approach for real, we'd probably want to either use something like <https://python-poetry.org/docs/pyproject#scripts> or a [`cargo xtask`](https://github.com/matklad/cargo-xtask).


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
