### PR TITLE
conflicts: insert trailing newline when materializing conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Conflicts involving non-empty files that do not end in a newline no longer
+  look broken when materialized.
+  [#3968](https://github.com/martinvonz/jj/issues/3968). This is a partial fix,
+  see also [#3975](https://github.com/martinvonz/jj/issues/3968) which is not
+  yet fixed.
+
 ## [0.19.0] - 2024-07-03
 
 ### Breaking changes

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -144,7 +144,7 @@ pub fn run_mergetool_external(
 ) -> Result<MergedTreeId, ConflictResolveError> {
     let initial_output_content: Vec<u8> = if editor.merge_tool_edits_conflict_markers {
         let mut materialized_conflict = vec![];
-        materialize_merge_result(&content, &mut materialized_conflict)
+        materialize_merge_result(content.clone(), &mut materialized_conflict)
             .expect("Writing to an in-memory buffer should never fail");
         materialized_conflict
     } else {

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -191,7 +191,7 @@ async fn materialize_tree_value_no_access_denied(
             if let Some(file_merge) = conflict.to_file_merge() {
                 let file_merge = file_merge.simplify();
                 let content = extract_as_single_hunk(&file_merge, store, path).await?;
-                materialize_merge_result(&content, &mut contents)
+                materialize_merge_result(content, &mut contents)
                     .expect("Failed to materialize conflict to in-memory buffer");
             } else {
                 // Unless all terms are regular files, we can't do much better than to try to
@@ -215,7 +215,7 @@ async fn materialize_tree_value_no_access_denied(
 }
 
 pub fn materialize_merge_result(
-    single_hunk: &Merge<ContentHunk>,
+    single_hunk: Merge<ContentHunk>,
     output: &mut dyn Write,
 ) -> std::io::Result<()> {
     let slices = single_hunk.map(|content| content.0.as_slice());
@@ -456,7 +456,7 @@ pub async fn update_from_content(
     // copy.
     let mut old_content = Vec::with_capacity(content.len());
     let merge_hunk = extract_as_single_hunk(simplified_file_ids, store, path).await?;
-    materialize_merge_result(&merge_hunk, &mut old_content).unwrap();
+    materialize_merge_result(merge_hunk, &mut old_content).unwrap();
     if content == old_content {
         return Ok(file_ids.clone());
     }

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -346,6 +346,12 @@ impl<T> Merge<T> {
     }
 
     /// Creates a new merge by applying `f` to each remove and add.
+    pub fn into_map<U>(self, f: impl FnMut(T) -> U) -> Merge<U> {
+        let values = self.values.into_iter().map(f).collect();
+        Merge { values }
+    }
+
+    /// Creates a new merge by applying `f` to each remove and add.
     pub fn map<'a, U>(&'a self, f: impl FnMut(&'a T) -> U) -> Merge<U> {
         let values = self.values.iter().map(f).collect();
         Merge { values }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -1024,6 +1024,6 @@ fn materialize_conflict_string(
     let contents = extract_as_single_hunk(conflict, store, path)
         .block_on()
         .unwrap();
-    materialize_merge_result(&contents, &mut result).unwrap();
+    materialize_merge_result(contents, &mut result).unwrap();
     String::from_utf8(result).unwrap()
 }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -357,15 +357,31 @@ fn test_materialize_conflict_no_newlines_at_eof() {
         @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
-    -base+++++++ Contents of side #2
-    right>>>>>>> Conflict 1 of 1 ends
+    -base
+    +++++++ Contents of side #2
+    right
+    >>>>>>> Conflict 1 of 1 ends
     "###
     );
-    // BUG(#3968): These conflict markers cannot be parsed
+    // These conflict markers can be parsed (#3968)
+    // TODO(#3975): BUG: The result of the parsing has newlines where original files
+    // didn't.
     insta::assert_debug_snapshot!(parse_conflict(
         materialized.as_bytes(),
         conflict.num_sides()
-    ),@"None");
+    ),@r###"
+    Some(
+        [
+            Conflicted(
+                [
+                    "",
+                    "base\n",
+                    "right\n",
+                ],
+            ),
+        ],
+    )
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
This happens for non-empty files only; the materialization code can
handle files and hunks with 0 or more lines, but each line should
terminate in a newline.

This is an imperfect fix to https://github.com/martinvonz/jj/issues/3968, a better fix is TODO; see https://github.com/martinvonz/jj/issues/3975.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
