### PR TITLE
revset: migrate syntactic tests to AST-based

### DIFF
--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -594,7 +594,7 @@ mod tests {
         );
 
         // Trailing comma isn't allowed for empty argument
-        assert!(parse_normalized("foo(,)").is_err());
+        assert!(parse_into_kind("foo(,)").is_err());
 
         // Trailing comma is allowed for the last argument
         assert_eq!(
@@ -605,14 +605,14 @@ mod tests {
             parse_normalized("foo(a ,  )").unwrap(),
             parse_normalized("foo(a)").unwrap()
         );
-        assert!(parse_normalized("foo(,a)").is_err());
-        assert!(parse_normalized("foo(a,,)").is_err());
-        assert!(parse_normalized("foo(a  , , )").is_err());
+        assert!(parse_into_kind("foo(,a)").is_err());
+        assert!(parse_into_kind("foo(a,,)").is_err());
+        assert!(parse_into_kind("foo(a  , , )").is_err());
         assert_eq!(
             parse_normalized("foo(a,b,)").unwrap(),
             parse_normalized("foo(a,b)").unwrap()
         );
-        assert!(parse_normalized("foo(a,,b)").is_err());
+        assert!(parse_into_kind("foo(a,,b)").is_err());
     }
 
     #[test]


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
