### PR TITLE
Show paths of config files when configurations contain errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Show paths to config files when configuration errors occur
+
 ### Fixed bugs
 
 ## [0.18.0] - 2024-06-05

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -228,10 +228,18 @@ impl LayeredConfigs {
         Ok(())
     }
 
+    pub fn user_config_path(&self) -> Result<Option<PathBuf>, ConfigError> {
+        existing_config_path()
+    }
+
     #[instrument]
     pub fn read_repo_config(&mut self, repo_path: &Path) -> Result<(), ConfigError> {
-        self.repo = Some(read_config_file(&repo_path.join("config.toml"))?);
+        self.repo = Some(read_config_file(&self.repo_config_path(repo_path))?);
         Ok(())
+    }
+
+    pub fn repo_config_path(&self, repo_path: &Path) -> PathBuf {
+        repo_path.join("config.toml")
     }
 
     pub fn parse_config_args(&mut self, toml_strs: &[String]) -> Result<(), ConfigError> {


### PR DESCRIPTION
This addresses issue #3317, where as discussed we want to show the paths to configuration files if they contain errors, to make it easier for the user to locate them.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
