### PR TITLE
working_copy: Add `is_file_states_sorted` to tree state proto

### DIFF
--- a/lib/src/protos/working_copy.proto
+++ b/lib/src/protos/working_copy.proto
@@ -47,6 +47,7 @@ message TreeState {
   // single (positive) value
   repeated bytes tree_ids = 5;
   repeated FileStateEntry file_states = 2;
+  bool is_file_states_sorted = 6;
   SparsePatterns sparse_patterns = 3;
   WatchmanClock watchman_clock = 4;
 }

--- a/lib/src/protos/working_copy.rs
+++ b/lib/src/protos/working_copy.rs
@@ -38,6 +38,8 @@ pub struct TreeState {
     pub tree_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(message, repeated, tag = "2")]
     pub file_states: ::prost::alloc::vec::Vec<FileStateEntry>,
+    #[prost(bool, tag = "6")]
+    pub is_file_states_sorted: bool,
     #[prost(message, optional, tag = "3")]
     pub sparse_patterns: ::core::option::Option<SparsePatterns>,
     #[prost(message, optional, tag = "4")]


### PR DESCRIPTION
See #2651 and a935a4f70c9c4c4a76009f9aee3bdaa1f7b9084e for more background.

This speeds up `jj log` in a large repo with watchman enabled by around 9%:

```
$ hyperfine --sort command --warmup 3 --runs 20 -L bin \
jj-before,jj-after "target/release/{bin} -R ~/chromiumjj/src log"
Benchmark 1: target/release/jj-before -R ~/chromiumjj/src log
  Time (mean ± σ):     788.3 ms ±   3.4 ms    [User: 618.6 ms, System: 168.8 ms]
  Range (min … max):   783.1 ms … 793.3 ms    20 runs

Benchmark 2: target/release/jj-after -R ~/chromiumjj/src log
  Time (mean ± σ):     713.4 ms ±   5.2 ms    [User: 536.1 ms, System: 176.2 ms]
  Range (min … max):   706.6 ms … 724.7 ms    20 runs

Relative speed comparison
        1.11 ±  0.01  target/release/jj-before -R ~/chromiumjj/src log
        1.00          target/release/jj-after -R ~/chromiumjj/src log
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
