### PR TITLE
Allow restricting log diff/patch output to revset

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1099,6 +1099,9 @@ Spans of revisions that are not included in the graph per `--revisions` are rend
 
    For the syntax, see https://github.com/martinvonz/jj/blob/main/docs/templates.md
 * `-p`, `--patch` — Show patch
+* `--diff-revisions <DIFF_REVISIONS>` — Restrict diffs to the given revsets.
+
+   Defaults to all().
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
 * `--types` — For each path, show only its type before and after


### PR DESCRIPTION
Putting this up for now to gather feedback on the feature.

![1000006396](https://github.com/user-attachments/assets/c2138768-1684-400b-aa42-64121131927d)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
