### PR TITLE
changelog: Fix @mlcui-corp username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ Thanks to the people who made this release happen!
 * Yuya Nishihara (@yuja)
 * Daniel Ploch (@torquestomp)
 * jyn (@jyn514)
-* mlcui (@mlcui-google)
+* mlcui (@mlcui-corp)
 * tinger (@tingerrr)
 
 ## [0.17.1] - 2024-05-07
@@ -699,7 +699,7 @@ Thanks to the people who made this release happen!
 * Jesse Somerville (@jessesomerville)
 * Łukasz Kurowski (@crackcomm)
 * Martin von Zweigbergk (@martinvonz)
-* mlcui (@mlcui-google)
+* mlcui (@mlcui-corp)
 * Philip Metzger (@PhilipMetzger)
 * Waleed Khan (@arxanas)
 * Yuya Nishihara (@yuja)
@@ -1239,7 +1239,7 @@ Thanks to the people who made this release happen!
 * Isabella Basso (@isinyaaa)
 * Kevin Liao (@kevincliao)
 * Martin von Zweigbergk (@martinvonz)
-* mlcui (@mlcui-google)
+* mlcui (@mlcui-corp)
 * Samuel Tardieu (@samueltardieu)
 * Tal Pressman (@talpr)
 * Vamsi Avula (@avamsi)


### PR DESCRIPTION
I have renamed myself from @mlcui-google to @mlcui-corp, but the changelog still had the old username.

(That username is now taken by a squatter...)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
