### PR TITLE
Add `jj debug snapshot` command and use it in trigger

### DIFF
--- a/cli/src/commands/debug/mod.rs
+++ b/cli/src/commands/debug/mod.rs
@@ -17,6 +17,7 @@ pub mod index;
 pub mod operation;
 pub mod reindex;
 pub mod revset;
+pub mod snapshot;
 pub mod template;
 pub mod tree;
 pub mod watchman;
@@ -33,6 +34,7 @@ use self::index::{cmd_debug_index, IndexArgs};
 use self::operation::{cmd_debug_operation, OperationArgs};
 use self::reindex::{cmd_debug_reindex, ReindexArgs};
 use self::revset::{cmd_debug_revset, RevsetArgs};
+use self::snapshot::{cmd_debug_snapshot, SnapshotArgs};
 use self::template::{cmd_debug_template, TemplateArgs};
 use self::tree::{cmd_debug_tree, TreeArgs};
 use self::watchman::{cmd_debug_watchman, WatchmanCommand};
@@ -57,6 +59,7 @@ pub enum DebugCommand {
     Tree(TreeArgs),
     #[command(subcommand)]
     Watchman(WatchmanCommand),
+    Snapshot(SnapshotArgs),
 }
 
 pub fn cmd_debug(
@@ -74,6 +77,7 @@ pub fn cmd_debug(
         DebugCommand::Operation(args) => cmd_debug_operation(ui, command, args),
         DebugCommand::Tree(args) => cmd_debug_tree(ui, command, args),
         DebugCommand::Watchman(args) => cmd_debug_watchman(ui, command, args),
+        DebugCommand::Snapshot(args) => cmd_debug_snapshot(ui, command, args),
     }
 }
 

--- a/cli/src/commands/debug/snapshot.rs
+++ b/cli/src/commands/debug/snapshot.rs
@@ -1,0 +1,33 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Trigger a snapshot in the op log
+#[derive(clap::Args, Clone, Debug)]
+pub struct SnapshotArgs {}
+
+pub fn cmd_debug_snapshot(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &SnapshotArgs,
+) -> Result<(), CommandError> {
+    // workspace helper will snapshot as needed
+    command.workspace_helper(ui)?;
+    Ok(())
+}

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -283,9 +283,8 @@ pub mod watchman {
                         name: "jj-background-monitor".to_string(),
                         command: vec![
                             "jj".to_string(),
-                            "files".to_string(),
-                            "-r".to_string(),
-                            "root()".to_string(),
+                            "debug".to_string(),
+                            "snapshot".to_string(),
                         ],
                         expression: Some(self.build_exclude_expr()),
                         ..Default::default()


### PR DESCRIPTION
The command only takes a snapshot and avoids other overhead, so it can be used as a target for the watchman trigger that gets installed.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
