### PR TITLE
Edit config files with a temp editor and add some validation

### DIFF
--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -16,7 +16,7 @@ use std::io::Write;
 
 use tracing::instrument;
 
-use crate::cli_util::{get_new_config_file_path, run_ui_editor, CommandHelper};
+use crate::cli_util::{edit_temp_file, get_config_file_contents, get_new_config_file_path, set_config_file_contents, CommandHelper};
 use crate::command_error::{config_error, user_error, CommandError};
 use crate::config::{
     to_toml_value, write_config_value_to_file, AnnotatedValue, ConfigNamePathBuf, ConfigSource,
@@ -305,8 +305,11 @@ pub(crate) fn cmd_config_edit(
     command: &CommandHelper,
     args: &ConfigEditArgs,
 ) -> Result<(), CommandError> {
-    let config_path = get_new_config_file_path(&args.level.expect_source_kind(), command)?;
-    run_ui_editor(command.settings(), &config_path)
+    let config_path_contents = get_config_file_contents(&args.level.expect_source_kind(), command)?;
+    let new_contents = edit_temp_file("config.toml", ".tmp", std::env::temp_dir().as_path(), config_path_contents.as_str(), command.settings())?;
+    set_config_file_contents(&args.level.expect_source_kind(), command, new_contents.as_str())?;
+
+    return Ok(());
 }
 
 #[instrument(skip_all)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -564,6 +564,14 @@ fn read_config_path(config_path: &Path) -> Result<config::Config, config::Config
         .build()
 }
 
+
+pub fn are_contents_valid_toml(contents: &str) -> Result<(), ConfigError> {
+    contents.parse::<toml_edit::Document>().map_err(|err| {
+        return config::ConfigError::FileParse { uri: None, cause: Box::new(err) };
+    })?;
+    Ok(())
+}
+
 pub fn write_config_value_to_file(
     key: &ConfigNamePathBuf,
     value_str: &str,


### PR DESCRIPTION
Fixes https://github.com/martinvonz/jj/issues/3905

This solves a problem where `jj config edit` drops you straight into an editor and allows you to save an invalid toml file. If you mess up your toml syntax, jj cannot launch (even `jj config edit`!)

This implements a pattern I've seen in tools like `crontab -e` or `visudo` where you get dropped into a temporary file editor and the tool does a bit of sanity checking before copying over the contents of the temporary file into the actual file.

Code wise: this reuses a utility function which takes care of the heavy lifting for creating a temporary file and launching an editor.  I put all the validation in a new function in cli/src/config.rs, which seemed a bit like overkill but I figured the details of the config format being toml shouldn't leak into cli_util or command/config

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
