### PR TITLE
revset: parse file() argument as fileset expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `tracked_remote_branches()` and `untracked_remote_branches()` revset
   functions can be used to select tracked/untracked remote branches.
 
+* The `file()` revset function now accepts fileset as argument.
+
 ### Fixed bugs
 
 ## [0.19.0] - 2024-07-03

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -140,42 +140,61 @@ fn test_bad_function_call() {
       = Function "file": Expected at least 1 arguments
     "###);
 
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "file(a, not@a-string)"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "file(not::a-fileset)"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Failed to parse revset: Expected expression of file pattern
-    Caused by:  --> 1:9
+    Error: Failed to parse revset: Invalid fileset expression
+    Caused by:
+    1:  --> 1:6
       |
-    1 | file(a, not@a-string)
-      |         ^----------^
+    1 | file(not::a-fileset)
+      |      ^------------^
       |
-      = Expected expression of file pattern
+      = Invalid fileset expression
+    2:  --> 1:5
+      |
+    1 | not::a-fileset
+      |     ^---
+      |
+      = expected <identifier>, <string_literal>, or <raw_string_literal>
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"file(foo:"bar")"#]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Failed to parse revset: Invalid file pattern
+    Error: Failed to parse revset: Invalid fileset expression
     Caused by:
     1:  --> 1:6
       |
     1 | file(foo:"bar")
       |      ^-------^
       |
+      = Invalid fileset expression
+    2:  --> 1:1
+      |
+    1 | foo:"bar"
+      | ^-------^
+      |
       = Invalid file pattern
-    2: Invalid file pattern kind "foo:"
+    3: Invalid file pattern kind "foo:"
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"file(a, "../out")"#]);
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Error: Failed to parse revset: Invalid file pattern
+    Error: Failed to parse revset: Invalid fileset expression
     Caused by:
     1:  --> 1:9
       |
     1 | file(a, "../out")
       |         ^------^
       |
+      = Invalid fileset expression
+    2:  --> 1:1
+      |
+    1 | "../out"
+      | ^------^
+      |
       = Invalid file pattern
-    2: Path "../out" is not in the repo "."
-    3: Invalid component ".." in repo-relative path "../out"
+    3: Path "../out" is not in the repo "."
+    4: Invalid component ".." in repo-relative path "../out"
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "branches(bad:pattern)"]);

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -268,14 +268,17 @@ given [string pattern](#string-patterns).
 * `empty()`: Commits modifying no files. This also includes `merges()` without
   user modifications and `root()`.
 
-* `file(pattern[, pattern]...)`: Commits modifying paths matching one of the
-  given [file patterns](filesets.md#file-patterns).
+* `file(expression)`: Commits modifying paths matching the given [fileset
+  expression](filesets.md).
 
   Paths are relative to the directory `jj` was invoked from. A directory name
   will match all files in that directory and its subdirectories.
 
   For example, `file(foo)` will match files `foo`, `foo/bar`, `foo/bar/baz`.
   It will *not* match `foobar` or `bar/foo`.
+
+  Some file patterns might need quoting because the `expression` must also be
+  parsable as a revset. For example, `.` has to be quoted in `file(".")`.
 
 * `conflict()`: Commits with conflicts.
 

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -446,6 +446,16 @@ fn resolve_expression(
     }
 }
 
+/// Parses text into `FilesetExpression` without bare string fallback.
+pub fn parse(
+    text: &str,
+    path_converter: &RepoPathUiConverter,
+) -> FilesetParseResult<FilesetExpression> {
+    let node = fileset_parser::parse_program(text)?;
+    // TODO: add basic tree substitution pass to eliminate redundant expressions
+    resolve_expression(path_converter, &node)
+}
+
 /// Parses text into `FilesetExpression` with bare string fallback.
 ///
 /// If the text can't be parsed as a fileset expression, and if it doesn't

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -305,7 +305,6 @@ fn parse_expression_node(pair: Pair<Rule>) -> FilesetParseResult<ExpressionNode>
 }
 
 /// Parses text into expression tree. No name resolution is made at this stage.
-#[cfg(test)] // TODO: alias will be parsed with no bare_string fallback
 pub fn parse_program(text: &str) -> FilesetParseResult<ExpressionNode> {
     let mut pairs = FilesetParser::parse(Rule::program, text)?;
     let first = pairs.next().unwrap();

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -804,7 +804,7 @@ pub fn expect_literal<T: FromStr>(
 
 /// Applies the give function to the innermost `node` by unwrapping alias
 /// expansion nodes.
-fn expect_expression_with<T>(
+pub(super) fn expect_expression_with<T>(
     node: &ExpressionNode,
     f: impl FnOnce(&ExpressionNode) -> Result<T, RevsetParseError>,
 ) -> Result<T, RevsetParseError> {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2989,6 +2989,15 @@ fn test_evaluate_expression_file() {
     assert_eq!(
         resolve_commit_ids_in_workspace(
             mut_repo,
+            r#"file("added_clean_clean"|"added_modified_clean")"#,
+            &test_workspace.workspace,
+            Some(test_workspace.workspace.workspace_root()),
+        ),
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids_in_workspace(
+            mut_repo,
             &format!(r#"{}:: & file("added_modified_clean")"#, commit2.id().hex()),
             &test_workspace.workspace,
             Some(test_workspace.workspace.workspace_root()),


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
