### PR TITLE
workspace add: add filename context to FS error

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -206,6 +206,12 @@ impl From<io::Error> for CommandError {
     }
 }
 
+impl From<jj_lib::file_util::PathError> for CommandError {
+    fn from(err: jj_lib::file_util::PathError) -> Self {
+        user_error(err)
+    }
+}
+
 impl From<config::ConfigError> for CommandError {
     fn from(err: config::ConfigError) -> Self {
         config_error(err)

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -21,6 +21,7 @@ use clap::Subcommand;
 use itertools::Itertools;
 use jj_lib::commit::CommitIteratorExt;
 use jj_lib::file_util;
+use jj_lib::file_util::IoResultExt;
 use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::{OpStoreError, WorkspaceId};
 use jj_lib::operation::Operation;
@@ -137,7 +138,7 @@ fn cmd_workspace_add(
     if destination_path.exists() {
         return Err(user_error("Workspace already exists"));
     } else {
-        fs::create_dir(&destination_path).unwrap();
+        fs::create_dir(&destination_path).context(&destination_path)?;
     }
     let name = if let Some(name) = &args.name {
         name.to_string()

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -31,7 +31,7 @@ pub struct PathError {
     pub error: io::Error,
 }
 
-pub(crate) trait IoResultExt<T> {
+pub trait IoResultExt<T> {
     fn context(self, path: impl AsRef<Path>) -> Result<T, PathError>;
 }
 


### PR DESCRIPTION
At work, a user encountered a panic upon attempting to create a dir at the line in the diff below, but it turned out to be difficult to debug because I didn't know what the path was. There already is a mechanism to add path context in the lib crate; make it available in the cli crate as well, and use the mechanism to add path context to "workspace add".

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
