### PR TITLE
commit: add `--reset-author` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commits with no description) if authored by the current user.
   [#2000](https://github.com/martinvonz/jj/issues/2000)
 
+* `jj commit` now accepts `--reset-author` option to match `jj describe`.
+
 ### Fixed bugs
 
 * `jj git push` now ignores immutable commits when checking whether a

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -437,6 +437,13 @@ Update the description and create a new change on top
 * `-i`, `--interactive` — Interactively choose which changes to include in the first commit
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
+* `--reset-author` — Reset the author to the configured user
+
+   This resets the author name, email, and timestamp.
+
+   You can use it in combination with the JJ_USER and JJ_EMAIL environment variables to set a different author:
+
+   $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj commit --reset-author
 
 
 


### PR DESCRIPTION
Since `jj describe --reset-author` works, I also expected `jj commit --reset-author` to work, so I think this would be a good option to add.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
