### PR TITLE
cli: rename `jj file print` (formerly `jj cat`) to `jj file show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `jj split --siblings` is deprecated in favor of `jj split --parallel` (to
   match `jj parallelize`).
 
-* `jj file print` replaces `jj cat`.
+* `jj file show` replaces `jj cat`.
 
 * `jj file chmod` replaces `jj chmod`.
 

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -14,7 +14,7 @@
 
 pub mod chmod;
 pub mod list;
-pub mod print;
+pub mod show;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
@@ -25,7 +25,7 @@ use crate::ui::Ui;
 pub enum FileCommand {
     Chmod(chmod::ChmodArgs),
     List(list::ListArgs),
-    Print(print::PrintArgs),
+    Show(show::ShowArgs),
 }
 
 pub fn cmd_file(
@@ -36,6 +36,6 @@ pub fn cmd_file(
     match subcommand {
         FileCommand::Chmod(args) => chmod::cmd_chmod(ui, command, args),
         FileCommand::List(args) => list::cmd_list(ui, command, args),
-        FileCommand::Print(args) => print::cmd_print(ui, command, args),
+        FileCommand::Show(args) => show::cmd_show(ui, command, args),
     }
 }

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -34,7 +34,7 @@ use crate::ui::Ui;
 /// If the given path is a directory, files in the directory will be visited
 /// recursively.
 #[derive(clap::Args, Clone, Debug)]
-pub(crate) struct PrintArgs {
+pub(crate) struct ShowArgs {
     /// The revision to get the file contents from
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,
@@ -47,24 +47,24 @@ pub(crate) struct PrintArgs {
 pub(crate) fn deprecated_cmd_cat(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &PrintArgs,
+    args: &ShowArgs,
 ) -> Result<(), CommandError> {
     writeln!(
         ui.warning_default(),
-        "`jj cat` is deprecated; use `jj file print` instead, which is equivalent"
+        "`jj cat` is deprecated; use `jj file show` instead, which is equivalent"
     )?;
     writeln!(
         ui.warning_default(),
         "`jj cat` will be removed in a future version, and this will be a hard error"
     )?;
-    cmd_print(ui, command, args)
+    cmd_show(ui, command, args)
 }
 
 #[instrument(skip_all)]
-pub(crate) fn cmd_print(
+pub(crate) fn cmd_show(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &PrintArgs,
+    args: &ShowArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision)?;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -76,7 +76,7 @@ enum Command {
     #[command(subcommand)]
     Branch(branch::BranchCommand),
     #[command(alias = "print", hide = true)]
-    Cat(file::print::PrintArgs),
+    Cat(file::show::ShowArgs),
     #[command(hide = true)]
     Checkout(checkout::CheckoutArgs),
     #[command(hide = true)]
@@ -174,7 +174,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         #[cfg(feature = "bench")]
         Command::Bench(args) => bench::cmd_bench(ui, command_helper, args),
         Command::Branch(args) => branch::cmd_branch(ui, command_helper, args),
-        Command::Cat(args) => file::print::deprecated_cmd_cat(ui, command_helper, args),
+        Command::Cat(args) => file::show::deprecated_cmd_cat(ui, command_helper, args),
         Command::Checkout(args) => checkout::cmd_checkout(ui, command_helper, args),
         Command::Chmod(args) => file::chmod::deprecated_cmd_chmod(ui, command_helper, args),
         Command::Commit(args) => commit::cmd_commit(ui, command_helper, args),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -38,7 +38,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj file`↴](#jj-file)
 * [`jj file chmod`↴](#jj-file-chmod)
 * [`jj file list`↴](#jj-file-list)
-* [`jj file print`↴](#jj-file-print)
+* [`jj file show`↴](#jj-file-show)
 * [`jj fix`↴](#jj-fix)
 * [`jj git`↴](#jj-git)
 * [`jj git clone`↴](#jj-git-clone)
@@ -690,7 +690,7 @@ File operations
 
 * `chmod` — Sets or removes the executable bit for paths in the repo
 * `list` — List files in a revision
-* `print` — Print contents of files in a revision
+* `show` — Print contents of files in a revision
 
 
 
@@ -740,13 +740,13 @@ List files in a revision
 
 
 
-## `jj file print`
+## `jj file show`
 
 Print contents of files in a revision
 
 If the given path is a directory, files in the directory will be visited recursively.
 
-**Usage:** `jj file print [OPTIONS] <PATHS>...`
+**Usage:** `jj file show [OPTIONS] <PATHS>...`
 
 ###### **Arguments:**
 

--- a/cli/tests/test_acls.rs
+++ b/cli/tests/test_acls.rs
@@ -110,7 +110,7 @@ fn test_cat() {
 
     SecretBackend::adopt_git_repo(&repo_path);
 
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "print", "."]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
     insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
     foo
     baz

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -394,7 +394,7 @@ fn test_diffedit_merge() {
     A file3
     "###);
     assert!(!repo_path.join("file1").exists());
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -68,7 +68,7 @@ fn test_chmod_regular_conflict() {
     @r###"
     file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
     @r###"
     <<<<<<< Conflict 1 of 1
@@ -87,7 +87,7 @@ fn test_chmod_regular_conflict() {
     @r###"
     file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: true })]))
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
     @r###"
     <<<<<<< Conflict 1 of 1
@@ -104,7 +104,7 @@ fn test_chmod_regular_conflict() {
     @r###"
     file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
     @r###"
     <<<<<<< Conflict 1 of 1
@@ -180,7 +180,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     @r###"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(Tree(TreeId("133bb38fc4e4bf6b551f1f04db7e48f04cac2877")))]))
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=file_dir", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_dir", "file"]);
     insta::assert_snapshot!(stdout,
     @r###"
     Conflict:
@@ -200,8 +200,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     @r###"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), None]))
     "###);
-    let stdout =
-        test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=file_deletion", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(stdout,
     @r###"
     <<<<<<< Conflict 1 of 1
@@ -236,8 +235,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     @r###"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), None]))
     "###);
-    let stdout =
-        test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=file_deletion", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(stdout,
     @r###"
     <<<<<<< Conflict 1 of 1

--- a/cli/tests/test_file_print_command.rs
+++ b/cli/tests/test_file_print_command.rs
@@ -27,13 +27,13 @@ fn test_print() {
     std::fs::write(repo_path.join("dir").join("file2"), "c\n").unwrap();
 
     // Can print the contents of a file in a commit
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "@-"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
 
     // Defaults to printing the working-copy version
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
@@ -44,25 +44,25 @@ fn test_print() {
     } else {
         "dir\\file2"
     };
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", subdir_file]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", subdir_file]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
 
     // Error if the path doesn't exist
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "print", "nonexistent"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "nonexistent"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: No such path: nonexistent
     "###);
 
     // Can print files under the specified directory
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "dir"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
 
     // Can print multiple files
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "."]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "."]);
     insta::assert_snapshot!(stdout, @r###"
     c
     b
@@ -70,7 +70,7 @@ fn test_print() {
 
     // Unmatched paths should generate warnings
     let (stdout, stderr) =
-        test_env.jj_cmd_ok(&repo_path, &["file", "print", "file1", "non-existent"]);
+        test_env.jj_cmd_ok(&repo_path, &["file", "show", "file1", "non-existent"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
@@ -82,7 +82,7 @@ fn test_print() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "@", "-d", "@--"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
@@ -107,7 +107,7 @@ fn test_print_symlink() {
     std::os::unix::fs::symlink("symlink1_target", repo_path.join("symlink1")).unwrap();
 
     // Can print multiple files
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "print", "."]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
     insta::assert_snapshot!(stdout, @r###"
     c
     a

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -79,9 +79,9 @@ fn test_fix_leaf_commit() {
     Parent commit      : qpvuntsm fda57e40 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@-"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@-"]);
     insta::assert_snapshot!(content, @"unaffected");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"AFFECTED");
 }
 
@@ -106,11 +106,11 @@ fn test_fix_parent_commit() {
     Parent commit      : qpvuntsm 4f4d2103 parent | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "parent"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "parent"]);
     insta::assert_snapshot!(content, @"PARENT");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "child1"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child1"]);
     insta::assert_snapshot!(content, @"CHILD1");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "child2"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child2"]);
     insta::assert_snapshot!(content, @"CHILD2");
 }
 
@@ -131,11 +131,11 @@ fn test_fix_sibling_commit() {
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "parent"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "parent"]);
     insta::assert_snapshot!(content, @"parent");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "child1"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child1"]);
     insta::assert_snapshot!(content, @"CHILD1");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "child2"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child2"]);
     insta::assert_snapshot!(content, @"child2");
 }
 
@@ -173,17 +173,17 @@ fn test_default_revset() {
     Parent commit      : yqosqzyt 4747dd17 bar1 | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "trunk1"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "trunk1"]);
     insta::assert_snapshot!(content, @"trunk1");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "trunk2"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "trunk2"]);
     insta::assert_snapshot!(content, @"trunk2");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "foo"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "foo"]);
     insta::assert_snapshot!(content, @"foo");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "bar1"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar1"]);
     insta::assert_snapshot!(content, @"BAR1");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "bar2"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar2"]);
     insta::assert_snapshot!(content, @"BAR2");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "bar3"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar3"]);
     insta::assert_snapshot!(content, @"BAR3");
 }
 
