### PR TITLE
cli: file: sort subcommands chronologically

### DIFF
--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -23,9 +23,9 @@ use crate::ui::Ui;
 /// File operations.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum FileCommand {
-    Print(print::PrintArgs),
     Chmod(chmod::ChmodArgs),
     List(list::ListArgs),
+    Print(print::PrintArgs),
 }
 
 pub fn cmd_file(
@@ -34,8 +34,8 @@ pub fn cmd_file(
     subcommand: &FileCommand,
 ) -> Result<(), CommandError> {
     match subcommand {
-        FileCommand::Print(sub_args) => print::cmd_print(ui, command, sub_args),
         FileCommand::Chmod(sub_args) => chmod::cmd_chmod(ui, command, sub_args),
         FileCommand::List(sub_args) => list::cmd_list(ui, command, sub_args),
+        FileCommand::Print(sub_args) => print::cmd_print(ui, command, sub_args),
     }
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -35,9 +35,9 @@ This document contains the help content for the `jj` command-line program.
 * [`jj duplicate`↴](#jj-duplicate)
 * [`jj edit`↴](#jj-edit)
 * [`jj file`↴](#jj-file)
-* [`jj file print`↴](#jj-file-print)
 * [`jj file chmod`↴](#jj-file-chmod)
 * [`jj file list`↴](#jj-file-list)
+* [`jj file print`↴](#jj-file-print)
 * [`jj fix`↴](#jj-fix)
 * [`jj git`↴](#jj-git)
 * [`jj git remote`↴](#jj-git-remote)
@@ -652,29 +652,9 @@ File operations
 
 ###### **Subcommands:**
 
-* `print` — Print contents of files in a revision
 * `chmod` — Sets or removes the executable bit for paths in the repo
 * `list` — List files in a revision
-
-
-
-## `jj file print`
-
-Print contents of files in a revision
-
-If the given path is a directory, files in the directory will be visited recursively.
-
-**Usage:** `jj file print [OPTIONS] <PATHS>...`
-
-###### **Arguments:**
-
-* `<PATHS>` — Paths to print
-
-###### **Options:**
-
-* `-r`, `--revision <REVISION>` — The revision to get the file contents from
-
-  Default value: `@`
+* `print` — Print contents of files in a revision
 
 
 
@@ -719,6 +699,26 @@ List files in a revision
 ###### **Options:**
 
 * `-r`, `--revision <REVISION>` — The revision to list files in
+
+  Default value: `@`
+
+
+
+## `jj file print`
+
+Print contents of files in a revision
+
+If the given path is a directory, files in the directory will be visited recursively.
+
+**Usage:** `jj file print [OPTIONS] <PATHS>...`
+
+###### **Arguments:**
+
+* `<PATHS>` — Paths to print
+
+###### **Options:**
+
+* `-r`, `--revision <REVISION>` — The revision to get the file contents from
 
   Default value: `@`
 


### PR DESCRIPTION
Otherwise they wouldn't be sorted in help. I also reordered the match statement. Since subcommands are split to per-file modules, there's no point to keep some logical ordering.


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
