### PR TITLE
revset: drop Eq/PartialEq from RevsetExpression and related types

### DIFF
--- a/cli/examples/custom-commit-templater/main.rs
+++ b/cli/examples/custom-commit-templater/main.rs
@@ -30,8 +30,8 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
 use jj_lib::revset::{
     FunctionCallNode, PartialSymbolResolver, RevsetExpression, RevsetFilterExtension,
-    RevsetFilterExtensionWrapper, RevsetFilterPredicate, RevsetParseContext, RevsetParseError,
-    RevsetResolutionError, SymbolResolverExtension,
+    RevsetFilterPredicate, RevsetParseContext, RevsetParseError, RevsetResolutionError,
+    SymbolResolverExtension,
 };
 use once_cell::sync::OnceCell;
 
@@ -185,7 +185,7 @@ fn even_digits(
 ) -> Result<Rc<RevsetExpression>, RevsetParseError> {
     function.expect_no_arguments()?;
     Ok(RevsetExpression::filter(RevsetFilterPredicate::Extension(
-        RevsetFilterExtensionWrapper(Rc::new(EvenDigitsFilter)),
+        Rc::new(EvenDigitsFilter),
     )))
 }
 

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -33,7 +33,7 @@ use crate::matchers::{Matcher, Visit};
 use crate::repo_path::RepoPath;
 use crate::revset::{
     ResolvedExpression, ResolvedPredicateExpression, Revset, RevsetEvaluationError,
-    RevsetFilterExtensionWrapper, RevsetFilterPredicate, GENERATION_RANGE_FULL,
+    RevsetFilterPredicate, GENERATION_RANGE_FULL,
 };
 use crate::store::Store;
 use crate::{rewrite, union_find};
@@ -1081,7 +1081,7 @@ fn build_predicate_fn(
             let commit = store.get_commit(&entry.commit_id()).unwrap();
             commit.has_conflict().unwrap()
         }),
-        RevsetFilterPredicate::Extension(RevsetFilterExtensionWrapper(ext)) => {
+        RevsetFilterPredicate::Extension(ext) => {
             let ext = ext.clone();
             box_pure_predicate_fn(move |index, pos| {
                 let entry = index.entry_by_pos(pos);

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -92,7 +92,7 @@ pub enum RevsetModifier {
 }
 
 /// Symbol or function to be resolved to `CommitId`s.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum RevsetCommitRef {
     WorkingCopy(WorkspaceId),
     WorkingCopies,
@@ -121,20 +121,7 @@ pub trait RevsetFilterExtension: std::fmt::Debug + Any {
     fn matches_commit(&self, commit: &Commit) -> bool;
 }
 
-// TODO: Refactor tests to not need the Eq trait so we can remove this wrapper.
 #[derive(Clone, Debug)]
-#[repr(transparent)]
-pub struct RevsetFilterExtensionWrapper(pub Rc<dyn RevsetFilterExtension>);
-
-impl PartialEq for RevsetFilterExtensionWrapper {
-    fn eq(&self, other: &RevsetFilterExtensionWrapper) -> bool {
-        Rc::ptr_eq(&self.0, &other.0)
-    }
-}
-
-impl Eq for RevsetFilterExtensionWrapper {}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RevsetFilterPredicate {
     /// Commits with number of parents in the range.
     ParentCount(Range<u32>),
@@ -149,10 +136,10 @@ pub enum RevsetFilterPredicate {
     /// Commits with conflicts
     HasConflict,
     /// Custom predicates provided by extensions
-    Extension(RevsetFilterExtensionWrapper),
+    Extension(Rc<dyn RevsetFilterExtension>),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, Debug)]
 pub enum RevsetExpression {
     None,
     All,
@@ -479,7 +466,7 @@ impl RevsetExpression {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum ResolvedPredicateExpression {
     /// Pure filter predicate.
     Filter(RevsetFilterPredicate),
@@ -499,7 +486,7 @@ pub enum ResolvedPredicateExpression {
 /// properties.
 ///
 /// Use `RevsetExpression` API to build a query programmatically.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum ResolvedExpression {
     Commits(Vec<CommitId>),
     Ancestors {


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
