### PR TITLE
docs: fix another missing shell quoting around root()

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -165,7 +165,7 @@ commit ID consisting of all '0's (`00000000...`) and a change ID consisting of
 all 'z's (`zzzzzzzz...`). It can be referred to in [revsets](#revset) by the
 function `root()`. Note that our definition of "root commit" is different from
 Git's; Git's "root commits" are the first commit(s) in the repository, i.e. the
-commits `jj log -r root()+` will show.
+commits `jj log -r 'root()+'` will show.
 
 ## Tree
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
