### PR TITLE
Change bg color of whitespace-only hunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New command `jj branch move` let you update branches by name pattern or source
   revision.
 
+* In color-words diffs, whitespace-only hunks are marked with a background
+  color. (If a hunk contains printable characters, it is displayed with a
+  foreground color as usual.)
+
 ### Fixed bugs
 
 ## [0.18.0] - 2024-06-05

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -80,6 +80,10 @@
 "diff hunk_header" = "cyan"
 "diff removed" = "red"
 "diff added" = "green"
+# fg typically has no effect on whitespace, but add it here anyway to make debug
+# text visible when using --color=debug.
+"diff removed whitespace" = { fg = "default", bg = "red" }
+"diff added whitespace" = { fg = "default", bg = "green" }
 "diff modified" = "cyan"
 "diff access-denied" = { bg = "red" }
 

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -387,13 +387,18 @@ fn show_color_words_diff_line(
                 formatter.write_all(data)?;
             }
             DiffHunk::Different(data) => {
-                let before = data[0];
-                let after = data[1];
-                if !before.is_empty() {
-                    formatter.with_label("removed", |formatter| formatter.write_all(before))?;
-                }
-                if !after.is_empty() {
-                    formatter.with_label("added", |formatter| formatter.write_all(after))?;
+                for (hunk_part, label) in data.iter().zip(["removed", "added"]) {
+                    if !hunk_part.is_empty() {
+                        formatter.with_label(label, |formatter| {
+                            if hunk_part.iter().all(u8::is_ascii_whitespace) {
+                                formatter.with_label("whitespace", |formatter| {
+                                    formatter.write_all(hunk_part)
+                                })
+                            } else {
+                                formatter.write_all(hunk_part)
+                            }
+                        })?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
With the default color-words diff formatting, if a diff hunk (a sequence of removed and/or added characters) consists only of whitespace characters, it will not be visible on a terminal because the default configuration only changes their foreground color (which has no effect because all these characters are whitespace).

Therefore, change the background color of these diff hunks. The user may further customize their appearance by configuring the "removed whitespace" and "added whitespace" formats.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
