### PR TITLE
commit_builder: reset author timestamp on discardable commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * New command `jj git remote set-url` that sets the url of a git remote.
 
+* Author timestamp is now reset when rewriting discardable commits (empty
+  commits with no description) if authored by the current user.
+  [#2000](https://github.com/martinvonz/jj/issues/2000)
+
 ### Fixed bugs
 
 * `jj git push` now ignores immutable commits when checking whether a

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -165,7 +165,7 @@ fn test_branch_move() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "delete", "foo"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     foo (deleted)
-      @origin: qpvuntsm 29a62310 (empty) commit
+      @origin: qpvuntsm 1eb845f3 (empty) commit
     "###);
 
     // Deleted tracking branch name should still be allocated
@@ -179,8 +179,8 @@ fn test_branch_move() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "set", "foo"]);
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    foo: mzvwutvl d5f17aba (empty) (no description set)
-      @origin (behind by 1 commits): qpvuntsm 29a62310 (empty) commit
+    foo: mzvwutvl 66d48752 (empty) (no description set)
+      @origin (behind by 1 commits): qpvuntsm 1eb845f3 (empty) commit
     "###);
 
     // Untracked remote branch shouldn't block creation of local branch
@@ -189,8 +189,8 @@ fn test_branch_move() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "create", "foo"]);
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    foo: mzvwutvl d5f17aba (empty) (no description set)
-    foo@origin: qpvuntsm 29a62310 (empty) commit
+    foo: mzvwutvl 66d48752 (empty) (no description set)
+    foo@origin: qpvuntsm 1eb845f3 (empty) commit
     "###);
 }
 
@@ -496,7 +496,7 @@ fn test_branch_delete_glob() {
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--all"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  bar-2 foo-1 foo-3 foo-4 6fbf398c2d59
+    @  bar-2 foo-1 foo-3 foo-4 312a98d6f27b
     ◉   000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "delete", "glob:foo-[1-3]"]);
@@ -511,7 +511,7 @@ fn test_branch_delete_glob() {
     Deleted 2 branches.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  bar-2 foo-1@origin foo-3@origin foo-4 6fbf398c2d59
+    @  bar-2 foo-1@origin foo-3@origin foo-4 312a98d6f27b
     ◉   000000000000
     "###);
 
@@ -531,20 +531,20 @@ fn test_branch_delete_glob() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  bar-2 foo-1@origin foo-3@origin foo-4@origin 6fbf398c2d59
+    @  bar-2 foo-1@origin foo-3@origin foo-4@origin 312a98d6f27b
     ◉   000000000000
     "###);
 
     // The deleted branches are still there
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    bar-2: qpvuntsm 6fbf398c (empty) commit
-      @origin: qpvuntsm 6fbf398c (empty) commit
+    bar-2: qpvuntsm 312a98d6 (empty) commit
+      @origin: qpvuntsm 312a98d6 (empty) commit
     foo-1 (deleted)
-      @origin: qpvuntsm 6fbf398c (empty) commit
+      @origin: qpvuntsm 312a98d6 (empty) commit
     foo-3 (deleted)
-      @origin: qpvuntsm 6fbf398c (empty) commit
+      @origin: qpvuntsm 312a98d6 (empty) commit
     foo-4 (deleted)
-      @origin: qpvuntsm 6fbf398c (empty) commit
+      @origin: qpvuntsm 312a98d6 (empty) commit
     "###);
 
     // Malformed glob
@@ -1014,11 +1014,11 @@ fn test_branch_track_conflict() {
     );
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "track", "main@origin"]);
     insta::assert_snapshot!(stderr, @r###"
-main (conflicted):
-  + qpvuntsm b4a6b8c5 (empty) b
-  + qpvuntsm hidden 4bfd80cd (empty) a
-  @origin (behind by 1 commits): qpvuntsm hidden 4bfd80cd (empty) a
-"###);
+    main (conflicted):
+      + qpvuntsm e802c4f8 (empty) b
+      + qpvuntsm hidden 427890ea (empty) a
+      @origin (behind by 1 commits): qpvuntsm hidden 427890ea (empty) a
+    "###);
 }
 
 #[test]

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -52,7 +52,7 @@ fn test_builtin_alias_trunk_matches_main() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
+    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -64,7 +64,7 @@ fn test_builtin_alias_trunk_matches_master() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 master 45a3aa29
+    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 master d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -76,7 +76,7 @@ fn test_builtin_alias_trunk_matches_trunk() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 trunk 45a3aa29
+    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 trunk d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -91,7 +91,7 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 main 45a3aa29
+    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -107,7 +107,7 @@ fn test_builtin_alias_trunk_override_alias() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 override-trunk 45a3aa29
+    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 override-trunk d13ecdbd
     │  (empty) description 1
     ~
     "###);

