### PR TITLE
Fix stdout warnings

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1416,7 +1416,7 @@ impl TreeState {
                     }
                 }
                 MaterializedTreeValue::GitSubmodule(_) => {
-                    println!("ignoring git submodule at {path:?}");
+                    eprintln!("ignoring git submodule at {path:?}");
                     FileState::for_gitsubmodule()
                 }
                 MaterializedTreeValue::Tree(_) => {
@@ -1463,7 +1463,7 @@ impl TreeState {
                             panic!("unexpected conflict entry in diff at {path:?}");
                         }
                         TreeValue::GitSubmodule(_id) => {
-                            println!("ignoring git submodule at {path:?}");
+                            eprintln!("ignoring git submodule at {path:?}");
                             FileType::GitSubmodule
                         }
                         TreeValue::Tree(_id) => {

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -66,8 +66,8 @@ impl GpgEnvironment {
         let res = gpg.wait_with_output().unwrap();
 
         if !res.status.success() {
-            println!("Failed to add private key to gpg-agent. Make sure it is running!");
-            println!("{}", String::from_utf8_lossy(&res.stderr));
+            eprintln!("Failed to add private key to gpg-agent. Make sure it is running!");
+            eprintln!("{}", String::from_utf8_lossy(&res.stderr));
             return Err(res);
         }
 


### PR DESCRIPTION

This PR fixes warnings ending up on stdout.

As suggested by @crackcomm on discord, use eprintln!() to print warnings
to avoid messing up template output, e.g.:
    
    jj --no-pager --ignore-working-copy show --tool true -T change_id -r rv...
    rv...ignoring git submodule at "some/submodule"

