### PR TITLE
changelog: move "rebase --skip-emptied" entry to unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* `jj rebase --skip-empty` has been renamed to `jj rebase --skip-emptied`
+
 ### Deprecations
 
 ### New features
@@ -39,8 +41,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj branch set` now creates new branch if it doesn't exist. Use `jj branch
   move` to ensure that the target branch already exists.
   [#3584](https://github.com/martinvonz/jj/issues/3584)
-
-* `jj rebase --skip-empty` has been renamed to `jj rebase --skip-emptied`
 
 ### Deprecations
 


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