--- a/cli/tests/test_checkout.rs
+++ b/cli/tests/test_checkout.rs
@@ -31,23 +31,23 @@ fn test_checkout() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj checkout` is deprecated; use `jj new` instead, which is equivalent
     Warning: `jj checkout` will be removed in a future version, and this will be a hard error
-    Working copy now at: zsuskuln 05ce7118 (empty) (no description set)
-    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    Working copy now at: zsuskuln c97da310 (empty) (no description set)
+    Parent commit      : rlvkpnrz 9ed53a4a (empty) second
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  05ce7118568d3007efc9163b055f9cb4a6becfde
-    ◉  5c52832c3483e0ace06d047a806024984f28f1d7 second
-    ◉  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
+    @  c97da310c66008034013412d321397242e1e43ef
+    ◉  9ed53a4a1becd028f9a2fe0d5275973acea7e8da second
+    ◉  fa15625b4a986997697639dfc2844138900c79f2 first
     ◉  0000000000000000000000000000000000000000
     "###);
 
     // Can provide a description
     test_env.jj_cmd_ok(&repo_path, &["checkout", "@--", "-m", "my message"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  1191baaf276e3d0b96b1747e885b3a517be80d6f my message
-    │ ◉  5c52832c3483e0ace06d047a806024984f28f1d7 second
+    @  6f9c4a002224fde4ebc48ce6ec03d5ffcfa64ad2 my message
+    │ ◉  9ed53a4a1becd028f9a2fe0d5275973acea7e8da second
     ├─╯
-    ◉  69542c1984c1f9d91f7c6c9c9e6941782c944bd9 first
+    ◉  fa15625b4a986997697639dfc2844138900c79f2 first
     ◉  0000000000000000000000000000000000000000
     "###);
 }
@@ -70,11 +70,11 @@ fn test_checkout_not_single_rev() {
     Warning: `jj checkout` will be removed in a future version, and this will be a hard error
     Error: Revset "root()..@" resolved to more than one revision
     Hint: The revset "root()..@" resolved to these revisions:
-      royxmykx 2f859371 (empty) (no description set)
-      mzvwutvl 5c1afd8b (empty) fifth
-      zsuskuln 009f88bf (empty) fourth
-      kkmpptxz 3fa8931e (empty) third
-      rlvkpnrz 5c52832c (empty) second
+      royxmykx 554d2245 (empty) (no description set)
+      mzvwutvl a497e2bf (empty) fifth
+      zsuskuln 9d7e5e99 (empty) fourth
+      kkmpptxz 30056b0c (empty) third
+      rlvkpnrz 9ed53a4a (empty) second
       ...
     "###);
 
@@ -84,11 +84,11 @@ fn test_checkout_not_single_rev() {
     Warning: `jj checkout` will be removed in a future version, and this will be a hard error
     Error: Revset "root()..@-" resolved to more than one revision
     Hint: The revset "root()..@-" resolved to these revisions:
-      mzvwutvl 5c1afd8b (empty) fifth
-      zsuskuln 009f88bf (empty) fourth
-      kkmpptxz 3fa8931e (empty) third
-      rlvkpnrz 5c52832c (empty) second
-      qpvuntsm 69542c19 (empty) first
+      mzvwutvl a497e2bf (empty) fifth
+      zsuskuln 9d7e5e99 (empty) fourth
+      kkmpptxz 30056b0c (empty) third
+      rlvkpnrz 9ed53a4a (empty) second
+      qpvuntsm fa15625b (empty) first
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "@-|@--"]);
@@ -97,8 +97,8 @@ fn test_checkout_not_single_rev() {
     Warning: `jj checkout` will be removed in a future version, and this will be a hard error
     Error: Revset "@-|@--" resolved to more than one revision
     Hint: The revset "@-|@--" resolved to these revisions:
-      mzvwutvl 5c1afd8b (empty) fifth
-      zsuskuln 009f88bf (empty) fourth
+      mzvwutvl a497e2bf (empty) fifth
+      zsuskuln 9d7e5e99 (empty) fourth
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["checkout", "none()"]);

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -25,8 +25,8 @@ fn test_commit_with_description_from_cli() {
     // Description applies to the current working-copy (not the new one)
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  b88fb4e51bdd
-    ◉  69542c1984c1 first
+    @  e8ea92a8b6b3
+    ◉  fa15625b4a98 first
     ◉  000000000000
     "###);
 }
@@ -44,8 +44,8 @@ fn test_commit_with_editor() {
     std::fs::write(&edit_script, ["dump editor0", "write\nmodified"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  3df78bc2b9b5
-    ◉  30a8c2b3d6eb modified
+    @  a57b2c95fb75
+    ◉  159271101e05 modified
     ◉  000000000000
     "###);
     insta::assert_snapshot!(
@@ -136,11 +136,11 @@ fn test_commit_with_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r#"
-    @  8dc0591d00f7
-    ◉  7e780ba80aeb TESTED=TODO
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    @  c65242099289
+    ◉  573b6df51aea TESTED=TODO
     ◉  000000000000
-    "#);
+    "###);
     assert_eq!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(),
         r#"
@@ -203,8 +203,8 @@ fn test_commit_paths_warning() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first", "file3"]);
     insta::assert_snapshot!(stderr, @r###"
     Warning: The given paths do not match any file: file3
-    Working copy now at: rlvkpnrz 67872820 (no description set)
-    Parent commit      : qpvuntsm 69542c19 (empty) first
+    Working copy now at: rlvkpnrz d1872100 (no description set)
+    Parent commit      : qpvuntsm fa15625b (empty) first
     "###);
     insta::assert_snapshot!(stdout, @"");
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -89,7 +89,7 @@ fn test_log_author_timestamp() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 04:05:09.000 +07:00
-    ◉  2001-02-03 04:05:07.000 +07:00
+    ◉  2001-02-03 04:05:08.000 +07:00
     ◉  1970-01-01 00:00:00.000 +00:00
     "###);
 }
@@ -189,9 +189,9 @@ fn test_log_default() {
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-branch 9de54178
+    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-branch bac9ff9e
     │  (empty) description 1
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 4291e264
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aa2015d7
     │  add a file
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -199,9 +199,9 @@ fn test_log_default() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
+    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
+    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     │  add a file
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -209,9 +209,9 @@ fn test_log_default() {
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12m9[38;5;8mde54178[39m[0m
+    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
-    [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m291e264[39m
+    [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     add a file
     [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -440,7 +440,7 @@ fn test_log_obslog_divergence() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 7a17d52e
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -452,9 +452,9 @@ fn test_log_obslog_divergence() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 8979953d
+    ◉  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 6ba70e00
     │  description 2
-    │ @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 7a17d52e
+    │ @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     ├─╯  description 1
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -465,9 +465,9 @@ fn test_log_obslog_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m8[0m[38;5;8m979953d[39m
+    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m6[0m[38;5;8mba70e00[39m
     │  description 2
-    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
+    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     ├─╯  [1mdescription 1[0m
     ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
@@ -475,9 +475,9 @@ fn test_log_obslog_divergence() {
     // Obslog and hidden divergent
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 7a17d52e
+    @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 3b68ce25
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 485d52a9
     │  (no description set)
     ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
@@ -486,9 +486,9 @@ fn test_log_obslog_divergence() {
     // Colored obslog
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m7[38;5;8ma17d52e[39m[0m
+    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     │  [1mdescription 1[0m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m3[0m[38;5;8mb68ce25[39m
+    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m85d52a9[39m
     │  [38;5;3m(no description set)[39m
     ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
@@ -548,7 +548,7 @@ fn test_log_branches() {
     ◉  fed794e2ba44 branch3?? branch3@origin
     │ ◉  b1bb3766d584 branch3??
     ├─╯
-    │ ◉  21c33875443e branch1*
+    │ ◉  28ff13ce7195 branch1*
     ├─╯
     │ @  a5b4d15489cc branch2* new-branch
     │ ◉  8476341eb395 branch2@origin unchanged
@@ -658,7 +658,7 @@ fn test_log_customize_short_id() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  Q_pvun test.user@example.com 2001-02-03 08:05:08 6_9542
+    @  Q_pvun test.user@example.com 2001-02-03 08:05:08 F_a156
     │  (empty) first
     ◉  Z_zzzz root() 0_0000
     "###);
@@ -676,7 +676,7 @@ fn test_log_customize_short_id() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 69542c19
+    @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ◉  ZZZZZZZZ root() 00000000
     "###);

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -33,10 +33,10 @@ fn test_concurrent_operation_divergence() {
     // "op log" doesn't merge the concurrent operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  bd72b691e2a8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ◉  48f4a48f3f70 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'message 2' --at-op @-
-    │ ◉  aff16879e85e test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ◉  e31015019d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │    args: jj describe -m 'message 1'
     ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -69,10 +69,10 @@ fn test_concurrent_operations_auto_rebase() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  254fed738276 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
-    │  describe commit 123ed18e4c4c0d77428df41112bc02ffc83fb935
+    @  66d1dd775c54 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
-    ◉  1a6e7a5002b6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ◉  130d67859810 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj describe -m initial
     ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -92,8 +92,8 @@ fn test_concurrent_operations_auto_rebase() {
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  3f06323826b4a293a9ee6d24cc0e07ad2961b5d5 new child
-    @  d91437157468ec86bbbc9e6a14a60d3e8d1790ac rewritten
+    ◉  db141860e12c2d5591c56fde4fc99caf71cec418 new child
+    @  07c3641e495cce57ea4ca789123b52f421c57aa2 rewritten
     ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
@@ -126,10 +126,10 @@ fn test_concurrent_operations_wc_modified() {
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    @  4eb0610031b7cd148ff9f729a673a3f815033170 new child1
-    │ ◉  4b20e61d23ee7d7c4d5e61e11e97c26e716f9c30 new child2
+    @  4eadcf3df11f46ef3d825c776496221cc8303053 new child1
+    │ ◉  68119f1643b7e3c301c5f7c2b6c9bf4ccba87379 new child2
     ├─╯
-    ◉  52c893bf3cd201e215b23e084e8a871244ca14d5 initial
+    ◉  2ff7ae858a3a11837fdf9d1a76be295ef53f1bb3 initial
     ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
@@ -155,7 +155,7 @@ fn test_concurrent_operations_wc_modified() {
     ◉ │  new empty commit
     │ ◉  new empty commit
     ├─╯
-    ◉  describe commit cf911c223d3e24e001fc8264d6dbf0610804fc40
+    ◉  describe commit 506f4ec3c2c62befa15fabc34ca9d4e6d7bef254
     ◉  snapshot working copy
     ◉  add workspace 'default'
     ◉  initialize repo
@@ -184,16 +184,16 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let template = r#"id ++ "\n" ++ description ++ "\n" ++ tags"#;
     let op_log_stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
     insta::assert_snapshot!(op_log_stdout, @r###"
-    @  072711d601c17a74367ab8654d797d1743063208689cafad1bd43581490b4a4180916964824916c5e10d1ecdbaa0763efe79066554959978af0f7ff4b5ed66f0
-    │  commit 323b414dd255b51375d7f4392b7b2641ffe4289f
+    @  9f11958bcf79340028eeabf9b0381cd8d2ae2258d0097b8ce8bd24fe7138eca08d9eb113bb4722ebacd9b7a6fa017e3888f72907be7487f275823c8d21359eed
+    │  commit 554d22b2c43c1c47e279430197363e8daabe2fd6
     │  args: jj commit -m 'new child1'
-    ◉  ab6c5b4e16160c48cabbde43a267ee6991b78668695e744b97e2ae150995458e3ea1d553550e2305028b23af62f74270dc86bd8826b36ad7f1fa7e3986cfdaa3
+    ◉  f5460e8f43a04fbc61553d12fa5ba8d3b12e4fdcfda1999db6b67cc8e1e473b7e62cc0536196a53b84f34e18c1c6d608f427bb64bd5f834f845a9859e39cb320
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ◉  6454b2aacf0821685fda129124aecd7a379bdc2da9c3f9b5e0d58da24d1300bf6a09806a572aa7040263fbe57d430aa706d9cea1f3356fe042029e53d9faa991
-    │  commit 3d918700494a9895696e955b85fa05eb0d314cc6
+    ◉  49359b6597ead3fbb66802a6bbd8761c0ad4646a2b089090d6fd72fb6e2568aa99c4a92f9f1f252a83cce56ec84961c36e85f731f19fc5a4c24d6a3f7282b774
+    │  commit de71e09289762a65f80bb1c3dae2a949df6bcde7
     │  args: jj commit -m initial
-    ◉  8ae097b5e512914cd62b7e13b2ce27ded56ced97005b6e0232438f08b067df1272b06ad428984a6d28496df5ae41aa3522c5b54d7588abf76210922345d94b17
+    ◉  86dbba2b96a4a801abef7f77f8fdf338b6e36f81ea4a531aacf06acbd06f4037731fffef42503c2225fdb206488971c1601ca8b2b4a83a3fe2dce64ee4db085e
     │  snapshot working copy
     │  args: jj commit -m initial
     ◉  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
@@ -218,8 +218,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "new child2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kkmpptxz 4011424e new child2
-    Parent commit      : rlvkpnrz e08863ee new child1
+    Working copy now at: kkmpptxz 1795621b new child2
+    Parent commit      : rlvkpnrz 86f54245 new child1
     "###);
 
     // Since the repo can be reloaded before snapshotting, "child2" should be
@@ -227,11 +227,11 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let template = r#"commit_id ++ " " ++ description"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template, "-s"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  4011424ea0a210a914f869ea3c47d76931598d1d new child2
+    @  1795621b54f4ebb435978b65d66bc0f90d8f20b6 new child2
     │  A child2
-    ◉  e08863ee7a0df688755d3d3126498afdf4f580ad new child1
+    ◉  86f54245e13f850f8275b5541e56da996b6a47b7 new child1
     │  A child1
-    ◉  79989e62f8331e69a803058b57bacc264405cb65 initial
+    ◉  84f07f6bca2ffeddac84a8b09f60c6b81112375c initial
     │  A base
     ◉  0000000000000000000000000000000000000000
     "###);

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -27,7 +27,7 @@ fn test_describe() {
         test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description from CLI"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm cf3e8673 (empty) description from CLI
+    Working copy now at: qpvuntsm 95979928 (empty) description from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
@@ -59,7 +59,7 @@ fn test_describe() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm 100943ae (empty) description from editor
+    Working copy now at: qpvuntsm 94fcb906 (empty) description from editor
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
@@ -72,7 +72,7 @@ fn test_describe() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm ccefa58b (empty) description among comment
+    Working copy now at: qpvuntsm 7a348923 (empty) description among comment
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
@@ -81,7 +81,7 @@ fn test_describe() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm e932ba42 (empty) line1
+    Working copy now at: qpvuntsm 749361b5 (empty) line1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     let stdout =
@@ -106,7 +106,7 @@ fn test_describe() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm 13f903c1 (empty) line1
+    Working copy now at: qpvuntsm dc44dbee (empty) line1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     let stdout =
@@ -120,7 +120,7 @@ fn test_describe() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-m", ""]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm 3196270d (empty) (no description set)
+    Working copy now at: qpvuntsm 6296963b (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     std::fs::write(&edit_script, "write\n").unwrap();
@@ -190,7 +190,7 @@ fn test_multiple_message_args() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm bdee9366 (empty) First Paragraph from CLI
+    Working copy now at: qpvuntsm 99a36a50 (empty) First Paragraph from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
@@ -233,7 +233,7 @@ fn test_multiple_message_args() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm a7506fe0 (empty) First Paragraph from CLI
+    Working copy now at: qpvuntsm 01ac40b3 (empty) First Paragraph from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 
@@ -261,7 +261,7 @@ fn test_describe_default_description() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm 7e780ba8 TESTED=TODO
+    Working copy now at: qpvuntsm 573b6df5 TESTED=TODO
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     assert_eq!(

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -896,14 +896,14 @@ fn test_diff_external_tool() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-p", "--tool=fake-diff-editor"]), @r###"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 0cba70c7
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 39d9055d
     │  (no description set)
     │  file1
     │  file2
     │  --
     │  file2
     │  file3
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 39b5a56f
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 0ad4ef22
     │  (no description set)
     │  --
     │  file1
@@ -914,9 +914,9 @@ fn test_diff_external_tool() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["show", "--tool=fake-diff-editor"]), @r###"
-    Commit ID: 0cba70c72186eabb5a2f91be63a8366b9f6da6c6
+    Commit ID: 39d9055d70873099fd924b9af218289d5663eac8
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
-    Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Author: Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
         (no description set)
@@ -961,9 +961,9 @@ fn test_diff_external_tool() {
     std::fs::write(&edit_script, "print diff\0fail").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["show", "--tool=fake-diff-editor"]);
     insta::assert_snapshot!(stdout, @r###"
-    Commit ID: 0cba70c72186eabb5a2f91be63a8366b9f6da6c6
+    Commit ID: 39d9055d70873099fd924b9af218289d5663eac8
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
-    Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Author: Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
         (no description set)

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -105,9 +105,9 @@ fn test_diffedit() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz cc387f43 (no description set)
-    Working copy now at: kkmpptxz cc387f43 (no description set)
-    Parent commit      : rlvkpnrz 613028a4 (no description set)
+    Created kkmpptxz cbc7a725 (no description set)
+    Working copy now at: kkmpptxz cbc7a725 (no description set)
+    Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -121,10 +121,10 @@ fn test_diffedit() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz d842b979 (no description set)
+    Created rlvkpnrz d4eef3fc (no description set)
     Rebased 1 descendant commits
-    Working copy now at: kkmpptxz bc2b2dd6 (no description set)
-    Parent commit      : rlvkpnrz d842b979 (no description set)
+    Working copy now at: kkmpptxz 59ef1b95 (no description set)
+    Parent commit      : rlvkpnrz d4eef3fc (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let contents = String::from_utf8(std::fs::read(repo_path.join("file3")).unwrap()).unwrap();
@@ -142,9 +142,9 @@ fn test_diffedit() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz d78a207f (no description set)
-    Working copy now at: kkmpptxz d78a207f (no description set)
-    Parent commit      : rlvkpnrz 613028a4 (no description set)
+    Created kkmpptxz 5b585bd1 (no description set)
+    Working copy now at: kkmpptxz 5b585bd1 (no description set)
+    Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -189,9 +189,9 @@ fn test_diffedit_new_file() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz 7b849299 (no description set)
-    Working copy now at: rlvkpnrz 7b849299 (no description set)
-    Parent commit      : qpvuntsm 414e1614 (no description set)
+    Created rlvkpnrz b0376e2b (no description set)
+    Working copy now at: rlvkpnrz b0376e2b (no description set)
+    Parent commit      : qpvuntsm b739eb46 (no description set)
     Added 1 files, modified 0 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -290,9 +290,9 @@ fn test_diffedit_3pane() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz 1930da4a (no description set)
-    Working copy now at: kkmpptxz 1930da4a (no description set)
-    Parent commit      : rlvkpnrz 613028a4 (no description set)
+    Created kkmpptxz ed8aada3 (no description set)
+    Working copy now at: kkmpptxz ed8aada3 (no description set)
+    Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -309,9 +309,9 @@ fn test_diffedit_3pane() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz ff2907b6 (no description set)
-    Working copy now at: kkmpptxz ff2907b6 (no description set)
-    Parent commit      : rlvkpnrz 613028a4 (no description set)
+    Created kkmpptxz 7c19e689 (no description set)
+    Working copy now at: kkmpptxz 7c19e689 (no description set)
+    Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 1 files, modified 0 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -380,10 +380,10 @@ fn test_diffedit_merge() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created royxmykx b9539d6e (conflict) merge
+    Created royxmykx 263b3c63 (conflict) merge
     Rebased 1 descendant commits
-    Working copy now at: yqosqzyt 0a24ed24 (conflict) (empty) (no description set)
-    Parent commit      : royxmykx b9539d6e (conflict) merge
+    Working copy now at: yqosqzyt 5771c919 (conflict) (empty) (no description set)
+    Parent commit      : royxmykx 263b3c63 (conflict) merge
     Added 0 files, modified 0 files, removed 1 files
     There are unresolved conflicts at these paths:
     file2    2-sided conflict
@@ -453,9 +453,9 @@ fn test_diffedit_old_restore_interactive_tests() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz abdbf627 (no description set)
-    Working copy now at: rlvkpnrz abdbf627 (no description set)
-    Parent commit      : qpvuntsm 2375fa16 (no description set)
+    Created rlvkpnrz 69811eda (no description set)
+    Working copy now at: rlvkpnrz 69811eda (no description set)
+    Parent commit      : qpvuntsm fc687cb8 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -469,9 +469,9 @@ fn test_diffedit_old_restore_interactive_tests() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz e31f7f33 (no description set)
-    Working copy now at: rlvkpnrz e31f7f33 (no description set)
-    Parent commit      : qpvuntsm 2375fa16 (no description set)
+    Created rlvkpnrz 2b76a42e (no description set)
+    Working copy now at: rlvkpnrz 2b76a42e (no description set)
+    Parent commit      : qpvuntsm fc687cb8 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -41,14 +41,14 @@ fn test_edit() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm f41390a5 first
+    Working copy now at: qpvuntsm 73383c0b first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  b2f7e9c549aa second
-    @  f41390a5efbf first
+    ◉  2c910ae2d628 second
+    @  73383c0b6439 first
     ◉  000000000000
     "###);
     insta::assert_snapshot!(stderr, @"");
@@ -58,8 +58,8 @@ fn test_edit() {
     std::fs::write(repo_path.join("file2"), "0").unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  51d937a3eeb4 second
-    @  409306de8f44 first
+    ◉  b384b2cc1883 second
+    @  ff3f7b0dc386 first
     ◉  000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
@@ -105,8 +105,8 @@ fn test_edit_current_wc_commit_missing() {
     Internal error: Failed to edit a commit
     Caused by:
     1: Current working-copy commit not found
-    2: Object 69542c1984c1f9d91f7c6c9c9e6941782c944bd9 of type commit not found
-    3: An object with id 69542c1984c1f9d91f7c6c9c9e6941782c944bd9 could not be found
+    2: Object fa15625b4a986997697639dfc2844138900c79f2 of type commit not found
+    3: An object with id fa15625b4a986997697639dfc2844138900c79f2 could not be found
     "###);
 }
 

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -75,8 +75,8 @@ fn test_fix_leaf_commit() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: rlvkpnrz 8b02703b (no description set)
-    Parent commit      : qpvuntsm fda57e40 (no description set)
+    Working copy now at: rlvkpnrz 85ce8924 (no description set)
+    Parent commit      : qpvuntsm b2ca2bc5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@-"]);
@@ -102,8 +102,8 @@ fn test_fix_parent_commit() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 3 commits of 3 checked.
-    Working copy now at: mzvwutvl d6abb1f4 child2 | (no description set)
-    Parent commit      : qpvuntsm 4f4d2103 parent | (no description set)
+    Working copy now at: mzvwutvl d30c8ae2 child2 | (no description set)
+    Parent commit      : qpvuntsm 70a4dae2 parent | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "parent"]);
@@ -169,8 +169,8 @@ fn test_default_revset() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 3 commits of 3 checked.
-    Working copy now at: yostqsxw 0bd830d2 bar2 | (no description set)
-    Parent commit      : yqosqzyt 4747dd17 bar1 | (no description set)
+    Working copy now at: yostqsxw dabc47b2 bar2 | (no description set)
+    Parent commit      : yqosqzyt 984b5924 bar1 | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "trunk1"]);
@@ -225,7 +225,7 @@ fn test_fix_immutable_commit() {
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["fix", "-s", "immutable"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 83eee3c8dce2 is immutable
+    Error: Commit e4b41a3ce243 is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "immutable"]);
@@ -259,7 +259,7 @@ fn test_fix_some_paths() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: qpvuntsm 3f72f723 (no description set)
+    Working copy now at: qpvuntsm 54a90d2b (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
@@ -280,7 +280,7 @@ fn test_fix_cyclic() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: qpvuntsm affcf432 (no description set)
+    Working copy now at: qpvuntsm bf5e6a5a (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
@@ -291,7 +291,7 @@ fn test_fix_cyclic() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: qpvuntsm 2de05835 (no description set)
+    Working copy now at: qpvuntsm 0e2d20d6 (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
@@ -324,8 +324,8 @@ fn test_deduplication() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 4 commits of 4 checked.
-    Working copy now at: yqosqzyt 5ac0edc4 d | (no description set)
-    Parent commit      : mzvwutvl 90d9a032 c | (empty) (no description set)
+    Working copy now at: yqosqzyt cf770245 d | (no description set)
+    Parent commit      : mzvwutvl 370615a5 c | (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
@@ -399,7 +399,7 @@ fn test_stderr_success() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     errorFixed 1 commits of 1 checked.
-    Working copy now at: qpvuntsm e8c5cda3 (no description set)
+    Working copy now at: qpvuntsm 487808ba (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
@@ -451,7 +451,7 @@ fn test_fix_file_types() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: qpvuntsm 72bf7048 (no description set)
+    Working copy now at: qpvuntsm 6836a9e4 (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
@@ -473,7 +473,7 @@ fn test_fix_executable() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: qpvuntsm eea49ac9 (no description set)
+    Working copy now at: qpvuntsm fee78e99 (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
@@ -533,9 +533,9 @@ fn test_fix_adding_merge_commit() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
-    Working copy now at: mzvwutvl 899a1398 (no description set)
-    Parent commit      : qpvuntsm 34782c48 a | (no description set)
-    Parent commit      : kkmpptxz 82e9bc6a b | (no description set)
+    Working copy now at: mzvwutvl f93eb5a9 (no description set)
+    Parent commit      : qpvuntsm 6e64e7a7 a | (no description set)
+    Parent commit      : kkmpptxz c536f264 b | (no description set)
     Added 0 files, modified 4 files, removed 0 files
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_a", "-r", "@"]);
@@ -564,9 +564,9 @@ fn test_fix_both_sides_of_conflict() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 3 commits of 3 checked.
-    Working copy now at: mzvwutvl b7967885 (conflict) (empty) (no description set)
-    Parent commit      : qpvuntsm 06fe435a a | (no description set)
-    Parent commit      : kkmpptxz ce7ee79e b | (no description set)
+    Working copy now at: mzvwutvl 88866235 (conflict) (empty) (no description set)
+    Parent commit      : qpvuntsm 8e8aad69 a | (no description set)
+    Parent commit      : kkmpptxz 91f9b284 b | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -608,9 +608,9 @@ fn test_fix_resolve_conflict() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Fixed 3 commits of 3 checked.
-    Working copy now at: mzvwutvl 669396ce (empty) (no description set)
-    Parent commit      : qpvuntsm 3c63716f a | (no description set)
-    Parent commit      : kkmpptxz 82703f5e b | (no description set)
+    Working copy now at: mzvwutvl 50fd048d (empty) (no description set)
+    Parent commit      : qpvuntsm dd2721f1 a | (no description set)
+    Parent commit      : kkmpptxz 07c27a8e b | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -70,7 +70,7 @@ fn test_git_colocated() {
     // HEAD commit should not
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  b26951a9c6f5c270e4d039880208952fd5faae5e
+    @  4f546c80f30abc0803fb83e5032a4d49fede4d68
     ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -82,14 +82,14 @@ fn test_git_colocated() {
     // Create a new change from jj and check that it's reflected in Git
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  9dbb23ff2ff5e66c43880f1042369d704f7a321e
-    ◉  b26951a9c6f5c270e4d039880208952fd5faae5e HEAD@git
+    @  0e2301a42b288b9568344e32cfdd8c76d1e56a83
+    ◉  4f546c80f30abc0803fb83e5032a4d49fede4d68 HEAD@git
     ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
     ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
-        @"b26951a9c6f5c270e4d039880208952fd5faae5e"
+        @"4f546c80f30abc0803fb83e5032a4d49fede4d68"
     );
 }
 
@@ -139,7 +139,7 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  fcdbbd731496cae17161cd6be9b6cf1f759655a8
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -157,18 +157,18 @@ fn test_git_colocated_unborn_branch() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: royxmykx 76c60bf0 (empty) (no description set)
-    Parent commit      : kkmpptxz f8d5bc77 (no description set)
+    Working copy now at: royxmykx 0e146103 (empty) (no description set)
+    Parent commit      : kkmpptxz e3e01407 (no description set)
     "###);
     assert!(git_repo.head().unwrap().symbolic_target().is_none());
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
-        @"f8d5bc772d1147351fd6e8cea52a4f935d3b31e7"
+        @"e3e01407bd3539722ae4ffff077700d97c60cb11"
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  76c60bf0a66dcbe74d74d58c23848d96f9e86e84
-    ◉  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 HEAD@git
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    @  0e14610343ef50775f5c44db5aeef19aee45d9ad
+    ◉  e3e01407bd3539722ae4ffff077700d97c60cb11 HEAD@git
+    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -176,8 +176,8 @@ fn test_git_colocated_unborn_branch() {
     checkout_index();
     insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
     The working copy is clean
-    Working copy : royxmykx 76c60bf0 (empty) (no description set)
-    Parent commit: kkmpptxz f8d5bc77 (no description set)
+    Working copy : royxmykx 0e146103 (empty) (no description set)
+    Parent commit: kkmpptxz e3e01407 (no description set)
     "###);
 
     // Assign the default branch. The branch is no longer "unborn".
@@ -196,10 +196,10 @@ fn test_git_colocated_unborn_branch() {
     assert!(git_repo.head().is_err());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  10dd328bb906e15890e55047740eab2812a3b2f7
-    │ ◉  2c576a57d2e6e8494616629cfdbb8fe5e3fea73b
-    │ ◉  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 master
+    │ ◉  ef75c0b0dcc9b080e00226908c21316acaa84dc6
+    │ ◉  e3e01407bd3539722ae4ffff077700d97c60cb11 master
     ├─╯
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -216,16 +216,16 @@ fn test_git_colocated_unborn_branch() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: wqnwkozp cab23370 (empty) (no description set)
-    Parent commit      : znkkpsqq 8f5b2638 (no description set)
+    Working copy now at: wqnwkozp 101e2723 (empty) (no description set)
+    Parent commit      : znkkpsqq fc8af934 (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  cab233704a5c0b21bde070943055f22142fb2043
-    ◉  8f5b263819457712a2937428b9c58a2a84afbb1c HEAD@git
-    │ ◉  2c576a57d2e6e8494616629cfdbb8fe5e3fea73b
-    │ ◉  f8d5bc772d1147351fd6e8cea52a4f935d3b31e7 master
+    @  101e272377a9daff75358f10dbd078df922fe68c
+    ◉  fc8af9345b0830dcb14716e04cd2af26e2d19f63 HEAD@git
+    │ ◉  ef75c0b0dcc9b080e00226908c21316acaa84dc6
+    │ ◉  e3e01407bd3539722ae4ffff077700d97c60cb11 master
     ├─╯
-    │ ◉  1de814dbef9641cc6c5c80d2689b80778edcce09
+    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -245,7 +245,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     std::fs::write(workspace_root.join("file"), "initial").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "foo"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  438471f3fbf1004298d8fb01eeb13663a051a643 foo
+    @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7 foo
     ◉  0000000000000000000000000000000000000000
     "###);
 
@@ -253,7 +253,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     // exported to Git without requiring any other changes
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca foo
+    @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf foo
     ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(git_repo
@@ -261,7 +261,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
         .unwrap()
         .target()
         .unwrap()
-        .to_string(), @"fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca");
+        .to_string(), @"4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf");
 }
 
 #[test]
@@ -295,8 +295,8 @@ fn test_git_colocated_rebase_on_import() {
     git_repo.set_head("refs/heads/master").unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
     insta::assert_snapshot!(stdout, @r###"
-    @  7f96185cfbe36341d0f9a86ebfaeab67a5922c7e
-    ◉  4bcbeaba9a4b309c5f45a8807fbf5499b9714315 master HEAD@git add a file
+    @  5539e55eb3690b85a7ebd4a37a5e3b57f469ee94
+    ◉  47fe984daf66f7bf3ebf31b9cb3513c995afb857 master HEAD@git add a file
     ◉  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
@@ -453,7 +453,7 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-"]);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "new"]);
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kkmpptxz 4c049607 (empty) new
+    Working copy now at: kkmpptxz 149cc31c (empty) new
     Parent commit      : lnksqltp e61b6729 master | initial
     "###);
 
@@ -463,7 +463,7 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
     assert_eq!(git_head_target, "refs/heads/master");
 
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
-    @  4c04960765ca906d0cb25b15a946be4c0dd71b8e new
+    @  149cc31cb08a1589e6c5ee2cb2061559dc758ecb new
     │ ◉  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
     ├─╯
     ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
@@ -490,12 +490,12 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     test_env.jj_cmd_ok(&clone_path, &["git", "init", "--git-repo=."]);
     test_env.jj_cmd_ok(&clone_path, &["new", "A"]);
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
-    @  0335878796213c3a701f1c9c34dcae242bee4131
-    │ ◉  8d4e006fd63547965fbc3a26556a9aa531076d32 C_to_move original C
+    @  9c2de797c3c299a40173c5af724329012b77cbdd
+    │ ◉  4a191a9013d3f3398ccf5e172792a61439dbcf3a C_to_move original C
     ├─╯
-    │ ◉  929e298ae9edf969b405a304c75c10457c47d52c B_to_delete B_to_delete
+    │ ◉  c49ec4fb50844d0e693f1609da970b11878772ee B_to_delete B_to_delete
     ├─╯
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A HEAD@git A
+    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A HEAD@git A
     ◉  0000000000000000000000000000000000000000
     "###);
 
@@ -512,10 +512,10 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     // "original C" and "B_to_delete" are abandoned, as the corresponding branches
     // were deleted or moved on the remote (#864)
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
-    ◉  04fd29df05638156b20044b3b6136b42abcb09ab C_to_move moved C
-    │ @  0335878796213c3a701f1c9c34dcae242bee4131
+    ◉  4f3d13296f978cbc351c46a43b4619c91b888475 C_to_move moved C
+    │ @  9c2de797c3c299a40173c5af724329012b77cbdd
     ├─╯
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b A HEAD@git A
+    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A HEAD@git A
     ◉  0000000000000000000000000000000000000000
     "###);
 }
@@ -546,8 +546,8 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     insta::assert_snapshot!(stdout, @r###"
     Working copy changes:
     M file
-    Working copy : rlvkpnrz d6c5e664 feature?? | (no description set)
-    Parent commit: qpvuntsm 5973d373 (no description set)
+    Working copy : rlvkpnrz 6bad94b1 feature?? | (no description set)
+    Parent commit: qpvuntsm 3230d522 (no description set)
     These branches have conflicts:
       feature
       Use `jj branch list` to see details. Use `jj branch set <name> -r <rev>` to resolve.
@@ -558,8 +558,8 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     Done importing changes from the underlying Git repo.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  d6c5e66473426f5ed3a24ecce8ce8b44ff23cf81 feature??
-    ◉  5973d3731aba9dd86c00b4a765fbc4cc13f1e14b HEAD@git
+    @  6bad94b10401f5fafc8a91064661224650d10d1b feature??
+    ◉  3230d52258f6de7e9afbd10da8d64503cc7cdca5 HEAD@git
     ◉  0000000000000000000000000000000000000000
     "###);
 
@@ -589,7 +589,7 @@ fn test_git_colocated_external_checkout() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f8a23336e41840ed1757ef323402a770427dc89a
     ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
-    │ ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master A
+    │ ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -601,8 +601,8 @@ fn test_git_colocated_external_checkout() {
     // be abandoned. (#1042)
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    @  adadbd65a794e2294962b3c3da9aada09fe1b472
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master HEAD@git A
+    @  8bb9e8d42a37c2a4e8dcfad97fce0b8f49bc7afa
+    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master HEAD@git A
     │ ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
     ◉  0000000000000000000000000000000000000000
@@ -618,7 +618,7 @@ fn test_git_colocated_external_checkout() {
     ◉  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
     @  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
     ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
-    │ ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master A
+    │ ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -629,8 +629,8 @@ fn test_git_colocated_external_checkout() {
     // The old working-copy commit shouldn't be abandoned. (#3747)
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    @  f9f6929eae811496820623f44199a9e04ee402e8
-    ◉  a86754f975f953fa25da4265764adc0c62e9ce6b master HEAD@git A
+    @  ca2a4e32f08688c6fb795c4c034a0a7e09c0d804
+    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master HEAD@git A
     │ ◉  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
     │ ◉  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
     │ ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a B
@@ -651,23 +651,23 @@ fn test_git_colocated_squash_undo() {
     test_env.jj_cmd_ok(&repo_path, &["ci", "-m=A"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  rlvkpnrzqnoo 8f71e3b6a3be
-    ◉  qpvuntsmwlqt a86754f975f9 A HEAD@git
+    @  rlvkpnrzqnoo 9670380ac379
+    ◉  qpvuntsmwlqt a7e4cec4256b A HEAD@git
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  zsuskulnrvyr f0c12b0396d9
-    ◉  qpvuntsmwlqt 2f376ea1478c A HEAD@git
+    @  zsuskulnrvyr 6ee662324e5a
+    ◉  qpvuntsmwlqt 13ab6b96d82e A HEAD@git
     ◉  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
-    @  rlvkpnrzqnoo 8f71e3b6a3be
-    ◉  qpvuntsmwlqt a86754f975f9 A HEAD@git
+    @  rlvkpnrzqnoo 9670380ac379
+    ◉  qpvuntsmwlqt a7e4cec4256b A HEAD@git
     ◉  zzzzzzzzzzzz 000000000000
     "###);
 }

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -33,8 +33,8 @@ fn test_resolution_of_git_tracking_branches() {
     // Move the local branch somewhere else
     test_env.jj_cmd_ok(&repo_path, &["describe", "-r", "main", "-m", "new_message"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 3af37026 (empty) new_message
-      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 16d541ca (empty) old_message
+    main: qpvuntsm b61d21b6 (empty) new_message
+      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 03757d22 (empty) old_message
     "###);
 
     // Test that we can address both revisions
@@ -46,10 +46,10 @@ fn test_resolution_of_git_tracking_branches() {
         )
     };
     insta::assert_snapshot!(query("main"), @r###"
-    3af370264cdcbba791762f8ef6bc79b456dcbf3b new_message
+    b61d21b660c17a7191f3f73873bfe7d3f7938628 new_message
     "###);
     insta::assert_snapshot!(query("main@git"), @r###"
-    16d541ca40f42baf2dea41aa61a0b5f1cbf1f91b old_message
+    03757d2212d89990ec158e97795b612a38446652 old_message
     "###);
     // Can't be selected by remote_branches()
     insta::assert_snapshot!(query(r#"remote_branches(exact:"main", exact:"git")"#), @"");

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -51,8 +51,8 @@ fn test_git_push_nothing() {
     let (test_env, workspace_root) = set_up();
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: lzmmnrxq 45a3aa29 (empty) description 1
-      @origin: lzmmnrxq 45a3aa29 (empty) description 1
+    branch1: xtvrqkyv d13ecdbd (empty) description 1
+      @origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     "###);
@@ -80,35 +80,35 @@ fn test_git_push_current_branch() {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq hidden 45a3aa29 (empty) description 1
-    branch2: yostqsxw 10ee3363 (empty) foo
+    branch1: xtvrqkyv 96cc58bf (empty) modified branch1 commit
+      @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
+    branch2: yostqsxw bc7610b6 (empty) foo
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
-    my-branch: yostqsxw 10ee3363 (empty) foo
+    my-branch: yostqsxw bc7610b6 (empty) foo
     "###);
     // First dry-run. `branch1` should not get pushed.
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--dry-run"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move forward branch branch2 from 8476341eb395 to 10ee3363b259
-      Add branch my-branch to 10ee3363b259
+      Move forward branch branch2 from 8476341eb395 to bc7610b65a91
+      Add branch my-branch to bc7610b65a91
     Dry-run requested, not pushing.
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move forward branch branch2 from 8476341eb395 to 10ee3363b259
-      Add branch my-branch to 10ee3363b259
+      Move forward branch branch2 from 8476341eb395 to bc7610b65a91
+      Add branch my-branch to bc7610b65a91
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: lzmmnrxq 19e00bf6 (empty) modified branch1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq hidden 45a3aa29 (empty) description 1
-    branch2: yostqsxw 10ee3363 (empty) foo
-      @origin: yostqsxw 10ee3363 (empty) foo
-    my-branch: yostqsxw 10ee3363 (empty) foo
-      @origin: yostqsxw 10ee3363 (empty) foo
+    branch1: xtvrqkyv 96cc58bf (empty) modified branch1 commit
+      @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
+    branch2: yostqsxw bc7610b6 (empty) foo
+      @origin: yostqsxw bc7610b6 (empty) foo
+    my-branch: yostqsxw bc7610b6 (empty) foo
+      @origin: yostqsxw bc7610b6 (empty) foo
     "###);
 
     // Try pushing backwards
@@ -135,7 +135,7 @@ fn test_git_push_current_branch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move backward branch branch2 from 10ee3363b259 to 8476341eb395
+      Move backward branch branch2 from bc7610b65a91 to 8476341eb395
     "###);
 }
 
@@ -154,7 +154,7 @@ fn test_git_push_parent_branch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch branch1 from 45a3aa29e907 to d47326d59ee1
+      Move sideways branch branch1 from d13ecdbda2a2 to 78bdfdea51c7
     "###);
 }
 
@@ -214,7 +214,7 @@ fn test_git_push_other_remote_has_branch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch branch1 from 45a3aa29e907 to 50421a29358a
+      Move sideways branch branch1 from d13ecdbda2a2 to a657f1b61b94
     "###);
     // Since it's already pushed to origin, nothing will happen if push again
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -235,7 +235,7 @@ fn test_git_push_other_remote_has_branch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to other:
-      Add branch branch1 to 50421a29358a
+      Add branch branch1 to a657f1b61b94
     "###);
 }
 
@@ -259,7 +259,7 @@ fn test_git_push_forward_unexpectedly_moved() {
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move forward branch branch1 from 45a3aa29e907 to c35839cb8e8c
+      Move forward branch branch1 from d13ecdbda2a2 to 6750425ff51c
     Error: Refusing to push a branch that unexpectedly moved on the remote. Affected refs: refs/heads/branch1
     Hint: Try fetching from the remote, then make the branch point to where you want it to be, and push again.
     "###);
@@ -275,8 +275,8 @@ fn test_git_push_sideways_unexpectedly_moved() {
     std::fs::write(origin_path.join("remote"), "remote").unwrap();
     test_env.jj_cmd_ok(&origin_path, &["branch", "set", "branch1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &origin_path), @r###"
-    branch1: vruxwmqv fb645b4b remote
-      @git (behind by 1 commits): qpvuntsm 45a3aa29 (empty) description 1
+    branch1: vruxwmqv 80284bec remote
+      @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
     branch2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
     "###);
@@ -291,7 +291,7 @@ fn test_git_push_sideways_unexpectedly_moved() {
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
     branch1: kmkuslsw 0f8bf988 local
-      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
+      @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     "###);
@@ -299,7 +299,7 @@ fn test_git_push_sideways_unexpectedly_moved() {
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch branch1 from 45a3aa29e907 to 0f8bf988588e
+      Move sideways branch branch1 from d13ecdbda2a2 to 0f8bf988588e
     Error: Refusing to push a branch that unexpectedly moved on the remote. Affected refs: refs/heads/branch1
     Hint: Try fetching from the remote, then make the branch point to where you want it to be, and push again.
     "###);
@@ -317,8 +317,8 @@ fn test_git_push_deletion_unexpectedly_moved() {
     std::fs::write(origin_path.join("remote"), "remote").unwrap();
     test_env.jj_cmd_ok(&origin_path, &["branch", "set", "branch1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &origin_path), @r###"
-    branch1: vruxwmqv fb645b4b remote
-      @git (behind by 1 commits): qpvuntsm 45a3aa29 (empty) description 1
+    branch1: vruxwmqv 80284bec remote
+      @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
     branch2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
     "###);
@@ -328,7 +328,7 @@ fn test_git_push_deletion_unexpectedly_moved() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "delete", "branch1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
     branch1 (deleted)
-      @origin: lzmmnrxq 45a3aa29 (empty) description 1
+      @origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     "###);
@@ -336,7 +336,7 @@ fn test_git_push_deletion_unexpectedly_moved() {
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--branch", "branch1"]);
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
+      Delete branch branch1 from d13ecdbda2a2
     Error: Refusing to push a branch that unexpectedly moved on the remote. Affected refs: refs/heads/branch1
     Hint: Try fetching from the remote, then make the branch point to where you want it to be, and push again.
     "###);
@@ -351,7 +351,7 @@ fn test_git_push_unexpectedly_deleted() {
     test_env.jj_cmd_ok(&origin_path, &["branch", "delete", "branch1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &origin_path), @r###"
     branch1 (deleted)
-      @git: qpvuntsm 45a3aa29 (empty) description 1
+      @git: qpvuntsm d13ecdbd (empty) description 1
     branch2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
     "###);
@@ -366,7 +366,7 @@ fn test_git_push_unexpectedly_deleted() {
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
     branch1: kpqxywon 1ebe27ba local
-      @origin (ahead by 1 commits, behind by 1 commits): lzmmnrxq 45a3aa29 (empty) description 1
+      @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     "###);
@@ -375,7 +375,7 @@ fn test_git_push_unexpectedly_deleted() {
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch branch1 from 45a3aa29e907 to 1ebe27ba04bf
+      Move sideways branch branch1 from d13ecdbda2a2 to 1ebe27ba04bf
     Error: Refusing to push a branch that unexpectedly moved on the remote. Affected refs: refs/heads/branch1
     Hint: Try fetching from the remote, then make the branch point to where you want it to be, and push again.
     "###);
@@ -383,7 +383,7 @@ fn test_git_push_unexpectedly_deleted() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "delete", "branch1"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
     branch1 (deleted)
-      @origin: lzmmnrxq 45a3aa29 (empty) description 1
+      @origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     "###);
@@ -393,7 +393,7 @@ fn test_git_push_unexpectedly_deleted() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
+      Delete branch branch1 from d13ecdbda2a2
     "###);
 }
 
@@ -442,8 +442,8 @@ fn test_git_push_locally_created_and_rewritten() {
     // set to "tracking"
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-mlocal 2"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: lzmmnrxq 45a3aa29 (empty) description 1
-      @origin: lzmmnrxq 45a3aa29 (empty) description 1
+    branch1: xtvrqkyv d13ecdbd (empty) description 1
+      @origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     my: vruxwmqv bde1d2e4 (empty) local 2
@@ -469,10 +469,10 @@ fn test_git_push_multiple() {
     // Check the setup
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
     branch1 (deleted)
-      @origin: lzmmnrxq 45a3aa29 (empty) description 1
-    branch2: yqosqzyt 15dcdaa4 (empty) foo
+      @origin: xtvrqkyv d13ecdbd (empty) description 1
+    branch2: yqosqzyt c4a3c310 (empty) foo
       @origin (ahead by 1 commits, behind by 1 commits): rlzusymt 8476341e (empty) description 2
-    my-branch: yqosqzyt 15dcdaa4 (empty) foo
+    my-branch: yqosqzyt c4a3c310 (empty) foo
     "###);
     // First dry-run
     let (stdout, stderr) =
@@ -480,9 +480,9 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
-      Move sideways branch branch2 from 8476341eb395 to 15dcdaa4f12f
-      Add branch my-branch to 15dcdaa4f12f
+      Delete branch branch1 from d13ecdbda2a2
+      Move sideways branch branch2 from 8476341eb395 to c4a3c3105d92
+      Add branch my-branch to c4a3c3105d92
     Dry-run requested, not pushing.
     "###);
     // Dry run requesting two specific branches
@@ -493,8 +493,8 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
-      Add branch my-branch to 15dcdaa4f12f
+      Delete branch branch1 from d13ecdbda2a2
+      Add branch my-branch to c4a3c3105d92
     Dry-run requested, not pushing.
     "###);
     // Dry run requesting two specific branches twice
@@ -513,8 +513,8 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
-      Add branch my-branch to 15dcdaa4f12f
+      Delete branch branch1 from d13ecdbda2a2
+      Add branch my-branch to c4a3c3105d92
     Dry-run requested, not pushing.
     "###);
     // Dry run with glob pattern
@@ -525,8 +525,8 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
-      Move sideways branch branch2 from 8476341eb395 to 15dcdaa4f12f
+      Delete branch branch1 from d13ecdbda2a2
+      Move sideways branch branch2 from 8476341eb395 to c4a3c3105d92
     Dry-run requested, not pushing.
     "###);
 
@@ -547,23 +547,23 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
-      Move sideways branch branch2 from 8476341eb395 to 15dcdaa4f12f
-      Add branch my-branch to 15dcdaa4f12f
+      Delete branch branch1 from d13ecdbda2a2
+      Move sideways branch branch2 from 8476341eb395 to c4a3c3105d92
+      Add branch my-branch to c4a3c3105d92
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch2: yqosqzyt 15dcdaa4 (empty) foo
-      @origin: yqosqzyt 15dcdaa4 (empty) foo
-    my-branch: yqosqzyt 15dcdaa4 (empty) foo
-      @origin: yqosqzyt 15dcdaa4 (empty) foo
+    branch2: yqosqzyt c4a3c310 (empty) foo
+      @origin: yqosqzyt c4a3c310 (empty) foo
+    my-branch: yqosqzyt c4a3c310 (empty) foo
+      @origin: yqosqzyt c4a3c310 (empty) foo
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 branch2 my-branch 15dcdaa4
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 branch2 my-branch c4a3c310
     │  (empty) foo
     │ ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
     ├─╯  (empty) description 2
-    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
+    │ ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -582,7 +582,7 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stderr, @r###"
     Creating branch push-yostqsxwqrlt for revision yostqsxwqrlt
     Branch changes to push to origin:
-      Add branch push-yostqsxwqrlt to 28d7620ea63a
+      Add branch push-yostqsxwqrlt to cf1a53a8800a
     "###);
     // test pushing two changes at once
     std::fs::write(workspace_root.join("file"), "modified2").unwrap();
@@ -590,8 +590,8 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "(@|@-)" resolved to more than one revision
     Hint: The revset "(@|@-)" resolved to these revisions:
-      yostqsxw 48d8c794 push-yostqsxwqrlt* | bar
-      yqosqzyt fa16a141 foo
+      yostqsxw 16c16966 push-yostqsxwqrlt* | bar
+      yqosqzyt a050abf4 foo
     Hint: Prefix the expression with 'all:' to allow any number of revisions (i.e. 'all:(@|@-)').
     "###);
     // test pushing two changes at once, part 2
@@ -600,8 +600,8 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stderr, @r###"
     Creating branch push-yqosqzytrlsw for revision yqosqzytrlsw
     Branch changes to push to origin:
-      Move sideways branch push-yostqsxwqrlt from 28d7620ea63a to 48d8c7948133
-      Add branch push-yqosqzytrlsw to fa16a14170fb
+      Move sideways branch push-yostqsxwqrlt from cf1a53a8800a to 16c169664e9f
+      Add branch push-yqosqzytrlsw to a050abf4ff07
     "###);
     // specifying the same change twice doesn't break things
     std::fs::write(workspace_root.join("file"), "modified3").unwrap();
@@ -609,7 +609,7 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch push-yostqsxwqrlt from 48d8c7948133 to 8a2941b572b9
+      Move sideways branch push-yostqsxwqrlt from 16c169664e9f to ef6313d50ac1
     "###);
 
     // specifying the same branch with --change/--branch doesn't break things
@@ -621,7 +621,7 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch push-yostqsxwqrlt from 8a2941b572b9 to 5b65c040beef
+      Move sideways branch push-yostqsxwqrlt from ef6313d50ac1 to c1e65d3a64ce
     "###);
 
     // try again with --change that moves the branch forward
@@ -640,8 +640,8 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stdout, @r###"
     Working copy changes:
     M file
-    Working copy : yostqsxw 361948b1 bar
-    Parent commit: yqosqzyt fa16a141 push-yostqsxwqrlt* push-yqosqzytrlsw | foo
+    Working copy : yostqsxw 38cb417c bar
+    Parent commit: yqosqzyt a050abf4 push-yostqsxwqrlt* push-yqosqzytrlsw | foo
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
@@ -650,14 +650,14 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Move sideways branch push-yostqsxwqrlt from 5b65c040beef to 361948b172e3
+      Move sideways branch push-yostqsxwqrlt from c1e65d3a64ce to 38cb417ce3a6
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
     Working copy changes:
     M file
-    Working copy : yostqsxw 361948b1 push-yostqsxwqrlt | bar
-    Parent commit: yqosqzyt fa16a141 push-yqosqzytrlsw | foo
+    Working copy : yostqsxw 38cb417c push-yostqsxwqrlt | bar
+    Parent commit: yqosqzyt a050abf4 push-yqosqzytrlsw | foo
     "###);
 
     // Test changing `git.push-branch-prefix`. It causes us to push again.
@@ -675,7 +675,7 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(stderr, @r###"
     Creating branch test-yostqsxwqrlt for revision yostqsxwqrlt
     Branch changes to push to origin:
-      Add branch test-yostqsxwqrlt to 361948b172e3
+      Add branch test-yostqsxwqrlt to 38cb417ce3a6
     "###);
 }
 
@@ -711,7 +711,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Add branch branch-1 to 7decc7932d9c
+      Add branch branch-1 to 5f432a855e59
     Dry-run requested, not pushing.
     "###);
     // Push multiple revisions of which some have branches
@@ -723,7 +723,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: No branches point to the specified revisions: @--
     Branch changes to push to origin:
-      Add branch branch-1 to 7decc7932d9c
+      Add branch branch-1 to 5f432a855e59
     Dry-run requested, not pushing.
     "###);
     // Push a revision with a multiple branches
@@ -732,8 +732,8 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Add branch branch-2a to 1b45449e18d0
-      Add branch branch-2b to 1b45449e18d0
+      Add branch branch-2a to 84f499037f5c
+      Add branch branch-2b to 84f499037f5c
     Dry-run requested, not pushing.
     "###);
     // Repeating a commit doesn't result in repeated messages about the branch
@@ -744,7 +744,7 @@ fn test_git_push_revisions() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Add branch branch-1 to 7decc7932d9c
+      Add branch branch-1 to 5f432a855e59
     Dry-run requested, not pushing.
     "###);
 }
@@ -770,10 +770,10 @@ fn test_git_push_mixed() {
     insta::assert_snapshot!(stderr, @r###"
     Creating branch push-yqosqzytrlsw for revision yqosqzytrlsw
     Branch changes to push to origin:
-      Add branch push-yqosqzytrlsw to fa16a14170fb
-      Add branch branch-1 to 7decc7932d9c
-      Add branch branch-2a to 1b45449e18d0
-      Add branch branch-2b to 1b45449e18d0
+      Add branch push-yqosqzytrlsw to a050abf4ff07
+      Add branch branch-1 to 5f432a855e59
+      Add branch branch-2a to 84f499037f5c
+      Add branch branch-2b to 84f499037f5c
     "###);
 }
 
@@ -791,7 +791,7 @@ fn test_git_push_existing_long_branch() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Add branch push-19b790168e73f7a73a98deae21e807c0 to fa16a14170fb
+      Add branch push-19b790168e73f7a73a98deae21e807c0 to a050abf4ff07
     "###);
 }
 
@@ -818,7 +818,7 @@ fn test_git_push_conflict() {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "third"]);
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Won't push commit 739c4f08a056 since it has conflicts
+    Error: Won't push commit 73c265a92cfd since it has conflicts
     "###);
 }
 
@@ -1024,13 +1024,13 @@ fn test_git_push_deleted() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to origin:
-      Delete branch branch1 from 45a3aa29e907
+      Delete branch branch1 from d13ecdbda2a2
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
     ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 branch2 8476341e
     │  (empty) description 2
-    │ ◉  lzmmnrxq test.user@example.com 2001-02-03 08:05:08 45a3aa29
+    │ ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     │ @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     ├─╯  (empty) (no description set)
@@ -1064,8 +1064,8 @@ fn test_git_push_conflicting_branches() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "branch2"]);
     test_env.jj_cmd_ok(&workspace_root, &["git", "fetch"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: lzmmnrxq 45a3aa29 (empty) description 1
-      @origin: lzmmnrxq 45a3aa29 (empty) description 1
+    branch1: xtvrqkyv d13ecdbd (empty) description 1
+      @origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2 (conflicted):
       + yostqsxw 8e670e2d (empty) description 3
       + rlzusymt 8476341e (empty) description 2
@@ -1101,7 +1101,7 @@ fn test_git_push_conflicting_branches() {
     Warning: Branch branch2 is conflicted
     Hint: Run `jj branch list` to inspect, and use `jj branch set` to fix it up.
     Branch changes to push to origin:
-      Move forward branch branch1 from 45a3aa29e907 to fd1d63e031ea
+      Move forward branch branch1 from d13ecdbda2a2 to 8df52121b022
     "###);
 
     // --revisions shouldn't be blocked by conflicting branch
@@ -1112,7 +1112,7 @@ fn test_git_push_conflicting_branches() {
     Warning: Branch branch2 is conflicted
     Hint: Run `jj branch list` to inspect, and use `jj branch set` to fix it up.
     Branch changes to push to origin:
-      Move forward branch branch1 from fd1d63e031ea to 8263cf992d33
+      Move forward branch branch1 from 8df52121b022 to 345e1f64a64d
     "###);
 }
 
@@ -1144,8 +1144,8 @@ fn test_git_push_tracked_vs_all() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "untrack", "branch1@origin"]);
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "branch3"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: vruxwmqv a25f24af (empty) moved branch1
-    branch1@origin: lzmmnrxq 45a3aa29 (empty) description 1
+    branch1: vruxwmqv 0b16bb02 (empty) moved branch1
+    branch1@origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2 (deleted)
       @origin: rlzusymt 8476341e (empty) description 2
     branch3: znkkpsqq 998d6a78 (empty) moved branch2
@@ -1164,8 +1164,8 @@ fn test_git_push_tracked_vs_all() {
     // Untrack the last remaining tracked branch.
     test_env.jj_cmd_ok(&workspace_root, &["branch", "untrack", "branch2@origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
-    branch1: vruxwmqv a25f24af (empty) moved branch1
-    branch1@origin: lzmmnrxq 45a3aa29 (empty) description 1
+    branch1: vruxwmqv 0b16bb02 (empty) moved branch1
+    branch1@origin: xtvrqkyv d13ecdbd (empty) description 1
     branch2@origin: rlzusymt 8476341e (empty) description 2
     branch3: znkkpsqq 998d6a78 (empty) moved branch2
     "###);
@@ -1248,7 +1248,7 @@ fn test_git_push_to_remote_named_git() {
         test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all", "--remote=git"]);
     insta::assert_snapshot!(stderr, @r###"
     Branch changes to push to git:
-      Add branch branch1 to 45a3aa29e907
+      Add branch branch1 to d13ecdbda2a2
       Add branch branch2 to 8476341eb395
     Error: Git remote named 'git' is reserved for local Git repository
     "###);

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -88,12 +88,12 @@ fn test_gitignores_ignored_file_in_target_commit() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["edit", "with-file"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: qpvuntsm 4a703628 with-file | (no description set)
+    Working copy now at: qpvuntsm 5ada929e with-file | (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
-    Hint: Inspect the changes compared to the intended target with `jj diff --from 4a703628bcb2`.
-    Discard the conflicting changes with `jj restore --from 4a703628bcb2`.
+    Hint: Inspect the changes compared to the intended target with `jj diff --from 5ada929e5d2e`.
+    Discard the conflicting changes with `jj restore --from 5ada929e5d2e`.
     "###);
     let stdout = test_env.jj_cmd_success(
         &workspace_root,

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -109,8 +109,8 @@ fn test_no_subcommand() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &[]);
     assert_eq!(stdout, "");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kxryzmor 70ac3df3 (empty) (no description set)
-    Parent commit      : lylxulpl 9dbbb452 foo
+    Working copy now at: kxryzmor 89c70edf (empty) (no description set)
+    Parent commit      : lylxulpl 51bd3589 foo
     "###);
 }
 
@@ -124,7 +124,7 @@ fn test_ignore_working_copy() {
     std::fs::write(repo_path.join("file"), "initial").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  438471f3fbf1004298d8fb01eeb13663a051a643
+    @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7
     ◉  0000000000000000000000000000000000000000
     "###);
 
@@ -140,7 +140,7 @@ fn test_ignore_working_copy() {
     // But without --ignore-working-copy, we get a new commit ID.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  fab22d1acf5bb9c5aa48cb2c3dd2132072a359ca
+    @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf
     ◉  0000000000000000000000000000000000000000
     "###);
 }

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -28,11 +28,11 @@ fn test_rewrite_immutable_generic() {
     std::fs::write(repo_path.join("file"), "c").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 78ebd449
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 7adb43e8
     │  c
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main c8d4c7ca
+    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main 72e1b68c
     ├─╯  b
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 46a8dc51
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 b84b821b
     │  a
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -41,13 +41,13 @@ fn test_rewrite_immutable_generic() {
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit c8d4c7ca95d0 is immutable
+    Error: Commit 72e1b68cbcf2 is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // Cannot rewrite an ancestor of the configured set
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "main-"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 46a8dc5175be is immutable
+    Error: Commit b84b821b8a2b is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // Cannot rewrite the root commit even with an empty set of immutable commits
@@ -73,8 +73,8 @@ fn test_rewrite_immutable_generic() {
     insta::assert_snapshot!(stdout, @r###"
     "###);
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kkmpptxz c8d4c7ca main | b
-    Parent commit      : qpvuntsm 46a8dc51 a
+    Working copy now at: kkmpptxz 72e1b68c main | b
+    Parent commit      : qpvuntsm b84b821b a
     Added 0 files, modified 1 files, removed 0 files
     "###);
     // ... but not the root commit
@@ -91,8 +91,8 @@ fn test_rewrite_immutable_generic() {
     insta::assert_snapshot!(stdout, @r###"
     "###);
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: wqnwkozp de8b93b4 (empty) (no description set)
-    Parent commit      : kkmpptxz c8d4c7ca main | b
+    Working copy now at: wqnwkozp fc921593 (empty) (no description set)
+    Parent commit      : kkmpptxz 72e1b68c main | b
     "###);
 
     // immutable_heads() of different arity doesn't shadow the 0-ary one
@@ -112,9 +112,9 @@ fn test_new_wc_commit_when_wc_immutable() {
     test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
     let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["branch", "set", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-Working copy now at: zsuskuln 87e33403 (empty) (no description set)
-Parent commit      : kkmpptxz 7272528e main | (empty) a
+    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
+    Working copy now at: zsuskuln ef5fa85b (empty) (no description set)
+    Parent commit      : kkmpptxz a164195b main | (empty) a
     "###);
 }
 
@@ -126,9 +126,9 @@ fn test_immutable_heads_set_to_working_copy() {
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "@""#);
     let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
     insta::assert_snapshot!(stderr, @r###"
-Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-Working copy now at: pmmvwywv 09dafa31 (empty) (no description set)
-Parent commit      : kkmpptxz 4963e243 (empty) a
+    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
+    Working copy now at: pmmvwywv 7278b2d8 (empty) (no description set)
+    Parent commit      : kkmpptxz a713ef56 (empty) a
     "###);
 }
 
@@ -144,22 +144,22 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     test_env.jj_cmd_ok(workspace1_envroot.as_path(), &["edit", "default@"]);
     let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["branch", "set", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
-Working copy now at: royxmykx c37fd624 (empty) (no description set)
-Parent commit      : kkmpptxz ada0ee19 main | a
+    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
+    Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
+    Working copy now at: royxmykx 5bcb7da6 (empty) (no description set)
+    Parent commit      : kkmpptxz 40cbbd52 main | a
     "###);
     test_env.jj_cmd_ok(workspace1_envroot.as_path(), &["workspace", "update-stale"]);
     let (stdout, _) = test_env.jj_cmd_ok(workspace1_envroot.as_path(), &["log", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-nppvrztz test.user@example.com 2001-02-03 08:05:11 workspace1@ f5e1b845
-(empty) (no description set)
-royxmykx test.user@example.com 2001-02-03 08:05:12 default@ c37fd624
-(empty) (no description set)
-kkmpptxz test.user@example.com 2001-02-03 08:05:12 main ada0ee19
-a
-zzzzzzzz root() 00000000
-        "###);
+    nppvrztz test.user@example.com 2001-02-03 08:05:11 workspace1@ 44082ceb
+    (empty) (no description set)
+    royxmykx test.user@example.com 2001-02-03 08:05:12 default@ 5bcb7da6
+    (empty) (no description set)
+    kkmpptxz test.user@example.com 2001-02-03 08:05:12 main 40cbbd52
+    a
+    zzzzzzzz root() 00000000
+    "###);
 }
 
 #[test]
@@ -185,14 +185,14 @@ fn test_rewrite_immutable_commands() {
     // Log shows mutable commits, their parents, and trunk() by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 3f89addf
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 65147295
     │  (empty) (no description set)
-    │ ◉  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 3e025082 conflict
+    │ ◉  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 1d5af877 conflict
     ╭─┤  merge
     │ │
     │ ~
     │
-    ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c8d4c7ca
+    ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 72e1b68c
     │  b
     ~
     "###);
@@ -200,31 +200,31 @@ fn test_rewrite_immutable_commands() {
     // abandon
     let stderr = test_env.jj_cmd_failure(&repo_path, &["abandon", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // chmod
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "chmod", "-r=main", "x", "file"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // describe
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // diffedit
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit", "-r=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // edit
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // move --from
@@ -232,7 +232,7 @@ fn test_rewrite_immutable_commands() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // move --to
@@ -240,91 +240,91 @@ fn test_rewrite_immutable_commands() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // new --insert-before
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "--insert-before", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // new --insert-after parent_of_main
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "--insert-after", "description(b)"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // parallelize
     let stderr = test_env.jj_cmd_failure(&repo_path, &["parallelize", "description(b)", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // rebase -s
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s=main", "-d=@"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // rebase -b
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-b=main", "-d=@"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 6e11f430f297 is immutable
+    Error: Commit 77cee210cbf5 is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // rebase -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r=main", "-d=@"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // resolve
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve", "-r=description(merge)", "file"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // restore -c
     let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "-c=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // restore --to
     let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "--to=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // split
     let stderr = test_env.jj_cmd_failure(&repo_path, &["split", "-r=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // squash -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "-r=description(b)"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit c8d4c7ca95d0 is immutable
+    Error: Commit 72e1b68cbcf2 is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // squash --from
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--from=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // squash --into
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--into=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
     // unsquash
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash", "-r=main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Commit 3e0250828ca5 is immutable
+    Error: Commit 1d5af877b8bb is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -353,7 +353,7 @@ fn test_log_shortest_accessors() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "c", "original"]);
     insta::assert_snapshot!(
         render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
-        @"q[pvuntsmwlqt] b[a1a30916d29]");
+        @"q[pvuntsmwlqt] e[0e22b9fae75]");
 
     // Create a chain of 10 commits
     for i in 1..10 {
@@ -367,37 +367,37 @@ fn test_log_shortest_accessors() {
 
     insta::assert_snapshot!(
         render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
-        @"qpv[untsmwlqt] ba1[a30916d29]");
+        @"qpv[untsmwlqt] e0[e22b9fae75]");
 
     insta::assert_snapshot!(
         render("::@", r#"change_id.shortest() ++ " " ++ commit_id.shortest() ++ "\n""#),
         @r###"
-    wq 03
-    km f7
-    kp e7
-    zn 38
-    yo 0cf
-    vr 9e
-    yq 06
-    ro 1f
-    mz 7b
-    qpv ba1
+    wq ed
+    km ef3
+    kp af
+    zn 23
+    yo b87
+    vr 1e
+    yq 34
+    ro cc
+    mz 1b
+    qpv e0
     zzz 00
     "###);
 
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
         @r###"
-    wq[nwkozpkust] 03[f51310b83e]
-    km[kuslswpqwq] f7[7fb1909080]
-    kp[qxywonksrl] e7[15ad5db646]
-    zn[kkpsqqskkl] 38[622e54e2e5]
-    yo[stqsxwqrlt] 0cf[42f60199c]
-    vr[uxwmqvtpmx] 9e[6015e4e622]
-    yq[osqzytrlsw] 06[f34d9b1475]
-    ro[yxmykxtrkr] 1f[99a5e19891]
-    mz[vwutvlkqwt] 7b[1f7dee65b4]
-    qpv[untsmwlqt] ba1[a30916d29]
+    wq[nwkozpkust] ed[e204633421]
+    km[kuslswpqwq] ef3[d013266cd]
+    kp[qxywonksrl] af[95b841712d]
+    zn[kkpsqqskkl] 23[c1103d3427]
+    yo[stqsxwqrlt] b87[aa9b24921]
+    vr[uxwmqvtpmx] 1e[a31a205ce9]
+    yq[osqzytrlsw] 34[befb94f4eb]
+    ro[yxmykxtrkr] cc[0c127948ef]
+    mz[vwutvlkqwt] 1b[7b715afc3f]
+    qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
     "###);
 
@@ -406,16 +406,16 @@ fn test_log_shortest_accessors() {
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
         @r###"
-    w[qnwkozpkust] 03[f51310b83e]
-    km[kuslswpqwq] f[77fb1909080]
-    kp[qxywonksrl] e[715ad5db646]
-    z[nkkpsqqskkl] 3[8622e54e2e5]
-    y[ostqsxwqrlt] 0c[f42f60199c]
-    vr[uxwmqvtpmx] 9e[6015e4e622]
-    yq[osqzytrlsw] 06f[34d9b1475]
-    ro[yxmykxtrkr] 1f[99a5e19891]
-    mz[vwutvlkqwt] 7b[1f7dee65b4]
-    qpv[untsmwlqt] ba1[a30916d29]
+    w[qnwkozpkust] ed[e204633421]
+    km[kuslswpqwq] ef[3d013266cd]
+    kp[qxywonksrl] a[f95b841712d]
+    z[nkkpsqqskkl] 2[3c1103d3427]
+    y[ostqsxwqrlt] b[87aa9b24921]
+    vr[uxwmqvtpmx] 1e[a31a205ce9]
+    yq[osqzytrlsw] 34[befb94f4eb]
+    ro[yxmykxtrkr] cc[0c127948ef]
+    mz[vwutvlkqwt] 1b[7b715afc3f]
+    qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
     "###);
 
@@ -424,16 +424,16 @@ fn test_log_shortest_accessors() {
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
         @r###"
-    wq[nwkozpkust] 03[f51310b83e]
-    km[kuslswpqwq] f7[7fb1909080]
-    kp[qxywonksrl] e7[15ad5db646]
-    zn[kkpsqqskkl] 38[622e54e2e5]
-    yo[stqsxwqrlt] 0cf[42f60199c]
-    vr[uxwmqvtpmx] 9e[6015e4e622]
-    yq[osqzytrlsw] 06f[34d9b1475]
-    ro[yxmykxtrkr] 1f[99a5e19891]
-    mz[vwutvlkqwt] 7b[1f7dee65b4]
-    qpv[untsmwlqt] ba1[a30916d29]
+    wq[nwkozpkust] ed[e204633421]
+    km[kuslswpqwq] ef3[d013266cd]
+    kp[qxywonksrl] af[95b841712d]
+    zn[kkpsqqskkl] 23c[1103d3427]
+    yo[stqsxwqrlt] b87[aa9b24921]
+    vr[uxwmqvtpmx] 1e[a31a205ce9]
+    yq[osqzytrlsw] 34[befb94f4eb]
+    ro[yxmykxtrkr] cc[0c127948ef]
+    mz[vwutvlkqwt] 1b[7b715afc3f]
+    qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
     "###);
 }
@@ -486,7 +486,7 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
         @r###"
-    @  Change qpvuntsmwlqt initial ba1a30916d29 original
+    @  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
     "###
@@ -505,7 +505,7 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
         @r###"
-    ◉  Change qpvuntsmwlqt initial ba1a30916d29 original
+    ◉  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
     "###
@@ -523,16 +523,16 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4m03[0m[38;5;8mf51310b83e[39m
-    ◉  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7fb1909080[39m
-    ◉  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4me7[0m[38;5;8m15ad5db646[39m
-    ◉  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m38[0m[38;5;8m622e54e2e5[39m
-    ◉  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m0cf[0m[38;5;8m42f60199c[39m
-    ◉  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6015e4e622[39m
-    ◉  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m06[0m[38;5;8mf34d9b1475[39m
-    ◉  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4m1f[0m[38;5;8m99a5e19891[39m
-    ◉  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1f7dee65b4[39m
-    ◉  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4mba1[0m[38;5;8ma30916d29[39m [38;5;5moriginal[39m
+    @  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4med[0m[38;5;8me204633421[39m
+    ◉  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mef3[0m[38;5;8md013266cd[39m
+    ◉  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4maf[0m[38;5;8m95b841712d[39m
+    ◉  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m23[0m[38;5;8mc1103d3427[39m
+    ◉  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4mb87[0m[38;5;8maa9b24921[39m
+    ◉  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m1e[0m[38;5;8ma31a205ce9[39m
+    ◉  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m34[0m[38;5;8mbefb94f4eb[39m
+    ◉  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4mcc[0m[38;5;8m0c127948ef[39m
+    ◉  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7b715afc3f[39m
+    ◉  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4me0[0m[38;5;8me22b9fae75[39m [38;5;5moriginal[39m
     ◉  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
     "###
     );
@@ -549,16 +549,16 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4m03[0m[38;5;8mf[39m
-    ◉  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mf7[0m[38;5;8m7[39m
-    ◉  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4me7[0m[38;5;8m1[39m
-    ◉  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m38[0m[38;5;8m6[39m
-    ◉  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m0cf[0m
-    ◉  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m9e[0m[38;5;8m6[39m
-    ◉  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m06[0m[38;5;8mf[39m
-    ◉  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4m1f[0m[38;5;8m9[39m
-    ◉  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m7b[0m[38;5;8m1[39m
-    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
+    @  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4med[0m[38;5;8me[39m
+    ◉  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mef3[0m
+    ◉  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4maf[0m[38;5;8m9[39m
+    ◉  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m23[0m[38;5;8mc[39m
+    ◉  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4mb87[0m
+    ◉  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m1e[0m[38;5;8ma[39m
+    ◉  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m34[0m[38;5;8mb[39m
+    ◉  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4mcc[0m[38;5;8m0[39m
+    ◉  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7[39m
+    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m[38;5;8me[39m [38;5;5moriginal[39m
     ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
     "###
     );
@@ -575,16 +575,16 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4m03[0m
-    ◉  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mf7[0m
-    ◉  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4me7[0m
-    ◉  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m38[0m
-    ◉  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4m0cf[0m
-    ◉  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m9e[0m
-    ◉  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m06[0m
-    ◉  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4m1f[0m
-    ◉  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m7b[0m
-    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4mba1[0m [38;5;5moriginal[39m
+    @  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4med[0m
+    ◉  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mef3[0m
+    ◉  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4maf[0m
+    ◉  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m23[0m
+    ◉  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4mb87[0m
+    ◉  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m1e[0m
+    ◉  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m34[0m
+    ◉  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4mcc[0m
+    ◉  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m1b[0m
+    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m [38;5;5moriginal[39m
     ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
     "###
     );
@@ -620,7 +620,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
         @r###"
-    @  Change q[pvuntsmwlqt] initial b[a1a30916d29] original
+    @  Change q[pvuntsmwlqt] initial e0[e22b9fae75] original
     ◉  Change z[zzzzzzzzzzz] 0[00000000000]
     "###
     );
@@ -637,7 +637,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-T", prefix_format]),
         @r###"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
-    │ ◉  Change qpv[untsmwlqt] initial ba[1a30916d29] original
+    │ ◉  Change qpv[untsmwlqt] initial e0e[22b9fae75] original
     ├─╯
     ◉  Change zzz[zzzzzzzzz] 00[0000000000]
     "###
@@ -1303,29 +1303,29 @@ fn test_log_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["log", "-r@"], 40, false), @r###"
-    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 68518a7e
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 044c0400
     │  (empty) merge
     ~
     "###);
     insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @r###"
     @  mzvwutvl test.user@example.com
-    │  2001-02-03 08:05:11 68518a7e
+    │  2001-02-03 08:05:11 044c0400
     ~  (empty) merge
     "###);
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @r###"
-    mzvwutvl test.user@example.com 2001-02-03 08:05:11 68518a7e
+    mzvwutvl test.user@example.com 2001-02-03 08:05:11 044c0400
     (empty) merge
     "###);
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, true), @r###"
     mzvwutvl test.user@example.com
-    2001-02-03 08:05:11 68518a7e
+    2001-02-03 08:05:11 044c0400
     (empty) merge
     "###);
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r###"
     @  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
-    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12m6[38;5;8m8518a7e[39m[0m
+    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12m04[38;5;8m4c0400[39m[0m
     ~  [1m[38;5;10m(empty)[39m merge[0m
     "###);
 
@@ -1358,7 +1358,7 @@ fn test_log_word_wrap() {
     │  test.user@example.com
     ~  2001-02-03
        08:05:11
-       68518a7e
+       044c0400
        (empty)
        merge
     "###);
@@ -1367,7 +1367,7 @@ fn test_log_word_wrap() {
     │  test.user@example.com
     ~  2001-02-03
        08:05:11
-       68518a7e
+       044c0400
        (empty)
        merge
     "###);

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -55,13 +55,13 @@ fn test_move() {
     std::fs::write(repo_path.join("file2"), "f\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  0d7353584003 f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    @  a847ab4967fe f
+    ◉  c2f9de87325d e
+    ◉  e0dac715116f d
+    │ ◉  59597b34a0d8 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
 
@@ -89,17 +89,17 @@ fn test_move() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Working copy now at: kmkuslsw 1c03e3d3 f | (no description set)
-    Parent commit      : znkkpsqq e9515f21 e | (no description set)
+    Working copy now at: kmkuslsw a45950b1 f | (no description set)
+    Parent commit      : znkkpsqq c2f9de87 e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  1c03e3d3c63f f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  55171e33db26 b c
+    @  a45950b1b7ff f
+    ◉  c2f9de87325d e
+    ◉  e0dac715116f d
+    │ ◉  12d6103dc0c8 b c
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The change from the source has been applied
@@ -120,18 +120,18 @@ fn test_move() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Working copy now at: kmkuslsw c8d83075 f | (no description set)
-    Parent commit      : znkkpsqq 2c50bfc5 e | (no description set)
+    Working copy now at: kmkuslsw 5e5727af f | (no description set)
+    Parent commit      : znkkpsqq ed9c4164 e | (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  c8d83075e8c2 f
-    ◉  2c50bfc59c68 e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    @  5e5727af3d75 f
+    ◉  ed9c41643a77 e
+    │ ◉  59597b34a0d8 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a d
+    ◉  b7b767179c44 a d
     ◉  000000000000
     "###);
     // The change from the source has been applied (the file contents were already
@@ -149,18 +149,18 @@ fn test_move() {
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
-    Working copy now at: kmkuslsw 2b723b1d f | (no description set)
-    Parent commit      : vruxwmqv 4293930d d e | (no description set)
+    Working copy now at: kmkuslsw e21f6bb0 f | (no description set)
+    Parent commit      : vruxwmqv 3cf0fa77 d e | (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  2b723b1d6033 f
-    ◉  4293930d6333 d e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    @  e21f6bb01bae f
+    ◉  3cf0fa772663 d e
+    │ ◉  59597b34a0d8 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The change from the source has been applied
@@ -199,11 +199,11 @@ fn test_move_partial() {
     std::fs::write(repo_path.join("file3"), "d\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  bdd835cae844 d
-    │ ◉  5028db694b6b c
-    │ ◉  55171e33db26 b
+    @  e0dac715116f d
+    │ ◉  087591be5a01 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
 
@@ -215,15 +215,15 @@ fn test_move_partial() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Working copy now at: vruxwmqv 71b69e43 d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Working copy now at: vruxwmqv 987bcfb2 d | (no description set)
+    Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  71b69e433fbc d
-    │ ◉  55171e33db26 b c
+    @  987bcfb2eb62 d
+    │ ◉  12d6103dc0c8 b c
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The changes from the source has been applied
@@ -249,16 +249,16 @@ fn test_move_partial() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Working copy now at: vruxwmqv 63f1a6e9 d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Working copy now at: vruxwmqv 576244e8 d | (no description set)
+    Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  63f1a6e96edb d
-    │ ◉  d027c6e3e6bc c
-    │ ◉  55171e33db26 b
+    @  576244e87883 d
+    │ ◉  6f486f2f4539 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
@@ -286,16 +286,16 @@ fn test_move_partial() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj move` is deprecated; use `jj squash` instead, which is equivalent
     Warning: `jj move` will be removed in a future version, and this will be a hard error
