### PR TITLE
nix: use `-ld_new` on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,12 +48,6 @@
         libiconv
       ];
 
-      # work around https://github.com/nextest-rs/nextest/issues/267
-      # this needs to exist in both the devShell and preCheck phase!
-      darwinNextestHack = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
-        export DYLD_FALLBACK_LIBRARY_PATH=$(${ourRustVersion}/bin/rustc --print sysroot)/lib
-      '';
-      
       # these are needed in both devShell and buildInputs
       linuxNativeDeps = with pkgs; lib.optionals stdenv.isLinux [
         mold-wrapped
@@ -113,7 +107,7 @@
 
           preCheck = ''
             export RUST_BACKTRACE=1
-          '' + darwinNextestHack;
+          '';
 
           postInstall = ''
             $out/bin/jj util mangen > ./jj.1
@@ -185,7 +179,7 @@
           export LIBSSH2_SYS_USE_PKG_CONFIG=1
 
           export RUSTFLAGS="-Zthreads=0 ${rustLinkFlagsString}"
-        '' + darwinNextestHack;
+        '';
       };
     }));
 }


### PR DESCRIPTION
The new parallel macOS linker reduces link time for the debug `jj` binary from 3s to 0.7s on my M2 Macbook Air, which is a significant reduction for nearly no cost at all.

However, enabling it is rather strange because we have to give a full path to the /Applications directory, and I don't know of a good way to encapsulate it with existing Nix primitives inside Nixpkgs...

This change requires Sonoma and Xcode 15, but in theory I think we could target a lower macOS SDK version in order to produce binaries that are more backwards compatible, so the only real cost is that developers who also use Nix would require Sonoma.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
