### PR TITLE
Add a branch option to `jj new`

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1130,6 +1130,7 @@ For more information, see https://github.com/martinvonz/jj/blob/main/docs/workin
 
 * `-r` — Ignored (but lets you pass `-r` for consistency with other commands)
 * `-m`, `--message <MESSAGE>` — The change description to use
+* `-b`, `--branch <BRANCH>` — Create a new branch or set an existing branch to the new commit
 * `-L`, `--allow-large-revsets` — Deprecated. Please prefix the revset with `all:` instead
 
   Possible values: `true`, `false`


### PR DESCRIPTION
Adds a new flag to `jj new` called `branch` (`-b` or `--branch`)
Passing this flag creates a new branch with the given name or sets an existing branch to the new commit

Often, in my workflow, I create a commit and a branch at the same time.
Meaning I often perform the following two commands in series:
```
> jj new -m "quick fix"
> jj branch c quick_fix
```
It would be nice to add a flag `-b` to `jj new` just like `-m` which also creates/sets a branch to the newly created commit like so:
```
jj new -m "quick fix" -b quick_fix
```

The setting of the branch (as opposed to creation) I'm not married to so if we want to just create new branches and error on existing branch names that is fine too.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
