### PR TITLE
workspace: abandon discardable working copy on forget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   default branch of the remote as repository settings for
   `revset-aliases."trunk()"`.`
 
+* `jj workspace forget` now abandons the workspace's working-copy commit if it
+  was empty.
+
 ### Fixed bugs
 
 ## [0.19.0] - 2024-07-03

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -44,7 +44,7 @@ use crate::ui::Ui;
 /// while you're continuing to write code in another workspace.
 ///
 /// Each workspace has its own working-copy commit. When you have more than one
-/// workspace attached to a repo, they are indicated by `@<workspace name>` in
+/// workspace attached to a repo, they are indicated by `<workspace name>@` in
 /// `jj log`.
 ///
 /// Each workspace also has own sparse patterns.

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -260,7 +260,8 @@ fn cmd_workspace_forget(
     // bundle every workspace forget into a single transaction, so that e.g.
     // undo correctly restores all of them at once.
     let mut tx = workspace_command.start_transaction();
-    wss.iter().for_each(|ws| tx.mut_repo().remove_wc_commit(ws));
+    wss.iter()
+        .try_for_each(|ws| tx.mut_repo().remove_wc_commit(ws))?;
     let description = if let [ws] = wss.as_slice() {
         format!("forget workspace {}", ws.as_str())
     } else {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1977,7 +1977,7 @@ Commands for working with workspaces
 
 Workspaces let you add additional working copies attached to the same repo. A common use case is so you can run a slow build or test in one workspace while you're continuing to write code in another workspace.
 
-Each workspace has its own working-copy commit. When you have more than one workspace attached to a repo, they are indicated by `@<workspace name>` in `jj log`.
+Each workspace has its own working-copy commit. When you have more than one workspace attached to a repo, they are indicated by `<workspace name>@` in `jj log`.
 
 Each workspace also has own sparse patterns.
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1290,8 +1290,10 @@ impl MutableRepo {
         Ok(())
     }
 
-    pub fn remove_wc_commit(&mut self, workspace_id: &WorkspaceId) {
+    pub fn remove_wc_commit(&mut self, workspace_id: &WorkspaceId) -> Result<(), EditCommitError> {
+        self.maybe_abandon_wc_commit(workspace_id)?;
         self.view_mut().remove_wc_commit(workspace_id);
+        Ok(())
     }
 
     pub fn check_out(

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -158,7 +158,7 @@ fn test_merge_views_checkout() {
     tx1.mut_repo()
         .set_wc_commit(ws2_id.clone(), commit2.id().clone())
         .unwrap();
-    tx1.mut_repo().remove_wc_commit(&ws4_id);
+    tx1.mut_repo().remove_wc_commit(&ws4_id).unwrap();
     tx1.mut_repo()
         .set_wc_commit(ws5_id.clone(), commit2.id().clone())
         .unwrap();
@@ -176,7 +176,7 @@ fn test_merge_views_checkout() {
     tx2.mut_repo()
         .set_wc_commit(ws4_id.clone(), commit3.id().clone())
         .unwrap();
-    tx2.mut_repo().remove_wc_commit(&ws5_id);
+    tx2.mut_repo().remove_wc_commit(&ws5_id).unwrap();
     tx2.mut_repo()
         .set_wc_commit(ws7_id.clone(), commit3.id().clone())
         .unwrap();


### PR DESCRIPTION
Sometimes I create a temporary workspace and then forget it when I'm done, but currently it leaves behind a working copy commit which I have to manually abandon. I think it would be more convenient if it was abandoned automatically like `jj` already does for discardable commits in other situations.

While working on this, I also noticed that if two workspaces are editing the same discardable commit, it will be abandoned whenever either workspace's working copy moves (and then it is immediately created again, but with a new change ID). I think that working copies should be treated similarly to branches and should also prevent discardable commits from being abandoned like branches do, so I included that change as well since it seems related. I don't feel strongly about this, so if this change isn't necessary I can remove it from the PR.

I also noticed a typo in the docs for `jj workspace`, so I fixed that as well.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