@@ -207,9 +207,9 @@ fn test_custom_default_revset() {
     insta::assert_snapshot!(stderr, @r###"
     Fixed 1 commits of 1 checked.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "foo"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "foo"]);
     insta::assert_snapshot!(content, @"foo");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "bar"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar"]);
     insta::assert_snapshot!(content, @"BAR");
 }
 
@@ -228,10 +228,9 @@ fn test_fix_immutable_commit() {
     Error: Commit 83eee3c8dce2 is immutable
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
     "###);
-    let content =
-        test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "immutable"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "immutable"]);
     insta::assert_snapshot!(content, @"immutable");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "mutable"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "mutable"]);
     insta::assert_snapshot!(content, @"mutable");
 }
 
@@ -246,7 +245,7 @@ fn test_fix_empty_file() {
     Fixed 0 commits of 1 checked.
     Nothing changed.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"");
 }
 
@@ -264,11 +263,11 @@ fn test_fix_some_paths() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(content, @r###"
     FOO
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(content, @"bar");
 }
 
@@ -285,7 +284,7 @@ fn test_fix_cyclic() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"tnetnoc\n");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
@@ -296,7 +295,7 @@ fn test_fix_cyclic() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"content\n");
 }
 
@@ -329,13 +328,13 @@ fn test_deduplication() {
     Parent commit      : mzvwutvl 90d9a032 c | (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "a"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
     insta::assert_snapshot!(content, @"FOO\n");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "b"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "b"]);
     insta::assert_snapshot!(content, @"BAR\n");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "c"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "c"]);
     insta::assert_snapshot!(content, @"BAR\n");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "d"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "d"]);
     insta::assert_snapshot!(content, @"FOO\n");
 
     // Each new content string only appears once in the log, because all the other
