### PR TITLE
docs: document code.cmd editor on Windows

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -438,6 +438,7 @@ For GUI editors you possibly need to use a `-w` or `--wait`. Some examples:
 
 ```toml
 ui.editor = "code -w"       # VS Code
+ui.editor = "code.cmd -w"   # VS Code on Windows
 ui.editor = "bbedit -w"     # BBEdit
 ui.editor = "subl -n -w"    # Sublime Text
 ui.editor = "mate -w"       # TextMate


### PR DESCRIPTION
On Windows `code` works in the shell, but not when specified to jj, because the executable is actually named `code.cmd`! This is a feature of Windows, where certain file extensions (defined by the PATHEXT environment variable) are automatically treated as executable and can have their extensions omitted.

Presumably, jj doesn't support this feature on Windows, though perhaps it should. For now, avoid adding an explanation of PATHEXT so as to not clutter things too much, and just suggest `code.cmd` on Windows. Most readers should be able to put two and two together from there.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
