### PR TITLE
chore: Allow the aliases map to map to arbitrary types.

### DIFF
--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -552,7 +552,7 @@ pub fn parse_template(template_text: &str) -> TemplateParseResult<ExpressionNode
     }
 }
 
-pub type TemplateAliasesMap = AliasesMap<TemplateAliasParser>;
+pub type TemplateAliasesMap = AliasesMap<TemplateAliasParser, String>;
 
 #[derive(Clone, Debug, Default)]
 pub struct TemplateAliasParser;

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -682,7 +682,7 @@ fn parse_function_call_node(pair: Pair<Rule>) -> Result<FunctionCallNode, Revset
     })
 }
 
-pub type RevsetAliasesMap = AliasesMap<RevsetAliasParser>;
+pub type RevsetAliasesMap = AliasesMap<RevsetAliasParser, String>;
 
 #[derive(Clone, Debug, Default)]
 pub struct RevsetAliasParser;


### PR DESCRIPTION
For #3673, we will have aliases such as:
```toml
'upload(revision)' = [
  ["fix", "-r", "$revision"],
  ["lint", "-r", "$revision"],
  ["git", "push", "-r", "$revision"],
]
```

Which will require aliases to map to `Vec<Vec<String>>`

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [N/A] I have updated `CHANGELOG.md`
- [N/A] I have updated the documentation (README.md, docs/, demos/)
- [N/A] I have updated the config schema (cli/src/config-schema.json)
- [N/A] I have added tests to cover my changes
