### PR TITLE
diff: highlight word-level changes in git diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   individually instead of being passed a directory by setting
   `merge-tools.$TOOL.diff-invocation-mode="file-by-file"` in config.toml.
 
+* In git diffs, word-level hunks are now highlighted with underline. See [diff
+  colors and styles](docs/config.md#diff-colors-and-styles) for customization.
+
 * `jj git clone` and `jj git init` with an existing git repository adds the
   default branch of the remote as repository settings for
   `revset-aliases."trunk()"`.`

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -903,26 +903,15 @@ fn show_unified_diff_hunks(
             hunk.right_line_range.len()
         )?;
         for (line_type, content) in hunk.lines {
-            match line_type {
-                DiffLineType::Context => {
-                    formatter.with_label("context", |formatter| {
-                        write!(formatter, " ")?;
-                        formatter.write_all(content)
-                    })?;
-                }
-                DiffLineType::Removed => {
-                    formatter.with_label("removed", |formatter| {
-                        write!(formatter, "-")?;
-                        formatter.write_all(content)
-                    })?;
-                }
-                DiffLineType::Added => {
-                    formatter.with_label("added", |formatter| {
-                        write!(formatter, "+")?;
-                        formatter.write_all(content)
-                    })?;
-                }
-            }
+            let (label, sigil) = match line_type {
+                DiffLineType::Context => ("context", " "),
+                DiffLineType::Removed => ("removed", "-"),
+                DiffLineType::Added => ("added", "+"),
+            };
+            formatter.with_label(label, |formatter| {
+                write!(formatter, "{sigil}")?;
+                formatter.write_all(content)
+            })?;
             if !content.ends_with(b"\n") {
                 write!(formatter, "\n\\ No newline at end of file\n")?;
             }

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -140,23 +140,23 @@ fn test_diff_basic() {
     [1m<<diff file_header::--- a/>><<diff file_header::file1>><<diff file_header::>>[0m
     [1m<<diff file_header::+++ /dev/null>>[0m
     [38;5;6m<<diff hunk_header::@@ ->><<diff hunk_header::1>><<diff hunk_header::,>><<diff hunk_header::1>><<diff hunk_header:: +>><<diff hunk_header::1>><<diff hunk_header::,>><<diff hunk_header::0>><<diff hunk_header:: @@>>[39m
-    [38;5;1m<<diff removed::->><<diff removed::foo>>[39m
+    [38;5;1m<<diff removed::->>[4m<<diff removed token::foo>>[24m[39m
     [1m<<diff file_header::diff --git a/>><<diff file_header::file2>><<diff file_header:: b/>><<diff file_header::file2>><<diff file_header::>>[0m
     [1m<<diff file_header::index >><<diff file_header::523a4a9de8>><<diff file_header::...>><<diff file_header::485b56a572>><<diff file_header:: >><<diff file_header::100644>><<diff file_header::>>[0m
     [1m<<diff file_header::--- a/>><<diff file_header::file2>><<diff file_header::>>[0m
     [1m<<diff file_header::+++ b/>><<diff file_header::file2>><<diff file_header::>>[0m
     [38;5;6m<<diff hunk_header::@@ ->><<diff hunk_header::1>><<diff hunk_header::,>><<diff hunk_header::2>><<diff hunk_header:: +>><<diff hunk_header::1>><<diff hunk_header::,>><<diff hunk_header::3>><<diff hunk_header:: @@>>[39m
     <<diff context:: >><<diff context::foo>>
-    [38;5;1m<<diff removed::->><<diff removed::baz qux>>[39m
-    [38;5;2m<<diff added::+>><<diff added::bar>>[39m
-    [38;5;2m<<diff added::+>><<diff added::baz quux>>[39m
+    [38;5;1m<<diff removed::->><<diff removed::baz >>[4m<<diff removed token::qux>>[24m<<diff removed::>>[39m
+    [38;5;2m<<diff added::+>>[4m<<diff added token::bar>>[24m[39m
+    [38;5;2m<<diff added::+>><<diff added::baz >>[4m<<diff added token::quux>>[24m<<diff added::>>[39m
     [1m<<diff file_header::diff --git a/>><<diff file_header::file3>><<diff file_header:: b/>><<diff file_header::file3>><<diff file_header::>>[0m
     [1m<<diff file_header::new file mode >><<diff file_header::100644>><<diff file_header::>>[0m
     [1m<<diff file_header::index 0000000000..>><<diff file_header::257cc5642c>><<diff file_header::>>[0m
     [1m<<diff file_header::--- /dev/null>>[0m
     [1m<<diff file_header::+++ b/>><<diff file_header::file3>><<diff file_header::>>[0m
     [38;5;6m<<diff hunk_header::@@ ->><<diff hunk_header::1>><<diff hunk_header::,>><<diff hunk_header::0>><<diff hunk_header:: +>><<diff hunk_header::1>><<diff hunk_header::,>><<diff hunk_header::1>><<diff hunk_header:: @@>>[39m
-    [38;5;2m<<diff added::+>><<diff added::foo>>[39m
+    [38;5;2m<<diff added::+>>[4m<<diff added token::foo>>[24m[39m
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "--git"]);

--- a/docs/config.md
+++ b/docs/config.md
@@ -168,8 +168,8 @@ ui.default-description = "\n\nTESTED=TODO"
 
 ### Diff colors and styles
 
-In color-words diffs, hunks are rendered with underline. You can override the
-default style with the following keys:
+In color-words and git diffs, word-level hunks are rendered with underline. You
+can override the default style with the following keys:
 
 ```toml
 [colors]


### PR DESCRIPTION
default style:
![image](https://github.com/martinvonz/jj/assets/172069/6d160599-648f-4ffe-b774-c2bf37bcb37d)

with bg color:
![image](https://github.com/martinvonz/jj/assets/172069/1ed9542d-7292-48f3-b547-95aef875e637)


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
