### PR TITLE
hide `move` form CLI reference, mark `move`, `checkout`, and `merge` as deprecated

### DIFF
--- a/cli/src/commands/checkout.rs
+++ b/cli/src/commands/checkout.rs
@@ -20,7 +20,8 @@ use crate::command_error::CommandError;
 use crate::description_util::join_message_paragraphs;
 use crate::ui::Ui;
 
-/// Create a new, empty change and edit it in the working copy
+/// Create a new, empty change and edit it in the working copy (DEPRECATED, use
+/// `jj new`)
 ///
 /// For more information, see
 /// https://github.com/martinvonz/jj/blob/main/docs/working-copy.md.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -108,6 +108,7 @@ enum Command {
     /// arguments.
     #[command(hide = true)]
     Merge(new::NewArgs),
+    #[command(hide = true)]
     Move(r#move::MoveArgs),
     New(new::NewArgs),
     Next(next::NextArgs),

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -97,7 +97,7 @@ enum Command {
     Init(init::InitArgs),
     Interdiff(interdiff::InterdiffArgs),
     Log(log::LogArgs),
-    /// Merge work from multiple branches
+    /// Merge work from multiple branches (DEPRECATED, use `jj new`)
     ///
     /// Unlike most other VCSs, `jj merge` does not implicitly include the
     /// working copy revision's parent as one of the parents of the merge;

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -21,7 +21,7 @@ use crate::cli_util::{CommandHelper, RevisionArg};
 use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
 
-/// Move changes from one revision into another
+/// Move changes from one revision into another (DEPRECATED, use `jj squash`)
 ///
 /// Use `--interactive` to move only part of the source revision into the
 /// destination. The selected changes (or all the changes in the source revision

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -52,7 +52,6 @@ This document contains the help content for the `jj` command-line program.
 * [`jj init`↴](#jj-init)
 * [`jj interdiff`↴](#jj-interdiff)
 * [`jj log`↴](#jj-log)
-* [`jj move`↴](#jj-move)
 * [`jj new`↴](#jj-new)
 * [`jj next`↴](#jj-next)
 * [`jj obslog`↴](#jj-obslog)
@@ -122,7 +121,6 @@ To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/d
 * `init` — Create a new repo in the given directory
 * `interdiff` — Compare the changes of two commits
 * `log` — Show revision history
-* `move` — Move changes from one revision into another
 * `new` — Create a new, empty change and (by default) edit it in the working copy
 * `next` — Move the working-copy commit to the child revision
 * `obslog` — Show how a change has evolved over time
@@ -1077,34 +1075,6 @@ Spans of revisions that are not included in the graph per `--revisions` are rend
 
 * `--tool <TOOL>` — Generate diff by external command
 * `--context <CONTEXT>` — Number of lines of context to show
-
-
-
-## `jj move`
-
-Move changes from one revision into another
-
-Use `--interactive` to move only part of the source revision into the destination. The selected changes (or all the changes in the source revision if not using `--interactive`) will be moved into the destination. The changes will be removed from the source. If that means that the source is now empty compared to its parent, it will be abandoned. Without `--interactive`, the source change will always be empty.
-
-If the source became empty and both the source and destination had a non-empty description, you will be asked for the combined description. If either was empty, then the other one will be used.
-
-If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
-
-**Usage:** `jj move [OPTIONS] <--from <FROM>|--to <TO>> [PATHS]...`
-
-###### **Arguments:**
-
-* `<PATHS>` — Move only changes to these paths (instead of all paths)
-
-###### **Options:**
-
-* `-f`, `--from <FROM>` — Move part of this change into the destination
-* `-t`, `--to <TO>` — Move part of the source into this change
-* `-i`, `--interactive` — Interactively choose which parts to move
-
-  Possible values: `true`, `false`
-
-* `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 
 
 


### PR DESCRIPTION
The first commit fixes #3807

The second commit puts a deprecation message in `jj move -h`, `jj checkout -h`, and `jj merge -h`. I can get rid of this commit, but I can't think of a reason not to do it.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
