### PR TITLE
build: correctly set version hash for merge commits

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -63,6 +63,7 @@ fn get_git_hash() -> Option<String> {
             "--color=never",
             "log",
             "--no-graph",
+            "--limit=1",
             "-r=@-",
             "-T=commit_id",
         ])


### PR DESCRIPTION
I noticed a weird issue while trying to run tests with a working-copy merge commit. The build script concatenated the commit ID hashes of all of the merge commit's parents and put them all together in the version string, which caused `test_global_opts::test_version` to fail since it expects a 40-digit hash.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