-    Working copy now at: vruxwmqv 17c2e663 d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Working copy now at: vruxwmqv 5b407c24 d | (no description set)
+    Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  17c2e6632cc5 d
-    │ ◉  6a3ae047a03e c
-    │ ◉  55171e33db26 b
+    @  5b407c249fa7 d
+    │ ◉  724d64da1487 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
@@ -327,11 +327,11 @@ fn test_move_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  21253406d416 c
-    ◉  e1cf08aae711 b
-    │ @  bdd835cae844 d
+    ◉  d2a587ae205d c
+    ◉  a53394306362 b
+    │ @  e0dac715116f d
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The selected change from the source has been applied

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -26,8 +26,8 @@ fn test_new() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "a new commit"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    @  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
+    ◉  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ◉  0000000000000000000000000000000000000000
     "###);
 
@@ -35,8 +35,8 @@ fn test_new() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "off of root", "root()"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ◉  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    │ ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    │ ◉  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
+    │ ◉  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -46,8 +46,8 @@ fn test_new() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  101cbec5cae8049cb9850a906ef3675631ed48fa yet another commit
     ◉  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ◉  4f2d6e0a3482a6a34e4856a4a63869c0df109e79 a new commit
-    │ ◉  5d5c60b2aa96b8dbf55710656c50285c66cdcd74 add a file
+    │ ◉  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
+    │ ◉  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -78,10 +78,10 @@ fn test_new_merge() {
     // Create a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "main", "@"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @    0c4e5b9b68ae0cbe7ce3c61042619513d09005bf
+    @    2f9a61ea1fef257eca52fcee2feec1cbd2e41660
     ├─╮
     │ ◉  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    ◉ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -95,13 +95,13 @@ fn test_new_merge() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "main", "@", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created new commit znkkpsqq 200ed1a1 (empty) (no description set)
+    Created new commit znkkpsqq 496490a6 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    200ed1a14c8acf09783dafefe5bebf2ff58f12fd
+    ◉    496490a66cebb31730c4103b7b22a1098d49af91
     ├─╮
     │ @  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    ◉ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -110,10 +110,10 @@ fn test_new_merge() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["merge", "main", "@"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @    3a44e52b073cbb5deb11bb8fa0763a369e96427a
+    @    114023233c454e2eca22b8b209f9e42f755eb28c
     ├─╮
     │ ◉  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  38e8e2f6c92ffb954961fc391b515ff551b41636 add file1
+    ◉ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
@@ -135,14 +135,14 @@ fn test_new_merge() {
     // merge with non-unique revisions
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "@", "3a44e"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: More than one revset resolved to revision 3a44e52b073c
+    Error: Revision "3a44e" doesn't exist
     "###);
     // if prefixed with all:, duplicates are allowed
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "@", "all:visible_heads()"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: xznxytkn dddeb489 (empty) (no description set)
-    Parent commit      : wqnwkozp 3a44e52b (empty) (no description set)
+    Working copy now at: xznxytkn 6286a0ff (empty) (no description set)
+    Parent commit      : wqnwkozp 11402323 (empty) (no description set)
     "###);
 
     // merge with root
@@ -179,8 +179,8 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
-    Working copy now at: kxryzmor ca7c6481 (empty) G
-    Parent commit      : kkmpptxz 6041917c B | (empty) B
+    Working copy now at: kxryzmor 1fc93fd1 (empty) G
+    Parent commit      : kkmpptxz bfd4157e B | (empty) B
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
@@ -269,9 +269,9 @@ fn test_new_insert_after_children() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kxryzmor b48d4d73 (empty) G
-    Parent commit      : qpvuntsm 65b1ef43 A | (empty) A
-    Parent commit      : mzvwutvl ec18c57d C | (empty) C
+    Working copy now at: kxryzmor 6d63e17b (empty) G
+    Parent commit      : qpvuntsm 5ef24e4b A | (empty) A
+    Parent commit      : mzvwutvl 83376b27 C | (empty) C
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
@@ -324,8 +324,8 @@ fn test_new_insert_before() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
-    Working copy now at: kxryzmor 19e53931 (empty) G
-    Parent commit      : kkmpptxz 6041917c B | (empty) B
+    Working copy now at: kxryzmor 7ed2d6ff (empty) G
+    Parent commit      : kkmpptxz bfd4157e B | (empty) B
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     Parent commit      : znkkpsqq 41a89ffc E | (empty) E
     "###);
@@ -421,9 +421,9 @@ fn test_new_insert_before_no_loop() {
     │ ◉  41a89ffcbba2 E
     ◉ │  c9257eff5bf9 D
     ├─╯
-    │ ◉  ec18c57d72d8 C
-    │ ◉  6041917ceeb5 B
-    │ ◉  65b1ef43c737 A
+    │ ◉  83376b270925 C
+    │ ◉  bfd4157e6ea4 B
+    │ ◉  5ef24e4bf2be A
     ├─╯
     ◉  000000000000 root
     "###);
@@ -441,7 +441,7 @@ fn test_new_insert_before_no_loop() {
         ],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to create a loop: commit 6041917ceeb5 would be both an ancestor and a descendant of the new commit
+    Error: Refusing to create a loop: commit bfd4157e6ea4 would be both an ancestor and a descendant of the new commit
     "###);
 }
 
@@ -533,8 +533,8 @@ fn test_new_insert_after_before() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: kxryzmor 33be1218 (empty) G
-    Parent commit      : mzvwutvl ec18c57d C | (empty) C
+    Working copy now at: kxryzmor 78a97058 (empty) G
+    Parent commit      : mzvwutvl 83376b27 C | (empty) C
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     ◉      F
@@ -592,9 +592,9 @@ fn test_new_insert_after_before_no_loop() {
     │ ◉  41a89ffcbba2 E
     ◉ │  c9257eff5bf9 D
     ├─╯
-    │ ◉  ec18c57d72d8 C
-    │ ◉  6041917ceeb5 B
-    │ ◉  65b1ef43c737 A
+    │ ◉  83376b270925 C
+    │ ◉  bfd4157e6ea4 B
+    │ ◉  5ef24e4bf2be A
     ├─╯
     ◉  000000000000 root
     "###);
@@ -612,7 +612,7 @@ fn test_new_insert_after_before_no_loop() {
         ],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to create a loop: commit ec18c57d72d8 would be both an ancestor and a descendant of the new commit
+    Error: Refusing to create a loop: commit 83376b270925 would be both an ancestor and a descendant of the new commit
     "###);
 }
 
@@ -646,7 +646,7 @@ fn test_new_conflicting_branches() {
     Hint: Branch foo resolved to multiple revisions because it's conflicted.
     It resolved to these revisions:
       kkmpptxz 66c6502d foo?? | (empty) two
-      qpvuntsm a9330854 foo?? | (empty) one
+      qpvuntsm 876f4b7e foo?? | (empty) one
     Hint: Set which revision the branch points to with `jj branch set foo -r <REVISION>`.
     "###);
 }
@@ -667,8 +667,8 @@ fn test_new_conflicting_change_ids() {
     insta::assert_snapshot!(stderr, @r###"
     Error: Revset "qpvuntsm" resolved to more than one revision
     Hint: The revset "qpvuntsm" resolved to these revisions:
-      qpvuntsm?? d2ae6806 (empty) two
-      qpvuntsm?? a9330854 (empty) one
+      qpvuntsm?? 66c6502d (empty) two
+      qpvuntsm?? 876f4b7e (empty) one
     Hint: Some of these commits have the same change id. Abandon one of them with `jj abandon -r <REVISION>`.
     "###);
 }

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -38,8 +38,8 @@ fn test_next_simple() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: royxmykx f039cf03 (empty) (no description set)
-    Parent commit      : kkmpptxz 3fa8931e (empty) third
+    Working copy now at: royxmykx fb00d619 (empty) (no description set)
+    Parent commit      : kkmpptxz 30056b0c (empty) third
     "###);
 }
 
@@ -58,8 +58,8 @@ fn test_next_multiple() {
     // We should now be the child of the fourth commit.
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: yqosqzyt 52a2e8c2 (empty) (no description set)
-    Parent commit      : zsuskuln 009f88bf (empty) fourth
+    Working copy now at: yqosqzyt 50168682 (empty) (no description set)
+    Parent commit      : zsuskuln 9d7e5e99 (empty) fourth
     "###);
 }
 
@@ -83,8 +83,8 @@ fn test_prev_simple() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: royxmykx 5647d685 (empty) (no description set)
-    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    Working copy now at: royxmykx 6db74f64 (empty) (no description set)
+    Parent commit      : rlvkpnrz 9ed53a4a (empty) second
     "###);
 }
 
@@ -110,8 +110,8 @@ fn test_prev_multiple_without_root() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: yqosqzyt d2edc95b (empty) (no description set)
-    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    Working copy now at: yqosqzyt 794ffd20 (empty) (no description set)
+    Parent commit      : rlvkpnrz 9ed53a4a (empty) second
     "###);
 }
 
@@ -200,8 +200,8 @@ fn test_next_with_merge_commit_parent() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout,@r###""###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: vruxwmqv 718bbcd9 (empty) (no description set)
-    Parent commit      : mzvwutvl cb5881ec (empty) 4
+    Working copy now at: vruxwmqv e2cefcb7 (empty) (no description set)
+    Parent commit      : mzvwutvl b54bbdea (empty) 4
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  vruxwmqvtpmx
@@ -243,8 +243,8 @@ fn test_next_on_merge_commit() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout,@r###""###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: mzvwutvl cb5881ec (empty) 4
-    Parent commit      : zsuskuln 038acb86 (empty) 3
+    Working copy now at: mzvwutvl b54bbdea (empty) 4
+    Parent commit      : zsuskuln 5542f0b4 (empty) 3
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt 4
@@ -296,8 +296,8 @@ fn test_next_fails_on_branching_children_quit_prompt() {
     let stderr = test_env.normalize_output(&get_stderr_string(&assert));
     insta::assert_snapshot!(stdout,@r###"
     ambiguous next commit, choose one to target:
-    1: zsuskuln 40a959a0 (empty) third
-    2: rlvkpnrz 5c52832c (empty) second
+    1: zsuskuln 5f24490d (empty) third
+    2: rlvkpnrz 9ed53a4a (empty) second
     q: quit the prompt
     enter the index of the commit you want to target: 
     "###);
@@ -322,15 +322,15 @@ fn test_next_choose_branching_child() {
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["next"], "2\n");
     insta::assert_snapshot!(stdout,@r###"
     ambiguous next commit, choose one to target:
-    1: royxmykx e488d731 (empty) fourth
-    2: zsuskuln 40a959a0 (empty) third
-    3: rlvkpnrz 5c52832c (empty) second
+    1: royxmykx d00fe885 (empty) fourth
+    2: zsuskuln 5f24490d (empty) third
+    3: rlvkpnrz 9ed53a4a (empty) second
     q: quit the prompt
     enter the index of the commit you want to target: 
     "###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: yostqsxw 3e7e69dc (empty) (no description set)
-    Parent commit      : zsuskuln 40a959a0 (empty) third
+    Working copy now at: yostqsxw 5c8fa96d (empty) (no description set)
+    Parent commit      : zsuskuln 5f24490d (empty) third
     "###);
 }
 
@@ -367,12 +367,12 @@ fn test_prev_on_merge_commit() {
     insta::assert_snapshot!(stdout, @r###"
     ambiguous prev commit, choose one to target:
     1: zsuskuln b0d21db3 right | (empty) second
-    2: qpvuntsm 69542c19 left | (empty) first
+    2: qpvuntsm fa15625b left | (empty) first
     q: quit the prompt
     enter the index of the commit you want to target: 
     "###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: qpvuntsm 69542c19 left | (empty) first
+    Working copy now at: qpvuntsm fa15625b left | (empty) first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
 }
@@ -412,14 +412,14 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     insta::assert_snapshot!(stdout, @r###"
     ambiguous prev commit, choose one to target:
     1: kkmpptxz 146d5c67 (empty) y
-    2: qpvuntsm c56e5035 (empty) x
+    2: qpvuntsm 6799aaa2 (empty) x
     3: zzzzzzzz 00000000 (empty) (no description set)
     q: quit the prompt
     enter the index of the commit you want to target: 
     "###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: vruxwmqv e8ff4fa0 (empty) (no description set)
-    Parent commit      : qpvuntsm c56e5035 (empty) x
+    Working copy now at: vruxwmqv e5a6794c (empty) (no description set)
+    Parent commit      : qpvuntsm 6799aaa2 (empty) x
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -427,13 +427,13 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     insta::assert_snapshot!(stdout, @r###"
     ambiguous prev commit, choose one to target:
     1: mzvwutvl 89b8a355 (empty) 1
-    2: zsuskuln 1ef71474 (empty) z
+    2: zsuskuln a83fc061 (empty) z
     q: quit the prompt
     enter the index of the commit you want to target: 
     "###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: zsuskuln 1ef71474 (empty) z
-    Parent commit      : qpvuntsm c56e5035 (empty) x
+    Working copy now at: zsuskuln a83fc061 (empty) z
+    Parent commit      : qpvuntsm 6799aaa2 (empty) x
     Parent commit      : kkmpptxz 146d5c67 (empty) y
     "###);
 }
@@ -469,15 +469,15 @@ fn test_prev_prompts_on_multiple_parents() {
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev"], "3\n");
     insta::assert_snapshot!(stdout,@r###"
     ambiguous prev commit, choose one to target:
-    1: mzvwutvl a082e25d (empty) third
-    2: kkmpptxz 09881e5f (empty) second
-    3: qpvuntsm 69542c19 (empty) first
+    1: mzvwutvl bc4f4fe3 (empty) third
+    2: kkmpptxz b0d21db3 (empty) second
+    3: qpvuntsm fa15625b (empty) first
     q: quit the prompt
     enter the index of the commit you want to target: 
     "###);
     insta::assert_snapshot!(stderr,@r###"
-    Working copy now at: znkkpsqq 94715f3c (empty) (no description set)
-    Parent commit      : qpvuntsm 69542c19 (empty) first
+    Working copy now at: znkkpsqq 07b409e8 (empty) (no description set)
+    Parent commit      : qpvuntsm fa15625b (empty) first
     "###);
 }
 
@@ -529,15 +529,15 @@ fn test_prev_editing() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit"]);
     insta::assert_snapshot!(stdout, @r"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kkmpptxz 3fa8931e (empty) third
-    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    Working copy now at: kkmpptxz 30056b0c (empty) third
+    Parent commit      : rlvkpnrz 9ed53a4a (empty) second
     "###);
     // --edit is implied when already editing a non-head commit
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: rlvkpnrz 5c52832c (empty) second
-    Parent commit      : qpvuntsm 69542c19 (empty) first
+    Working copy now at: rlvkpnrz 9ed53a4a (empty) second
+    Parent commit      : qpvuntsm fa15625b (empty) first
     "###);
 }
 
@@ -555,15 +555,15 @@ fn test_next_editing() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kkmpptxz 3fa8931e (empty) third
-    Parent commit      : rlvkpnrz 5c52832c (empty) second
+    Working copy now at: kkmpptxz 30056b0c (empty) third
+    Parent commit      : rlvkpnrz 9ed53a4a (empty) second
     "###);
     // --edit is implied when already editing a non-head commit
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: zsuskuln 009f88bf (empty) fourth
-    Parent commit      : kkmpptxz 3fa8931e (empty) third
+    Working copy now at: zsuskuln 9d7e5e99 (empty) fourth
+    Parent commit      : kkmpptxz 30056b0c (empty) third
     "###);
 }
 

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -33,9 +33,9 @@ fn test_obslog_with_or_without_diff() {
     │  my description
     ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
     "###);
 
@@ -46,9 +46,9 @@ fn test_obslog_with_or_without_diff() {
     │  [1mmy description[0m
     ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mc[0m[38;5;8mf73917d[39m [38;5;1mconflict[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m6f[0m[38;5;8mbba7bc[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m06[0m[38;5;8m8224a7[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4me[0m[38;5;8mac0d0da[39m
+    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m2b[0m[38;5;8m023b5f[39m
        [38;5;2m(empty)[39m my description
     "###);
 
@@ -68,14 +68,14 @@ fn test_obslog_with_or_without_diff() {
     │     7     : >>>>>>> Conflict 1 of 1 ends
     ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
     "###);
 
@@ -95,9 +95,9 @@ fn test_obslog_with_or_without_diff() {
     my description
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
     (empty) my description
     "###);
 
@@ -121,7 +121,7 @@ fn test_obslog_with_or_without_diff() {
     +resolved
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     my description
-    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     my description
     diff --git a/file1 b/file1
     index 257cc5642c...3bd1f0e297 100644
@@ -137,7 +137,7 @@ fn test_obslog_with_or_without_diff() {
     +++ b/file2
     @@ -1,0 +1,1 @@
     +foo
-    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
     (empty) my description
     "###);
 }
@@ -164,9 +164,9 @@ fn test_obslog_with_custom_symbols() {
     │  my description
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
-    ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 6fbba7bc
+    ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     │  my description
-    ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 eac0d0da
+    ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
     "###);
 }
@@ -194,28 +194,28 @@ fn test_obslog_word_wrap() {
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
-    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 69542c19
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
     @  qpvuntsm test.user@example.com
-    │  2001-02-03 08:05:08 69542c19
+    │  2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ◉  qpvuntsm hidden test.user@example.com
        2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, false), @r###"
-    qpvuntsm test.user@example.com 2001-02-03 08:05:08 69542c19
+    qpvuntsm test.user@example.com 2001-02-03 08:05:08 fa15625b
     (empty) first
     qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog", "--no-graph"], 40, true), @r###"
     qpvuntsm test.user@example.com
-    2001-02-03 08:05:08 69542c19
+    2001-02-03 08:05:08 fa15625b
     (empty) first
     qpvuntsm hidden test.user@example.com
     2001-02-03 08:05:07 230dd059
@@ -240,25 +240,25 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉    qpvuntsm test.user@example.com 2001-02-03 08:05:10 27e721a5
+    ◉    qpvuntsm test.user@example.com 2001-02-03 08:05:10 68647e34
     ├─╮  squashed
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 9764e503
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 766420db
     │ │  first
     │ │  Added regular file file1:
     │ │          1: foo
-    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 69542c19
+    ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 fa15625b
     │ │  (empty) first
     ◉ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
       │  (empty) (no description set)
-      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 f09a3889
+      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 46acd22a
       │  second
       │  Modified regular file file1:
       │     1    1: foo
       │          2: bar
-      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 57996536
+      ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 cba41deb
          (empty) second
     "###);
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -36,7 +36,7 @@ fn test_op_log() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r###"
-    @  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  c1851f1c3d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
     ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -59,7 +59,7 @@ fn test_op_log() {
     "###);
     // "@" resolves to the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@"), @r###"
-    @  bc8f18aa6f396a93572811632313cbb5625d475d
+    @  19611c995a342c01f525583e5fcafdd211f6d009
     ◉  0000000000000000000000000000000000000000
     "###);
     // "@-" resolves to the parent of the head operation
@@ -113,7 +113,7 @@ fn test_op_log_with_custom_symbols() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r###"
-    $  52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    $  c1851f1c3d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
     ┝  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -200,7 +200,7 @@ fn test_op_log_no_graph_null_terminated() {
             r#"id.short(4) ++ "\0""#,
         ],
     );
-    insta::assert_debug_snapshot!(stdout, @r###""22d4\023da\0b514\09a7d\00000\0""###);
+    insta::assert_debug_snapshot!(stdout, @r###""8a30\05cec\0b514\09a7d\00000\0""###);
 }
 
 #[test]
@@ -263,7 +263,7 @@ fn test_op_log_builtin_templates() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
 
     insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r###"
-    52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    c1851f1c3d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     args: jj describe -m 'description 0'
     b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -275,7 +275,7 @@ fn test_op_log_builtin_templates() {
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r###"
-    52ac15d375ba test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    c1851f1c3d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     args: jj describe -m 'description 0'
 
@@ -362,10 +362,10 @@ fn test_op_abandon_ancestors() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 1"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 2"]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
-    @  de138472a722 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  commit a8ac27b29a157ae7dabc0deb524df68823505730
+    @  c2878c428b1c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
-    ◉  652e5aecc9f7 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ◉  5d0ab09ab0fa test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj commit -m 'commit 1'
     ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -382,12 +382,12 @@ fn test_op_abandon_ancestors() {
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r###"
-    Current operation: OperationId("10e856d0579c4aca88972ffea0a515f47f8c09dceaa2b1a5d531c83b04350f7aa64a3eff422def01eebd65df26089ef5e0f925f247a8f929c8cc858d16306e53")
+    Current operation: OperationId("8545e013752445fd845c84eb961dbfbce47e1deb628e4ef20df10f6dc9aae2ef9e47200b0fcc70ca51f050aede05d0fa6dd1db40e20ae740876775738a07d02e")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
-    @  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  commit a8ac27b29a157ae7dabc0deb524df68823505730
+    @  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
     ◉  000000000000 root()
     "###);
@@ -401,11 +401,11 @@ fn test_op_abandon_ancestors() {
     Abandoned 2 operations and reparented 1 descendant operations.
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
-    @  70112b4447b6 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
-    │  commit e184d62c9ab118b0f62de91959b857550a9273a5
+    @  d92d0753399f test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    │  commit c5f7dd51add0046405055336ef443f882a0a8968
     │  args: jj commit -m 'commit 5'
-    ◉  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  commit a8ac27b29a157ae7dabc0deb524df68823505730
+    ◉  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
     ◉  000000000000 root()
     "###);
@@ -431,15 +431,15 @@ fn test_op_abandon_ancestors() {
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r###"
-    Current operation: OperationId("445e93662d714f53fb97e450eb3793a8e1a9a4cca1e329d5a9096e65085fb96d5bb51659531145c8abf0db5da803cd11c4cecdcf9025391bc97fc6a42204a0fe")
+    Current operation: OperationId("0699d720d0cecd80fb7d765c45955708c61b12feb1d7ed9ff2777ae719471f04ffed3c1dc24efdbf94bdb74426065d6fa9a4f0862a89db2c8c8e359eefc45462")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
-    @  445e93662d71 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  undo operation 70112b4447b65fa811038b2b119fe22e959e3b3194b461a32475f6528c2b684ac6baebc86cce7ad7e0bb92c033852850e561506508ca43e823626f107e81ed76
+    @  0699d720d0ce test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  undo operation d92d0753399f732e438bdd88fa7e5214cba2a310d120ec1714028a514c7116bcf04b4a0b26c04dbecf0a917f1d4c8eb05571b8816dd98b0502aaf321e92500b3
     │  args: jj undo
-    ◉  10e856d0579c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  commit a8ac27b29a157ae7dabc0deb524df68823505730
+    ◉  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
     ◉  000000000000 root()
     "###);
@@ -450,8 +450,8 @@ fn test_op_abandon_ancestors() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1"]), @r###"
-    @  445e93662d71 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  undo operation 70112b4447b65fa811038b2b119fe22e959e3b3194b461a32475f6528c2b684ac6baebc86cce7ad7e0bb92c033852850e561506508ca43e823626f107e81ed76
+    @  0699d720d0ce test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  undo operation d92d0753399f732e438bdd88fa7e5214cba2a310d120ec1714028a514c7116bcf04b4a0b26c04dbecf0a917f1d4c8eb05571b8816dd98b0502aaf321e92500b3
     │  args: jj undo
     "###);
 }
@@ -476,13 +476,13 @@ fn test_op_abandon_without_updating_working_copy() {
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r###"
-    Current operation: OperationId("61aeade2493b190412c61b9b0711025c2cccf95966870a5f7dc2e34ab313fbef64da70d00cab2cd69ad39816faeb80a6bc866927549b84dce6cb5a437e0e515b")
+    Current operation: OperationId("cd2b4690faf20cdc477e90c224f15a1f4d62b4d16d0d515fc0f9c998ff91a971cb114d82075c9a7331f3f94d7188c1f93628b7b93e4ca77ac89435a7b536de1e")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1", "--ignore-working-copy"]), @r###"
-    @  ae6364994418 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
-    │  commit 268f5f16139313ff25bef31280b2ec2e675200f3
+    @  467d42715f00 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  commit 220cb0b1b5d1c03cc0d351139d824598bb3c1967
     │  args: jj commit -m 'commit 3'
     "###);
 
@@ -492,17 +492,17 @@ fn test_op_abandon_without_updating_working_copy() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", "@-"]);
     insta::assert_snapshot!(stderr, @r###"
     Abandoned 1 operations and reparented 1 descendant operations.
-    Warning: The working copy operation 61aeade2493b is not updated because it differs from the repo ae6364994418.
+    Warning: The working copy operation cd2b4690faf2 is not updated because it differs from the repo 467d42715f00.
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r###"
-    Current operation: OperationId("61aeade2493b190412c61b9b0711025c2cccf95966870a5f7dc2e34ab313fbef64da70d00cab2cd69ad39816faeb80a6bc866927549b84dce6cb5a437e0e515b")
+    Current operation: OperationId("cd2b4690faf20cdc477e90c224f15a1f4d62b4d16d0d515fc0f9c998ff91a971cb114d82075c9a7331f3f94d7188c1f93628b7b93e4ca77ac89435a7b536de1e")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1", "--ignore-working-copy"]), @r###"
-    @  51192a90e899 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
-    │  commit 268f5f16139313ff25bef31280b2ec2e675200f3
+    @  050b33d674ff test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  commit 220cb0b1b5d1c03cc0d351139d824598bb3c1967
     │  args: jj commit -m 'commit 3'
     "###);
 }

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -27,27 +27,27 @@ fn test_parallelize_no_descendants() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  b911505e443e 6 parents: 5
-    ◉  2e00cb15c7b6 5 parents: 4
-    ◉  9df3c87db1a2 4 parents: 3
-    ◉  9f5b59fa4622 3 parents: 2
-    ◉  d826910d21fb 2 parents: 1
-    ◉  dc0e5d6135ce 1 parents:
+    @  02b7709cc4e9 6 parents: 5
+    ◉  1b2f08d76b66 5 parents: 4
+    ◉  e5c4cf44e237 4 parents: 3
+    ◉  4cd999dfaac0 3 parents: 2
+    ◉  d3902619fade 2 parents: 1
+    ◉  8b64ddff700d 1 parents:
     ◉  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  6c7b60a45eb6 6 parents:
-    │ ◉  296f48966777 5 parents:
+    @  4850b4629edb 6 parents:
+    │ ◉  87627fbb7d29 5 parents:
     ├─╯
-    │ ◉  524062469789 4 parents:
+    │ ◉  5b9815e28fae 4 parents:
     ├─╯
-    │ ◉  a9334ecaa379 3 parents:
+    │ ◉  bb1bb465ccc2 3 parents:
     ├─╯
-    │ ◉  3a7b37ebe843 2 parents:
+    │ ◉  337eca1ef3a8 2 parents:
     ├─╯
-    │ ◉  dc0e5d6135ce 1 parents:
+    │ ◉  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -65,12 +65,12 @@ fn test_parallelize_with_descendants_simple() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  b911505e443e 6 parents: 5
-    ◉  2e00cb15c7b6 5 parents: 4
-    ◉  9df3c87db1a2 4 parents: 3
-    ◉  9f5b59fa4622 3 parents: 2
-    ◉  d826910d21fb 2 parents: 1
-    ◉  dc0e5d6135ce 1 parents:
+    @  02b7709cc4e9 6 parents: 5
+    ◉  1b2f08d76b66 5 parents: 4
+    ◉  e5c4cf44e237 4 parents: 3
+    ◉  4cd999dfaac0 3 parents: 2
+    ◉  d3902619fade 2 parents: 1
+    ◉  8b64ddff700d 1 parents:
     ◉  000000000000 parents:
     "###);
 
@@ -79,15 +79,15 @@ fn test_parallelize_with_descendants_simple() {
         &["parallelize", "description(1)::description(4)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  259d624373d7 6 parents: 5
-    ◉        60d419591c77 5 parents: 1 2 3 4
+    @  9bc057f8b6e3 6 parents: 5
+    ◉        9e36a8afe793 5 parents: 1 2 3 4
     ├─┬─┬─╮
-    │ │ │ ◉  524062469789 4 parents:
-    │ │ ◉ │  a9334ecaa379 3 parents:
+    │ │ │ ◉  5b9815e28fae 4 parents:
+    │ │ ◉ │  bb1bb465ccc2 3 parents:
     │ │ ├─╯
-    │ ◉ │  3a7b37ebe843 2 parents:
+    │ ◉ │  337eca1ef3a8 2 parents:
     │ ├─╯
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -108,30 +108,33 @@ fn test_parallelize_where_interior_has_non_target_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(2)", "-m=2c"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(5)", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  d27ee705f7a9 6 parents: 5
-    ◉  2e00cb15c7b6 5 parents: 4
-    ◉  9df3c87db1a2 4 parents: 3
-    ◉  9f5b59fa4622 3 parents: 2
-    │ ◉  9c8865930f3c 2c parents: 2
+    @  2508ea92308a 6 parents: 5
+    ◉  1b2f08d76b66 5 parents: 4
+    ◉  e5c4cf44e237 4 parents: 3
+    ◉  4cd999dfaac0 3 parents: 2
+    │ ◉  3e7571e62c87 2c parents: 2
     ├─╯
-    ◉  d826910d21fb 2 parents: 1
-    ◉  dc0e5d6135ce 1 parents:
+    ◉  d3902619fade 2 parents: 1
+    ◉  8b64ddff700d 1 parents:
     ◉  000000000000 parents:
     "###);
 
-    test_env.jj_cmd_ok(&workspace_path, &["parallelize", "dc0::9df"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["parallelize", "description(1)::description(4)"],
+    );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  a42de3959cae 6 parents: 5
-    ◉        d907c901bad0 5 parents: 1 2 3 4
+    @  c9525dff9d03 6 parents: 5
+    ◉        b3ad09518546 5 parents: 1 2 3 4
     ├─┬─┬─╮
-    │ │ │ ◉  b8f977c12383 4 parents:
-    │ │ ◉ │  7be8374575b9 3 parents:
+    │ │ │ ◉  3b125ed6a683 4 parents:
+    │ │ ◉ │  1ed8c0c5be30 3 parents:
     │ │ ├─╯
-    │ │ │ ◉  2a4c3dab2a50 2c parents: 1 2
+    │ │ │ ◉  c01d8e85ea96 2c parents: 1 2
     ╭─┬───╯
-    │ ◉ │  96ce11389312 2 parents:
+    │ ◉ │  7efea6c89b60 2 parents:
     │ ├─╯
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -149,12 +152,12 @@ fn test_parallelize_where_root_has_non_target_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(1)", "-m=1c"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m=4"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  7636b3f489f4 4 parents: 3
-    ◉  9f5b59fa4622 3 parents: 2
-    ◉  d826910d21fb 2 parents: 1
-    │ ◉  50e2ced81124 1c parents: 1
+    @  9132691e6256 4 parents: 3
+    ◉  4cd999dfaac0 3 parents: 2
+    ◉  d3902619fade 2 parents: 1
+    │ ◉  6c64110df0a5 1c parents: 1
     ├─╯
-    ◉  dc0e5d6135ce 1 parents:
+    ◉  8b64ddff700d 1 parents:
     ◉  000000000000 parents:
     "###);
     test_env.jj_cmd_ok(
@@ -162,14 +165,14 @@ fn test_parallelize_where_root_has_non_target_children() {
         &["parallelize", "description(1)::description(3)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @      d024344469c3 4 parents: 1 2 3
+    @      3397916989e7 4 parents: 1 2 3
     ├─┬─╮
-    │ │ ◉  5bd049136a7c 3 parents:
-    │ ◉ │  60f737a5a4a7 2 parents:
+    │ │ ◉  1f768c1bc591 3 parents:
+    │ ◉ │  12ef12b4640e 2 parents:
     │ ├─╯
-    │ │ ◉  50e2ced81124 1c parents: 1
+    │ │ ◉  6c64110df0a5 1c parents: 1
     ├───╯
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -193,13 +196,13 @@ fn test_parallelize_with_merge_commit_child() {
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m", "4"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  90a65779e2ec 4 parents: 3
-    ◉  9f5b59fa4622 3 parents: 2
-    │ ◉  a01c1fad8506 2a-c parents: 2 a
+    @  99ffaf5b3984 4 parents: 3
+    ◉  4cd999dfaac0 3 parents: 2
+    │ ◉  4313cc3b476f 2a-c parents: 2 a
     ╭─┤
     │ ◉  1eb902150bb9 a parents:
-    ◉ │  d826910d21fb 2 parents: 1
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  d3902619fade 2 parents: 1
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -210,16 +213,16 @@ fn test_parallelize_with_merge_commit_child() {
         &["parallelize", "description(1)::description(3)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @      6107429ab54b 4 parents: 1 2 3
+    @      3ee9279847a6 4 parents: 1 2 3
     ├─┬─╮
-    │ │ ◉  a9334ecaa379 3 parents:
-    │ │ │ ◉  a386386b94bc 2a-c parents: 1 2 a
+    │ │ ◉  bb1bb465ccc2 3 parents:
+    │ │ │ ◉  c70ee196514b 2a-c parents: 1 2 a
     ╭─┬───┤
     │ │ │ ◉  1eb902150bb9 a parents:
     │ │ ├─╯
-    │ ◉ │  3a7b37ebe843 2 parents:
+    │ ◉ │  337eca1ef3a8 2 parents:
     │ ├─╯
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -236,9 +239,9 @@ fn test_parallelize_disconnected_target_commits() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  9f5b59fa4622 3 parents: 2
-    ◉  d826910d21fb 2 parents: 1
-    ◉  dc0e5d6135ce 1 parents:
+    @  4cd999dfaac0 3 parents: 2
+    ◉  d3902619fade 2 parents: 1
+    ◉  8b64ddff700d 1 parents:
     ◉  000000000000 parents:
     "###);
 
@@ -251,9 +254,9 @@ fn test_parallelize_disconnected_target_commits() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  9f5b59fa4622 3 parents: 2
-    ◉  d826910d21fb 2 parents: 1
-    ◉  dc0e5d6135ce 1 parents:
+    @  4cd999dfaac0 3 parents: 2
+    ◉  d3902619fade 2 parents: 1
+    ◉  8b64ddff700d 1 parents:
     ◉  000000000000 parents:
     "###);
 }
@@ -274,28 +277,28 @@ fn test_parallelize_head_is_a_merge() {
         &["new", "description(2)", "description(b)", "-m=merged-head"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @    f2087b66e475 merged-head parents: 2 b
+    @    1fb53c45237e merged-head parents: 2 b
     ├─╮
-    │ ◉  5164ab888473 b parents: a
-    │ ◉  f16fe8ac5ce9 a parents:
-    ◉ │  fe79412860e8 2 parents: 1
-    ◉ │  a915696cf0ad 1 parents: 0
-    ◉ │  a56846756248 0 parents:
+    │ ◉  a7bf5001cfd8 b parents: a
+    │ ◉  6ca0450a05f5 a parents:
+    ◉ │  1f81bd465ed0 2 parents: 1
+    ◉ │  0c058af014a6 1 parents: 0
+    ◉ │  745bea8029c1 0 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @    babb4191912d merged-head parents: 0 b
+    @    82131a679769 merged-head parents: 0 b
     ├─╮
-    │ ◉  5164ab888473 b parents: a
-    │ ◉  f16fe8ac5ce9 a parents:
-    │ │ ◉  36b2f866a798 2 parents: 0
+    │ ◉  a7bf5001cfd8 b parents: a
+    │ ◉  6ca0450a05f5 a parents:
+    │ │ ◉  daef04bc3fae 2 parents: 0
     ├───╯
-    │ │ ◉  a915696cf0ad 1 parents: 0
+    │ │ ◉  0c058af014a6 1 parents: 0
     ├───╯
-    ◉ │  a56846756248 0 parents:
+    ◉ │  745bea8029c1 0 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -315,26 +318,26 @@ fn test_parallelize_interior_target_is_a_merge() {
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  a6321093e3d3 3 parents: 2
-    ◉    705c32f67ce1 2 parents: 1 a
+    @  9b77792c77ac 3 parents: 2
+    ◉    1e29145c95fd 2 parents: 1 a
     ├─╮
     │ ◉  427890ea3f2b a parents:
-    ◉ │  a915696cf0ad 1 parents: 0
-    ◉ │  a56846756248 0 parents:
+    ◉ │  0c058af014a6 1 parents: 0
+    ◉ │  745bea8029c1 0 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @    cd0ac6ad1415 3 parents: 0 a
+    @    042fc3f4315c 3 parents: 0 a
     ├─╮
-    │ │ ◉  1c240e875670 2 parents: 0 a
+    │ │ ◉  80603361bb48 2 parents: 0 a
     ╭─┬─╯
     │ ◉  427890ea3f2b a parents:
-    │ │ ◉  a915696cf0ad 1 parents: 0
+    │ │ ◉  0c058af014a6 1 parents: 0
     ├───╯
-    ◉ │  a56846756248 0 parents:
+    ◉ │  745bea8029c1 0 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -354,12 +357,12 @@ fn test_parallelize_root_is_a_merge() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=2"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  9f66b50aa1f2 3 parents: 2
-    ◉  dd995ce87f21 2 parents: 1
-    ◉    4b4941342e06 1 parents: y x
+    @  cc239b744d01 3 parents: 2
+    ◉  2bf00c2ad44c 2 parents: 1
+    ◉    1c6853121f3c 1 parents: y x
     ├─╮
     │ ◉  4035b23c8f72 x parents:
-    ◉ │  f3ec359cf9ff y parents:
+    ◉ │  ca57511e158f y parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -369,14 +372,14 @@ fn test_parallelize_root_is_a_merge() {
         &["parallelize", "description(1)::description(2)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @    d6df04b236b0 3 parents: 1 2
+    @    2c7fdfa00b38 3 parents: 1 2
     ├─╮
-    │ ◉    38945baf55f4 2 parents: y x
+    │ ◉    3acbd32944d6 2 parents: y x
     │ ├─╮
-    ◉ │ │  4b4941342e06 1 parents: y x
+    ◉ │ │  1c6853121f3c 1 parents: y x
     ╰─┬─╮
       │ ◉  4035b23c8f72 x parents:
-      ◉ │  f3ec359cf9ff y parents:
+      ◉ │  ca57511e158f y parents:
       ├─╯
       ◉  000000000000 parents:
     "###);
@@ -391,19 +394,19 @@ fn test_parallelize_multiple_heads() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=1"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  8314addde180 2 parents: 0
-    │ ◉  a915696cf0ad 1 parents: 0
+    @  97d7522f40e8 2 parents: 0
+    │ ◉  0c058af014a6 1 parents: 0
     ├─╯
-    ◉  a56846756248 0 parents:
+    ◉  745bea8029c1 0 parents:
     ◉  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(0)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  e84481c26195 2 parents:
-    │ ◉  2047527ade93 1 parents:
+    │ ◉  6270540ee067 1 parents:
     ├─╯
-    │ ◉  a56846756248 0 parents:
+    │ ◉  745bea8029c1 0 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -421,10 +424,10 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=1"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  8314addde180 2 parents: 0
-    │ ◉  a915696cf0ad 1 parents: 0
+    @  97d7522f40e8 2 parents: 0
+    │ ◉  0c058af014a6 1 parents: 0
     ├─╯
-    ◉  a56846756248 0 parents:
+    ◉  745bea8029c1 0 parents:
     ◉  000000000000 parents:
     "###);
 
@@ -433,9 +436,9 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
         &["parallelize", "description(0)", "description(1)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    ◉  2047527ade93 1 parents:
-    │ @  8314addde180 2 parents: 0
-    │ ◉  a56846756248 0 parents:
+    ◉  6270540ee067 1 parents:
+    │ @  97d7522f40e8 2 parents: 0
+    │ ◉  745bea8029c1 0 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -454,11 +457,11 @@ fn test_parallelize_multiple_roots() {
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  299099c22761 3 parents: 2
-    ◉    0c4da981fc0a 2 parents: 1 a
+    @  34da938ad94a 3 parents: 2
+    ◉    85d5043b881d 2 parents: 1 a
     ├─╮
     │ ◉  6d37472c632c a parents:
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -471,7 +474,7 @@ fn test_parallelize_multiple_roots() {
     ├─╯
     │ ◉  6d37472c632c a parents:
     ├─╯
-    │ ◉  dc0e5d6135ce 1 parents:
+    │ ◉  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -490,13 +493,13 @@ fn test_parallelize_multiple_heads_with_different_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=b"]);
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=c"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  9b5fa4b364d4 parents: c
-    ◉  7b095ae9b21f c parents: b
-    ◉  5164ab888473 b parents: a
-    ◉  f16fe8ac5ce9 a parents:
-    │ ◉  9f5b59fa4622 3 parents: 2
-    │ ◉  d826910d21fb 2 parents: 1
-    │ ◉  dc0e5d6135ce 1 parents:
+    @  4bc4dace0e65 parents: c
+    ◉  63b0da9212c0 c parents: b
+    ◉  a7bf5001cfd8 b parents: a
+    ◉  6ca0450a05f5 a parents:
+    │ ◉  4cd999dfaac0 3 parents: 2
+    │ ◉  d3902619fade 2 parents: 1
+    │ ◉  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -510,17 +513,17 @@ fn test_parallelize_multiple_heads_with_different_children() {
         ],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  582c6bd1e1fd parents: c
-    ◉    dd2db8b60a69 c parents: a b
+    @  f6c9d9ee3db8 parents: c
+    ◉    62661d5f0c77 c parents: a b
     ├─╮
-    │ ◉  190b857f6cdd b parents:
-    ◉ │  f16fe8ac5ce9 a parents:
+    │ ◉  c9ea9058f5c7 b parents:
+    ◉ │  6ca0450a05f5 a parents:
     ├─╯
-    │ ◉    bbc313370f45 3 parents: 1 2
+    │ ◉    dac1be696563 3 parents: 1 2
     │ ├─╮
-    │ │ ◉  96ce11389312 2 parents:
+    │ │ ◉  7efea6c89b60 2 parents:
     ├───╯
-    │ ◉  dc0e5d6135ce 1 parents:
+    │ ◉  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -541,12 +544,12 @@ fn test_parallelize_multiple_roots_with_different_parents() {
         &["new", "description(2)", "description(b)", "-m=merged-head"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @    1a8db14a8cf0 merged-head parents: 2 b
+    @    ba4297d53c1a merged-head parents: 2 b
     ├─╮
-    │ ◉  401e43e9461f b parents: a
-    │ ◉  66ea2ab19a70 a parents:
-    ◉ │  d826910d21fb 2 parents: 1
-    ◉ │  dc0e5d6135ce 1 parents:
+    │ ◉  6577defaca2d b parents: a
+    │ ◉  1eb902150bb9 a parents:
+    ◉ │  d3902619fade 2 parents: 1
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);
@@ -556,14 +559,14 @@ fn test_parallelize_multiple_roots_with_different_parents() {
         &["parallelize", "description(2)::", "description(b)::"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @    4224f9c9e598 merged-head parents: 1 a
+    @    0943ed52b3ed merged-head parents: 1 a
     ├─╮
-    │ │ ◉  401e43e9461f b parents: a
+    │ │ ◉  6577defaca2d b parents: a
     │ ├─╯
-    │ ◉  66ea2ab19a70 a parents:
-    │ │ ◉  d826910d21fb 2 parents: 1
+    │ ◉  1eb902150bb9 a parents:
+    │ │ ◉  d3902619fade 2 parents: 1
     ├───╯
-    ◉ │  dc0e5d6135ce 1 parents:
+    ◉ │  8b64ddff700d 1 parents:
     ├─╯
     ◉  000000000000 parents:
     "###);

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -33,15 +33,15 @@ fn test_report_conflicts() {
     insta::assert_snapshot!(stderr, @r###"
     Rebased 3 commits
     New conflicts appeared in these commits:
-      kkmpptxz 7afb7d5a (conflict) C
-      rlvkpnrz 1b74c6ee (conflict) B
+      kkmpptxz 64bdec0c (conflict) C
+      rlvkpnrz 10a5fd45 (conflict) B
     To resolve the conflicts, start by updating to the first one:
       jj new rlvkpnrzqnoo
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: zsuskuln 6ab4d738 (conflict) (empty) (no description set)
-    Parent commit      : kkmpptxz 7afb7d5a (conflict) C
+    Working copy now at: zsuskuln aa73e2ae (conflict) (empty) (no description set)
+    Parent commit      : kkmpptxz 64bdec0c (conflict) C
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
@@ -52,10 +52,10 @@ fn test_report_conflicts() {
     insta::assert_snapshot!(stderr, @r###"
     Rebased 3 commits
     Existing conflicts were resolved or abandoned from these commits:
-      kkmpptxz hidden 7afb7d5a (conflict) C
-      rlvkpnrz hidden 1b74c6ee (conflict) B
-    Working copy now at: zsuskuln 355a2e34 (empty) (no description set)
-    Parent commit      : kkmpptxz ed071401 C
+      kkmpptxz hidden 64bdec0c (conflict) C
+      rlvkpnrz hidden 10a5fd45 (conflict) B
+    Working copy now at: zsuskuln d70c003d (empty) (no description set)
+    Parent commit      : kkmpptxz 43e94449 C
     Added 0 files, modified 1 files, removed 0 files
     "###);
 
@@ -67,16 +67,16 @@ fn test_report_conflicts() {
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     New conflicts appeared in these commits:
-      kkmpptxz d1edf578 (conflict) C
-      rlvkpnrz 262c4c38 (conflict) B
+      kkmpptxz 17c72220 (conflict) C
+      rlvkpnrz eb93a73d (conflict) B
     To resolve the conflicts, start by updating to one of the first ones:
       jj new kkmpptxzrspx
       jj new rlvkpnrzqnoo
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: zsuskuln b56d36a0 (conflict) (empty) (no description set)
-    Parent commit      : kkmpptxz d1edf578 (conflict) C
+    Working copy now at: zsuskuln 99fb9018 (conflict) (empty) (no description set)
+    Parent commit      : kkmpptxz 17c72220 (conflict) C
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
@@ -86,8 +86,8 @@ fn test_report_conflicts() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "rlvkpnrzqnoo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv d1eb7305 (conflict) (empty) (no description set)
-    Parent commit      : rlvkpnrz 262c4c38 (conflict) B
+    Working copy now at: vruxwmqv 1d87c702 (conflict) (empty) (no description set)
+    Parent commit      : rlvkpnrz eb93a73d (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
@@ -97,9 +97,9 @@ fn test_report_conflicts() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Existing conflicts were resolved or abandoned from these commits:
-      rlvkpnrz hidden 262c4c38 (conflict) B
-    Working copy now at: yostqsxw 8e160bc4 (empty) (no description set)
-    Parent commit      : rlvkpnrz c5319490 B
+      rlvkpnrz hidden eb93a73d (conflict) B
+    Working copy now at: yostqsxw f5a0cf8c (empty) (no description set)
+    Parent commit      : rlvkpnrz 87370844 B
     "###);
 }
 
@@ -148,8 +148,8 @@ fn test_report_conflicts_with_divergent_commits() {
       zsuskuln hidden b535189c (conflict) C3
       zsuskuln hidden 97ce1783 (conflict) C2
       kkmpptxz hidden eb93a73d (conflict) B
-    Working copy now at: zsuskuln?? 9c33e9a9 C2
-    Parent commit      : kkmpptxz 9ce42c2a B
+    Working copy now at: zsuskuln?? f2d7a228 C2
+    Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
     "###);
 
@@ -196,8 +196,8 @@ fn test_report_conflicts_with_divergent_commits() {
     Rebased 1 commits
     Existing conflicts were resolved or abandoned from these commits:
       zsuskuln hidden b15416ac (conflict) C2
-    Working copy now at: zsuskuln?? 24f79296 C2
-    Parent commit      : kkmpptxz 9ce42c2a B
+    Working copy now at: zsuskuln?? 1f9680bd C2
+    Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
     "###);
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -42,9 +42,9 @@ fn test_restore() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz ed1678e3 (empty) (no description set)
-    Working copy now at: kkmpptxz ed1678e3 (empty) (no description set)
-    Parent commit      : rlvkpnrz 1a986a27 (no description set)
+    Created kkmpptxz 370d81ea (empty) (no description set)
+    Working copy now at: kkmpptxz 370d81ea (empty) (no description set)
+    Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 1 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -59,17 +59,17 @@ fn test_restore() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz e25100af (empty) (no description set)
+    Created rlvkpnrz b9b6011e (empty) (no description set)
     Rebased 1 descendant commits
     New conflicts appeared in these commits:
-      kkmpptxz 4906178a (conflict) (no description set)
+      kkmpptxz d05c4d2a (conflict) (no description set)
     To resolve the conflicts, start by updating to it:
       jj new kkmpptxzrspx
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kkmpptxz 4906178a (conflict) (no description set)
-    Parent commit      : rlvkpnrz e25100af (empty) (no description set)
+    Working copy now at: kkmpptxz d05c4d2a (conflict) (no description set)
+    Parent commit      : rlvkpnrz b9b6011e (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file2    2-sided conflict including 1 deletion
@@ -82,9 +82,9 @@ fn test_restore() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz 1dd6eb63 (no description set)
-    Working copy now at: kkmpptxz 1dd6eb63 (no description set)
-    Parent commit      : rlvkpnrz 1a986a27 (no description set)
+    Created kkmpptxz 1154634b (no description set)
+    Working copy now at: kkmpptxz 1154634b (no description set)
+    Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 1 files, modified 0 files, removed 2 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
@@ -97,10 +97,10 @@ fn test_restore() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz ec9d5b59 (no description set)
+    Created rlvkpnrz ad805965 (no description set)
     Rebased 1 descendant commits
-    Working copy now at: kkmpptxz d6f3c681 (empty) (no description set)
-    Parent commit      : rlvkpnrz ec9d5b59 (no description set)
+    Working copy now at: kkmpptxz 3fcdcbf2 (empty) (no description set)
+    Parent commit      : rlvkpnrz ad805965 (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -117,10 +117,10 @@ fn test_restore() {
         test_env.jj_cmd_ok(&repo_path, &["restore", "--from", "@", "--to", "@-"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created rlvkpnrz 5f6eb3d5 (no description set)
+    Created rlvkpnrz f256040a (no description set)
     Rebased 1 descendant commits
-    Working copy now at: kkmpptxz 525afd5d (empty) (no description set)
-    Parent commit      : rlvkpnrz 5f6eb3d5 (no description set)
+    Working copy now at: kkmpptxz 9c6f2083 (empty) (no description set)
+    Parent commit      : rlvkpnrz f256040a (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
@@ -136,9 +136,9 @@ fn test_restore() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Created kkmpptxz 569ce73d (no description set)
-    Working copy now at: kkmpptxz 569ce73d (no description set)
-    Parent commit      : rlvkpnrz 1a986a27 (no description set)
+    Created kkmpptxz 4ad35a2f (no description set)
+    Working copy now at: kkmpptxz 4ad35a2f (no description set)
+    Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 0 files, modified 1 files, removed 1 files
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -41,7 +41,7 @@ fn test_split_by_paths() {
     ◉  zzzzzzzzzzzz true
     "###);
     insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r###"
-    Author date:  2001-02-03 04:05:07.000 +07:00
+    Author date:  2001-02-03 04:05:08.000 +07:00
     Committer date: 2001-02-03 04:05:08.000 +07:00
     "###);
 
@@ -54,10 +54,10 @@ fn test_split_by_paths() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    First part: qpvuntsm d62c056f (no description set)
-    Second part: zsuskuln 5a32af4a (no description set)
-    Working copy now at: zsuskuln 5a32af4a (no description set)
-    Parent commit      : qpvuntsm d62c056f (no description set)
+    First part: qpvuntsm 65569ca7 (no description set)
+    Second part: zsuskuln 709756f0 (no description set)
+    Working copy now at: zsuskuln 709756f0 (no description set)
+    Parent commit      : qpvuntsm 65569ca7 (no description set)
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
@@ -79,11 +79,11 @@ fn test_split_by_paths() {
     // The author dates of the new commits should be inherited from the commit being
     // split. The committer dates should be newer.
     insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r###"
-    Author date:  2001-02-03 04:05:07.000 +07:00
+    Author date:  2001-02-03 04:05:08.000 +07:00
     Committer date: 2001-02-03 04:05:10.000 +07:00
     "###);
     insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@-"), @r###"
-    Author date:  2001-02-03 04:05:07.000 +07:00
+    Author date:  2001-02-03 04:05:08.000 +07:00
     Committer date: 2001-02-03 04:05:10.000 +07:00
     "###);
 
@@ -103,10 +103,10 @@ fn test_split_by_paths() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    First part: qpvuntsm b76d731d (no description set)
-    Second part: znkkpsqq 924604b2 (empty) (no description set)
-    Working copy now at: zsuskuln fffe30fb (no description set)
-    Parent commit      : znkkpsqq 924604b2 (empty) (no description set)
+    First part: qpvuntsm 9da0eea0 (no description set)
+    Second part: znkkpsqq 5b5714a3 (empty) (no description set)
+    Working copy now at: zsuskuln 0c798ee7 (no description set)
+    Parent commit      : znkkpsqq 5b5714a3 (empty) (no description set)
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -131,10 +131,10 @@ fn test_split_by_paths() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: The given paths do not match any file: nonexistent
     Rebased 1 descendant commits
-    First part: qpvuntsm 7086b0bc (empty) (no description set)
-    Second part: lylxulpl 2252ed18 (no description set)
-    Working copy now at: zsuskuln a3f2136a (no description set)
-    Parent commit      : lylxulpl 2252ed18 (no description set)
+    First part: qpvuntsm bd42f95a (empty) (no description set)
+    Second part: lylxulpl ed55c86b (no description set)
+    Working copy now at: zsuskuln 1e1ed741 (no description set)
+    Parent commit      : lylxulpl ed55c86b (no description set)
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -176,10 +176,10 @@ fn test_split_with_non_empty_description() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    First part: qpvuntsm 41e04d04 part 1
-    Second part: kkmpptxz 093b6c0d part 2
-    Working copy now at: kkmpptxz 093b6c0d part 2
-    Parent commit      : qpvuntsm 41e04d04 part 1
+    First part: qpvuntsm 231a3c00 part 1
+    Second part: kkmpptxz e96291aa part 2
+    Working copy now at: kkmpptxz e96291aa part 2
+    Parent commit      : qpvuntsm 231a3c00 part 1
     "###);
 
     assert_eq!(
@@ -234,10 +234,10 @@ fn test_split_with_default_description() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    First part: qpvuntsm 5afe936c TESTED=TODO
-    Second part: kkmpptxz 0e09a2df test_branch | (no description set)
-    Working copy now at: kkmpptxz 0e09a2df test_branch | (no description set)
-    Parent commit      : qpvuntsm 5afe936c TESTED=TODO
+    First part: qpvuntsm 48018df6 TESTED=TODO
+    Second part: kkmpptxz 350b4c13 test_branch | (no description set)
+    Working copy now at: kkmpptxz 350b4c13 test_branch | (no description set)
+    Parent commit      : qpvuntsm 48018df6 TESTED=TODO
     "###);
 
     // Since the commit being split has no description, the user will only be
@@ -302,8 +302,8 @@ fn test_split_with_merge_child() {
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
     Second part: royxmykx 5e1b793d Add file2
-    Working copy now at: zsuskuln 0315e471 (empty) 2
-    Parent commit      : qpvuntsm dc0e5d61 (empty) 1
+    Working copy now at: zsuskuln 696935af (empty) 2
+    Parent commit      : qpvuntsm 8b64ddff (empty) 1
     Parent commit      : royxmykx 5e1b793d Add file2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
@@ -346,9 +346,9 @@ fn test_split_siblings_no_descendants() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    First part: qpvuntsm 8d2b7558 TESTED=TODO
-    Second part: zsuskuln acd41528 test_branch | (no description set)
-    Working copy now at: zsuskuln acd41528 test_branch | (no description set)
+    First part: qpvuntsm 0dced07a TESTED=TODO
+    Second part: zsuskuln 0473f014 test_branch | (no description set)
+    Working copy now at: zsuskuln 0473f014 test_branch | (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
@@ -425,9 +425,9 @@ fn test_split_siblings_with_descendants() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
-    First part: qpvuntsm 27b151c3 Add file1
-    Second part: vruxwmqv c0857cfb Add file2
-    Working copy now at: vruxwmqv c0857cfb Add file2
+    First part: qpvuntsm 84df941d Add file1
+    Second part: vruxwmqv 94753be3 Add file2
+    Working copy now at: vruxwmqv 94753be3 Add file2
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
@@ -507,8 +507,8 @@ fn test_split_siblings_with_merge_child() {
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
     Second part: royxmykx 2cc60f3d Add file2
-    Working copy now at: zsuskuln 2f04d1d1 (empty) 2
-    Parent commit      : qpvuntsm dc0e5d61 (empty) 1
+    Working copy now at: zsuskuln 35b5d7eb (empty) 2
+    Parent commit      : qpvuntsm 8b64ddff (empty) 1
     Parent commit      : kkmpptxz e8006b47 Add file1
     Parent commit      : royxmykx 2cc60f3d Add file2
     "###);
@@ -534,7 +534,7 @@ fn test_split_empty() {
 
     let stderr = test_env.jj_cmd_failure(&workspace_path, &["split"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to split empty commit 82b6292b775dc4e5c5e6f402faa599dad02d02a0.
+    Error: Refusing to split empty commit 2ab033062e9fdf7fad2ded8e89c1f145e3698190.
     Hint: Use `jj new` if you want to create another empty commit.
     "###);
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -32,9 +32,9 @@ fn test_squash() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  90fe0a96fc90 c
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
+    @  382c9bad7d42 c
+    ◉  d5d59175b481 b
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
 
@@ -42,13 +42,13 @@ fn test_squash() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv b9280a98 (empty) (no description set)
-    Parent commit      : kkmpptxz 6ca29c9d b c | (no description set)
+    Working copy now at: vruxwmqv f7bb78d8 (empty) (no description set)
+    Parent commit      : kkmpptxz 59f44460 b c | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  b9280a9898cb
-    ◉  6ca29c9d2e7c b c
-    ◉  90aeefd03044 a
+    @  f7bb78d8da62
+    ◉  59f4446070a0 b c
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -62,12 +62,12 @@ fn test_squash() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl e87cf8eb c | (no description set)
-    Parent commit      : qpvuntsm 893c93ae a b | (no description set)
+    Working copy now at: mzvwutvl 1d70f50a c | (no description set)
+    Parent commit      : qpvuntsm 9146bcc8 a b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  e87cf8ebc7e1 c
-    ◉  893c93ae2a87 a b
+    @  1d70f50afa6d c
+    ◉  9146bcc8d996 a b
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
@@ -89,13 +89,13 @@ fn test_squash() {
     test_env.jj_cmd_ok(&repo_path, &["new", "c", "d"]);
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "e"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @    c7a11b36d333 e
+    @    41219719ab5f e
     ├─╮
-    │ ◉  5658521e0f8b d
-    ◉ │  90fe0a96fc90 c
+    │ ◉  f86e2b3af3e3 d
+    ◉ │  382c9bad7d42 c
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
+    ◉  d5d59175b481 b
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash"]);
@@ -109,18 +109,18 @@ fn test_squash() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: xlzxqlsl 959145c1 (empty) (no description set)
-    Parent commit      : nmzmmopx 80960125 e | (no description set)
+    Working copy now at: xlzxqlsl b50b843d (empty) (no description set)
+    Parent commit      : nmzmmopx 338cbc05 e | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  959145c11426
-    ◉    80960125bb96 e
+    @  b50b843d8555
+    ◉    338cbc05e4e6 e
     ├─╮
-    │ ◉  5658521e0f8b d
-    ◉ │  90fe0a96fc90 c
+    │ ◉  f86e2b3af3e3 d
+    ◉ │  382c9bad7d42 c
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
+    ◉  d5d59175b481 b
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "e"]);
@@ -148,9 +148,9 @@ fn test_squash_partial() {
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  d989314f3df0 c
-    ◉  2a2d19a3283f b
-    ◉  47a1e795d146 a
+    @  a0b1a272ebc4 c
+    ◉  d117da276a0f b
+    ◉  54d3c1c0e9fd a
     ◉  000000000000
     "###);
 
@@ -161,12 +161,12 @@ fn test_squash_partial() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl f03d5ce4 c | (no description set)
-    Parent commit      : qpvuntsm c9f931cd a b | (no description set)
+    Working copy now at: mzvwutvl 3c633226 c | (no description set)
+    Parent commit      : qpvuntsm 38ffd8b9 a b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  f03d5ce4a973 c
-    ◉  c9f931cd78af a b
+    @  3c6332267ea8 c
+    ◉  38ffd8b98578 a b
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
@@ -181,13 +181,13 @@ fn test_squash_partial() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
-    Working copy now at: mzvwutvl e7a40106 c | (no description set)
-    Parent commit      : kkmpptxz 05d95164 b | (no description set)
+    Working copy now at: mzvwutvl 57c3cf20 c | (no description set)
+    Parent commit      : kkmpptxz c4925e01 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  e7a40106bee6 c
-    ◉  05d951646873 b
-    ◉  0c5ddc685260 a
+    @  57c3cf20d0b1 c
+    ◉  c4925e01d298 b
+    ◉  1fc159063ed3 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
@@ -215,13 +215,13 @@ fn test_squash_partial() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
-    Working copy now at: mzvwutvl a911fa1d c | (no description set)
-    Parent commit      : kkmpptxz fb73ad17 b | (no description set)
+    Working copy now at: mzvwutvl 64d7ad7c c | (no description set)
+    Parent commit      : kkmpptxz 60a26452 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  a911fa1d0627 c
-    ◉  fb73ad17899f b
-    ◉  70621f4c7a42 a
+    @  64d7ad7c43c1 c
+    ◉  60a264527aee b
+    ◉  7314692d32e3 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
@@ -298,13 +298,13 @@ fn test_squash_from_to() {
     std::fs::write(repo_path.join("file2"), "f\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  0d7353584003 f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    @  a847ab4967fe f
+    ◉  c2f9de87325d e
+    ◉  e0dac715116f d
+    │ ◉  59597b34a0d8 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
 
@@ -318,17 +318,17 @@ fn test_squash_from_to() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kmkuslsw 5337fca9 f | (no description set)
-    Parent commit      : znkkpsqq e9515f21 e | (no description set)
+    Working copy now at: kmkuslsw b902d1dd f | (no description set)
+    Parent commit      : znkkpsqq c2f9de87 e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  5337fca918e8 f
-    ◉  e9515f21068c e
-    ◉  bdd835cae844 d
-    │ ◉  55171e33db26 b c
+    @  b902d1dd59d9 f
+    ◉  c2f9de87325d e
+    ◉  e0dac715116f d
+    │ ◉  12d6103dc0c8 b c
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The change from the source has been applied
@@ -347,18 +347,18 @@ fn test_squash_from_to() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kmkuslsw 66ff309f f | (no description set)
-    Parent commit      : znkkpsqq 16f4e7c4 e | (no description set)
+    Working copy now at: kmkuslsw cfc5eb87 f | (no description set)
+    Parent commit      : znkkpsqq 4dc7c279 e | (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  66ff309f65e8 f
-    ◉  16f4e7c4886f e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    @  cfc5eb876eb1 f
+    ◉  4dc7c27994bd e
+    │ ◉  59597b34a0d8 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a d
+    ◉  b7b767179c44 a d
     ◉  000000000000
     "###);
     // The change from the source has been applied (the file contents were already
@@ -375,18 +375,18 @@ fn test_squash_from_to() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: kmkuslsw b4f8051d f | (no description set)
-    Parent commit      : vruxwmqv f74c102f d e | (no description set)
+    Working copy now at: kmkuslsw 6de62c22 f | (no description set)
+    Parent commit      : vruxwmqv 32196a11 d e | (no description set)
     "###);
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  b4f8051d8466 f
-    ◉  f74c102ff29a d e
-    │ ◉  caa4d0b23201 c
-    │ ◉  55171e33db26 b
+    @  6de62c22fa07 f
+    ◉  32196a117ee3 d e
+    │ ◉  59597b34a0d8 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The change from the source has been applied
@@ -425,11 +425,11 @@ fn test_squash_from_to_partial() {
     std::fs::write(repo_path.join("file3"), "d\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  bdd835cae844 d
-    │ ◉  5028db694b6b c
-    │ ◉  55171e33db26 b
+    @  e0dac715116f d
+    │ ◉  087591be5a01 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
 
@@ -439,15 +439,15 @@ fn test_squash_from_to_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv 71b69e43 d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Working copy now at: vruxwmqv 987bcfb2 d | (no description set)
+    Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  71b69e433fbc d
-    │ ◉  55171e33db26 b c
+    @  987bcfb2eb62 d
+    │ ◉  12d6103dc0c8 b c
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The changes from the source has been applied
@@ -471,16 +471,16 @@ fn test_squash_from_to_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv 63f1a6e9 d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Working copy now at: vruxwmqv 576244e8 d | (no description set)
+    Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  63f1a6e96edb d
-    │ ◉  d027c6e3e6bc c
-    │ ◉  55171e33db26 b
+    @  576244e87883 d
+    │ ◉  6f486f2f4539 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
@@ -506,16 +506,16 @@ fn test_squash_from_to_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: vruxwmqv 17c2e663 d | (no description set)
-    Parent commit      : qpvuntsm 3db0a2f5 a | (no description set)
+    Working copy now at: vruxwmqv 5b407c24 d | (no description set)
+    Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  17c2e6632cc5 d
-    │ ◉  6a3ae047a03e c
-    │ ◉  55171e33db26 b
+    @  5b407c249fa7 d
+    │ ◉  724d64da1487 c
+    │ ◉  12d6103dc0c8 b
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
@@ -547,11 +547,11 @@ fn test_squash_from_to_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  21253406d416 c
-    ◉  e1cf08aae711 b
-    │ @  bdd835cae844 d
+    ◉  d2a587ae205d c
+    ◉  a53394306362 b
+    │ @  e0dac715116f d
     ├─╯
-    ◉  3db0a2f5b535 a
+    ◉  b7b767179c44 a
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
@@ -609,15 +609,15 @@ fn test_squash_from_multiple() {
     std::fs::write(&file, "f\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  7c982f87d244 f
-    ◉      90fb23310e1d e
+    @  94e57ecb8d4f f
+    ◉      78ed28eb87b8 e
     ├─┬─╮
-    │ │ ◉  512dff087306 b
-    │ ◉ │  5ee503da2262 c
+    │ │ ◉  35e764e4357c b
+    │ ◉ │  02a128cd4344 c
     │ ├─╯
-    ◉ │  cb214cffd91a d
+    ◉ │  aaf7b53a1b64 d
     ├─╯
-    ◉  37941ee54ace a
+    ◉  3b1673b6370c a
     ◉  000000000000
     "###);
 
@@ -628,22 +628,22 @@ fn test_squash_from_multiple() {
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
     New conflicts appeared in these commits:
-      yqosqzyt 50bd7d24 d | (conflict) (no description set)
+      yqosqzyt 98759deb d | (conflict) (no description set)
     To resolve the conflicts, start by updating to it:
       jj new yqosqzytrlsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kpqxywon dd653e49 f | (no description set)
-    Parent commit      : yostqsxw e40f2544 e | (no description set)
+    Working copy now at: kpqxywon 3e25ee21 f | (no description set)
+    Parent commit      : yostqsxw abb5a4ea e | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  dd653e494199 f
-    ◉    e40f2544ad31 e
+    @  3e25ee211f3f f
+    ◉    abb5a4ea1222 e
     ├─╮
-    ◉ │  50bd7d246d8e d
+    ◉ │  98759debcee5 d
     ├─╯
-    ◉  37941ee54ace a b c
+    ◉  3b1673b6370c a b c
     ◉  000000000000
     "###);
     // The changes from the sources have been applied
@@ -667,16 +667,16 @@ fn test_squash_from_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: xznxytkn 59801ce3 (empty) (no description set)
-    Parent commit      : yostqsxw b7bc1dda e f | (no description set)
+    Working copy now at: xznxytkn 6a670d1a (empty) (no description set)
+    Parent commit      : yostqsxw c1293ff7 e f | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  59801ce3ff81
-    ◉    b7bc1dda247e e f
+    @  6a670d1ac76e
+    ◉    c1293ff7be51 e f
     ├─╮
-    ◉ │  cb214cffd91a d
+    ◉ │  aaf7b53a1b64 d
     ├─╯
-    ◉  37941ee54ace a b c
+    ◉  3b1673b6370c a b c
     ◉  000000000000
     "###);
     // The changes from the sources have been applied to the destination
@@ -734,15 +734,15 @@ fn test_squash_from_multiple_partial() {
     std::fs::write(&file2, "f\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  5adc4b1fb0f9 f
-    ◉      8ba764396a28 e
+    @  30980b9045f7 f
+    ◉      5326a04aac1f e
     ├─┬─╮
-    │ │ ◉  2a2d19a3283f b
-    │ ◉ │  864a16169cef c
+    │ │ ◉  d117da276a0f b
+    │ ◉ │  93a7bfff61e7 c
     │ ├─╯
-    ◉ │  5def0e76dfaf d
+    ◉ │  763809ca0131 d
     ├─╯
-    ◉  47a1e795d146 a
+    ◉  54d3c1c0e9fd a
     ◉  000000000000
     "###);
 
@@ -753,25 +753,25 @@ fn test_squash_from_multiple_partial() {
     insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
     New conflicts appeared in these commits:
-      yqosqzyt 85d3ae29 d | (conflict) (no description set)
+      yqosqzyt b91b1157 d | (conflict) (no description set)
     To resolve the conflicts, start by updating to it:
       jj new yqosqzytrlsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kpqxywon 97861bbf f | (no description set)
-    Parent commit      : yostqsxw 2dbaf4e8 e | (no description set)
+    Working copy now at: kpqxywon 056dc38b f | (no description set)
+    Parent commit      : yostqsxw 45069475 e | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  97861bbf7ae5 f
-    ◉      2dbaf4e8c7f7 e
+    @  056dc38bf286 f
+    ◉      450694753699 e
     ├─┬─╮
-    │ │ ◉  ba60ddff2d41 b
-    │ ◉ │  8ef5a315bf7d c
+    │ │ ◉  450d1499c1ae b
+    │ ◉ │  14b44bf0473c c
     │ ├─╯
-    ◉ │  85d3ae290b9b d
+    ◉ │  b91b11575906 d
     ├─╯
-    ◉  47a1e795d146 a
+    ◉  54d3c1c0e9fd a
     ◉  000000000000
     "###);
     // The selected changes have been removed from the sources
@@ -811,19 +811,19 @@ fn test_squash_from_multiple_partial() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: kpqxywon 610a144d f | (no description set)
-    Parent commit      : yostqsxw ac27a136 e | (no description set)
+    Working copy now at: kpqxywon 3b7559b8 f | (no description set)
+    Parent commit      : yostqsxw a3b1714c e | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  610a144de39b f
-    ◉      ac27a1361b09 e
+    @  3b7559b89a57 f
+    ◉      a3b1714cdfb2 e
     ├─┬─╮
-    │ │ ◉  0c8eab864a32 b
-    │ ◉ │  ad1776ad0b1b c
+    │ │ ◉  867efb38e801 b
+    │ ◉ │  84dcb3d4b3eb c
     │ ├─╯
-    ◉ │  5def0e76dfaf d
+    ◉ │  763809ca0131 d
     ├─╯
-    ◉  47a1e795d146 a
+    ◉  54d3c1c0e9fd a
     ◉  000000000000
     "###);
     // The selected changes have been removed from the sources
@@ -875,12 +875,12 @@ fn test_squash_from_multiple_partial_no_op() {
     std::fs::write(file_d, "d\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  09441f0a6266 d
-    │ ◉  5ad3ca4090a7 c
+    @  b37ca1ee3306 d
+    │ ◉  f40b442af3e8 c
     ├─╯
-    │ ◉  285201979c90 b
+    │ ◉  b73077b08c59 b
     ├─╯
-    ◉  3df52ee1f8a9 a
+    ◉  2443ea76b0b1 a
     ◉  000000000000
     "###);
 
@@ -891,15 +891,15 @@ fn test_squash_from_multiple_partial_no_op() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: mzvwutvl 9227d0d7 d
-    Parent commit      : qpvuntsm 3df52ee1 a
+    Working copy now at: mzvwutvl e178068a d
+    Parent commit      : qpvuntsm 2443ea76 a
     Added 1 files, modified 0 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  9227d0d780fa d
-    │ ◉  5ad3ca4090a7 c
+    @  e178068add8c d
+    │ ◉  f40b442af3e8 c
     ├─╯
-    ◉  3df52ee1f8a9 a
+    ◉  2443ea76b0b1 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(
@@ -911,12 +911,12 @@ fn test_squash_from_multiple_partial_no_op() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @    9227d0d780fa d
+    @    e178068add8c d
     ├─╮
-    ◉ │  09441f0a6266 d
-    ◉ │  cba0f0aa472b d
-      ◉  285201979c90 b
-      ◉  81187418277d b
+    ◉ │  b37ca1ee3306 d
+    ◉ │  1d9eb34614c9 d
+      ◉  b73077b08c59 b
+      ◉  a786561e909f b
     "###);
 
     // If no source commits match the paths, then the whole operation is a no-op
@@ -930,12 +930,12 @@ fn test_squash_from_multiple_partial_no_op() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  09441f0a6266 d
-    │ ◉  5ad3ca4090a7 c
+    @  b37ca1ee3306 d
+    │ ◉  f40b442af3e8 c
     ├─╯
-    │ ◉  285201979c90 b
+    │ ◉  b73077b08c59 b
     ├─╯
-    ◉  3df52ee1f8a9 a
+    ◉  2443ea76b0b1 a
     ◉  000000000000
     "###);
 }
@@ -1041,8 +1041,8 @@ fn test_squash_empty() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: kkmpptxz e45abe2c (empty) (no description set)
-    Parent commit      : qpvuntsm 1265289b (empty) parent
+    Working copy now at: kkmpptxz adece6e8 (empty) (no description set)
+    Parent commit      : qpvuntsm 5076fc41 (empty) parent
     "###);
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
     parent
@@ -1069,18 +1069,18 @@ fn test_squash_use_destination_message() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=c"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
-    @  71f7c810d8ed c
-    ◉  10dd87c3b4e2 b
-    ◉  4c5b3042d9e0 a
+    @  8aac283daeac c
+    ◉  017c7f689ed7 b
+    ◉  d8d5f980a897 a
     ◉  000000000000
     "###);
 
     // Squash the current revision using the short name for the option.
     test_env.jj_cmd_ok(&repo_path, &["squash", "-u"]);
     insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
-    @  10e30ce4a910
-    ◉  1c21278b775f b
-    ◉  4c5b3042d9e0 a
+    @  fd33e4bc332b
+    ◉  3a17aa5dcce9 b
+    ◉  d8d5f980a897 a
     ◉  000000000000
     "###);
 
@@ -1098,8 +1098,8 @@ fn test_squash_use_destination_message() {
         ],
     );
     insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
-    @  da1507508bdf
-    ◉  f1387f804776 a
+    @  7c832accbf60
+    ◉  688660377651 a
     ◉  000000000000
     "###);
 }

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -54,9 +54,9 @@ fn test_status_merge() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
     insta::assert_snapshot!(stdout, @r###"
     The working copy is clean
-    Working copy : mzvwutvl c965365c (empty) (no description set)
-    Parent commit: rlvkpnrz 9ae48ddb left | (empty) left
-    Parent commit: zsuskuln 29b991e9 right
+    Working copy : mzvwutvl a538c72d (empty) (no description set)
+    Parent commit: rlvkpnrz d3dd19f1 left | (empty) left
+    Parent commit: zsuskuln 705a356d right
     "###);
 }
 
@@ -80,7 +80,7 @@ fn test_status_ignored_gitignore() {
     insta::assert_snapshot!(stdout, @r###"
     Working copy changes:
     A .gitignore
-    Working copy : qpvuntsm 88a40909 (no description set)
+    Working copy : qpvuntsm 3cef2183 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     "###);
 }
@@ -99,7 +99,7 @@ fn test_status_filtered() {
     insta::assert_snapshot!(stdout, @r###"
     Working copy changes:
     A file_1
-    Working copy : qpvuntsm abcaaacd (no description set)
+    Working copy : qpvuntsm c8fb8395 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     "###);
 }
@@ -146,17 +146,17 @@ fn test_status_display_rebase_instructions() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::@"]);
 
     insta::assert_snapshot!(stdout, @r###"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 93e9928b conflict
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 65143fef conflict
     │  (empty) boom-cont-2
-    ◉  royxmykx test.user@example.com 2001-02-03 08:05:12 ac5398e8 conflict
+    ◉  royxmykx test.user@example.com 2001-02-03 08:05:12 a4e88714 conflict
     │  (empty) boom-cont
-    ◉    mzvwutvl test.user@example.com 2001-02-03 08:05:11 be6032ca conflict
+    ◉    mzvwutvl test.user@example.com 2001-02-03 08:05:11 538415e7 conflict
     ├─╮  (empty) boom
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 55ce6709
+    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 1e8c2956
     │ │  First part of conflicting change
-    ◉ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 ba5f8773
+    ◉ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 2c8b19fd
     ├─╯  Second part of conflicting change
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 98e0dcf8
+    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◉  zzzzzzzz root() 00000000
     "###);
@@ -167,8 +167,8 @@ fn test_status_display_rebase_instructions() {
     The working copy is clean
     There are unresolved conflicts at these paths:
     conflicted.txt    2-sided conflict
-    Working copy : yqosqzyt 93e9928b (conflict) (empty) boom-cont-2
-    Parent commit: royxmykx ac5398e8 (conflict) (empty) boom-cont
+    Working copy : yqosqzyt 65143fef (conflict) (empty) boom-cont-2
+    Parent commit: royxmykx a4e88714 (conflict) (empty) boom-cont
     To resolve the conflicts, start by updating to the first one:
       jj new mzvwutvlkqwt
     Then use `jj resolve`, or edit the conflict markers in the file directly.

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -69,8 +69,8 @@ fn test_git_push_undo() {
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -81,8 +81,8 @@ fn test_git_push_undo() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin: qpvuntsm 8c05de15 (empty) BB
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin: qpvuntsm 75e78001 (empty) BB
     "###);
 
     // Undo the push
@@ -94,8 +94,8 @@ fn test_git_push_undo() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -110,10 +110,10 @@ fn test_git_push_undo() {
     // git fetch && jj undo && jj git fetch` would become a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm hidden 0cffb614 (empty) AA
-      + qpvuntsm?? 0a3e99f0 (empty) CC
-      + qpvuntsm?? 8c05de15 (empty) BB
-      @origin (behind by 1 commits): qpvuntsm?? 8c05de15 (empty) BB
+      - qpvuntsm hidden 2080bdb8 (empty) AA
+      + qpvuntsm?? 20b2cc4b (empty) CC
+      + qpvuntsm?? 75e78001 (empty) BB
+      @origin (behind by 1 commits): qpvuntsm?? 75e78001 (empty) BB
     "###);
 }
 
@@ -142,8 +142,8 @@ fn test_git_push_undo_with_import() {
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -154,8 +154,8 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin: qpvuntsm 8c05de15 (empty) BB
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin: qpvuntsm 75e78001 (empty) BB
     "###);
 
     // Undo the push
@@ -167,8 +167,8 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
 
     // PROBLEM: inserting this import changes the outcome compared to previous test
@@ -182,8 +182,8 @@ fn test_git_push_undo_with_import() {
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin: qpvuntsm 8c05de15 (empty) BB
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin: qpvuntsm 75e78001 (empty) BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -191,8 +191,8 @@ fn test_git_push_undo_with_import() {
     // There is not a conflict. This seems like a good outcome; undoing `git push`
     // was essentially a no-op.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 0a3e99f0 (empty) CC
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 8c05de15 (empty) BB
+    main: qpvuntsm 20b2cc4b (empty) CC
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 75e78001 (empty) BB
     "###);
 }
 
@@ -222,9 +222,9 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @git: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @git: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -235,9 +235,9 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | BB      |   BB   | BB
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @git: qpvuntsm 8c05de15 (empty) BB
-      @origin: qpvuntsm 8c05de15 (empty) BB
+    main: qpvuntsm 75e78001 (empty) BB
+      @git: qpvuntsm 75e78001 (empty) BB
+      @origin: qpvuntsm 75e78001 (empty) BB
     "###);
 
     // Undo the push
@@ -257,9 +257,9 @@ fn test_git_push_undo_colocated() {
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @git: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @git: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
@@ -268,11 +268,11 @@ fn test_git_push_undo_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     main (conflicted):
-      - qpvuntsm hidden 0cffb614 (empty) AA
-      + qpvuntsm?? 0a3e99f0 (empty) CC
-      + qpvuntsm?? 8c05de15 (empty) BB
-      @git (behind by 1 commits): qpvuntsm?? 0a3e99f0 (empty) CC
-      @origin (behind by 1 commits): qpvuntsm?? 8c05de15 (empty) BB
+      - qpvuntsm hidden 2080bdb8 (empty) AA
+      + qpvuntsm?? 20b2cc4b (empty) CC
+      + qpvuntsm?? 75e78001 (empty) BB
+      @git (behind by 1 commits): qpvuntsm?? 20b2cc4b (empty) CC
+      @origin (behind by 1 commits): qpvuntsm?? 75e78001 (empty) BB
     "###);
 }
 
@@ -293,14 +293,14 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 0cffb614 (empty) AA
-      @origin: qpvuntsm 0cffb614 (empty) AA
+    main: qpvuntsm 2080bdb8 (empty) AA
+      @origin: qpvuntsm 2080bdb8 (empty) AA
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 0cffb614 (empty) AA
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
     "###);
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
@@ -311,16 +311,16 @@ fn test_git_push_undo_repo_only() {
         &["op", "restore", "--what=repo", &pre_push_opid],
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 8c05de15 (empty) BB
-      @origin: qpvuntsm 8c05de15 (empty) BB
+    main: qpvuntsm 75e78001 (empty) BB
+      @origin: qpvuntsm 75e78001 (empty) BB
     "###);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // This currently gives an identical result to `test_git_push_undo_import`.
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    main: qpvuntsm 0a3e99f0 (empty) CC
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 8c05de15 (empty) BB
+    main: qpvuntsm 20b2cc4b (empty) CC
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 75e78001 (empty) BB
     "###);
 }
 
@@ -338,10 +338,10 @@ fn test_branch_track_untrack_undo() {
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     test_env.jj_cmd_ok(&repo_path, &["branch", "delete", "feature2"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: qpvuntsm 270721f5 (empty) commit
-      @origin: qpvuntsm 270721f5 (empty) commit
+    feature1: qpvuntsm 8da1cfc8 (empty) commit
+      @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2 (deleted)
-      @origin: qpvuntsm 270721f5 (empty) commit
+      @origin: qpvuntsm 8da1cfc8 (empty) commit
     "###);
 
     // Track/untrack can be undone so long as states can be trivially merged.
@@ -350,38 +350,38 @@ fn test_branch_track_untrack_undo() {
         &["branch", "untrack", "feature1@origin", "feature2@origin"],
     );
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: qpvuntsm 270721f5 (empty) commit
-    feature1@origin: qpvuntsm 270721f5 (empty) commit
-    feature2@origin: qpvuntsm 270721f5 (empty) commit
+    feature1: qpvuntsm 8da1cfc8 (empty) commit
+    feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
+    feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: qpvuntsm 270721f5 (empty) commit
-      @origin: qpvuntsm 270721f5 (empty) commit
+    feature1: qpvuntsm 8da1cfc8 (empty) commit
+      @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2 (deleted)
-      @origin: qpvuntsm 270721f5 (empty) commit
+      @origin: qpvuntsm 8da1cfc8 (empty) commit
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: qpvuntsm 270721f5 (empty) commit
-    feature1@origin: qpvuntsm 270721f5 (empty) commit
-    feature2@origin: qpvuntsm 270721f5 (empty) commit
+    feature1: qpvuntsm 8da1cfc8 (empty) commit
+    feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
+    feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["branch", "track", "feature1@origin"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: qpvuntsm 270721f5 (empty) commit
-      @origin: qpvuntsm 270721f5 (empty) commit
-    feature2@origin: qpvuntsm 270721f5 (empty) commit
+    feature1: qpvuntsm 8da1cfc8 (empty) commit
+      @origin: qpvuntsm 8da1cfc8 (empty) commit
+    feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
-    feature1: qpvuntsm 270721f5 (empty) commit
-    feature1@origin: qpvuntsm 270721f5 (empty) commit
-    feature2@origin: qpvuntsm 270721f5 (empty) commit
+    feature1: qpvuntsm 8da1cfc8 (empty) commit
+    feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
+    feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
     "###);
 }
 

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -32,9 +32,9 @@ fn test_unsquash() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  90fe0a96fc90 c
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
+    @  382c9bad7d42 c
+    ◉  d5d59175b481 b
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
 
@@ -42,12 +42,12 @@ fn test_unsquash() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: mzvwutvl 1b10d78f c | (no description set)
-    Parent commit      : qpvuntsm 90aeefd0 a b | (no description set)
+    Working copy now at: mzvwutvl 9177132c c | (no description set)
+    Parent commit      : qpvuntsm 184ddbcc a b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  1b10d78f6136 c
-    ◉  90aeefd03044 a b
+    @  9177132cfbb9 c
+    ◉  184ddbcce5a9 a b
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -61,12 +61,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl 45b8b3dd c | (no description set)
-    Parent commit      : kkmpptxz 9146bcc8 b | (no description set)
+    Working copy now at: mzvwutvl b353b29c c | (no description set)
+    Parent commit      : kkmpptxz 27772b15 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  45b8b3ddc25a c
-    ◉  9146bcc8d996 b
+    @  b353b29c423d c
+    ◉  27772b156771 b
     ◉  000000000000 a
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
@@ -88,13 +88,13 @@ fn test_unsquash() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "merge", "c", "d"]);
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "e"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @    1f8f152ff48e e
+    @    b780e7469252 e
     ├─╮
-    │ ◉  5658521e0f8b d
-    ◉ │  90fe0a96fc90 c
+    │ ◉  f86e2b3af3e3 d
+    ◉ │  382c9bad7d42 c
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
+    ◉  d5d59175b481 b
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash"]);
@@ -108,18 +108,18 @@ fn test_unsquash() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: pzsxstzt 3217340c merge
-    Parent commit      : mzvwutvl 90fe0a96 c e?? | (no description set)
-    Parent commit      : xznxytkn 5658521e d e?? | (no description set)
+    Working copy now at: pzsxstzt bd05eb69 merge
+    Parent commit      : mzvwutvl 382c9bad c e?? | (no description set)
+    Parent commit      : xznxytkn f86e2b3a d e?? | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @    3217340cb761
+    @    bd05eb698d1e
     ├─╮
-    │ ◉  5658521e0f8b d e??
-    ◉ │  90fe0a96fc90 c e??
+    │ ◉  f86e2b3af3e3 d e??
+    ◉ │  382c9bad7d42 c e??
     ├─╯
-    ◉  fa5efbdf533c b
-    ◉  90aeefd03044 a
+    ◉  d5d59175b481 b
+    ◉  184ddbcce5a9 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -147,9 +147,9 @@ fn test_unsquash_partial() {
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  d989314f3df0 c
-    ◉  2a2d19a3283f b
-    ◉  47a1e795d146 a
+    @  a0b1a272ebc4 c
+    ◉  d117da276a0f b
+    ◉  54d3c1c0e9fd a
     ◉  000000000000
     "###);
 
@@ -160,13 +160,13 @@ fn test_unsquash_partial() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl 37c961d0 c | (no description set)
-    Parent commit      : kkmpptxz 000af220 b | (no description set)
+    Working copy now at: mzvwutvl 8802263d c | (no description set)
+    Parent commit      : kkmpptxz 5bd83140 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  37c961d0d1e2 c
-    ◉  000af22057b9 b
-    ◉  ee67504598b6 a
+    @  8802263dbd92 c
+    ◉  5bd83140fd47 b
+    ◉  c93de9257191 a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
@@ -180,13 +180,13 @@ fn test_unsquash_partial() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: mzvwutvl a8e8fded c | (no description set)
-    Parent commit      : kkmpptxz 46cc0667 b | (no description set)
+    Working copy now at: mzvwutvl a896ffde c | (no description set)
+    Parent commit      : kkmpptxz 904111b4 b | (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    @  a8e8fded1021 c
-    ◉  46cc06672a99 b
-    ◉  47a1e795d146 a
+    @  a896ffdebb85 c
+    ◉  904111b4d3c4 b
+    ◉  54d3c1c0e9fd a
     ◉  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
@@ -218,8 +218,8 @@ fn test_unsquash_partial() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: mzvwutvl 1c82d27c c | (no description set)
-    Parent commit      : kkmpptxz b9d23fd8 b | (no description set)
+    Working copy now at: mzvwutvl aaca9268 c | (no description set)
+    Parent commit      : kkmpptxz fe8eb117 b | (no description set)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -91,7 +91,7 @@ fn test_gc_operation_log() {
     // Now this doesn't work.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["debug", "operation", &op_to_remove]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: No operation ID matching "6b842a00d6a5655d32c8a0ee40c4aaaed49337cdcaca98b8d7c1f3a1c82f58b4968c2ed5b13d9d2a5d41f04040f42e6daf77c0f4646d09138bd1e25c754e2411"
+    Error: No operation ID matching "1708ccd0d25f313f1559dfd1c4d16f0424de23a58e946830b0f27eb1252ce9295fe018e03fa4356e6aa39520cd8b5d44b7688024428988fe4d015291a4706172"
     "###);
 }
 

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -29,7 +29,7 @@ fn test_workspaces_add_second_workspace() {
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz e0e6d567 (empty) (no description set)
+    default: rlvkpnrz 8183d0fc (empty) (no description set)
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -39,33 +39,33 @@ fn test_workspaces_add_second_workspace() {
     insta::assert_snapshot!(stdout.replace('\\', "/"), @"");
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Created workspace in "../secondary"
-    Working copy now at: rzvqmyuk 397eac93 (empty) (no description set)
-    Parent commit      : qpvuntsm 7d308bc9 initial
+    Working copy now at: rzvqmyuk 5ed2222c (empty) (no description set)
+    Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
     "###);
 
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  397eac932ad3 second@
-    │ @  e0e6d5672858 default@
+    ◉  5ed2222c28e2 second@
+    │ @  8183d0fcaa4c default@
     ├─╯
-    ◉  7d308bc9d934
+    ◉  751b12b7b981
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
-    @  397eac932ad3 second@
-    │ ◉  e0e6d5672858 default@
+    @  5ed2222c28e2 second@
+    │ ◉  8183d0fcaa4c default@
     ├─╯
-    ◉  7d308bc9d934
+    ◉  751b12b7b981
     ◉  000000000000
     "###);
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz e0e6d567 (empty) (no description set)
-    second: rzvqmyuk 397eac93 (empty) (no description set)
+    default: rlvkpnrz 8183d0fc (empty) (no description set)
+    second: rzvqmyuk 5ed2222c (empty) (no description set)
     "###);
 }
 
@@ -107,7 +107,7 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: zsuskuln 21a0ea6d (empty) merge
+    default: zsuskuln 35e47bff (empty) merge
     "###);
 
     test_env.jj_cmd_ok(
@@ -117,11 +117,11 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     // The new workspace's working-copy commit shares all parents with the old one.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉    6d4c2b8ab610 second@
+    ◉    7013a493bd09 second@
     ├─╮
-    │ │ @  21a0ea6d1c86 default@
+    │ │ @  35e47bff781e default@
     ╭─┬─╯
-    │ ◉  09ba8d9dfa21
+    │ ◉  444b77e99d43
     ◉ │  1694f2ddf8ec
     ├─╯
     ◉  000000000000
@@ -144,7 +144,7 @@ fn test_workspaces_add_workspace_at_revision() {
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: kkmpptxz 2801c219 (empty) (no description set)
+    default: kkmpptxz dadeedb4 (empty) (no description set)
     "###);
 
     let (_, stderr) = test_env.jj_cmd_ok(
@@ -161,27 +161,27 @@ fn test_workspaces_add_workspace_at_revision() {
     );
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Created workspace in "../secondary"
-    Working copy now at: zxsnswpr e6baf9d9 (empty) (no description set)
-    Parent commit      : qpvuntsm e7d7dbb9 first
+    Working copy now at: zxsnswpr e374e74a (empty) (no description set)
+    Parent commit      : qpvuntsm f6097c2f first
     Added 1 files, modified 0 files, removed 0 files
     "###);
 
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  e6baf9d9cfd0 second@
-    │ @  2801c219094d default@
-    │ ◉  4ec5df5a189c
+    ◉  e374e74aa0c8 second@
+    │ @  dadeedb493e8 default@
+    │ ◉  c420244c6398
     ├─╯
-    ◉  e7d7dbb91c5a
+    ◉  f6097c2f7cac
     ◉  000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
-    @  e6baf9d9cfd0 second@
-    │ ◉  2801c219094d default@
-    │ ◉  4ec5df5a189c
+    @  e374e74aa0c8 second@
+    │ ◉  dadeedb493e8 default@
+    │ ◉  c420244c6398
     ├─╯
-    ◉  e7d7dbb91c5a
+    ◉  f6097c2f7cac
     ◉  000000000000
     "###);
 }
@@ -208,11 +208,11 @@ fn test_workspaces_add_workspace_multiple_revisions() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  5b36783cd11c
-    │ ◉  23881f07b53c
+    │ ◉  6c843d62ca29
     ├─╯
-    │ ◉  1f6a15f0af2a
+    │ ◉  544cd61f2d26
     ├─╯
-    │ ◉  e7d7dbb91c5a
+    │ ◉  f6097c2f7cac
     ├─╯
     ◉  000000000000
     "###);
@@ -224,27 +224,27 @@ fn test_workspaces_add_workspace_multiple_revisions() {
             "add",
             "--name=merge",
             "../merged",
-            "-r=238",
-            "-r=1f6",
-            "-r=e7d",
+            "-r=description(third)",
+            "-r=description(second)",
+            "-r=description(first)",
         ],
     );
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Created workspace in "../merged"
-    Working copy now at: wmwvqwsz fa8fdc28 (empty) (no description set)
-    Parent commit      : mzvwutvl 23881f07 third
-    Parent commit      : kkmpptxz 1f6a15f0 second
-    Parent commit      : qpvuntsm e7d7dbb9 first
+    Working copy now at: wmwvqwsz f4fa64f4 (empty) (no description set)
+    Parent commit      : mzvwutvl 6c843d62 third
+    Parent commit      : kkmpptxz 544cd61f second
+    Parent commit      : qpvuntsm f6097c2f first
     Added 3 files, modified 0 files, removed 0 files
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉      fa8fdc28af12 merge@
+    ◉      f4fa64f40944 merge@
     ├─┬─╮
-    │ │ ◉  e7d7dbb91c5a
-    │ ◉ │  1f6a15f0af2a
+    │ │ ◉  f6097c2f7cac
+    │ ◉ │  544cd61f2d26
     │ ├─╯
-    ◉ │  23881f07b53c
+    ◉ │  6c843d62ca29
     ├─╯
     │ @  5b36783cd11c default@
     ├─╯
@@ -267,10 +267,10 @@ fn test_workspaces_conflicting_edits() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  265af0cdbcc7 secondary@
-    │ @  351099fa72cf default@
+    ◉  3224de8ae048 secondary@
+    │ @  06b57f44a3ca default@
     ├─╯
-    ◉  cf911c223d3e
+    ◉  506f4ec3c2c6
     ◉  000000000000
     "###);
 
@@ -283,28 +283,28 @@ fn test_workspaces_conflicting_edits() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl fe8f41ed (empty) (no description set)
-    Parent commit      : qpvuntsm c0d4a99e (no description set)
+    Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
+    Parent commit      : qpvuntsm d4124476 (no description set)
     "###);
 
     // The secondary workspace's working-copy commit was updated
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    @  fe8f41ed01d6 default@
-    │ ◉  a1896a17282f secondary@
+    @  a58c9a9b19ce default@
+    │ ◉  e82cd4ee8faa secondary@
     ├─╯
-    ◉  c0d4a99ef98a
+    ◉  d41244767d45
     ◉  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation 58b580b12eee).
+    Error: The working copy is stale (not updated since operation f46ea702e886).
     Hint: Run `jj workspace update-stale` to update it.
     See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
     "###);
     // Same error on second run, and from another command
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["log"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation 58b580b12eee).
+    Error: The working copy is stale (not updated since operation f46ea702e886).
     Hint: Run `jj workspace update-stale` to update it.
     See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
     "###);
@@ -316,29 +316,29 @@ fn test_workspaces_conflicting_edits() {
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    Working copy now at: pmmvwywv?? a1896a17 (empty) (no description set)
+    Working copy now at: pmmvwywv?? e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ◉  92498bf020d4 (divergent)
-    │ ◉  fe8f41ed01d6 default@
+    ◉  a28c85ce128b (divergent)
+    │ ◉  a58c9a9b19ce default@
     ├─╯
-    │ @  a1896a17282f secondary@ (divergent)
+    │ @  e82cd4ee8faa secondary@ (divergent)
     ├─╯
-    ◉  c0d4a99ef98a
+    ◉  d41244767d45
     ◉  000000000000
     "###);
     // The stale working copy should have been resolved by the previous command
     let stdout = get_log_output(&test_env, &secondary_path);
     assert!(!stdout.starts_with("The working copy is stale"));
     insta::assert_snapshot!(stdout, @r###"
-    ◉  92498bf020d4 (divergent)
-    │ ◉  fe8f41ed01d6 default@
+    ◉  a28c85ce128b (divergent)
+    │ ◉  a58c9a9b19ce default@
     ├─╯
-    │ @  a1896a17282f secondary@ (divergent)
+    │ @  e82cd4ee8faa secondary@ (divergent)
     ├─╯
-    ◉  c0d4a99ef98a
+    ◉  d41244767d45
     ◉  000000000000
     "###);
 }
@@ -357,10 +357,10 @@ fn test_workspaces_updated_by_other() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  265af0cdbcc7 secondary@
-    │ @  351099fa72cf default@
+    ◉  3224de8ae048 secondary@
+    │ @  06b57f44a3ca default@
     ├─╯
-    ◉  cf911c223d3e
+    ◉  506f4ec3c2c6
     ◉  000000000000
     "###);
 
@@ -370,21 +370,21 @@ fn test_workspaces_updated_by_other() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits
-    Working copy now at: mzvwutvl fe8f41ed (empty) (no description set)
-    Parent commit      : qpvuntsm c0d4a99e (no description set)
+    Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
+    Parent commit      : qpvuntsm d4124476 (no description set)
     "###);
 
     // The secondary workspace's working-copy commit was updated.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    @  fe8f41ed01d6 default@
-    │ ◉  a1896a17282f secondary@
+    @  a58c9a9b19ce default@
+    │ ◉  e82cd4ee8faa secondary@
     ├─╯
-    ◉  c0d4a99ef98a
+    ◉  d41244767d45
     ◉  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation 58b580b12eee).
+    Error: The working copy is stale (not updated since operation f46ea702e886).
     Hint: Run `jj workspace update-stale` to update it.
     See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
     "###);
@@ -393,15 +393,15 @@ fn test_workspaces_updated_by_other() {
     // divergent commit should be created.
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Working copy now at: pmmvwywv a1896a17 (empty) (no description set)
+    Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ◉  fe8f41ed01d6 default@
-    │ @  a1896a17282f secondary@
+    ◉  a58c9a9b19ce default@
+    │ @  e82cd4ee8faa secondary@
     ├─╯
-    ◉  c0d4a99ef98a
+    ◉  d41244767d45
     ◉  000000000000
     "###);
 }
@@ -455,13 +455,13 @@ fn test_workspaces_current_op_discarded_by_other() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  716b8d737e abandon commit 8ac26d0060e2be7f3fce2b5ebd2eb0c75053666f6cbc41bee50bb6da463868704a0bcf1ed9848761206d77694a71e3c657e5e250245e342779df1b00f0da9009
-    ◉  bb8aec2a1c Create initial working-copy commit in workspace secondary
-    ◉  af6f39b411 add workspace 'secondary'
-    ◉  05c14c7e78 new empty commit
-    ◉  92bb962606 snapshot working copy
-    ◉  553e0ea3a4 new empty commit
-    ◉  b3755a9026 snapshot working copy
+    @  8e5ea0fbda abandon commit 3540d386892997a2a927078635a2d933e37499fb8691938a2f540c25bccffd9e8a60b2d5a8cb94bb3eeab17e1c56f96aafa2bcb66fa1e4eb96911d093d7a579e
+    ◉  f336f5b6e8 Create initial working-copy commit in workspace secondary
+    ◉  aacb3bda7d add workspace 'secondary'
+    ◉  46bcf7d75e new empty commit
+    ◉  4d2f5d7cbf snapshot working copy
+    ◉  2f863a1573 new empty commit
+    ◉  f01631d976 snapshot working copy
     ◉  17dbb2fe40 add workspace 'default'
     ◉  cecfee9647 initialize repo
     ◉  0000000000
@@ -472,10 +472,10 @@ fn test_workspaces_current_op_discarded_by_other() {
     test_env.jj_cmd_ok(&main_path, &["util", "gc", "--expire=now"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  ec4904a30161 secondary@
-    │ @  74769415363f default@
+    @  cc0b087cb874 default@
+    │ ◉  376eee1462a7 secondary@
     ├─╯
-    ◉  bd711986720f
+    ◉  7788883a847c
     ◉  000000000000
     "###);
 
@@ -488,17 +488,17 @@ fn test_workspaces_current_op_discarded_by_other() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     insta::assert_snapshot!(stderr, @r###"
-    Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object bb8aec2a1ca33ebafdfe8866bc4ad3464dffd25634fde19d1025625880791b141d35753e10737c41b2bc133ab84047312f3021d905bb711960253e7f430100fc of type operation not found
-    Created and checked out recovery commit 30ee0d1fbd7a
+    Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object f336f5b6e83bb901dce6d05d83193f7d0cad2b6375a9910d586c844a479feb130c30d417bdf3030f980d9bacca117584a654e9bdf74b41b30021651e28fbfc8c of type operation not found
+    Created and checked out recovery commit 6803354995e6
     "###);
     insta::assert_snapshot!(stdout, @"");
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  b93a924213f3 secondary@
-    ◉  ec4904a30161
-    │ @  74769415363f default@
+    ◉  a8f7db7868c1 secondary@
+    ◉  376eee1462a7
+    │ @  cc0b087cb874 default@
     ├─╯
-    ◉  bd711986720f
+    ◉  7788883a847c
     ◉  000000000000
     "###);
 
@@ -516,8 +516,8 @@ fn test_workspaces_current_op_discarded_by_other() {
     A added
     D deleted
     M modified
-    Working copy : kmkuslsw b93a9242 (no description set)
-    Parent commit: rzvqmyuk ec4904a3 (empty) (no description set)
+    Working copy : kmkuslsw a8f7db78 (no description set)
+    Parent commit: rzvqmyuk 376eee14 (empty) (no description set)
     "###);
     // The modified file should have the same contents it had before (not reset to
     // the base contents)
@@ -528,9 +528,9 @@ fn test_workspaces_current_op_discarded_by_other() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["obslog"]);
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(stdout, @r###"
-    @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ b93a9242
+    @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ a8f7db78
     │  (no description set)
-    ◉  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 30ee0d1f
+    ◉  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 68033549
        (empty) (no description set)
     "###);
 }
@@ -590,11 +590,11 @@ fn test_workspaces_update_stale_snapshot() {
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
-    @  4976dfa88529 secondary@
-    │ ◉  8357b22214ba default@
-    │ ◉  1a769966ed69
+    @  e672fd8fefac secondary@
+    │ ◉  ea37b073f5ab default@
+    │ ◉  b13c81dedc64
     ├─╯
-    ◉  b4a6c25e7778
+    ◉  e6e9989f1179
     ◉  000000000000
     "###);
 }
@@ -617,7 +617,7 @@ fn test_workspaces_forget() {
     // When listing workspaces, only the secondary workspace shows up
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    secondary: pmmvwywv feda1c4e (empty) (no description set)
+    secondary: pmmvwywv 18463f43 (empty) (no description set)
     "###);
 
     // `jj status` tells us that there's no working copy here
@@ -633,10 +633,10 @@ fn test_workspaces_forget() {
     // there's only one workspace. We should show it when the command is not run
     // from that workspace.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  feda1c4e5ffe
-    │ ◉  e949be04e93e
+    ◉  18463f438cc9
+    │ ◉  909d51b17292
     ├─╯
-    ◉  123ed18e4c4c
+    ◉  4e8f9d2be039
     ◉  000000000000
     "###);
 
@@ -680,22 +680,22 @@ fn test_workspaces_forget_multi_transaction() {
     // there should be three workspaces
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz e949be04 (empty) (no description set)
-    second: pmmvwywv feda1c4e (empty) (no description set)
-    third: rzvqmyuk 485853ed (empty) (no description set)
+    default: rlvkpnrz 909d51b1 (empty) (no description set)
+    second: pmmvwywv 18463f43 (empty) (no description set)
+    third: rzvqmyuk cc383fa2 (empty) (no description set)
     "###);
 
     // delete two at once, in a single tx
     test_env.jj_cmd_ok(&main_path, &["workspace", "forget", "second", "third"]);
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz e949be04 (empty) (no description set)
+    default: rlvkpnrz 909d51b1 (empty) (no description set)
     "###);
 
     // the op log should have multiple workspaces forgotten in a single tx
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  c28e1481737d test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  6c88cdee70e6 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third
     "###);
@@ -706,9 +706,9 @@ fn test_workspaces_forget_multi_transaction() {
     // finally, there should be three workspaces at the end
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz e949be04 (empty) (no description set)
-    second: pmmvwywv feda1c4e (empty) (no description set)
-    third: rzvqmyuk 485853ed (empty) (no description set)
+    default: rlvkpnrz 909d51b1 (empty) (no description set)
+    second: pmmvwywv 18463f43 (empty) (no description set)
+    third: rzvqmyuk cc383fa2 (empty) (no description set)
     "###);
 }
 
@@ -736,14 +736,14 @@ fn test_list_workspaces_template() {
     // "current_working_copy" should point to the workspace we operate on
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: e0e6d5672858  (current)
-    second: f68da2d114f1 
+    default: 8183d0fcaa4c  (current)
+    second: 0a77a39d7d6f 
     "###);
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "list"]);
     insta::assert_snapshot!(stdout, @r###"
-    default: e0e6d5672858 
-    second: f68da2d114f1  (current)
+    default: 8183d0fcaa4c 
+    second: 0a77a39d7d6f  (current)
     "###);
 }
 
@@ -792,7 +792,7 @@ fn test_debug_snapshot() {
     test_env.jj_cmd_ok(&repo_path, &["debug", "snapshot"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  2d01fc903f0f test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  e1e762d39b39 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
     ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
@@ -804,10 +804,10 @@ fn test_debug_snapshot() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  53a64275e379 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
-    │  describe commit 123ed18e4c4c0d77428df41112bc02ffc83fb935
+    @  9ac6e7144e8a test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
-    ◉  2d01fc903f0f test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ◉  e1e762d39b39 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
     ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -85,6 +85,17 @@ impl CommitBuilder<'_> {
         {
             commit.author.email = commit.committer.email.clone();
         }
+
+        // Reset author timestamp on discardable commits if the author is the
+        // committer. While it's unlikely we'll have somebody else's commit
+        // with no description in our repo, we'd like to be extra safe.
+        if commit.author.name == commit.committer.name
+            && commit.author.email == commit.committer.email
+            && predecessor.is_discardable(mut_repo).unwrap_or_default()
+        {
+            commit.author.timestamp = commit.committer.timestamp.clone();
+        }
+
         CommitBuilder {
             mut_repo,
             commit,


### PR DESCRIPTION
This is my first time contributing, but I thought this might be a useful feature. This PR resolves #2000 by adding a revset to configure which commits have their author timestamps updated when they are rewritten. This gives a lot of flexibility for configuration, but it's more complex than having a single hard-coded rule. Another alternative might be to have a configuration option with a few fixed enum variants instead of a revset. I would appreciate any comments and feedback!

One thing which I was unsure about is whether all of the existing tests should be updated (it caused a large number of changes since many commit IDs are different due to the different timestamps), or if this feature should be disabled by default in tests except for a few new tests created to test this feature.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
