### PR TITLE
revset: update tests to not require private field access to err.kind

### DIFF
--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -116,8 +116,7 @@ impl Rule {
 #[derive(Debug, Error)]
 #[error("{pest_error}")]
 pub struct RevsetParseError {
-    // TODO: move parsing tests to this module and drop pub(super)
-    pub(super) kind: RevsetParseErrorKind,
+    kind: RevsetParseErrorKind,
     pest_error: Box<pest::error::Error<Rule>>,
     source: Option<Box<dyn error::Error + Send + Sync>>,
 }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