@@ -367,7 +366,7 @@ fn test_executed_but_nothing_changed() {
     Fixed 0 commits of 1 checked.
     Nothing changed.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"content\n");
     let copy_content = std::fs::read_to_string(repo_path.join("file-copy").as_os_str()).unwrap();
     insta::assert_snapshot!(copy_content, @"content\n");
@@ -384,7 +383,7 @@ fn test_failure() {
     Fixed 0 commits of 1 checked.
     Nothing changed.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"content");
 }
 
@@ -404,7 +403,7 @@ fn test_stderr_success() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"new content");
 }
 
@@ -420,7 +419,7 @@ fn test_stderr_failure() {
     errorFixed 0 commits of 1 checked.
     Nothing changed.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"old content");
 }
 
@@ -456,7 +455,7 @@ fn test_fix_file_types() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"CONTENT");
 }
 
@@ -478,7 +477,7 @@ fn test_fix_executable() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"CONTENT");
     let executable = std::fs::metadata(&path).unwrap().permissions().mode() & 0o111;
     assert_eq!(executable, 0o111);
@@ -504,11 +503,11 @@ fn test_fix_trivial_merge_commit() {
     Fixed 0 commits of 1 checked.
     Nothing changed.
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_a", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_a", "-r", "@"]);
     insta::assert_snapshot!(content, @"content a");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_b", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_b", "-r", "@"]);
     insta::assert_snapshot!(content, @"content b");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_c", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_c", "-r", "@"]);
     insta::assert_snapshot!(content, @"content c");
 }
 
