### PR TITLE
cli `branch create/set`: add `--to` aliases to `-r`

### DIFF
--- a/cli/src/commands/branch/create.rs
+++ b/cli/src/commands/branch/create.rs
@@ -25,7 +25,10 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub struct BranchCreateArgs {
     /// The branch's target revision
-    #[arg(long, short)]
+    //
+    // The `--to` alias exists for making it easier for the user to switch
+    // between `branch create`, `branch move`, and `branch set`.
+    #[arg(long, short, visible_alias = "to")]
     revision: Option<RevisionArg>,
 
     /// The branches to create

--- a/cli/src/commands/branch/set.rs
+++ b/cli/src/commands/branch/set.rs
@@ -25,7 +25,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub struct BranchSetArgs {
     /// The branch's target revision
-    #[arg(long, short)]
+    #[arg(long, short, visible_alias = "to")]
     revision: Option<RevisionArg>,
 
     /// Allow moving the branch backwards or sideways


### PR DESCRIPTION
Now that `jj move` does not accept `-r` (since it has `--from` and `--to`), `jj set --to` seems more useful
than `jj set -r`. `create --to` is also added for ease of switching
between `branch create` and `branch move`.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
