### PR TITLE
Use closest branches if none specified for `jj branch set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added new revsets `mutable()` and `immutable()`.
 
+* `jj branch set` automatically picks the closest branch on an ancestor if no
+  branch names are explicitly specified.
+
 ### Fixed bugs
 
 * When the working copy commit becomes immutable, a new one is automatically created on top of it 


### PR DESCRIPTION
Some users find themselves frequently re-setting the branch they're working on to point to the most recent commit in order to push new work they've added on top. This requires remembering and typing or pasting potentially long branch names such as `jj branch set feature/what-ever-this-is`.

Maybe we could make this easier by picking the closest branch pointing to an ancestor of the target, if no branch names are explicitly specified.

Some questions that come to mind:

1. Does this make sense within the `branch set` subcommand or should it be its own, such as `branch advance`?
2. Is there a better way to search the commit graph for the closest branch(es), such as a revset expression, or should we keep this rather simple implementation for walking the ancestors?
3. Is it necessary to implement some sort of limit to prevent Jujutsu potentially traversing all the way back to the root if there are no local branches, or would searching until found (or not found in that case) be the expected behavior?