### PR TITLE
diff: stricter uncommon lcs, match up leading/trailing ranges instead

### DIFF
--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -59,13 +59,13 @@ fn test_obslog_with_or_without_diff() {
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     │  Resolved conflict in file1:
-    │     1    1: <<<<<<< Conflict 1 of 1resolved
+    │     1     : <<<<<<< Conflict 1 of 1
     │     2     : %%%%%%% Changes from base to side #1
     │     3     : -foo
     │     4     : +++++++ Contents of side #2
     │     5     : foo
     │     6     : bar
-    │     7     : >>>>>>> Conflict 1 of 1 ends
+    │     7    1: >>>>>>> Conflict 1 of 1 endsresolved
     ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
     ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -178,38 +178,27 @@ pub(crate) fn unchanged_ranges(
     let common_leading_len = iter::zip(left_ranges, right_ranges)
         .take_while(|&(l, r)| left[l.clone()] == right[r.clone()])
         .count();
-    if common_leading_len > 0 {
-        let (left_leading_ranges, left_ranges) = left_ranges.split_at(common_leading_len);
-        let (right_leading_ranges, right_ranges) = right_ranges.split_at(common_leading_len);
-        let mut result = unchanged_ranges(left, right, left_ranges, right_ranges);
-        result.splice(
-            0..0,
-            iter::zip(
-                left_leading_ranges.iter().cloned(),
-                right_leading_ranges.iter().cloned(),
-            ),
-        );
-        return result;
-    }
+    let (left_leading_ranges, left_ranges) = left_ranges.split_at(common_leading_len);
+    let (right_leading_ranges, right_ranges) = right_ranges.split_at(common_leading_len);
 
     // Trim trailing common ranges (i.e. grow next unchanged region)
     let common_trailing_len = iter::zip(left_ranges.iter().rev(), right_ranges.iter().rev())
         .take_while(|&(l, r)| left[l.clone()] == right[r.clone()])
         .count();
-    if common_trailing_len > 0 {
-        let (left_ranges, left_trailing_ranges) =
-            left_ranges.split_at(left_ranges.len() - common_trailing_len);
-        let (right_ranges, right_trailing_ranges) =
-            right_ranges.split_at(right_ranges.len() - common_trailing_len);
-        let mut result = unchanged_ranges(left, right, left_ranges, right_ranges);
-        result.extend(iter::zip(
+    let left_trailing_ranges = &left_ranges[(left_ranges.len() - common_trailing_len)..];
+    let right_trailing_ranges = &right_ranges[(right_ranges.len() - common_trailing_len)..];
+
+    itertools::chain(
+        iter::zip(
+            left_leading_ranges.iter().cloned(),
+            right_leading_ranges.iter().cloned(),
+        ),
+        iter::zip(
             left_trailing_ranges.iter().cloned(),
             right_trailing_ranges.iter().cloned(),
-        ));
-        return result;
-    }
-
-    vec![]
+        ),
+    )
+    .collect()
 }
 
 fn unchanged_ranges_lcs(

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -373,10 +373,20 @@ mod tests {
             ])
         );
         // One side changes a line and adds a block after. The other side just adds the
-        // same block. This currently behaves as one would reasonably hope, but
-        // it's likely that it will change if when we fix
-        // https://github.com/martinvonz/jj/issues/761. Git and Mercurial both duplicate
-        // the block in the result.
+        // same block. You might expect the last block would be deduplicated. However,
+        // the changes in the first side can be parsed as follows:
+        // ```
+        //  a {
+        // -    p
+        // +    q
+        // +}
+        // +
+        // +b {
+        // +    x
+        //  }
+        // ```
+        // Therefore, the first side modifies the block `a { .. }`, and the second side
+        // adds `b { .. }`. Git and Mercurial both duplicate the block in the result.
         assert_eq!(
             merge(
                 &[b"\
@@ -409,6 +419,10 @@ b {
                 b"\
 a {
     q
+}
+
+b {
+    x
 }
 
 b {


### PR DESCRIPTION
The last patch is copied from #763 with a few modifications.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
