### PR TITLE
cli: clear line after writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ to avoid letting the user edit the immutable one.
 * Files with conflicts are now checked out as executable if all sides of the 
   conflict are executable.
 
+* The progress bar (visible when using e.g. `jj git clone`) clears the
+  remainder of the cursor row after drawing rather than clearing the entire row
+  before drawing, eliminating the "flicker" effect seen on some terminals.
+
 ## [0.17.1] - 2024-05-07
 
 ### Fixed bugs

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -60,7 +60,7 @@ impl Progress {
         self.next_print = now.min(self.next_print + Duration::from_secs(1) / UPDATE_HZ);
 
         self.buffer.clear();
-        write!(self.buffer, "\r{}", Clear(ClearType::CurrentLine)).unwrap();
+        write!(self.buffer, "\r").unwrap();
         let control_chars = self.buffer.len();
         write!(self.buffer, "{: >3.0}% ", 100.0 * progress.overall).unwrap();
         if let Some(total) = progress.bytes_downloaded {
@@ -81,6 +81,7 @@ impl Progress {
         draw_progress(progress.overall, &mut self.buffer, bar_width);
         self.buffer.push(']');
 
+        write!(self.buffer, "{}", Clear(ClearType::UntilNewLine)).unwrap();
         write!(output, "{}", self.buffer)?;
         output.flush()?;
         Ok(())


### PR DESCRIPTION
Clear the rest of the cursor line (from the cursor to the end of the row) after drawing the progress bar rather than clearing the entire line before drawing. This reduces flickering on terminal emulators which are able to redraw rapidly.

It's not possible to capture this via asciinema, so I present two screen recordings instead:

**Before**

https://github.com/martinvonz/jj/assets/8965202/07725e05-e569-41b6-a09c-33554a7edc0b

**After**



https://github.com/martinvonz/jj/assets/8965202/05e954d7-b4bc-4633-b481-d6d2436bab0b



# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
