### PR TITLE
`cli` chore: standardize subcommand function and argument type names

### DIFF
--- a/cli/src/commands/debug/fileset.rs
+++ b/cli/src/commands/debug/fileset.rs
@@ -23,7 +23,7 @@ use crate::ui::Ui;
 
 /// Parse fileset expression
 #[derive(clap::Args, Clone, Debug)]
-pub struct FilesetArgs {
+pub struct DebugFilesetArgs {
     #[arg(value_hint = clap::ValueHint::AnyPath)]
     path: String,
 }
@@ -31,7 +31,7 @@ pub struct FilesetArgs {
 pub fn cmd_debug_fileset(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &FilesetArgs,
+    args: &DebugFilesetArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let path_converter = workspace_command.path_converter();

--- a/cli/src/commands/debug/index.rs
+++ b/cli/src/commands/debug/index.rs
@@ -24,12 +24,12 @@ use crate::ui::Ui;
 
 /// Show commit index stats
 #[derive(clap::Args, Clone, Debug)]
-pub struct IndexArgs {}
+pub struct DebugIndexArgs {}
 
 pub fn cmd_debug_index(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &IndexArgs,
+    _args: &DebugIndexArgs,
 ) -> Result<(), CommandError> {
     // Resolve the operation without loading the repo, so this command won't
     // merge concurrent operations and update the index.

--- a/cli/src/commands/debug/local_working_copy.rs
+++ b/cli/src/commands/debug/local_working_copy.rs
@@ -26,12 +26,12 @@ use crate::ui::Ui;
 ///
 /// This command only works with a standard local-disk working copy.
 #[derive(clap::Args, Clone, Debug)]
-pub struct LocalWorkingCopyArgs {}
+pub struct DebugLocalWorkingCopyArgs {}
 
 pub fn cmd_debug_local_working_copy(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &LocalWorkingCopyArgs,
+    _args: &DebugLocalWorkingCopyArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;

--- a/cli/src/commands/debug/mod.rs
+++ b/cli/src/commands/debug/mod.rs
@@ -30,17 +30,17 @@ use std::fmt::Debug;
 use clap::Subcommand;
 use jj_lib::local_working_copy::LocalWorkingCopy;
 
-use self::fileset::{cmd_debug_fileset, FilesetArgs};
-use self::index::{cmd_debug_index, IndexArgs};
-use self::local_working_copy::{cmd_debug_local_working_copy, LocalWorkingCopyArgs};
-use self::operation::{cmd_debug_operation, OperationArgs};
-use self::reindex::{cmd_debug_reindex, ReindexArgs};
-use self::revset::{cmd_debug_revset, RevsetArgs};
-use self::snapshot::{cmd_debug_snapshot, SnapshotArgs};
-use self::template::{cmd_debug_template, TemplateArgs};
-use self::tree::{cmd_debug_tree, TreeArgs};
-use self::watchman::{cmd_debug_watchman, WatchmanCommand};
-use self::working_copy::{cmd_debug_working_copy, WorkingCopyArgs};
+use self::fileset::{cmd_debug_fileset, DebugFilesetArgs};
+use self::index::{cmd_debug_index, DebugIndexArgs};
+use self::local_working_copy::{cmd_debug_local_working_copy, DebugLocalWorkingCopyArgs};
+use self::operation::{cmd_debug_operation, DebugOperationArgs};
+use self::reindex::{cmd_debug_reindex, DebugReindexArgs};
+use self::revset::{cmd_debug_revset, DebugRevsetArgs};
+use self::snapshot::{cmd_debug_snapshot, DebugSnapshotArgs};
+use self::template::{cmd_debug_template, DebugTemplateArgs};
+use self::tree::{cmd_debug_tree, DebugTreeArgs};
+use self::watchman::{cmd_debug_watchman, DebugWatchmanCommand};
+use self::working_copy::{cmd_debug_working_copy, DebugWorkingCopyArgs};
 use crate::cli_util::CommandHelper;
 use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
@@ -49,19 +49,19 @@ use crate::ui::Ui;
 #[derive(Subcommand, Clone, Debug)]
 #[command(hide = true)]
 pub enum DebugCommand {
-    Fileset(FilesetArgs),
-    Index(IndexArgs),
-    LocalWorkingCopy(LocalWorkingCopyArgs),
+    Fileset(DebugFilesetArgs),
+    Index(DebugIndexArgs),
+    LocalWorkingCopy(DebugLocalWorkingCopyArgs),
     #[command(visible_alias = "view")]
-    Operation(OperationArgs),
-    Reindex(ReindexArgs),
-    Revset(RevsetArgs),
-    Snapshot(SnapshotArgs),
-    Template(TemplateArgs),
-    Tree(TreeArgs),
+    Operation(DebugOperationArgs),
+    Reindex(DebugReindexArgs),
+    Revset(DebugRevsetArgs),
+    Snapshot(DebugSnapshotArgs),
+    Template(DebugTemplateArgs),
+    Tree(DebugTreeArgs),
     #[command(subcommand)]
-    Watchman(WatchmanCommand),
-    WorkingCopy(WorkingCopyArgs),
+    Watchman(DebugWatchmanCommand),
+    WorkingCopy(DebugWorkingCopyArgs),
 }
 
 pub fn cmd_debug(

--- a/cli/src/commands/debug/operation.rs
+++ b/cli/src/commands/debug/operation.rs
@@ -24,7 +24,7 @@ use crate::ui::Ui;
 
 /// Show information about an operation and its view
 #[derive(clap::Args, Clone, Debug)]
-pub struct OperationArgs {
+pub struct DebugOperationArgs {
     #[arg(default_value = "@")]
     operation: String,
     #[arg(long, value_enum, default_value = "all")]
@@ -46,7 +46,7 @@ pub enum OperationDisplay {
 pub fn cmd_debug_operation(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &OperationArgs,
+    args: &DebugOperationArgs,
 ) -> Result<(), CommandError> {
     // Resolve the operation without loading the repo, so this command can be used
     // even if e.g. the view object is broken.

--- a/cli/src/commands/debug/reindex.rs
+++ b/cli/src/commands/debug/reindex.rs
@@ -24,12 +24,12 @@ use crate::ui::Ui;
 
 /// Rebuild commit index
 #[derive(clap::Args, Clone, Debug)]
-pub struct ReindexArgs {}
+pub struct DebugReindexArgs {}
 
 pub fn cmd_debug_reindex(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &ReindexArgs,
+    _args: &DebugReindexArgs,
 ) -> Result<(), CommandError> {
     // Resolve the operation without loading the repo. The index might have to
     // be rebuilt while loading the repo.

--- a/cli/src/commands/debug/revset.rs
+++ b/cli/src/commands/debug/revset.rs
@@ -25,14 +25,14 @@ use crate::ui::Ui;
 
 /// Evaluate revset to full commit IDs
 #[derive(clap::Args, Clone, Debug)]
-pub struct RevsetArgs {
+pub struct DebugRevsetArgs {
     revision: String,
 }
 
 pub fn cmd_debug_revset(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &RevsetArgs,
+    args: &DebugRevsetArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let workspace_ctx = workspace_command.revset_parse_context();

--- a/cli/src/commands/debug/snapshot.rs
+++ b/cli/src/commands/debug/snapshot.rs
@@ -20,12 +20,12 @@ use crate::ui::Ui;
 
 /// Trigger a snapshot in the op log
 #[derive(clap::Args, Clone, Debug)]
-pub struct SnapshotArgs {}
+pub struct DebugSnapshotArgs {}
 
 pub fn cmd_debug_snapshot(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &SnapshotArgs,
+    _args: &DebugSnapshotArgs,
 ) -> Result<(), CommandError> {
     // workspace helper will snapshot as needed
     command.workspace_helper(ui)?;

--- a/cli/src/commands/debug/template.rs
+++ b/cli/src/commands/debug/template.rs
@@ -22,14 +22,14 @@ use crate::ui::Ui;
 
 /// Parse a template
 #[derive(clap::Args, Clone, Debug)]
-pub struct TemplateArgs {
+pub struct DebugTemplateArgs {
     template: String,
 }
 
 pub fn cmd_debug_template(
     ui: &mut Ui,
     _command: &CommandHelper,
-    args: &TemplateArgs,
+    args: &DebugTemplateArgs,
 ) -> Result<(), CommandError> {
     let node = template_parser::parse_template(&args.template)?;
     writeln!(ui.stdout(), "{node:#?}")?;

--- a/cli/src/commands/debug/tree.rs
+++ b/cli/src/commands/debug/tree.rs
@@ -26,7 +26,7 @@ use crate::ui::Ui;
 
 /// List the recursive entries of a tree.
 #[derive(clap::Args, Clone, Debug)]
-pub struct TreeArgs {
+pub struct DebugTreeArgs {
     #[arg(long, short = 'r')]
     revision: Option<RevisionArg>,
     #[arg(long, conflicts_with = "revision")]
@@ -40,7 +40,7 @@ pub struct TreeArgs {
 pub fn cmd_debug_tree(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &TreeArgs,
+    args: &DebugTreeArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let tree = if let Some(tree_id_hex) = &args.id {

--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -25,7 +25,7 @@ use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
 
 #[derive(Subcommand, Clone, Debug)]
-pub enum WatchmanCommand {
+pub enum DebugWatchmanCommand {
     /// Check whether `watchman` is enabled and whether it's correctly installed
     Status,
     QueryClock,
@@ -37,14 +37,14 @@ pub enum WatchmanCommand {
 pub fn cmd_debug_watchman(
     ui: &mut Ui,
     command: &CommandHelper,
-    subcommand: &WatchmanCommand,
+    subcommand: &DebugWatchmanCommand,
 ) -> Result<(), CommandError> {
     use jj_lib::local_working_copy::LockedLocalWorkingCopy;
 
     let mut workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo().clone();
     match subcommand {
-        WatchmanCommand::Status => {
+        DebugWatchmanCommand::Status => {
             // TODO(ilyagr): It would be nice to add colors here
             let config = match command.settings().fsmonitor_settings()? {
                 FsmonitorSettings::Watchman(config) => {
@@ -93,17 +93,17 @@ pub fn cmd_debug_watchman(
                 }
             )?;
         }
-        WatchmanCommand::QueryClock => {
+        DebugWatchmanCommand::QueryClock => {
             let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
             let (clock, _changed_files) = wc.query_watchman(&WatchmanConfig::default())?;
             writeln!(ui.stdout(), "Clock: {clock:?}")?;
         }
-        WatchmanCommand::QueryChangedFiles => {
+        DebugWatchmanCommand::QueryChangedFiles => {
             let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
             let (_clock, changed_files) = wc.query_watchman(&WatchmanConfig::default())?;
             writeln!(ui.stdout(), "Changed files: {changed_files:?}")?;
         }
-        WatchmanCommand::ResetClock => {
+        DebugWatchmanCommand::ResetClock => {
             let (mut locked_ws, _commit) = workspace_command.start_working_copy_mutation()?;
             let Some(locked_local_wc): Option<&mut LockedLocalWorkingCopy> =
                 locked_ws.locked_wc().as_any_mut().downcast_mut()
@@ -124,7 +124,7 @@ pub fn cmd_debug_watchman(
 pub fn cmd_debug_watchman(
     _ui: &mut Ui,
     _command: &CommandHelper,
-    _subcommand: &WatchmanCommand,
+    _subcommand: &DebugWatchmanCommand,
 ) -> Result<(), CommandError> {
     Err(user_error(
         "Cannot query Watchman because jj was not compiled with the `watchman` feature",

--- a/cli/src/commands/debug/working_copy.rs
+++ b/cli/src/commands/debug/working_copy.rs
@@ -21,12 +21,12 @@ use crate::ui::Ui;
 
 /// Show information about the working copy state
 #[derive(clap::Args, Clone, Debug)]
-pub struct WorkingCopyArgs {}
+pub struct DebugWorkingCopyArgs {}
 
 pub fn cmd_debug_working_copy(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &WorkingCopyArgs,
+    _args: &DebugWorkingCopyArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper_no_snapshot(ui)?;
     let wc = workspace_command.working_copy();

--- a/cli/src/commands/file/chmod.rs
+++ b/cli/src/commands/file/chmod.rs
@@ -37,7 +37,7 @@ enum ChmodMode {
 /// Unlike the POSIX `chmod`, `jj file chmod` also works on Windows, on
 /// conflicted files, and on arbitrary revisions.
 #[derive(clap::Args, Clone, Debug)]
-pub(crate) struct ChmodArgs {
+pub(crate) struct FileChmodArgs {
     mode: ChmodMode,
     /// The revision to update
     #[arg(long, short, default_value = "@")]
@@ -51,7 +51,7 @@ pub(crate) struct ChmodArgs {
 pub(crate) fn deprecated_cmd_chmod(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &ChmodArgs,
+    args: &FileChmodArgs,
 ) -> Result<(), CommandError> {
     writeln!(
         ui.warning_default(),
@@ -61,14 +61,14 @@ pub(crate) fn deprecated_cmd_chmod(
         ui.warning_default(),
         "`jj chmod` will be removed in a future version, and this will be a hard error"
     )?;
-    cmd_chmod(ui, command, args)
+    cmd_file_chmod(ui, command, args)
 }
 
 #[instrument(skip_all)]
-pub(crate) fn cmd_chmod(
+pub(crate) fn cmd_file_chmod(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &ChmodArgs,
+    args: &FileChmodArgs,
 ) -> Result<(), CommandError> {
     let executable_bit = match args.mode {
         ChmodMode::Executable => true,

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -22,7 +22,7 @@ use crate::ui::Ui;
 
 /// List files in a revision
 #[derive(clap::Args, Clone, Debug)]
-pub(crate) struct ListArgs {
+pub(crate) struct FileListArgs {
     /// The revision to list files in
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,
@@ -35,7 +35,7 @@ pub(crate) struct ListArgs {
 pub(crate) fn deprecated_cmd_files(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &ListArgs,
+    args: &FileListArgs,
 ) -> Result<(), CommandError> {
     writeln!(
         ui.warning_default(),
@@ -45,14 +45,14 @@ pub(crate) fn deprecated_cmd_files(
         ui.warning_default(),
         "`jj files` will be removed in a future version, and this will be a hard error"
     )?;
-    cmd_list(ui, command, args)
+    cmd_file_list(ui, command, args)
 }
 
 #[instrument(skip_all)]
-pub(crate) fn cmd_list(
+pub(crate) fn cmd_file_list(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &ListArgs,
+    args: &FileListArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision)?;

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -23,9 +23,9 @@ use crate::ui::Ui;
 /// File operations.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum FileCommand {
-    Chmod(chmod::ChmodArgs),
-    List(list::ListArgs),
-    Show(show::ShowArgs),
+    Chmod(chmod::FileChmodArgs),
+    List(list::FileListArgs),
+    Show(show::FileShowArgs),
 }
 
 pub fn cmd_file(
@@ -34,8 +34,8 @@ pub fn cmd_file(
     subcommand: &FileCommand,
 ) -> Result<(), CommandError> {
     match subcommand {
-        FileCommand::Chmod(args) => chmod::cmd_chmod(ui, command, args),
-        FileCommand::List(args) => list::cmd_list(ui, command, args),
-        FileCommand::Show(args) => show::cmd_show(ui, command, args),
+        FileCommand::Chmod(args) => chmod::cmd_file_chmod(ui, command, args),
+        FileCommand::List(args) => list::cmd_file_list(ui, command, args),
+        FileCommand::Show(args) => show::cmd_file_show(ui, command, args),
     }
 }

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -34,7 +34,7 @@ use crate::ui::Ui;
 /// If the given path is a directory, files in the directory will be visited
 /// recursively.
 #[derive(clap::Args, Clone, Debug)]
-pub(crate) struct ShowArgs {
+pub(crate) struct FileShowArgs {
     /// The revision to get the file contents from
     #[arg(long, short, default_value = "@")]
     revision: RevisionArg,
@@ -47,7 +47,7 @@ pub(crate) struct ShowArgs {
 pub(crate) fn deprecated_cmd_cat(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &ShowArgs,
+    args: &FileShowArgs,
 ) -> Result<(), CommandError> {
     writeln!(
         ui.warning_default(),
@@ -57,14 +57,14 @@ pub(crate) fn deprecated_cmd_cat(
         ui.warning_default(),
         "`jj cat` will be removed in a future version, and this will be a hard error"
     )?;
-    cmd_show(ui, command, args)
+    cmd_file_show(ui, command, args)
 }
 
 #[instrument(skip_all)]
-pub(crate) fn cmd_show(
+pub(crate) fn cmd_file_show(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &ShowArgs,
+    args: &FileShowArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(&args.revision)?;

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -31,7 +31,7 @@ use crate::ui::Ui;
 ///
 /// The Git repo will be a bare git repo stored inside the `.jj/` directory.
 #[derive(clap::Args, Clone, Debug)]
-pub struct CloneArgs {
+pub struct GitCloneArgs {
     /// URL or path of the Git repo to clone
     #[arg(value_hint = clap::ValueHint::DirPath)]
     source: String,
@@ -79,7 +79,7 @@ fn is_empty_dir(path: &Path) -> bool {
 pub fn cmd_git_clone(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &CloneArgs,
+    args: &GitCloneArgs,
 ) -> Result<(), CommandError> {
     let remote_name = "origin";
     let source = absolute_git_source(command.cwd(), &args.source);

--- a/cli/src/commands/git/export.rs
+++ b/cli/src/commands/git/export.rs
@@ -21,12 +21,12 @@ use crate::ui::Ui;
 
 /// Update the underlying Git repo with changes made in the repo
 #[derive(clap::Args, Clone, Debug)]
-pub struct ExportArgs {}
+pub struct GitExportArgs {}
 
 pub fn cmd_git_export(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &ExportArgs,
+    _args: &GitExportArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -29,7 +29,7 @@ use crate::ui::Ui;
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 #[derive(clap::Args, Clone, Debug)]
-pub struct FetchArgs {
+pub struct GitFetchArgs {
     /// Fetch only some of the branches
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
@@ -49,7 +49,7 @@ pub struct FetchArgs {
 pub fn cmd_git_fetch(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &FetchArgs,
+    args: &GitFetchArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let git_repo = get_git_repo(workspace_command.repo().store())?;

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -24,12 +24,12 @@ use crate::ui::Ui;
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 #[derive(clap::Args, Clone, Debug)]
-pub struct ImportArgs {}
+pub struct GitImportArgs {}
 
 pub fn cmd_git_import(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &ImportArgs,
+    _args: &GitImportArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -30,7 +30,7 @@ use crate::ui::Ui;
 
 /// Create a new Git backed repo.
 #[derive(clap::Args, Clone, Debug)]
-pub struct InitArgs {
+pub struct GitInitArgs {
     /// The destination directory where the `jj` repo will be created.
     /// If the directory does not exist, it will be created.
     /// If no directory is given, the current directory is used.
@@ -67,7 +67,7 @@ pub struct InitArgs {
 pub fn cmd_git_init(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &InitArgs,
+    args: &GitInitArgs,
 ) -> Result<(), CommandError> {
     let cwd = command.cwd();
     let wc_path = cwd.join(&args.destination);

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -23,14 +23,14 @@ pub mod submodule;
 
 use clap::Subcommand;
 
-use self::clone::{cmd_git_clone, CloneArgs};
-use self::export::{cmd_git_export, ExportArgs};
-use self::fetch::{cmd_git_fetch, FetchArgs};
-use self::import::{cmd_git_import, ImportArgs};
-use self::init::{cmd_git_init, InitArgs};
-use self::push::{cmd_git_push, PushArgs};
+use self::clone::{cmd_git_clone, GitCloneArgs};
+use self::export::{cmd_git_export, GitExportArgs};
+use self::fetch::{cmd_git_fetch, GitFetchArgs};
+use self::import::{cmd_git_import, GitImportArgs};
+use self::init::{cmd_git_init, GitInitArgs};
+use self::push::{cmd_git_push, GitPushArgs};
 use self::remote::{cmd_git_remote, RemoteCommand};
-use self::submodule::{cmd_git_submodule, SubmoduleCommand};
+use self::submodule::{cmd_git_submodule, GitSubmoduleCommand};
 use crate::cli_util::{CommandHelper, WorkspaceCommandHelper};
 use crate::command_error::{
     user_error, user_error_with_hint, user_error_with_message, CommandError,
@@ -43,16 +43,16 @@ use crate::ui::Ui;
 /// https://github.com/martinvonz/jj/blob/main/docs/git-comparison.md.
 #[derive(Subcommand, Clone, Debug)]
 pub enum GitCommand {
-    Clone(CloneArgs),
-    Export(ExportArgs),
-    Fetch(FetchArgs),
-    Import(ImportArgs),
-    Init(InitArgs),
-    Push(PushArgs),
+    Clone(GitCloneArgs),
+    Export(GitExportArgs),
+    Fetch(GitFetchArgs),
+    Import(GitImportArgs),
+    Init(GitInitArgs),
+    Push(GitPushArgs),
     #[command(subcommand)]
     Remote(RemoteCommand),
     #[command(subcommand, hide = true)]
-    Submodule(SubmoduleCommand),
+    Submodule(GitSubmoduleCommand),
 }
 
 pub fn cmd_git(

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -61,7 +61,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(ArgGroup::new("specific").args(&["branch", "change", "revisions"]).multiple(true)))]
 #[command(group(ArgGroup::new("what").args(&["all", "deleted", "tracked"]).conflicts_with("specific")))]
-pub struct PushArgs {
+pub struct GitPushArgs {
     /// The remote to push to (only named remotes are supported)
     #[arg(long)]
     remote: Option<String>,
@@ -123,7 +123,7 @@ enum BranchMoveDirection {
 pub fn cmd_git_push(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &PushArgs,
+    args: &GitPushArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let git_repo = get_git_repo(workspace_command.repo().store())?;

--- a/cli/src/commands/git/remote/add.rs
+++ b/cli/src/commands/git/remote/add.rs
@@ -22,17 +22,17 @@ use crate::ui::Ui;
 
 /// Add a Git remote
 #[derive(clap::Args, Clone, Debug)]
-pub struct AddArgs {
+pub struct GitRemoteAddArgs {
     /// The remote's name
     remote: String,
     /// The remote's URL
     url: String,
 }
 
-pub fn cmd_remote_add(
+pub fn cmd_git_remote_add(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &AddArgs,
+    args: &GitRemoteAddArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();

--- a/cli/src/commands/git/remote/list.rs
+++ b/cli/src/commands/git/remote/list.rs
@@ -23,12 +23,12 @@ use crate::ui::Ui;
 
 /// List Git remotes
 #[derive(clap::Args, Clone, Debug)]
-pub struct ListArgs {}
+pub struct GitRemoteListArgs {}
 
-pub fn cmd_remote_list(
+pub fn cmd_git_remote_list(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &ListArgs,
+    _args: &GitRemoteListArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();

--- a/cli/src/commands/git/remote/mod.rs
+++ b/cli/src/commands/git/remote/mod.rs
@@ -20,11 +20,11 @@ pub mod set_url;
 
 use clap::Subcommand;
 
-use self::add::{cmd_remote_add, AddArgs};
-use self::list::{cmd_remote_list, ListArgs};
-use self::remove::{cmd_remote_remove, RemoveArgs};
-use self::rename::{cmd_remote_rename, RenameArgs};
-use self::set_url::{cmd_remote_set_url, SetUrlArgs};
+use self::add::{cmd_git_remote_add, GitRemoteAddArgs};
+use self::list::{cmd_git_remote_list, GitRemoteListArgs};
+use self::remove::{cmd_git_remote_remove, GitRemoteRemoveArgs};
+use self::rename::{cmd_git_remote_rename, GitRemoteRenameArgs};
+use self::set_url::{cmd_git_remote_set_url, GitRemoteSetUrlArgs};
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
@@ -34,11 +34,11 @@ use crate::ui::Ui;
 /// The Git repo will be a bare git repo stored inside the `.jj/` directory.
 #[derive(Subcommand, Clone, Debug)]
 pub enum RemoteCommand {
-    Add(AddArgs),
-    List(ListArgs),
-    Remove(RemoveArgs),
-    Rename(RenameArgs),
-    SetUrl(SetUrlArgs),
+    Add(GitRemoteAddArgs),
+    List(GitRemoteListArgs),
+    Remove(GitRemoteRemoveArgs),
+    Rename(GitRemoteRenameArgs),
+    SetUrl(GitRemoteSetUrlArgs),
 }
 
 pub fn cmd_git_remote(
@@ -47,10 +47,10 @@ pub fn cmd_git_remote(
     subcommand: &RemoteCommand,
 ) -> Result<(), CommandError> {
     match subcommand {
-        RemoteCommand::Add(args) => cmd_remote_add(ui, command, args),
-        RemoteCommand::List(args) => cmd_remote_list(ui, command, args),
-        RemoteCommand::Remove(args) => cmd_remote_remove(ui, command, args),
-        RemoteCommand::Rename(args) => cmd_remote_rename(ui, command, args),
-        RemoteCommand::SetUrl(args) => cmd_remote_set_url(ui, command, args),
+        RemoteCommand::Add(args) => cmd_git_remote_add(ui, command, args),
+        RemoteCommand::List(args) => cmd_git_remote_list(ui, command, args),
+        RemoteCommand::Remove(args) => cmd_git_remote_remove(ui, command, args),
+        RemoteCommand::Rename(args) => cmd_git_remote_rename(ui, command, args),
+        RemoteCommand::SetUrl(args) => cmd_git_remote_set_url(ui, command, args),
     }
 }

--- a/cli/src/commands/git/remote/remove.rs
+++ b/cli/src/commands/git/remote/remove.rs
@@ -22,15 +22,15 @@ use crate::ui::Ui;
 
 /// Remove a Git remote and forget its branches
 #[derive(clap::Args, Clone, Debug)]
-pub struct RemoveArgs {
+pub struct GitRemoteRemoveArgs {
     /// The remote's name
     remote: String,
 }
 
-pub fn cmd_remote_remove(
+pub fn cmd_git_remote_remove(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &RemoveArgs,
+    args: &GitRemoteRemoveArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();

--- a/cli/src/commands/git/remote/rename.rs
+++ b/cli/src/commands/git/remote/rename.rs
@@ -22,17 +22,17 @@ use crate::ui::Ui;
 
 /// Rename a Git remote
 #[derive(clap::Args, Clone, Debug)]
-pub struct RenameArgs {
+pub struct GitRemoteRenameArgs {
     /// The name of an existing remote
     old: String,
     /// The desired name for `old`
     new: String,
 }
 
-pub fn cmd_remote_rename(
+pub fn cmd_git_remote_rename(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &RenameArgs,
+    args: &GitRemoteRenameArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();

--- a/cli/src/commands/git/remote/set_url.rs
+++ b/cli/src/commands/git/remote/set_url.rs
@@ -22,17 +22,17 @@ use crate::ui::Ui;
 
 /// Set the URL of a Git remote
 #[derive(clap::Args, Clone, Debug)]
-pub struct SetUrlArgs {
+pub struct GitRemoteSetUrlArgs {
     /// The remote's name
     remote: String,
     /// The desired url for `remote`
     url: String,
 }
 
-pub fn cmd_remote_set_url(
+pub fn cmd_git_remote_set_url(
     ui: &mut Ui,
     command: &CommandHelper,
-    args: &SetUrlArgs,
+    args: &GitRemoteSetUrlArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();

--- a/cli/src/commands/git/submodule.rs
+++ b/cli/src/commands/git/submodule.rs
@@ -26,7 +26,7 @@ use crate::ui::Ui;
 
 /// FOR INTERNAL USE ONLY Interact with git submodules
 #[derive(Subcommand, Clone, Debug)]
-pub enum SubmoduleCommand {
+pub enum GitSubmoduleCommand {
     /// Print the relevant contents from .gitmodules. For debugging purposes
     /// only.
     PrintGitmodules(PrintArgs),
@@ -35,10 +35,10 @@ pub enum SubmoduleCommand {
 pub fn cmd_git_submodule(
     ui: &mut Ui,
     command: &CommandHelper,
-    subcommand: &SubmoduleCommand,
+    subcommand: &GitSubmoduleCommand,
 ) -> Result<(), CommandError> {
     match subcommand {
-        SubmoduleCommand::PrintGitmodules(args) => cmd_submodule_print(ui, command, args),
+        GitSubmoduleCommand::PrintGitmodules(args) => cmd_submodule_print(ui, command, args),
     }
 }
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -76,11 +76,11 @@ enum Command {
     #[command(subcommand)]
     Branch(branch::BranchCommand),
     #[command(alias = "print", hide = true)]
-    Cat(file::show::ShowArgs),
+    Cat(file::show::FileShowArgs),
     #[command(hide = true)]
     Checkout(checkout::CheckoutArgs),
     #[command(hide = true)]
-    Chmod(file::chmod::ChmodArgs),
+    Chmod(file::chmod::FileChmodArgs),
     Commit(commit::CommitArgs),
     #[command(subcommand)]
     Config(config::ConfigCommand),
@@ -95,7 +95,7 @@ enum Command {
     File(file::FileCommand),
     /// List files in a revision (DEPRECATED use `jj file list`)
     #[command(hide = true)]
-    Files(file::list::ListArgs),
+    Files(file::list::FileListArgs),
     Fix(fix::FixArgs),
     #[command(subcommand)]
     Git(git::GitCommand),


### PR DESCRIPTION
Now, the command for `jj git remote add` is `cmd_git_remote_add` and its argument type is `GitRemoteAddArgs`. This should make it easier to find the CLI docs and the implementation for commands.

This is how `jj branch` commands were already set up in this way. The `jj op` commands were also already set up in this way, except the functions are called e.g. `cmd_op_undo`, I kept this for simplicity.

I was mainly motivated by the `jj file` commands. Most other commands had functions already named in the above pattern, but used to have shorter argument type names.


# Checklist

If applicable:
- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (README.md, docs/, demos/)
- n/a I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
