### PR TITLE
diff: underline added/removed parts by default

### DIFF
--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -78,8 +78,9 @@
 "diff binary" = "cyan"
 "diff file_header" = { bold = true }
 "diff hunk_header" = "cyan"
-"diff removed" = "red"
-"diff added" = "green"
+"diff removed" = { fg = "red", underline = true }
+"diff added" = { fg = "green", underline = true }
+"diff line_number" = { underline = false }
 "diff modified" = "cyan"
 "diff access-denied" = { bg = "red" }
 


### PR DESCRIPTION
This helps better visualize changes that contain leading and/or trailing whitespace.

It looks like this: (hmm...maybe the underlines would be confused with underscores)

![Screenshot from 2024-06-25 09-20-44](https://github.com/martinvonz/jj/assets/29559283/ede2bff4-99cc-464c-b110-810ddb00b96f)

<!--


There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
