### PR TITLE
cli: include untracked remote branches in default immutable_heads()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj backout --revision` has been renamed to `jj backout --revisions`.
   The short alias `-r` is still supported.
 
+* [The default `immutable_heads()` set](docs/config.md#set-of-immutable-commits)
+  now includes `untracked_remote_branches()` with the assumption that untracked
+  branches aren't managed by you. Therefore, untracked branches are no longer
+  displayed in `jj log` by default.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -391,7 +391,7 @@
                 "immutable_heads()": {
                     "type": "string",
                     "description": "Revisions to consider immutable. Ancestors of these are also considered immutable. The root commit is always considered immutable.",
-                    "default": "trunk() | tags()"
+                    "default": "trunk() | tags() | untracked_remote_branches()"
                 }
             },
             "additionalProperties": {

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -18,6 +18,6 @@ latest(
 )
 '''
 
-'immutable_heads()' = 'trunk() | tags()'
+'immutable_heads()' = 'trunk() | tags() | untracked_remote_branches()'
 'immutable()' = '::(immutable_heads() | root())'
 'mutable()' = '~immutable()'

--- a/docs/config.md
+++ b/docs/config.md
@@ -224,10 +224,10 @@ diff-invocation-mode = "file-by-file"
 
 ### Set of immutable commits
 
-You can configure the set of immutable commits via `revset-aliases."immutable_heads()"`.
-The default set of immutable heads is `trunk() | tags()`. For example, to
-prevent rewriting commits on `main@origin` and commits authored by other
-users:
+You can configure the set of immutable commits via
+`revset-aliases."immutable_heads()"`. The default set of immutable heads is
+`trunk() | tags() | untracked_remote_branches()`. For example, to prevent
+rewriting commits on `main@origin` and commits authored by other users:
 
 ```toml
 # The `main.. &` bit is an optimization to scan for non-`mine()` commits only

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -117,13 +117,6 @@ installer options are fine), clone the repository, and use `cargo build`
 `cargo test --workspace`. If you are preparing a PR, there are some additional
 recommended steps.
 
-You will probably also want to make the `gh-pages` branch immutable (and thereby
-hidden from the default `jj log` output) by running the following in your repo:
-
-```shell
-jj config set --repo "revset-aliases.'immutable_heads()'" 'remote_branches(exact:"main") | remote_branches(exact:"gh-pages")'
-```
-
 ### Summary
 
 One-time setup:

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -385,7 +385,8 @@ for a comprehensive list.
   'trunk()' = 'your-branch@your-remote'
   ```
 
-* `immutable_heads()`: Resolves to `trunk() | tags()` by default. See
+* `immutable_heads()`: Resolves to `trunk() | tags() |
+  untracked_remote_branches()` by default. See
   [here](config.md#set-of-immutable-commits) for details.
 
 * `immutable()`: The set of commits that `jj` treats as immutable. This is


### PR DESCRIPTION
I used to use "remote_branches() & ~mine()" to exclude "their" branches from the default log, and I don't think that's uncommon requirement. Suppose untracked branches are usually read-only, it's probably okay to make them immutable by default.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
