### PR TITLE
lib: internalize testutils::new_temp_dir() for unit tests

### DIFF
--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -52,6 +52,7 @@ mod tests {
     use crate::default_index::entry::{LocalPosition, SmallLocalPositionsVec};
     use crate::index::Index;
     use crate::object_id::{HexPrefix, ObjectId, PrefixResolution};
+    use crate::tests_common::new_temp_dir;
 
     /// Generator of unique 16-byte CommitId excluding root id
     fn commit_id_generator() -> impl FnMut() -> CommitId {
@@ -68,7 +69,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn index_empty(on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mutable_segment = MutableIndexSegment::full(3, 16);
         let index_segment: Box<DynIndexSegment> = if on_disk {
             let saved_index = mutable_segment.save_in(temp_dir.path()).unwrap();
@@ -95,7 +96,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn index_root_commit(on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();
         let mut mutable_segment = MutableIndexSegment::full(3, 16);
         let id_0 = CommitId::from_hex("000000");
@@ -147,7 +148,7 @@ mod tests {
     #[test_case(true, false; "incremental in memory")]
     #[test_case(true, true; "incremental on disk")]
     fn index_multiple_commits(incremental: bool, on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();
         let mut mutable_segment = MutableIndexSegment::full(3, 16);
         // 5
@@ -268,7 +269,7 @@ mod tests {
     #[test_case(false; "in memory")]
     #[test_case(true; "on disk")]
     fn index_many_parents(on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();
         let mut mutable_segment = MutableIndexSegment::full(3, 16);
         //     6
@@ -332,7 +333,7 @@ mod tests {
 
     #[test]
     fn resolve_commit_id_prefix() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();
         let mut mutable_segment = MutableIndexSegment::full(3, 16);
 
@@ -404,7 +405,7 @@ mod tests {
     #[test]
     #[allow(clippy::redundant_clone)] // allow id_n.clone()
     fn neighbor_commit_ids() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();
         let mut mutable_segment = MutableIndexSegment::full(3, 16);
 
@@ -532,7 +533,7 @@ mod tests {
 
     #[test]
     fn shortest_unique_commit_id_prefix() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();
         let mut mutable_segment = MutableIndexSegment::full(3, 16);
 
@@ -586,7 +587,7 @@ mod tests {
 
     #[test]
     fn resolve_change_id_prefix() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_commit_id = commit_id_generator();
         let local_positions_vec = |positions: &[u32]| -> SmallLocalPositionsVec {
             positions.iter().copied().map(LocalPosition).collect()
@@ -756,7 +757,7 @@ mod tests {
 
     #[test]
     fn neighbor_change_ids() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_commit_id = commit_id_generator();
 
         let id_0 = ChangeId::from_hex("00000001");
@@ -902,7 +903,7 @@ mod tests {
 
     #[test]
     fn shortest_unique_change_id_prefix() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let mut new_commit_id = commit_id_generator();
 
         let id_0 = ChangeId::from_hex("00000001");

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -201,6 +201,7 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+    use crate::tests_common::new_temp_dir;
 
     #[test]
     fn normalize_too_many_dot_dot() {
@@ -218,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_persist_no_existing_file() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let target = temp_dir.path().join("file");
         let mut temp_file = NamedTempFile::new_in(&temp_dir).unwrap();
         temp_file.write_all(b"contents").unwrap();
@@ -228,7 +229,7 @@ mod tests {
     #[test_case(false ; "existing file open")]
     #[test_case(true ; "existing file closed")]
     fn test_persist_target_exists(existing_file_closed: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let target = temp_dir.path().join("file");
         let mut temp_file = NamedTempFile::new_in(&temp_dir).unwrap();
         temp_file.write_all(b"contents").unwrap();

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1368,6 +1368,7 @@ mod tests {
 
     use super::*;
     use crate::content_hash::blake2b_hash;
+    use crate::tests_common::new_temp_dir;
 
     #[test_case(false; "legacy tree format")]
     #[test_case(true; "tree-level conflict format")]
@@ -1380,7 +1381,7 @@ mod tests {
                 .unwrap();
             UserSettings::from_config(config)
         };
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1540,7 +1541,7 @@ mod tests {
     #[test]
     fn read_git_commit_without_importing() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1580,7 +1581,7 @@ mod tests {
     #[test]
     fn read_signed_git_commit() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1672,7 +1673,7 @@ mod tests {
     #[test]
     fn git_commit_parents() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1737,7 +1738,7 @@ mod tests {
     #[test]
     fn write_tree_conflicts() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1834,7 +1835,7 @@ mod tests {
     #[test]
     fn commit_has_ref() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let backend = GitBackend::init_internal(&settings, temp_dir.path()).unwrap();
         let git_repo = backend.open_git_repo().unwrap();
         let signature = Signature {
@@ -1884,7 +1885,7 @@ mod tests {
     #[test]
     fn import_head_commits_duplicates() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let backend = GitBackend::init_internal(&settings, temp_dir.path()).unwrap();
         let git_repo = backend.open_git_repo().unwrap();
 
@@ -1920,7 +1921,7 @@ mod tests {
     #[test]
     fn overlapping_git_commit_id() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let backend = GitBackend::init_internal(&settings, temp_dir.path()).unwrap();
         let mut commit1 = Commit {
             parents: vec![backend.root_commit_id().clone()],
@@ -1960,7 +1961,7 @@ mod tests {
     #[test]
     fn write_signed_commit() {
         let settings = user_settings();
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let backend = GitBackend::init_internal(&settings, temp_dir.path()).unwrap();
 
         let commit = Commit {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -91,3 +91,18 @@ pub mod union_find;
 pub mod view;
 pub mod working_copy;
 pub mod workspace;
+
+/// Unit test utility for this crate.
+#[cfg(test)]
+mod tests_common {
+    use tempfile::TempDir;
+
+    /// Unlike `testutils::new_temp_dir()`, this function doesn't set up
+    /// hermetic libgit2 environment.
+    pub fn new_temp_dir() -> TempDir {
+        tempfile::Builder::new()
+            .prefix("jj-test-")
+            .tempdir()
+            .unwrap()
+    }
+}

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -498,11 +498,12 @@ mod tests {
     use pollster::FutureExt;
 
     use super::*;
+    use crate::tests_common::new_temp_dir;
 
     /// Test that parents get written correctly
     #[test]
     fn write_commit_parents() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
 
         let backend = LocalBackend::init(store_path);

--- a/lib/src/lock.rs
+++ b/lib/src/lock.rs
@@ -27,10 +27,11 @@ mod tests {
     use std::{fs, thread};
 
     use super::*;
+    use crate::tests_common::new_temp_dir;
 
     #[test]
     fn lock_basic() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let lock_path = temp_dir.path().join("test.lock");
         assert!(!lock_path.exists());
         {
@@ -42,7 +43,7 @@ mod tests {
 
     #[test]
     fn lock_concurrent() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let data_path = temp_dir.path().join("test");
         let lock_path = temp_dir.path().join("test.lock");
         fs::write(&data_path, 0_u32.to_le_bytes()).unwrap();

--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -523,6 +523,7 @@ mod tests {
     use itertools::Itertools as _;
 
     use super::*;
+    use crate::tests_common::new_temp_dir;
 
     fn repo_path(value: &str) -> &RepoPath {
         RepoPath::from_internal_string(value)
@@ -729,7 +730,7 @@ mod tests {
 
     #[test]
     fn parse_fs_path_wc_in_cwd() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let cwd_path = temp_dir.path().join("repo");
         let wc_path = &cwd_path;
 
@@ -788,7 +789,7 @@ mod tests {
 
     #[test]
     fn parse_fs_path_wc_in_cwd_parent() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let cwd_path = temp_dir.path().join("dir");
         let wc_path = cwd_path.parent().unwrap().to_path_buf();
 
@@ -827,7 +828,7 @@ mod tests {
 
     #[test]
     fn parse_fs_path_wc_in_cwd_child() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let cwd_path = temp_dir.path().join("cwd");
         let wc_path = cwd_path.join("repo");
 

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -696,6 +696,7 @@ mod tests {
     use maplit::{btreemap, hashmap, hashset};
 
     use super::*;
+    use crate::tests_common::new_temp_dir;
 
     fn create_view() -> View {
         let new_remote_ref = |target: &RefTarget| RemoteRef {
@@ -795,7 +796,7 @@ mod tests {
 
     #[test]
     fn test_read_write_view() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = SimpleOpStore::init(temp_dir.path());
         let view = create_view();
         let view_id = store.write_view(&view).unwrap();
@@ -805,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_read_write_operation() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = SimpleOpStore::init(temp_dir.path());
         let operation = create_operation();
         let op_id = store.write_operation(&operation).unwrap();

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -512,11 +512,12 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
+    use crate::tests_common::new_temp_dir;
 
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn stacked_table_empty(on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut_table = store.get_head().unwrap().start_mutation();
         let mut _saved_table = None;
@@ -536,7 +537,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn stacked_table_single_key(on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_table = store.get_head().unwrap().start_mutation();
         mut_table.add_entry(b"abc".to_vec(), b"value".to_vec());
@@ -557,7 +558,7 @@ mod tests {
     #[test_case(false; "memory")]
     #[test_case(true; "file")]
     fn stacked_table_multiple_keys(on_disk: bool) {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_table = store.get_head().unwrap().start_mutation();
         mut_table.add_entry(b"zzz".to_vec(), b"val3".to_vec());
@@ -583,7 +584,7 @@ mod tests {
 
     #[test]
     fn stacked_table_multiple_keys_with_parent_file() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_table = store.get_head().unwrap().start_mutation();
         mut_table.add_entry(b"abd".to_vec(), b"value 2".to_vec());
@@ -613,7 +614,7 @@ mod tests {
 
     #[test]
     fn stacked_table_merge() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_base_table = store.get_head().unwrap().start_mutation();
         mut_base_table.add_entry(b"abc".to_vec(), b"value1".to_vec());
@@ -646,7 +647,7 @@ mod tests {
     #[test]
     fn stacked_table_automatic_merge() {
         // Same test as above, but here we let the store do the merging on load
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
         let mut mut_base_table = store.get_head().unwrap().start_mutation();
         mut_base_table.add_entry(b"abc".to_vec(), b"value1".to_vec());
@@ -683,7 +684,7 @@ mod tests {
 
     #[test]
     fn stacked_table_store_save_empty() {
-        let temp_dir = testutils::new_temp_dir();
+        let temp_dir = new_temp_dir();
         let store = TableStore::init(temp_dir.path().to_path_buf(), 3);
 
         let mut mut_table = store.get_head().unwrap().start_mutation();


### PR DESCRIPTION
This fixes real dependency cycle that would expose slightly different versions of jj_lib types to unit tests, one from super::* and another from testutils::*.

I don't like the module name "tests_common", but I couldn't think of a better alternative other than "testutils" and "test_utils".

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
