### PR TITLE
`jj help git`: Include "Git remotes" in the title 

### DIFF
--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -51,7 +51,7 @@ use crate::git_util::{
 };
 use crate::ui::Ui;
 
-/// Commands for working with the underlying Git repo
+/// Commands for working with Git remotes and the underlying Git repo
 ///
 /// For a comparison with Git, including a table of commands, see
 /// https://github.com/martinvonz/jj/blob/main/docs/git-comparison.md.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -117,7 +117,7 @@ To get started, see the tutorial at https://github.com/martinvonz/jj/blob/main/d
 * `duplicate` — Create a new change with the same content as an existing one
 * `edit` — Sets the specified revision as the working-copy revision
 * `files` — List files in a revision
-* `git` — Commands for working with the underlying Git repo
+* `git` — Commands for working with Git remotes and the underlying Git repo
 * `init` — Create a new repo in the given directory
 * `interdiff` — Compare the changes of two commits
 * `log` — Show revision history
@@ -760,7 +760,7 @@ List files in a revision
 
 ## `jj git`
 
-Commands for working with the underlying Git repo
+Commands for working with Git remotes and the underlying Git repo
 
 For a comparison with Git, including a table of commands, see https://github.com/martinvonz/jj/blob/main/docs/git-comparison.md.
 


### PR DESCRIPTION
Previously, it sounded like `jj git` might only include highly-technical commands, while IMO the most important commands in here are `jj git fetch` and `jj git push`.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
