### PR TITLE
docs: Fix zsh-breaking logging example

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -296,7 +296,7 @@ jj log -r 'remote_branches(remote=origin)..'
 Show the initial commits in the repo (the ones Git calls "root commits"):
 
 ```
-jj log -r root()+
+jj log -r 'root()+'
 ```
 
 Show some important commits (like `git --simplify-by-decoration`):


### PR DESCRIPTION
Fixes #3822.

This is a pretty trivial change. I didn't alter other unquoted logging examples, but there's a number of them in the docs. I would not be surprised if some of them eventually cause someone else problems. It may be safest to quote all revset examples.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
