### PR TITLE
Add Unicode-3.0 to allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -85,6 +85,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "MIT",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
 ]
 # List of explicitly disallowed licenses


### PR DESCRIPTION
Without this, `cargo deny` fails after a `cargo update` (https://github.com/martinvonz/jj/actions/runs/9531433728/job/26272377250?pr=3892 failed, but once it includes this commit, #3892 no longer has a `cargo deny` failure. The windows failure is unrelated))
