### PR TITLE
windows: avoid UNC paths in `run_ui_editor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "dirs",
+ "dunce",
  "esl01-renderdag",
  "futures 0.3.30",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ criterion = "0.5.1"
 crossterm = { version = "0.27", default-features = false }
 digest = "0.10.7"
 dirs = "5.0.1"
+dunce = "1.0.4"
 either = "1.13.0"
 esl01-renderdag = "0.3.0"
 futures = "0.3.30"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,6 +61,7 @@ config = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossterm = { workspace = true }
 dirs = { workspace = true }
+dunce = { workspace = true }
 esl01-renderdag = { workspace = true }
 futures = { workspace = true }
 git2 = { workspace = true }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2137,7 +2137,10 @@ pub fn get_new_config_file_path(
     Ok(edit_path)
 }
 
-pub fn run_ui_editor(settings: &UserSettings, edit_path: &PathBuf) -> Result<(), CommandError> {
+pub fn run_ui_editor(settings: &UserSettings, edit_path: &Path) -> Result<(), CommandError> {
+    // Work around UNC paths not being well supported on Windows (no-op for
+    // non-Windows): https://github.com/martinvonz/jj/issues/3986
+    let edit_path = dunce::simplified(edit_path);
     let editor: CommandNameAndArgs = settings
         .config()
         .get("ui.editor")

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -628,7 +628,7 @@ fn test_config_edit_user() {
 
     let edited_path =
         PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
-    assert_eq!(&edited_path, test_env.config_path());
+    assert_eq!(edited_path, dunce::simplified(test_env.config_path()));
 }
 
 #[test]
@@ -643,7 +643,10 @@ fn test_config_edit_repo() {
 
     let edited_path =
         PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
-    assert_eq!(edited_path, repo_path.join(".jj/repo/config.toml"));
+    assert_eq!(
+        edited_path,
+        dunce::simplified(&repo_path.join(".jj/repo/config.toml"))
+    );
 }
 
 #[test]

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::common::TestEnvironment;
 
@@ -430,6 +430,32 @@ fn test_move_description() {
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
     source
     "###);
+}
+
+#[test]
+fn test_move_description_editor_avoids_unc() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let edit_script = test_env.set_up_fake_editor();
+    std::fs::write(repo_path.join("file1"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "a\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file1"), "b\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "b\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "destination"]);
+    test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "source"]);
+
+    std::fs::write(edit_script, "dump-path path").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["move", "--to", "@-"]);
+
+    let edited_path =
+        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+    // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
+    // cases, it fails when it is not safe to strip the prefix, such as paths
+    // over 260 chars.
+    assert_eq!(edited_path, dunce::simplified(&edited_path));
 }
 
 fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> String {

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::common::TestEnvironment;
 
@@ -311,6 +311,32 @@ fn test_unsquash_description() {
     insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
     destination
     "###);
+}
+
+#[test]
+fn test_unsquash_description_editor_avoids_unc() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let edit_script = test_env.set_up_fake_editor();
+    std::fs::write(repo_path.join("file1"), "a\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "a\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    std::fs::write(repo_path.join("file1"), "b\n").unwrap();
+    std::fs::write(repo_path.join("file2"), "b\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "destination"]);
+    test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "source"]);
+
+    std::fs::write(edit_script, "dump-path path").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
+
+    let edited_path =
+        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+    // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
+    // cases, it fails when it is not safe to strip the prefix, such as paths
+    // over 260 chars.
+    assert_eq!(edited_path, dunce::simplified(&edited_path));
 }
 
 fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> String {


### PR DESCRIPTION
~~**This PR depends on #3995. Please only review the last commit until that PR has been merged.**~~

See https://github.com/martinvonz/jj/issues/3986 for more details. This is a no-op for non-Windows.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

