### PR TITLE
cli: deprecate `jj split --siblings` in favor of `jj split --parallel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Replacing `-l` shorthand for `--limit` with `-n` in `jj log`, `jj op log` and `jj obslog`.
 
+* `jj split --siblings` is deprecated in favor of `jj split --parallel` (to
+  match `jj parallelize`).
+
 ### New features
 
 * Show paths to config files when configuration errors occur

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1771,7 +1771,7 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVISION>` — The revision to split
 
   Default value: `@`
-* `-s`, `--siblings` — Split the revision into two siblings instead of a parent and child
+* `-p`, `--parallel` — Split the revision into two parallel revisions instead of a parent and child
 
   Possible values: `true`, `false`
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -343,7 +343,7 @@ fn test_split_siblings_no_descendants() {
         ["dump editor1", "next invocation\n", "dump editor2"].join("\0"),
     )
     .unwrap();
-    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--siblings", "file1"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     First part: qpvuntsm 8d2b7558 TESTED=TODO
@@ -421,7 +421,7 @@ fn test_split_siblings_with_descendants() {
         .join("\0"),
     )
     .unwrap();
-    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--siblings", "file1"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
@@ -500,7 +500,7 @@ fn test_split_siblings_with_merge_child() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_path,
-        &["split", "-r", "description(a)", "--siblings", "file1"],
+        &["split", "-r", "description(a)", "--parallel", "file1"],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"


### PR DESCRIPTION

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