@@ -539,13 +538,13 @@ fn test_fix_adding_merge_commit() {
     Parent commit      : kkmpptxz 82e9bc6a b | (no description set)
     Added 0 files, modified 4 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_a", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_a", "-r", "@"]);
     insta::assert_snapshot!(content, @"CHANGE A");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_b", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_b", "-r", "@"]);
     insta::assert_snapshot!(content, @"CHANGE B");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_c", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_c", "-r", "@"]);
     insta::assert_snapshot!(content, @"CHANGE C");
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file_d", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_d", "-r", "@"]);
     insta::assert_snapshot!(content, @"CHANGE D");
 }
 
@@ -572,15 +571,15 @@ fn test_fix_both_sides_of_conflict() {
     There are unresolved conflicts at these paths:
     file    2-sided conflict
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "a"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
     insta::assert_snapshot!(content, @r###"
     CONTENT A
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "b"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "b"]);
     insta::assert_snapshot!(content, @r###"
     CONTENT B
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
@@ -614,7 +613,7 @@ fn test_fix_resolve_conflict() {
     Parent commit      : kkmpptxz 82703f5e b | (no description set)
     Added 0 files, modified 1 files, removed 0 files
     "###);
-    let content = test_env.jj_cmd_success(&repo_path, &["file", "print", "file", "-r", "@"]);
+    let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @r###"
     CONTENT
     "###);

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -236,7 +236,7 @@ fn test_bad_path() {
     test_env.add_config("ui.allow-filesets = true");
 
     // cwd == workspace_root
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "print", "../out"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "../out"]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
@@ -251,7 +251,7 @@ fn test_bad_path() {
     "###);
 
     // cwd != workspace_root, can't be parsed as repo-relative path
-    let stderr = test_env.jj_cmd_failure(&subdir, &["file", "print", "../.."]);
+    let stderr = test_env.jj_cmd_failure(&subdir, &["file", "show", "../.."]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
@@ -266,7 +266,7 @@ fn test_bad_path() {
     "###);
 
     // cwd != workspace_root, can be parsed as repo-relative path
-    let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "print", "-Rrepo", "out"]);
+    let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "show", "-Rrepo", "out"]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
@@ -284,7 +284,7 @@ fn test_bad_path() {
     test_env.add_config("ui.allow-filesets = false");
 
     // If fileset/pattern syntax is disabled, no hint should be generated
-    let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "print", "-Rrepo", "out"]);
+    let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "show", "-Rrepo", "out"]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Error: Path "out" is not in the repo "repo"
     Caused by: Invalid component ".." in repo-relative path "../out"

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -103,12 +103,12 @@ fn test_move() {
     ◉  000000000000
     "###);
     // The change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // File `file2`, which was not changed in source, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
@@ -136,7 +136,7 @@ fn test_move() {
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
@@ -164,7 +164,7 @@ fn test_move() {
     ◉  000000000000
     "###);
     // The change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "d"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     e
     "###);
@@ -227,16 +227,16 @@ fn test_move_partial() {
     ◉  000000000000
     "###);
     // The changes from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // File `file3`, which was not changed in source, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file3"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -262,17 +262,17 @@ fn test_move_partial() {
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // The unselected change from the source has not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
     // File `file3`, which was changed in source's parent, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file3"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -299,17 +299,17 @@ fn test_move_partial() {
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // The unselected change from the source has not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
     // File `file3`, which was changed in source's parent, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file3"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -335,12 +335,12 @@ fn test_move_partial() {
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // The unselected change from the source has not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -85,9 +85,9 @@ fn test_new_merge() {
     ├─╯
     ◉  0000000000000000000000000000000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @"a");
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @"b");
 
     // Same test with `--no-edit`

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -51,7 +51,7 @@ fn test_squash() {
     ◉  90aeefd03044 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
@@ -70,11 +70,11 @@ fn test_squash() {
     ◉  893c93ae2a87 a b
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
@@ -123,7 +123,7 @@ fn test_squash() {
     ◉  90aeefd03044 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "e"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "e"]);
     insta::assert_snapshot!(stdout, @r###"
     e
     "###);
@@ -169,7 +169,7 @@ fn test_squash_partial() {
     ◉  c9f931cd78af a b
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "a"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
@@ -190,19 +190,19 @@ fn test_squash_partial() {
     ◉  0c5ddc685260 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "a"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "a"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
@@ -224,19 +224,19 @@ fn test_squash_partial() {
     ◉  70621f4c7a42 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "a"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "a"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
@@ -332,12 +332,12 @@ fn test_squash_from_to() {
     ◉  000000000000
     "###);
     // The change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // File `file2`, which was not changed in source, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
@@ -363,7 +363,7 @@ fn test_squash_from_to() {
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
@@ -390,7 +390,7 @@ fn test_squash_from_to() {
     ◉  000000000000
     "###);
     // The change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "d"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "d"]);
     insta::assert_snapshot!(stdout, @r###"
     e
     "###);
@@ -451,16 +451,16 @@ fn test_squash_from_to_partial() {
     ◉  000000000000
     "###);
     // The changes from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // File `file3`, which was not changed in source, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file3"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -484,17 +484,17 @@ fn test_squash_from_to_partial() {
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // The unselected change from the source has not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
     // File `file3`, which was changed in source's parent, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file3"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -519,17 +519,17 @@ fn test_squash_from_to_partial() {
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // The unselected change from the source has not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
     // File `file3`, which was changed in source's parent, is unchanged
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file3"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -555,12 +555,12 @@ fn test_squash_from_to_partial() {
     ◉  000000000000
     "###);
     // The selected change from the source has been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
     // The unselected change from the source has not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
@@ -647,7 +647,7 @@ fn test_squash_from_multiple() {
     ◉  000000000000
     "###);
     // The changes from the sources have been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=d", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file"]);
     insta::assert_snapshot!(stdout, @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -680,7 +680,7 @@ fn test_squash_from_multiple() {
     ◉  000000000000
     "###);
     // The changes from the sources have been applied to the destination
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=e", "file"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
@@ -775,16 +775,16 @@ fn test_squash_from_multiple_partial() {
     ◉  000000000000
     "###);
     // The selected changes have been removed from the sources
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=b", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=c", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=c", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
     // The selected changes from the sources have been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=d", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -799,7 +799,7 @@ fn test_squash_from_multiple_partial() {
     "###);
     // The unselected change from the sources have not been applied to the
     // destination
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=d", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);
@@ -827,25 +827,25 @@ fn test_squash_from_multiple_partial() {
     ◉  000000000000
     "###);
     // The selected changes have been removed from the sources
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=b", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=c", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=c", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=f", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=f", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
     // The selected changes from the sources have been applied to the destination
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=e", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     f
     "###);
     // The unselected changes from the sources have not been applied
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "-r=d", "file2"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file2"]);
     insta::assert_snapshot!(stdout, @r###"
     d
     "###);

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -50,7 +50,7 @@ fn test_unsquash() {
     ◉  90aeefd03044 a b
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
@@ -69,11 +69,11 @@ fn test_unsquash() {
     ◉  9146bcc8d996 b
     ◉  000000000000 a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
@@ -122,7 +122,7 @@ fn test_unsquash() {
     ◉  90aeefd03044 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     e
     "###);
@@ -169,7 +169,7 @@ fn test_unsquash_partial() {
     ◉  ee67504598b6 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "a"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
@@ -189,19 +189,19 @@ fn test_unsquash_partial() {
     ◉  47a1e795d146 a
     ◉  000000000000
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "c"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "c"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "c"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "c"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
@@ -221,19 +221,19 @@ fn test_unsquash_partial() {
     Working copy now at: mzvwutvl 1c82d27c c | (no description set)
     Parent commit      : kkmpptxz b9d23fd8 b | (no description set)
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     a
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
     b
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file1", "-r", "c"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "c"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "print", "file2", "-r", "c"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "c"]);
     insta::assert_snapshot!(stdout, @r###"
     c
     "###);


### PR DESCRIPTION
We now have two `cmd_show` in the repo. I think this one should become `cmd_file_show`, but this should be done uniformly over all the commands for consistency.

I did *not* keep `print` as an alias (I couldn't find a compelling reason to do it), but let me know if anyone feels like keeping it.

(This was discussed in https://github.com/martinvonz/jj/issues/3812. We should decide before the release next week whether or not to do this).

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
