### PR TITLE
nix: use nightly `rustc` and improve devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714912032,
-        "narHash": "sha256-clkcOIkg8G4xuJh+1onLG4HPMpbtzdLv4rHxFzgsH9c=",
+        "lastModified": 1718089647,
+        "narHash": "sha256-COO4Xk2EzlZ3x9KCiJildlAA6cYDSPlnY8ms7pKl2Iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee4a6e0f566fe5ec79968c57a9c2c3c25f2cf41d",
+        "rev": "f7207adcc68d9cafa29e3cd252a18743ae512c6a",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714961776,
-        "narHash": "sha256-LiIxWRKbm1DZ+7l1a6FMmIO8leQx5yrRLIApCMai1DY=",
+        "lastModified": 1718072316,
+        "narHash": "sha256-p33h73iQ1HkLalCplV5MH0oP3HXRaH3zufnFqb5//ps=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f3b20ea4131408ea585bddb1f41f91c4de9499cf",
+        "rev": "bedc47af18fc41bb7d2edc2b212d59ca36253f59",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -175,8 +175,10 @@
           export RUST_BACKTRACE=1
           export ZSTD_SYS_USE_PKG_CONFIG=1
           export LIBSSH2_SYS_USE_PKG_CONFIG=1
+
+          export RUSTFLAGS="-Zthreads=0"
         '' + pkgs.lib.optionalString useMoldLinker ''
-          export RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+          export RUSTFLAGS+=" -C link-arg=-fuse-ld=mold"
         '' + darwinNextestHack;
       };
     }));

--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,7 @@
 
           export RUSTFLAGS="-Zthreads=0"
         '' + pkgs.lib.optionalString useMoldLinker ''
-          export RUSTFLAGS+=" -C link-arg=-fuse-ld=mold"
+          export RUSTFLAGS+=" -C link-arg=-fuse-ld=mold -C link-arg=-Wl,--compress-debug-sections=zstd"
         '' + darwinNextestHack;
       };
     }));

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             pkgs.lib.all (re: builtins.match re relPath == null) regexes;
         };
 
-      ourRustVersion = pkgs.rust-bin.stable."1.76.0".default;
+      ourRustVersion = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.complete);
 
       ourRustPlatform = pkgs.makeRustPlatform {
         rustc = ourRustVersion;
@@ -145,20 +145,7 @@
 
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
-          # The CI checks against the latest nightly rustfmt, so we should too.
-          # NOTE (aseipp): include this FIRST before the ourRustVersion override
-          # below; otherwise, it will be overridden by the ourRustVersion and
-          # we'll get stable rustfmt instead.
-          (rust-bin.selectLatestNightlyWith (toolchain: toolchain.rustfmt))
-
-          # Using the minimal profile with explicit "clippy" extension to avoid
-          # two versions of rustfmt
-          (ourRustVersion.override {
-            extensions = [
-              "rust-src" # for rust-analyzer
-              "clippy"
-            ];
-          })
+          ourRustVersion
 
           # Foreign dependencies
           openssl zstd libgit2 libssh2


### PR DESCRIPTION
Part of a tree of patches I've been holding onto. These are mostly useful for my iterations since I think I'm the only one actively developing in a Nix devShell, but:

- Moves to using `rustc` nightly for our Nix builds, on macOS and Linux. This applies to both development shells *and* `nix build`-built packages (e.g. `nix profile install github:martinvonz/jj`.)
- As a result, this also adds a nightly-enabled build entry into the Matrix, so we can track regressions against it, too.
- It also enables the parallel `rustc` frontend for dev shell usage, which has some marginal improvements in from scratch compile times (1m30s to 1m17s or something last I remember, for incremental it's much smaller.)
- It enables zstd-compressed debug sections in mold, on Linux, which improves debug binary sizes by 50% and total `target/` directory sizes by about 15% when built from scratch. This should help curve the infinite binary growth a bit.

I think the risk of using `nightly` here is low and we don't use any features anyway in the codebase, so the `-Zthreads=0` change is strictly nice to have. However nightly is also useful for experimenting with other features like `build-std` for example, so sometimes I like to poke around.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
