### PR TITLE
revset: add tracked/untracked_remote_branches()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   address unconditionally. Only ASCII case folding is currently implemented,
   but this will likely change in the future.
 
+* New `tracked_remote_branches()` and `untracked_remote_branches()` revset
+  functions can be used to select tracked/untracked remote branches.
+
 ### Fixed bugs
 
 ## [0.19.0] - 2024-07-03

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -553,6 +553,7 @@ fn find_branches_targeted_by_revisions<'a>(
         let current_branches_expression = RevsetExpression::remote_branches(
             StringPattern::everything(),
             StringPattern::exact(remote_name),
+            None,
         )
         .range(&RevsetExpression::commit(wc_commit_id))
         .intersection(&RevsetExpression::branches(StringPattern::everything()));

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -217,6 +217,14 @@ revsets (expressions) as arguments.
   While Git-tracking branches can be selected by `<name>@git`, these branches
   aren't included in `remote_branches()`.
 
+* `tracked_remote_branches([branch_pattern[, [remote=]remote_pattern]])`: All
+  targets of tracked remote branches. Supports the same optional arguments as
+  `remote_branches()`.
+
+* `untracked_remote_branches([branch_pattern[, [remote=]remote_pattern]])`:
+  All targets of untracked remote branches. Supports the same optional arguments
+  as `remote_branches()`.
+
 * `tags()`: All tag targets. If a tag is in a conflicted state, all its
   possible targets are included.
 


### PR DESCRIPTION
Mentioned in #3528 and #3529.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
