### PR TITLE
fake-editor: replace expectpath with dump-path

### DIFF
--- a/cli/testing/fake-editor.rs
+++ b/cli/testing/fake-editor.rs
@@ -50,18 +50,15 @@ fn main() {
                 let dest_path = edit_script_path.parent().unwrap().join(dest);
                 fs::copy(&args.file, dest_path).unwrap();
             }
+            ["dump-path", dest] => {
+                let dest_path = edit_script_path.parent().unwrap().join(dest);
+                fs::write(&dest_path, args.file.to_str().unwrap())
+                    .unwrap_or_else(|err| panic!("Failed to write file {dest_path:?}: {err}"));
+            }
             ["expect"] => {
                 let actual = String::from_utf8(fs::read(&args.file).unwrap()).unwrap();
                 if actual != payload {
                     eprintln!("fake-editor: Unexpected content.\n");
-                    eprintln!("EXPECTED: <{payload}>\nRECEIVED: <{actual}>");
-                    exit(1)
-                }
-            }
-            ["expectpath"] => {
-                let actual = args.file.to_str().unwrap();
-                if actual != payload {
-                    eprintln!("fake-editor: Unexpected path.\n");
                     eprintln!("EXPECTED: <{payload}>\nRECEIVED: <{actual}>");
                     exit(1)
                 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
+
 use insta::assert_snapshot;
 use itertools::Itertools;
 use regex::Regex;
@@ -621,12 +623,12 @@ fn test_config_edit_user() {
     let repo_path = test_env.env_root().join("repo");
     let edit_script = test_env.set_up_fake_editor();
 
-    std::fs::write(
-        edit_script,
-        format!("expectpath\n{}", test_env.config_path().to_str().unwrap()),
-    )
-    .unwrap();
+    std::fs::write(edit_script, "dump-path path").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["config", "edit", "--user"]);
+
+    let edited_path =
+        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+    assert_eq!(&edited_path, test_env.config_path());
 }
 
 #[test]
@@ -636,15 +638,12 @@ fn test_config_edit_repo() {
     let repo_path = test_env.env_root().join("repo");
     let edit_script = test_env.set_up_fake_editor();
 
-    std::fs::write(
-        edit_script,
-        format!(
-            "expectpath\n{}",
-            repo_path.join(".jj/repo/config.toml").to_str().unwrap()
-        ),
-    )
-    .unwrap();
+    std::fs::write(edit_script, "dump-path path").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["config", "edit", "--repo"]);
+
+    let edited_path =
+        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+    assert_eq!(edited_path, repo_path.join(".jj/repo/config.toml"));
 }
 
 #[test]


### PR DESCRIPTION
This allows us to assert the expected path in the test itself, rather than in the fake editor.

(This will be used for when we de-UNC-ify invocations of the editor, see #3986 for more details.)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
