### PR TITLE
str_util: support case‐insensitive string patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj git clone some/nested/path` now creates the full directory tree for 
    nested destination paths if they don't exist.
 
+* String patterns now support case‐insensitive matching by suffixing any
+  pattern kind with `-i`. `mine()` uses case‐insensitive matching on your email
+  address unconditionally. Only ASCII case folding is currently implemented,
+  but this will likely change in the future.
+
 ### Fixed bugs
 
 ## [0.19.0] - 2024-07-03

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -552,7 +552,7 @@ fn find_branches_targeted_by_revisions<'a>(
         };
         let current_branches_expression = RevsetExpression::remote_branches(
             StringPattern::everything(),
-            StringPattern::Exact(remote_name.to_owned()),
+            StringPattern::exact(remote_name),
         )
         .range(&RevsetExpression::commit(wc_commit_id))
         .intersection(&RevsetExpression::branches(StringPattern::everything()));

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -333,6 +333,9 @@ Functions that perform string matching support the following pattern syntax:
 * `glob:"pattern"`: Matches strings with Unix-style shell [wildcard
   `pattern`](https://docs.rs/glob/latest/glob/struct.Pattern.html).
 
+You can append `-i` after the kind to match case‐insensitively (e.g.
+`glob-i:"fix*jpeg*"`).
+
 ## Aliases
 
 New symbols and functions can be defined in the config file, by using any

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1052,8 +1052,7 @@ fn build_predicate_fn(
         RevsetFilterPredicate::Author(pattern) => {
             let pattern = pattern.clone();
             // TODO: Make these functions that take a needle to search for accept some
-            // syntax for specifying whether it's a regex and whether it's
-            // case-sensitive.
+            // syntax for specifying whether it's a regex.
             box_pure_predicate_fn(move |index, pos| {
                 let entry = index.entry_by_pos(pos);
                 let commit = store.get_commit(&entry.commit_id()).unwrap();

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -125,11 +125,11 @@ pub trait RevsetFilterExtension: std::fmt::Debug + Any {
 pub enum RevsetFilterPredicate {
     /// Commits with number of parents in the range.
     ParentCount(Range<u32>),
-    /// Commits with description containing the needle.
+    /// Commits with description matching the pattern.
     Description(StringPattern),
-    /// Commits with author's name or email containing the needle.
+    /// Commits with author name or email matching the pattern.
     Author(StringPattern),
-    /// Commits with committer's name or email containing the needle.
+    /// Commits with committer name or email matching the pattern.
     Committer(StringPattern),
     /// Commits modifying the paths specified by the fileset.
     File(FilesetExpression),

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2395,7 +2395,7 @@ fn test_evaluate_expression_author() {
         vec![commit2.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, "author(\"name3\")"),
+        resolve_commit_ids(mut_repo, "author(\"email3\")"),
         vec![commit3.id().clone()]
     );
     // Searches only among candidates if specified
@@ -2536,7 +2536,7 @@ fn test_evaluate_expression_committer() {
         vec![commit2.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, "committer(\"name3\")"),
+        resolve_commit_ids(mut_repo, "committer(\"email3\")"),
         vec![commit3.id().clone()]
     );
     // Searches only among candidates if specified

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2007,7 +2007,11 @@ fn test_evaluate_expression_branches() {
         vec![commit1.id().clone()]
     );
     assert_eq!(
-        resolve_commit_ids(mut_repo, r#"branches(glob:"branch?")"#),
+        resolve_commit_ids(mut_repo, r#"branches(glob:"Branch?")"#),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, r#"branches(glob-i:"Branch?")"#),
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     // Can silently resolve to an empty set if there's no matches
@@ -2398,6 +2402,15 @@ fn test_evaluate_expression_author() {
         resolve_commit_ids(mut_repo, "author(\"email3\")"),
         vec![commit3.id().clone()]
     );
+    // Can match case‐insensitively
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "author(substring-i:Name)"),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+        ]
+    );
     // Searches only among candidates if specified
     assert_eq!(
         resolve_commit_ids(mut_repo, "visible_heads() & author(\"name2\")"),
@@ -2452,7 +2465,8 @@ fn test_evaluate_expression_mine() {
         .set_parents(vec![commit2.id().clone()])
         .set_author(Signature {
             name: "name3".to_string(),
-            email: settings.user_email(),
+            // Test that matches are case‐insensitive
+            email: settings.user_email().to_ascii_uppercase(),
             timestamp,
         })
         .write()
@@ -2538,6 +2552,15 @@ fn test_evaluate_expression_committer() {
     assert_eq!(
         resolve_commit_ids(mut_repo, "committer(\"email3\")"),
         vec![commit3.id().clone()]
+    );
+    // Can match case‐insensitively
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "committer(substring-i:Name)"),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+        ]
     );
     // Searches only among candidates if specified
     assert_eq!(

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2443,7 +2443,7 @@ fn test_evaluate_expression_mine() {
         })
         .write()
         .unwrap();
-    // Can find a unique match by name
+    // Can find a unique match
     assert_eq!(
         resolve_commit_ids(mut_repo, "mine()"),
         vec![commit2.id().clone()]
@@ -2457,7 +2457,7 @@ fn test_evaluate_expression_mine() {
         })
         .write()
         .unwrap();
-    // Can find multiple matches by name
+    // Can find multiple matches
     assert_eq!(
         resolve_commit_ids(mut_repo, "mine()"),
         vec![commit3.id().clone(), commit2.id().clone()]


### PR DESCRIPTION
See the commit message for details. This resolves an old TODO and came up during the rework of https://github.com/martinvonz/jj/pull/3951. ~~I’m not totally sure about the defaults here, but the functionality seems good to have.~~

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
