### PR TITLE
templater: use .map_or() to silence clippy without sacrificing readability

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1027,15 +1027,8 @@ impl RefNamesIndex {
         }
     }
 
-    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
-    #[allow(clippy::manual_unwrap_or_default)]
-    #[allow(clippy::manual_unwrap_or)] // https://github.com/rust-lang/rust-clippy/issues/13018
     pub fn get(&self, id: &CommitId) -> &[Rc<RefName>] {
-        if let Some(names) = self.index.get(id) {
-            names
-        } else {
-            &[]
-        }
+        self.index.get(id).map_or(&[], |names: &Vec<_>| names)
     }
 }
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
