### PR TITLE
cli_util: short-prefixes for commit summary in transaction

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1645,8 +1645,10 @@ impl WorkspaceCommandTransaction<'_> {
         formatter: &mut dyn Formatter,
         commit: &Commit,
     ) -> std::io::Result<()> {
-        // TODO: Use the disambiguation revset
-        let id_prefix_context = IdPrefixContext::new(self.helper.revset_extensions.clone());
+        let id_prefix_context = self
+            .helper
+            .new_id_prefix_context()
+            .expect("parse error should be confined by WorkspaceCommandHelper::new()");
         let language = CommitTemplateLanguage::new(
             self.tx.repo(),
             self.helper.workspace_id(),


### PR DESCRIPTION
I've run into change ID prefixes being 4-5 characters instead of the usual 1-2 characters in commands like `jj duplicate` and `jj split` fairly often, and it seems like this should resolve that. I tried to avoid creating a new `IdPrefixContext` unless changes have already been made in the transaction, since several commands call `tx.format_commit_summary()` before making any changes.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
