### PR TITLE
lib id_prefix: look for divergent changes outside short prefix set 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to-be-pushed commit has conflicts, or has no description / committer / author
   set. [#3029](https://github.com/martinvonz/jj/issues/3029)
 
+* `jj` will look for divergent changes outside the short prefix set even if it finds the change id inside the short prefix set. [#2476](https://github.com/martinvonz/jj/issues/2476)
+
 ## [0.18.0] - 2024-06-05
 
 ### Breaking changes

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -365,12 +365,19 @@ fn test_id_prefix_divergent() {
         c.shortest_change_prefix_len(repo.as_ref(), second_commit.change_id()),
         1
     );
-    // Short prefix does not find the first commit (as intended).
-    // TODO(#2476): BUG: Looking up the divergent commits by their change id prefix
-    // only finds the id within the lookup set.
+    // This tests two issues, both important:
+    // - We find both commits with the same change id, even though
+    // `third_commit_divergent_with_second` is not in the short prefix set
+    // (#2476).
+    // - The short prefix set still works: we do *not* find the first commit and the
+    //   match is not ambiguous, even though the first commit's change id would also
+    //   match the prefix.
     assert_eq!(
         c.resolve_change_prefix(repo.as_ref(), &prefix("a")),
-        SingleMatch(vec![second_commit.id().clone()])
+        SingleMatch(vec![
+            second_commit.id().clone(),
+            third_commit_divergent_with_second.id().clone()
+        ])
     );
 
     // We can still resolve commits outside the set


### PR DESCRIPTION
Fixes https://github.com/martinvonz/jj/issues/2476.

Previously, if there was a change id match within the short prefix
lookup set, `jj` would not look for commits with that same change id
outside the short prefix set. So, it wouldn't find the conflicted
commits for a commit with a divergent (AKA conflicted) change id.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- n/a I have updated the documentation (README.md, docs/, demos/)
- n/a I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
