### PR TITLE
cli: remove deprecated --allow-large-revsets flag at all

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -51,9 +51,6 @@ pub(crate) struct NewArgs {
     /// The change description to use
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,
-    /// Deprecated. Please prefix the revset with `all:` instead.
-    #[arg(long, short = 'L', hide = true)]
-    allow_large_revsets: bool,
     /// Do not edit the newly created change
     #[arg(long, conflicts_with = "_edit")]
     no_edit: bool,
@@ -84,12 +81,6 @@ pub(crate) fn cmd_new(
     command: &CommandHelper,
     args: &NewArgs,
 ) -> Result<(), CommandError> {
-    if args.allow_large_revsets {
-        return Err(user_error(
-            "--allow-large-revsets has been deprecated.
-Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
-        ));
-    }
     let mut workspace_command = command.workspace_helper(ui)?;
 
     let parent_commits;

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -194,10 +194,6 @@ pub(crate) struct RebaseArgs {
     /// parents.
     #[arg(long, conflicts_with = "revisions")]
     skip_empty: bool,
-
-    /// Deprecated. Please prefix the revset with `all:` instead.
-    #[arg(long, short = 'L', hide = true)]
-    allow_large_revsets: bool,
 }
 
 #[instrument(skip_all)]
@@ -206,13 +202,6 @@ pub(crate) fn cmd_rebase(
     command: &CommandHelper,
     args: &RebaseArgs,
 ) -> Result<(), CommandError> {
-    if args.allow_large_revsets {
-        return Err(user_error(
-            "--allow-large-revsets has been deprecated.
-Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets -d x -d y`.",
-        ));
-    }
-
     let rebase_options = RebaseOptions {
         empty: match args.skip_empty {
             true => EmptyBehaviour::AbandonNewlyEmpty,


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
