### PR TITLE
diff: add headers to file-by-file mode

### DIFF
--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -1282,14 +1282,20 @@ fn test_diff_external_file_by_file_tool() {
     // diff without file patterns
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["diff", config]), @r###"
+
+    JJ (#1 of 3): comparing file1
     ==
     file1
     --
     file1
+
+    JJ (#2 of 3): comparing file2
     ==
     file2
     --
     file2
+
+    JJ (#3 of 3): comparing file3
     ==
     file3
     --
@@ -1299,6 +1305,7 @@ fn test_diff_external_file_by_file_tool() {
     // diff with file patterns
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["diff", config, "file1"]), @r###"
+    JJ (#1 of 1): comparing file1
     ==
     file1
     --
@@ -1309,24 +1316,32 @@ fn test_diff_external_file_by_file_tool() {
         test_env.jj_cmd_success(&repo_path, &["log", "-p", config]), @r###"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 39d9055d
     │  (no description set)
+    │  JJ (#1 of 3): comparing file1
     │  ==
     │  file1
     │  --
     │  file1
+    │
+    │  JJ (#2 of 3): comparing file2
     │  ==
     │  file2
     │  --
     │  file2
+    │
+    │  JJ (#3 of 3): comparing file3
     │  ==
     │  file3
     │  --
     │  file3
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 0ad4ef22
     │  (no description set)
+    │  JJ (#1 of 2): comparing file1
     │  ==
     │  file1
     │  --
     │  file1
+    │
+    │  JJ (#2 of 2): comparing file2
     │  ==
     │  file2
     │  --
@@ -1343,14 +1358,19 @@ fn test_diff_external_file_by_file_tool() {
 
         (no description set)
 
+    JJ (#1 of 3): comparing file1
     ==
     file1
     --
     file1
+
+    JJ (#2 of 3): comparing file2
     ==
     file2
     --
     file2
+
+    JJ (#3 of 3): comparing file3
     ==
     file3
     --


### PR DESCRIPTION
Based on earlier discussion we were undecided about whether external tools in file-by-file mode should have headers.  This change adds them fairly naively.  We probably want to consider more carefully how to handle differences like streamed/TUI/GUI diff tools and waiting for them to finish or doing them in parallel.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
