### PR TITLE
cargo: remove unused `ouroboros` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ maplit = "1.0.2"
 minus = { version = "5.6.1", features = ["dynamic_output", "search"] }
 num_cpus = "1.16.0"
 once_cell = "1.19.0"
-ouroboros = "0.18.0"
 pest = "2.7.11"
 pest_derive = "2.7.11"
 pollster = "0.3.0"


### PR DESCRIPTION
I saw this while looking over the Cargo file and remembered Martin removed usage of this a while back.
