### PR TITLE
obslog: reverse order of predecessors in topo traversal

### DIFF
--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -252,36 +252,36 @@ fn test_obslog_squash() {
     │ │     1    1: foo
     │ │     2    2: bar
     │ │          3: baz
-    ◉ │    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:10 e3c2a446
-    ├───╮  squashed 1
-    │ │ │  Modified regular file file1:
-    │ │ │     1    1: foo
-    │ │ │          2: bar
-    ◉ │ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 766420db
-    │ │ │  first
-    │ │ │  Added regular file file1:
-    │ │ │          1: foo
-    ◉ │ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 fa15625b
-    │ │ │  (empty) first
-    ◉ │ │  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
-      │ │  (empty) (no description set)
-      │ ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 46acd22a
-      │ │  second
-      │ │  Modified regular file file1:
-      │ │     1    1: foo
-      │ │          2: bar
-      │ ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 cba41deb
-      │    (empty) second
-      ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:12 7015a42c
-      │  third
-      │  Modified regular file file1:
-      │     1    1: foo
-      │     2    2: bar
-      │          3: baz
-      ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:11 66645763
-      │  (empty) third
-      ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:10 1c7afcb4
-         (empty) (no description set)
+    │ ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:12 7015a42c
+    │ │  third
+    │ │  Modified regular file file1:
+    │ │     1    1: foo
+    │ │     2    2: bar
+    │ │          3: baz
+    │ ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:11 66645763
+    │ │  (empty) third
+    │ ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:10 1c7afcb4
+    │    (empty) (no description set)
+    ◉    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:10 e3c2a446
+    ├─╮  squashed 1
+    │ │  Modified regular file file1:
+    │ │     1    1: foo
+    │ │          2: bar
+    │ ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 46acd22a
+    │ │  second
+    │ │  Modified regular file file1:
+    │ │     1    1: foo
+    │ │          2: bar
+    │ ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 cba41deb
+    │    (empty) second
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 766420db
+    │  first
+    │  Added regular file file1:
+    │          1: foo
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 fa15625b
+    │  (empty) first
+    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+       (empty) (no description set)
     "###);
 }
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -972,10 +972,10 @@ fn test_squash_from_multiple_partial_no_op() {
     insta::assert_snapshot!(stdout, @r###"
     @    e178068add8c d
     ├─╮
-    ◉ │  b37ca1ee3306 d
-    ◉ │  1d9eb34614c9 d
-      ◉  b73077b08c59 b
-      ◉  a786561e909f b
+    │ ◉  b73077b08c59 b
+    │ ◉  a786561e909f b
+    ◉  b37ca1ee3306 d
+    ◉  1d9eb34614c9 d
     "###);
 
     // If no source commits match the paths, then the whole operation is a no-op


### PR DESCRIPTION
Currently, when there is a commit with two predecessors, the graph splits into two branches, and all of the predecessors on the first branch are printed before all of the predecessors on the second branch. This causes the graph to grow wider with each squashed commit, since the second branch must always get indented one level farther each time a commit is squashed. I have some commits where the graph is indented more than 10 levels due to squashing more than 10 times, making it very difficult to read.

Reversing the order and printing the second branch before the first branch prevents this unnecessary indentation and makes the graph easier to read. This does not change the order of the edges in the graph (i.e. the first predecessor is still the first edge and the second predecessor is still the second edge in the graph).

## Output before this PR

<img width="570" alt="obslog before" src="https://github.com/user-attachments/assets/0beb03f8-1f20-460c-8875-954fc1124c15">

## Output after this PR

<img width="570" alt="obslog after" src="https://github.com/user-attachments/assets/2a68e78a-cbe8-4ecc-81b8-6fa46e6b8fb7">

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
