### PR TITLE
Enable the new graph nodes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   branches aren't managed by you. Therefore, untracked branches are no longer
   displayed in `jj log` by default.
 
+* Updated defaults for graph node symbol templates `templates.log_node` and
+  `templates.op_log_node`.
+
 ### Deprecations
 
 ### New features

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -43,13 +43,13 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] e
     ├─╮
-    │ ◉  [vru] d
-    │ ◉  [roy] c
-    │ │ ◉  [zsu] b
+    │ ○  [vru] d
+    │ ○  [roy] c
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a
+    ○ │  [rlv] a
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "d"]);
@@ -65,12 +65,12 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] e
     ├─╮
-    │ ◉  [roy] c d
-    │ │ ◉  [zsu] b
+    │ ○  [roy] c d
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a
+    ○ │  [rlv] a
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -86,13 +86,13 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [nkm]
     ├─╮
-    │ ◉  [vru] d e??
-    │ ◉  [roy] c
-    │ │ ◉  [zsu] b
+    │ ○  [vru] d e??
+    │ ○  [roy] c
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a e??
+    ○ │  [rlv] a e??
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -110,12 +110,12 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [xtn]
     ├─╮
-    │ ◉  [roy] c d e??
-    │ │ ◉  [zsu] b
+    │ ○  [roy] c d e??
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a e??
+    ○ │  [rlv] a e??
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     // Test abandoning the same commit twice directly
@@ -128,11 +128,11 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] e
     ├─╮
-    │ ◉  [vru] d
-    │ ◉  [roy] c
-    ◉ │  [rlv] a b
+    │ ○  [vru] d
+    │ ○  [roy] c
+    ○ │  [rlv] a b
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     // Test abandoning the same commit twice indirectly
@@ -151,12 +151,12 @@ fn test_basics() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [xlz]
     ├─╮
-    │ ◉  [roy] c d e??
-    │ │ ◉  [zsu] b
+    │ ○  [roy] c d e??
+    │ │ ○  [zsu] b
     ├───╯
-    ◉ │  [rlv] a e??
+    ○ │  [rlv] a e??
     ├─╯
-    ◉  [zzz]
+    ◆  [zzz]
     "###);
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "none()"]);
@@ -185,13 +185,13 @@ fn test_bug_2600() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉    [vru] b
+    ○    [vru] b
     ├─╮
-    │ ◉  [roy] a
+    │ ○  [roy] a
     ├─╯
-    ◉  [zsu] base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -209,12 +209,12 @@ fn test_bug_2600() {
     // should keep "a" as second parent.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉    [vru] b
+    ○    [vru] b
     ├─╮
-    │ ◉  [roy] a
+    │ ○  [roy] a
     ├─╯
-    ◉  [rlv] base nottherootcommit
-    ◉  [zzz]
+    ○  [rlv] base nottherootcommit
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -232,10 +232,10 @@ fn test_bug_2600() {
     // "a".
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉  [vru] b
-    ◉  [zsu] a base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [vru] b
+    ○  [zsu] a base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -253,24 +253,24 @@ fn test_bug_2600() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    [znk] c
     ├─╮
-    │ ◉  [roy] a b??
+    │ ○  [roy] a b??
     ├─╯
-    ◉  [zsu] b?? base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] b?? base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ========= Reminder of the setup ===========
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉    [vru] b
+    ○    [vru] b
     ├─╮
-    │ ◉  [roy] a
+    │ ○  [roy] a
     ├─╯
-    ◉  [zsu] base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "a", "b"]);
     insta::assert_snapshot!(stdout, @"");
@@ -287,9 +287,9 @@ fn test_bug_2600() {
     // not have two parent pointers to the same commit.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [znk] c
-    ◉  [zsu] a b base
-    ◉  [rlv] nottherootcommit
-    ◉  [zzz]
+    ○  [zsu] a b base
+    ○  [rlv] nottherootcommit
+    ◆  [zzz]
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "list", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -313,12 +313,12 @@ fn test_bug_2600_rootcommit_special_case() {
     // Setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  [vru] c
-    ◉    [roy] b
+    ○    [roy] b
     ├─╮
-    │ ◉  [zsu] a
+    │ ○  [zsu] a
     ├─╯
-    ◉  [rlv] base
-    ◉  [zzz]
+    ○  [rlv] base
+    ◆  [zzz]
     "###);
 
     // Now, the test

--- a/cli/tests/test_advance_branches.rs
+++ b/cli/tests/test_advance_branches.rs
@@ -77,7 +77,7 @@ fn test_advance_branches_enabled(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc:
+    ◆  branches{test_branch} desc:
     "###);
     }
 
@@ -86,8 +86,8 @@ fn test_advance_branches_enabled(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
     }
 
@@ -97,9 +97,9 @@ fn test_advance_branches_enabled(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc: second
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{} desc: second
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
     }
 }
@@ -119,7 +119,7 @@ fn test_advance_branches_at_minus(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{test_branch} desc:
-    ◉  branches{} desc:
+    ◆  branches{} desc:
     "###);
     }
 
@@ -127,8 +127,8 @@ fn test_advance_branches_at_minus(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
     }
 
@@ -139,9 +139,9 @@ fn test_advance_branches_at_minus(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch test_branch2} desc: second
-    ◉  branches{} desc: first
-    ◉  branches{} desc:
+    ○  branches{test_branch test_branch2} desc: second
+    ○  branches{} desc: first
+    ◆  branches{} desc:
     "###);
     }
 }
@@ -165,7 +165,7 @@ fn test_advance_branches_overrides(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc:
+    ◆  branches{test_branch} desc:
     "###);
     }
 
@@ -174,8 +174,8 @@ fn test_advance_branches_overrides(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc: first
-    ◉  branches{test_branch} desc:
+    ○  branches{} desc: first
+    ◆  branches{test_branch} desc:
     "###);
     }
 
@@ -193,17 +193,17 @@ fn test_advance_branches_overrides(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
     }
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc: second
-    ◉  branches{} desc: first
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: second
+    ○  branches{} desc: first
+    ◆  branches{} desc:
     "###);
     }
 
@@ -219,10 +219,10 @@ fn test_advance_branches_overrides(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc: third
-    ◉  branches{test_branch} desc: second
-    ◉  branches{} desc: first
-    ◉  branches{} desc:
+    ○  branches{} desc: third
+    ○  branches{test_branch} desc: second
+    ○  branches{} desc: first
+    ◆  branches{} desc:
     "###);
     }
 
@@ -239,21 +239,21 @@ fn test_advance_branches_overrides(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{second_branch test_branch} desc: third
-    ◉  branches{} desc: second
-    ◉  branches{} desc: first
-    ◉  branches{} desc:
+    ○  branches{second_branch test_branch} desc: third
+    ○  branches{} desc: second
+    ○  branches{} desc: first
+    ◆  branches{} desc:
     "###);
     }
     make_commit(&test_env, &workspace_path, "fourth");
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{second_branch} desc: fourth
-    ◉  branches{test_branch} desc: third
-    ◉  branches{} desc: second
-    ◉  branches{} desc: first
-    ◉  branches{} desc:
+    ○  branches{second_branch} desc: fourth
+    ○  branches{test_branch} desc: third
+    ○  branches{} desc: second
+    ○  branches{} desc: first
+    ◆  branches{} desc:
     "###);
     }
 }
@@ -280,7 +280,7 @@ fn test_advance_branches_multiple_branches(make_commit: CommitFn) {
     // Check the initial state of the repo.
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{first_branch second_branch} desc:
+    ◆  branches{first_branch second_branch} desc:
     "###);
     }
 
@@ -289,8 +289,8 @@ fn test_advance_branches_multiple_branches(make_commit: CommitFn) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{first_branch second_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{first_branch second_branch} desc: first
+    ◆  branches{} desc:
     "###);
     }
 }
@@ -308,7 +308,7 @@ fn test_new_advance_branches_interior() {
     // Check the initial state of the repo.
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc:
+    ◆  branches{} desc:
     "###);
 
     // Create a gap in the commits for us to insert our new commit with --before.
@@ -321,20 +321,20 @@ fn test_new_advance_branches_interior() {
     );
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc: third
-    ◉  branches{} desc: second
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{} desc: third
+    ○  branches{} desc: second
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["new", "-r", "@--"]);
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    │ ◉  branches{} desc: third
+    │ ○  branches{} desc: third
     ├─╯
-    ◉  branches{test_branch} desc: second
-    ◉  branches{} desc: first
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: second
+    ○  branches{} desc: first
+    ◆  branches{} desc:
     "###);
 }
 
@@ -350,7 +350,7 @@ fn test_new_advance_branches_before() {
     // Check the initial state of the repo.
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc:
+    ◆  branches{} desc:
     "###);
 
     // Create a gap in the commits for us to insert our new commit with --before.
@@ -363,19 +363,19 @@ fn test_new_advance_branches_before() {
     );
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc: third
-    ◉  branches{} desc: second
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{} desc: third
+    ○  branches{} desc: second
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["new", "--before", "@-"]);
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
-    ◉  branches{} desc: third
+    ○  branches{} desc: third
     @  branches{} desc:
-    ◉  branches{} desc: second
-    ◉  branches{test_branch} desc: first
-    ◉  branches{} desc:
+    ○  branches{} desc: second
+    ○  branches{test_branch} desc: first
+    ◆  branches{} desc:
     "###);
 }
 
@@ -395,15 +395,15 @@ fn test_new_advance_branches_after() {
     // Check the initial state of the repo.
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{test_branch} desc:
+    ◆  branches{test_branch} desc:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "--after", "@"]);
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc:
-    ◉  branches{} desc: first
-    ◉  branches{test_branch} desc:
+    ○  branches{} desc: first
+    ◆  branches{test_branch} desc:
     "###);
 }
 
@@ -425,10 +425,10 @@ fn test_new_advance_branches_merge_children() {
     // Check the initial state of the repo.
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @  branches{} desc: 2
-    │ ◉  branches{} desc: 1
+    │ ○  branches{} desc: 1
     ├─╯
-    ◉  branches{test_branch} desc: 0
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: 0
+    ◆  branches{} desc:
     "###);
 
     // The branch won't advance because `jj  new` had multiple targets.
@@ -439,10 +439,10 @@ fn test_new_advance_branches_merge_children() {
     insta::assert_snapshot!(get_log_output_with_branches(&test_env, &workspace_path), @r###"
     @    branches{} desc:
     ├─╮
-    │ ◉  branches{} desc: 2
-    ◉ │  branches{} desc: 1
+    │ ○  branches{} desc: 2
+    ○ │  branches{} desc: 1
     ├─╯
-    ◉  branches{test_branch} desc: 0
-    ◉  branches{} desc:
+    ○  branches{test_branch} desc: 0
+    ◆  branches{} desc:
     "###);
 }

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -166,7 +166,9 @@ fn test_alias_cannot_override_builtin() {
     test_env.add_config(r#"aliases.log = ["rebase"]"#);
     // Alias should give a warning
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "root()"]);
-    insta::assert_snapshot!(stdout, @"◉  zzzzzzzz root() 00000000\n");
+    insta::assert_snapshot!(stdout, @r###"
+    ◆  zzzzzzzz root() 00000000
+    "###);
     insta::assert_snapshot!(stderr, @"Warning: Cannot define an alias that overrides the built-in command 'log'\n");
 }
 
@@ -205,28 +207,28 @@ fn test_alias_global_args_before_and_after() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Can pass global args before
     let stdout = test_env.jj_cmd_success(&repo_path, &["l", "--at-op", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Can pass global args after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "@-", "l"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Test passing global args both before and after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "abc123", "l", "--at-op", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["-R", "../nonexistent", "l", "-R", "."]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -242,7 +244,7 @@ fn test_alias_global_args_in_definition() {
     // The global argument in the alias is respected
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 }
 

--- a/cli/tests/test_backout_command.rs
+++ b/cli/tests/test_backout_command.rs
@@ -46,7 +46,7 @@ fn test_backout() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1 a
-    ◉  000000000000
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -58,11 +58,11 @@ fn test_backout() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  6d845ed9fb6a Back out "a"
+    ○  6d845ed9fb6a Back out "a"
     │
     │  This backs out commit 2443ea76b0b1c531326908326aab7020abab8e6c.
     @  2443ea76b0b1 a
-    ◉  000000000000
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@+"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -75,14 +75,14 @@ fn test_backout() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  79555ea9040b Back out "Back out "a""
+    ○  79555ea9040b Back out "Back out "a""
     │
     │  This backs out commit 6d845ed9fb6a3d367e2d7068ef0256b1a10705a9.
     @  6d845ed9fb6a Back out "a"
     │
     │  This backs out commit 2443ea76b0b1c531326908326aab7020abab8e6c.
-    ◉  2443ea76b0b1 a
-    ◉  000000000000
+    ○  2443ea76b0b1 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@+"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -111,11 +111,11 @@ fn test_backout_multiple() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  208f8612074a e
-    ◉  ceeec03be46b d
-    ◉  413337bbd11f c
-    ◉  46cc97af6802 b
-    ◉  2443ea76b0b1 a
-    ◉  000000000000
+    ○  ceeec03be46b d
+    ○  413337bbd11f c
+    ○  46cc97af6802 b
+    ○  2443ea76b0b1 a
+    ◆  000000000000
     "###);
 
     // Backout multiple commits
@@ -124,21 +124,21 @@ fn test_backout_multiple() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  6504c4ded177 Back out "b"
+    ○  6504c4ded177 Back out "b"
     │
     │  This backs out commit 46cc97af6802301d8db381386e8485ff3ff24ae6.
-    ◉  d31d42e0267f Back out "c"
+    ○  d31d42e0267f Back out "c"
     │
     │  This backs out commit 413337bbd11f7a6636c010d9e196acf801d8df2f.
-    ◉  8ff3fbc2ccb0 Back out "e"
+    ○  8ff3fbc2ccb0 Back out "e"
     │
     │  This backs out commit 208f8612074af4c219d06568a8e1f04f2e80dc25.
     @  208f8612074a e
-    ◉  ceeec03be46b d
-    ◉  413337bbd11f c
-    ◉  46cc97af6802 b
-    ◉  2443ea76b0b1 a
-    ◉  000000000000
+    ○  ceeec03be46b d
+    ○  413337bbd11f c
+    ○  46cc97af6802 b
+    ○  2443ea76b0b1 a
+    ◆  000000000000
     "###);
     // View the output of each backed out commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "@+"]);

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -30,7 +30,7 @@ fn test_branch_multiple_names() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar foo 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -42,8 +42,8 @@ fn test_branch_multiple_names() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar foo 8bb159bc30a9
-    ◉   230dd059e1b0
-    ◉   000000000000
+    ○   230dd059e1b0
+    ◆   000000000000
     "###);
 
     let (stdout, stderr) =
@@ -54,8 +54,8 @@ fn test_branch_multiple_names() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   8bb159bc30a9
-    ◉   230dd059e1b0
-    ◉   000000000000
+    ○   230dd059e1b0
+    ◆   000000000000
     "###);
 
     // Hint should be omitted if -r is specified
@@ -247,12 +247,12 @@ fn test_branch_move_matching() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-mhead2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   a2781dd9ee37
-    ◉  c1 f4f38657a3dd
-    ◉  b1 f652c32197cf
-    │ ◉   6b5e840ea72b
-    │ ◉  a1 a2 230dd059e1b0
+    ○  c1 f4f38657a3dd
+    ○  b1 f652c32197cf
+    │ ○   6b5e840ea72b
+    │ ○  a1 a2 230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // The default could be considered "--from=all() glob:*", but is disabled
@@ -292,12 +292,12 @@ fn test_branch_move_matching() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b1 c1 a2781dd9ee37
-    ◉   f4f38657a3dd
-    ◉   f652c32197cf
-    │ ◉   6b5e840ea72b
-    │ ◉  a1 a2 230dd059e1b0
+    ○   f4f38657a3dd
+    ○   f652c32197cf
+    │ ○   6b5e840ea72b
+    │ ○  a1 a2 230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -309,12 +309,12 @@ fn test_branch_move_matching() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   a2781dd9ee37
-    ◉  c1 f4f38657a3dd
-    ◉  b1 f652c32197cf
-    │ ◉   6b5e840ea72b
-    │ ◉  a1 a2 230dd059e1b0
+    ○  c1 f4f38657a3dd
+    ○  b1 f652c32197cf
+    │ ○   6b5e840ea72b
+    │ ○  a1 a2 230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Select by revision and name
@@ -327,12 +327,12 @@ fn test_branch_move_matching() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @   a2781dd9ee37
-    ◉  c1 f4f38657a3dd
-    ◉  b1 f652c32197cf
-    │ ◉  a1 6b5e840ea72b
-    │ ◉  a2 230dd059e1b0
+    ○  c1 f4f38657a3dd
+    ○  b1 f652c32197cf
+    │ ○  a1 6b5e840ea72b
+    │ ○  a2 230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 }
 
@@ -363,12 +363,12 @@ fn test_branch_move_conflicting() {
     );
     insta::assert_snapshot!(get_log(), @r###"
     @  A1
-    ◉  A0 foo??
-    │ ◉  C0
+    ○  A0 foo??
+    │ ○  C0
     ├─╯
-    │ ◉  B0 foo??
+    │ ○  B0 foo??
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Can't move the branch to C0 since it's sibling.
@@ -388,12 +388,12 @@ fn test_branch_move_conflicting() {
     "###);
     insta::assert_snapshot!(get_log(), @r###"
     @  A1 foo
-    ◉  A0
-    │ ◉  C0
+    ○  A0
+    │ ○  C0
     ├─╯
-    │ ◉  B0
+    │ ○  B0
     ├─╯
-    ◉
+    ◆
     "###);
 }
 
@@ -461,7 +461,7 @@ fn test_branch_forget_glob() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1 foo-3 foo-4 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "forget", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
@@ -476,7 +476,7 @@ fn test_branch_forget_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-4 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Forgetting a branch via both explicit name and glob pattern, or with
@@ -491,7 +491,7 @@ fn test_branch_forget_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 230dd059e1b0
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Malformed glob
@@ -540,7 +540,7 @@ fn test_branch_delete_glob() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1 foo-3 foo-4 312a98d6f27b
-    ◉   000000000000
+    ◆   000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "delete", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
@@ -555,7 +555,7 @@ fn test_branch_delete_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1@origin foo-3@origin foo-4 312a98d6f27b
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // We get an error if none of the globs match live branches. Unlike `jj branch
@@ -577,7 +577,7 @@ fn test_branch_delete_glob() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  bar-2 foo-1@origin foo-3@origin foo-4@origin 312a98d6f27b
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // The deleted branches are still there
@@ -914,10 +914,10 @@ fn test_branch_track_untrack() {
     main@origin: sptzoqmo 7b33f629 commit 1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1@origin feature2@origin main@origin 7b33f6295eda
+    ◆  feature1@origin feature2@origin main@origin 7b33f6295eda
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Track new branch. Local branch should be created.
@@ -962,10 +962,10 @@ fn test_branch_track_untrack() {
       @origin: sptzoqmo 7b33f629 commit 1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1 feature1@origin feature2@origin main 7b33f6295eda
+    ◆  feature1 feature1@origin feature2@origin main 7b33f6295eda
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Fetch new commit. Only tracking branch "main" should be merged.
@@ -993,12 +993,12 @@ fn test_branch_track_untrack() {
       @origin: mmqqkyyt 40dabdaf commit 2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1@origin feature2@origin main 40dabdaf4abe
-    │ ◉  feature1 7b33f6295eda
+    ◆  feature1@origin feature2@origin main 40dabdaf4abe
+    │ ○  feature1 7b33f6295eda
     ├─╯
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 
     // Fetch new commit with auto tracking. Tracking branch "main" and new
@@ -1032,12 +1032,12 @@ fn test_branch_track_untrack() {
       @origin: wwnpyzpo 3f0f86fa commit 3
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  feature1@origin feature2@origin feature3 main 3f0f86fa0e57
-    │ ◉  feature1 7b33f6295eda
+    ◆  feature1@origin feature2@origin feature3 main 3f0f86fa0e57
+    │ ○  feature1 7b33f6295eda
     ├─╯
     │ @   230dd059e1b0
     ├─╯
-    ◉   000000000000
+    ◆   000000000000
     "###);
 }
 
@@ -1419,16 +1419,16 @@ fn test_branch_list_filtered() {
             &["log", "-r::(branches() | remote_branches())", "-T", template],
         ),
         @r###"
-    ◉  e31634b64294 remote-rewrite*
+    ○  e31634b64294 remote-rewrite*
     │ @  c7b4c09cd77c local-keep
     ├─╯
-    │ ◉  3e9a5af6ef15 remote-rewrite@origin (hidden)
+    │ ○  3e9a5af6ef15 remote-rewrite@origin (hidden)
     ├─╯
-    │ ◉  dad5f298ca57 remote-delete@origin
+    │ ○  dad5f298ca57 remote-delete@origin
     ├─╯
-    │ ◉  911e912015fb remote-keep
+    │ ○  911e912015fb remote-keep
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // All branches are listed by default.

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -52,7 +52,7 @@ fn test_builtin_alias_trunk_matches_main() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
+    ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -64,7 +64,7 @@ fn test_builtin_alias_trunk_matches_master() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 master d13ecdbd
+    ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 master d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -76,7 +76,7 @@ fn test_builtin_alias_trunk_matches_trunk() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 trunk d13ecdbd
+    ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 trunk d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -91,7 +91,7 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
+    ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -107,7 +107,7 @@ fn test_builtin_alias_trunk_override_alias() {
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 override-trunk d13ecdbd
+    ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 override-trunk d13ecdbd
     │  (empty) description 1
     ~
     "###);
@@ -119,7 +119,7 @@ fn test_builtin_alias_trunk_no_match() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     "###);
@@ -131,7 +131,7 @@ fn test_builtin_alias_trunk_no_match_only_exact() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     "###);

--- a/cli/tests/test_checkout.rs
+++ b/cli/tests/test_checkout.rs
@@ -36,19 +36,19 @@ fn test_checkout() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c97da310c66008034013412d321397242e1e43ef
-    ◉  9ed53a4a1becd028f9a2fe0d5275973acea7e8da second
-    ◉  fa15625b4a986997697639dfc2844138900c79f2 first
-    ◉  0000000000000000000000000000000000000000
+    ○  9ed53a4a1becd028f9a2fe0d5275973acea7e8da second
+    ○  fa15625b4a986997697639dfc2844138900c79f2 first
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Can provide a description
     test_env.jj_cmd_ok(&repo_path, &["checkout", "@--", "-m", "my message"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  6f9c4a002224fde4ebc48ce6ec03d5ffcfa64ad2 my message
-    │ ◉  9ed53a4a1becd028f9a2fe0d5275973acea7e8da second
+    │ ○  9ed53a4a1becd028f9a2fe0d5275973acea7e8da second
     ├─╯
-    ◉  fa15625b4a986997697639dfc2844138900c79f2 first
-    ◉  0000000000000000000000000000000000000000
+    ○  fa15625b4a986997697639dfc2844138900c79f2 first
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -26,8 +26,8 @@ fn test_commit_with_description_from_cli() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  e8ea92a8b6b3
-    ◉  fa15625b4a98 first
-    ◉  000000000000
+    ○  fa15625b4a98 first
+    ◆  000000000000
     "###);
 }
 
@@ -45,8 +45,8 @@ fn test_commit_with_editor() {
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  a57b2c95fb75
-    ◉  159271101e05 modified
-    ◉  000000000000
+    ○  159271101e05 modified
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
@@ -166,8 +166,8 @@ fn test_commit_with_default_description() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  c65242099289
-    ◉  573b6df51aea TESTED=TODO
-    ◉  000000000000
+    ○  573b6df51aea TESTED=TODO
+    ◆  000000000000
     "###);
     assert_eq!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(),

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -32,11 +32,11 @@ fn test_log_parents() {
     insta::assert_snapshot!(stdout, @r###"
     @    c067170d4ca1bc6162b64f7550617ec809647f84
     ├─╮  P: 2 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉ │  4db490c88528133d579540b6900b8098f0c17701
+    ○ │  4db490c88528133d579540b6900b8098f0c17701
     ├─╯  P: 1 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  P: 1 0000000000000000000000000000000000000000
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
        P: 0
     "###);
 
@@ -46,7 +46,7 @@ fn test_log_parents() {
         &["log", "-T", template, "-r@", "--color=always"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;4m4[0m[38;5;8mdb4[39m [1m[38;5;4m2[0m[38;5;8m30d[39m
+    [1m[38;5;2m@[0m  [1m[38;5;4m4[0m[38;5;8mdb4[39m [1m[38;5;4m2[0m[38;5;8m30d[39m
     │
     ~
     "###);
@@ -89,8 +89,8 @@ fn test_log_author_timestamp() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 04:05:09.000 +07:00
-    ◉  2001-02-03 04:05:08.000 +07:00
-    ◉  1970-01-01 00:00:00.000 +00:00
+    ○  2001-02-03 04:05:08.000 +07:00
+    ◆  1970-01-01 00:00:00.000 +00:00
     "###);
 }
 
@@ -121,7 +121,7 @@ fn test_log_author_timestamp_utc() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().utc()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-02 21:05:07.000 +00:00
-    ◉  1970-01-01 00:00:00.000 +00:00
+    ◆  1970-01-01 00:00:00.000 +00:00
     "###);
 }
 
@@ -136,13 +136,13 @@ fn test_log_author_timestamp_local() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 08:05:07.000 +11:00
-    ◉  1970-01-01 11:00:00.000 +11:00
+    ◆  1970-01-01 11:00:00.000 +11:00
     "###);
     test_env.add_env_var("TZ", "UTC+10:00");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
     insta::assert_snapshot!(stdout, @r###"
     @  2001-02-03 08:05:07.000 +11:00
-    ◉  1970-01-01 11:00:00.000 +11:00
+    ◆  1970-01-01 11:00:00.000 +11:00
     "###);
 }
 
@@ -170,8 +170,8 @@ fn test_mine_is_true_when_author_is_user() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  johndoe@example.com
-    ◉  mine
-    ◉  (no email set)
+    ○  mine
+    ◆  (no email set)
     "###);
 }
 
@@ -191,19 +191,19 @@ fn test_log_default() {
     insta::assert_snapshot!(stdout, @r###"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-branch bac9ff9e
     │  (empty) description 1
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aa2015d7
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aa2015d7
     │  add a file
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-branch[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
+    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     │  add a file
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     // Color without graph
@@ -311,31 +311,32 @@ fn test_log_builtin_templates_colored() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "my-branch"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
+    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-branch[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r###"
-    @  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
+    [1m[38;5;2m@[0m  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
     │  Change ID: [38;5;5mrlvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
     │  Branches: [38;5;5mmy-branch[39m
     │  Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m2001-02-03 08:05:08[39m)
@@ -343,14 +344,14 @@ fn test_log_builtin_templates_colored() {
     │
     │  [38;5;2m    (no description set)[39m
     │
-    ◉  Commit ID: [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    ○  Commit ID: [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     │  Change ID: [38;5;5mqpvuntsmwlqtpsluzzsnyyzlmlwvmlnu[39m
     │  Author: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
     │  Committer: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
     │
     │  [38;5;2m    (no description set)[39m
     │
-    ◉  Commit ID: [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;14m◆[0m  Commit ID: [38;5;4m0000000000000000000000000000000000000000[39m
        Change ID: [38;5;5mzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz[39m
        Author: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
        Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
@@ -379,32 +380,32 @@ fn test_log_builtin_templates_colored_debug() {
     test_env.jj_cmd_ok(&repo_path, &["branch", "create", "my-branch"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
-    <<node::@>>  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy branches name::my-branch>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
-    <<node::◉>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author username::test.user>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log:: >>[38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
-    <<node::◉>>  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
+    [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy branches name::my-branch>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
+    <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author username::test.user>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log:: >>[38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
+    [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
-    <<node::@>>  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy branches name::my-branch>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
+    [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy branches name::my-branch>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
     │  [1m[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
-    <<node::◉>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email::test.user@example.com>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log::>>
+    <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email::test.user@example.com>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log::>>
     │  [38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
-    <<node::◉>>  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
+    [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
-    <<node::@>>  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy branches name::my-branch>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
+    [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy branches name::my-branch>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
     │  [1m[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     │  <<log::>>
-    <<node::◉>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email::test.user@example.com>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log::>>
+    <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email::test.user@example.com>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log::>>
     │  [38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
     │  <<log::>>
-    <<node::◉>>  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
+    [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
        <<log::>>
     "###);
 
     insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r###"
-    <<node::@>>  <<log::Commit ID: >>[38;5;4m<<log commit_id::dc31539712c7294d1d712cec63cef4504b94ca74>>[39m<<log::>>
+    [1m[38;5;2m<<node working_copy::@>>[0m  <<log::Commit ID: >>[38;5;4m<<log commit_id::dc31539712c7294d1d712cec63cef4504b94ca74>>[39m<<log::>>
     │  <<log::Change ID: >>[38;5;5m<<log change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<log::>>
     │  <<log::Branches: >>[38;5;5m<<log local_branches name::my-branch>>[39m<<log::>>
     │  <<log::Author: >>[38;5;1m<<log name placeholder::(no name set)>>[39m<<log:: <>>[38;5;1m<<log email placeholder::(no email set)>>[39m<<log::> (>>[38;5;6m<<log author timestamp local format::2001-02-03 08:05:08>>[39m<<log::)>>
@@ -412,14 +413,14 @@ fn test_log_builtin_templates_colored_debug() {
     │  <<log::>>
     │  [38;5;2m<<log empty description placeholder::    (no description set)>>[39m<<log::>>
     │  <<log::>>
-    <<node::◉>>  <<log::Commit ID: >>[38;5;4m<<log commit_id::230dd059e1b059aefc0da06a2e5a7dbf22362f22>>[39m<<log::>>
+    <<node::○>>  <<log::Commit ID: >>[38;5;4m<<log commit_id::230dd059e1b059aefc0da06a2e5a7dbf22362f22>>[39m<<log::>>
     │  <<log::Change ID: >>[38;5;5m<<log change_id::qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu>>[39m<<log::>>
     │  <<log::Author: >><<log author name::Test User>><<log:: <>>[38;5;3m<<log author email::test.user@example.com>>[39m<<log::> (>>[38;5;6m<<log author timestamp local format::2001-02-03 08:05:07>>[39m<<log::)>>
     │  <<log::Committer: >><<log committer name::Test User>><<log:: <>>[38;5;3m<<log committer email::test.user@example.com>>[39m<<log::> (>>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log::)>>
     │  <<log::>>
     │  [38;5;2m<<log empty description placeholder::    (no description set)>>[39m<<log::>>
     │  <<log::>>
-    <<node::◉>>  <<log::Commit ID: >>[38;5;4m<<log commit_id::0000000000000000000000000000000000000000>>[39m<<log::>>
+    [1m[38;5;14m<<node immutable::◆>>[0m  <<log::Commit ID: >>[38;5;4m<<log commit_id::0000000000000000000000000000000000000000>>[39m<<log::>>
        <<log::Change ID: >>[38;5;5m<<log change_id::zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>>[39m<<log::>>
        <<log::Author: >>[38;5;1m<<log name placeholder::(no name set)>>[39m<<log:: <>>[38;5;1m<<log email placeholder::(no email set)>>[39m<<log::> (>>[38;5;6m<<log author timestamp local format::1970-01-01 11:00:00>>[39m<<log::)>>
        <<log::Committer: >>[38;5;1m<<log name placeholder::(no name set)>>[39m<<log:: <>>[38;5;1m<<log email placeholder::(no email set)>>[39m<<log::> (>>[38;5;6m<<log committer timestamp local format::1970-01-01 11:00:00>>[39m<<log::)>>
@@ -442,7 +443,7 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Create divergence
@@ -452,11 +453,11 @@ fn test_log_obslog_divergence() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 6ba70e00
+    ○  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 6ba70e00
     │  description 2
     │ @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     ├─╯  description 1
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -465,11 +466,11 @@ fn test_log_obslog_divergence() {
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m6[0m[38;5;8mba70e00[39m
+    ○  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m6[0m[38;5;8mba70e00[39m
     │  description 2
-    │ @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
+    │ [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     ├─╯  [1mdescription 1[0m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 
     // Obslog and hidden divergent
@@ -477,20 +478,20 @@ fn test_log_obslog_divergence() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 485d52a9
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 485d52a9
     │  (no description set)
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
 
     // Colored obslog
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
+    [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     │  [1mdescription 1[0m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m85d52a9[39m
+    ○  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m85d52a9[39m
     │  [38;5;3m(no description set)[39m
-    ◉  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ○  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     "###);
 }
@@ -545,43 +546,43 @@ fn test_log_branches() {
     let template = r#"commit_id.short() ++ " " ++ if(branches, branches, "(no branches)")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  fed794e2ba44 branch3?? branch3@origin
-    │ ◉  b1bb3766d584 branch3??
+    ○  fed794e2ba44 branch3?? branch3@origin
+    │ ○  b1bb3766d584 branch3??
     ├─╯
-    │ ◉  28ff13ce7195 branch1*
+    │ ○  28ff13ce7195 branch1*
     ├─╯
     │ @  a5b4d15489cc branch2* new-branch
-    │ ◉  8476341eb395 branch2@origin unchanged
+    │ ○  8476341eb395 branch2@origin unchanged
     ├─╯
-    ◉  000000000000 (no branches)
+    ◆  000000000000 (no branches)
     "###);
 
     let template = r#"branches.map(|b| separate("/", b.remote(), b.name())).join(", ")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  branch3, origin/branch3
-    │ ◉  branch3
+    ○  branch3, origin/branch3
+    │ ○  branch3
     ├─╯
-    │ ◉  branch1
+    │ ○  branch1
     ├─╯
     │ @  branch2, new-branch
-    │ ◉  origin/branch2, unchanged
+    │ ○  origin/branch2, unchanged
     ├─╯
-    ◉
+    ◆
     "###);
 
     let template = r#"separate(" ", "L:", local_branches, "R:", remote_branches)"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
     insta::assert_snapshot!(output, @r###"
-    ◉  L: branch3?? R: branch3@origin
-    │ ◉  L: branch3?? R:
+    ○  L: branch3?? R: branch3@origin
+    │ ○  L: branch3?? R:
     ├─╯
-    │ ◉  L: branch1* R:
+    │ ○  L: branch1* R:
     ├─╯
     │ @  L: branch2* new-branch R:
-    │ ◉  L: unchanged R: branch2@origin unchanged@origin
+    │ ○  L: unchanged R: branch2@origin unchanged@origin
     ├─╯
-    ◉  L: R:
+    ◆  L: R:
     "###);
 
     let template = r#"
@@ -597,12 +598,12 @@ fn test_log_branches() {
         &["log", "-r::remote_branches()", "-T", template],
     );
     insta::assert_snapshot!(output, @r###"
-    ◉  branch3@origin(+0/-1)
-    │ ◉  branch2@origin(+0/-1) unchanged@origin(+0/-0)
+    ○  branch3@origin(+0/-1)
+    │ ○  branch2@origin(+0/-1) unchanged@origin(+0/-0)
     ├─╯
-    │ ◉  branch1@origin(+1/-1)
+    │ ○  branch1@origin(+1/-1)
     ├─╯
-    ◉
+    ◆
     "###);
 }
 
@@ -625,17 +626,17 @@ fn test_log_git_head() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  remote: <Error: No RefName available>
-    ◉  name: HEAD, remote: git
-    ◉  remote: <Error: No RefName available>
+    ○  name: HEAD, remote: git
+    ◆  remote: <Error: No RefName available>
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
-    ◉  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
+    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mHEAD@git[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ◉  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     "###);
 }
 
@@ -660,7 +661,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  Q_pvun test.user@example.com 2001-02-03 08:05:08 F_a156
     │  (empty) first
-    ◉  Z_zzzz root() 0_0000
+    ◆  Z_zzzz root() 0_0000
     "###);
 
     // Customize only the change id
@@ -678,7 +679,7 @@ fn test_log_customize_short_id() {
     insta::assert_snapshot!(stdout, @r###"
     @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
-    ◉  ZZZZZZZZ root() 00000000
+    ◆  ZZZZZZZZ root() 00000000
     "###);
 }
 
@@ -705,11 +706,11 @@ fn test_log_immutable() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r::", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  D
-    │ ◉  C
-    │ ◉  B main [immutable]
-    │ ◉  A [immutable]
+    │ ○  C
+    │ ◆  B main [immutable]
+    │ ◆  A [immutable]
     ├─╯
-    ◉  [immutable]
+    ◆  [immutable]
     "###);
 
     // Suppress error that could be detected earlier
@@ -783,11 +784,11 @@ fn test_log_contained_in() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  D
-    │ ◉  C [contained_in]
-    │ ◉  B main [contained_in]
-    │ ◉  A [contained_in]
+    │ ○  C [contained_in]
+    │ ○  B main [contained_in]
+    │ ○  A [contained_in]
     ├─╯
-    ◉
+    ◆
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -801,11 +802,11 @@ fn test_log_contained_in() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  D [contained_in]
-    │ ◉  C [contained_in]
-    │ ◉  B main
-    │ ◉  A
+    │ ○  C [contained_in]
+    │ ○  B main
+    │ ○  A
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Suppress error that could be detected earlier

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -33,26 +33,26 @@ fn test_concurrent_operation_divergence() {
     // "op log" doesn't merge the concurrent operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  48f4a48f3f70 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  48f4a48f3f70 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'message 2' --at-op @-
-    │ ◉  e31015019d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ○  e31015019d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │    args: jj describe -m 'message 1'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  message 2
+    ○  message 2
     │ @  message 1
     ├─╯
-    ◉
+    ◆
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -72,14 +72,14 @@ fn test_concurrent_operations_auto_rebase() {
     @  66d1dd775c54 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
-    ◉  130d67859810 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  130d67859810 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj describe -m initial
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     let op_id_hex = stdout[3..15].to_string();
 
@@ -92,9 +92,9 @@ fn test_concurrent_operations_auto_rebase() {
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  db141860e12c2d5591c56fde4fc99caf71cec418 new child
+    ○  db141860e12c2d5591c56fde4fc99caf71cec418 new child
     @  07c3641e495cce57ea4ca789123b52f421c57aa2 rewritten
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -127,10 +127,10 @@ fn test_concurrent_operations_wc_modified() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
     @  4eadcf3df11f46ef3d825c776496221cc8303053 new child1
-    │ ◉  68119f1643b7e3c301c5f7c2b6c9bf4ccba87379 new child2
+    │ ○  68119f1643b7e3c301c5f7c2b6c9bf4ccba87379 new child2
     ├─╯
-    ◉  2ff7ae858a3a11837fdf9d1a76be295ef53f1bb3 initial
-    ◉  0000000000000000000000000000000000000000
+    ○  2ff7ae858a3a11837fdf9d1a76be295ef53f1bb3 initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -150,16 +150,16 @@ fn test_concurrent_operations_wc_modified() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription"]);
     insta::assert_snapshot!(stdout, @r###"
     @  snapshot working copy
-    ◉    resolve concurrent operations
+    ○    resolve concurrent operations
     ├─╮
-    ◉ │  new empty commit
-    │ ◉  new empty commit
+    ○ │  new empty commit
+    │ ○  new empty commit
     ├─╯
-    ◉  describe commit 506f4ec3c2c62befa15fabc34ca9d4e6d7bef254
-    ◉  snapshot working copy
-    ◉  add workspace 'default'
-    ◉  initialize repo
-    ◉
+    ○  describe commit 506f4ec3c2c62befa15fabc34ca9d4e6d7bef254
+    ○  snapshot working copy
+    ○  add workspace 'default'
+    ○  initialize repo
+    ○
     "###);
 }
 
@@ -187,20 +187,20 @@ fn test_concurrent_snapshot_wc_reloadable() {
     @  9f11958bcf79340028eeabf9b0381cd8d2ae2258d0097b8ce8bd24fe7138eca08d9eb113bb4722ebacd9b7a6fa017e3888f72907be7487f275823c8d21359eed
     │  commit 554d22b2c43c1c47e279430197363e8daabe2fd6
     │  args: jj commit -m 'new child1'
-    ◉  f5460e8f43a04fbc61553d12fa5ba8d3b12e4fdcfda1999db6b67cc8e1e473b7e62cc0536196a53b84f34e18c1c6d608f427bb64bd5f834f845a9859e39cb320
+    ○  f5460e8f43a04fbc61553d12fa5ba8d3b12e4fdcfda1999db6b67cc8e1e473b7e62cc0536196a53b84f34e18c1c6d608f427bb64bd5f834f845a9859e39cb320
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ◉  49359b6597ead3fbb66802a6bbd8761c0ad4646a2b089090d6fd72fb6e2568aa99c4a92f9f1f252a83cce56ec84961c36e85f731f19fc5a4c24d6a3f7282b774
+    ○  49359b6597ead3fbb66802a6bbd8761c0ad4646a2b089090d6fd72fb6e2568aa99c4a92f9f1f252a83cce56ec84961c36e85f731f19fc5a4c24d6a3f7282b774
     │  commit de71e09289762a65f80bb1c3dae2a949df6bcde7
     │  args: jj commit -m initial
-    ◉  86dbba2b96a4a801abef7f77f8fdf338b6e36f81ea4a531aacf06acbd06f4037731fffef42503c2225fdb206488971c1601ca8b2b4a83a3fe2dce64ee4db085e
+    ○  86dbba2b96a4a801abef7f77f8fdf338b6e36f81ea4a531aacf06acbd06f4037731fffef42503c2225fdb206488971c1601ca8b2b4a83a3fe2dce64ee4db085e
     │  snapshot working copy
     │  args: jj commit -m initial
-    ◉  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
+    ○  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
     │  add workspace 'default'
-    ◉  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
+    ○  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
     │  initialize repo
-    ◉  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
     "###);
     let op_log_lines = op_log_stdout.lines().collect_vec();
@@ -229,11 +229,11 @@ fn test_concurrent_snapshot_wc_reloadable() {
     insta::assert_snapshot!(stdout, @r###"
     @  1795621b54f4ebb435978b65d66bc0f90d8f20b6 new child2
     │  A child2
-    ◉  86f54245e13f850f8275b5541e56da996b6a47b7 new child1
+    ○  86f54245e13f850f8275b5541e56da996b6a47b7 new child1
     │  A child1
-    ◉  84f07f6bca2ffeddac84a8b09f60c6b81112375c initial
+    ○  84f07f6bca2ffeddac84a8b09f60c6b81112375c initial
     │  A base
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -1175,12 +1175,12 @@ fn test_diff_external_tool() {
     │  --
     │  file2
     │  file3
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 0ad4ef22
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 0ad4ef22
     │  (no description set)
     │  --
     │  file1
     │  file2
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
        --
     "###);
 
@@ -1321,7 +1321,7 @@ fn test_diff_external_file_by_file_tool() {
     │  file3
     │  --
     │  file3
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 0ad4ef22
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 0ad4ef22
     │  (no description set)
     │  ==
     │  file1
@@ -1331,7 +1331,7 @@ fn test_diff_external_file_by_file_tool() {
     │  file2
     │  --
     │  file2
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     insta::assert_snapshot!(

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -41,10 +41,10 @@ fn test_duplicate() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    17a00fc21654   c
     ├─╮
-    │ ◉  d370aee184ba   b
-    ◉ │  2443ea76b0b1   a
+    │ ○  d370aee184ba   b
+    ○ │  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "all()"]);
@@ -63,14 +63,14 @@ fn test_duplicate() {
     Duplicated 2443ea76b0b1 as kpqxywon f5b1e687 a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  f5b1e68729d6   a
+    ○  f5b1e68729d6   a
     │ @    17a00fc21654   c
     │ ├─╮
-    │ │ ◉  d370aee184ba   b
+    │ │ ○  d370aee184ba   b
     ├───╯
-    │ ◉  2443ea76b0b1   a
+    │ ○  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -82,14 +82,14 @@ fn test_duplicate() {
     Duplicated 17a00fc21654 as lylxulpl ef3b0f3d c
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    ef3b0f3d1046   c
+    ○    ef3b0f3d1046   c
     ├─╮
     │ │ @  17a00fc21654   c
     ╭─┬─╯
-    │ ◉  d370aee184ba   b
-    ◉ │  2443ea76b0b1   a
+    │ ○  d370aee184ba   b
+    ○ │  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -108,12 +108,12 @@ fn test_duplicate_many() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
     ├─╮
-    │ ◉  ebd06dba20ec   d
-    │ ◉  c0cb3a0b73e7   c
-    ◉ │  1394f625cbbd   b
+    │ ○  ebd06dba20ec   d
+    │ ○  c0cb3a0b73e7   c
+    ○ │  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b::"]);
@@ -123,18 +123,18 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as mouksmqu 8348ddce e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    8348ddcec733   e
+    ○    8348ddcec733   e
     ├─╮
-    ◉ │  3b74d9691015   b
+    ○ │  3b74d9691015   b
     │ │ @  921dde6e55c0   e
     │ ╭─┤
-    │ ◉ │  ebd06dba20ec   d
-    │ ◉ │  c0cb3a0b73e7   c
+    │ ○ │  ebd06dba20ec   d
+    │ ○ │  c0cb3a0b73e7   c
     ├─╯ │
-    │   ◉  1394f625cbbd   b
+    │   ○  1394f625cbbd   b
     ├───╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     // Try specifying the same commit twice directly
@@ -145,16 +145,16 @@ fn test_duplicate_many() {
     Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  0276d3d7c24d   b
+    ○  0276d3d7c24d   b
     │ @    921dde6e55c0   e
     │ ├─╮
-    │ │ ◉  ebd06dba20ec   d
-    │ │ ◉  c0cb3a0b73e7   c
+    │ │ ○  ebd06dba20ec   d
+    │ │ ○  c0cb3a0b73e7   c
     ├───╯
-    │ ◉  1394f625cbbd   b
+    │ ○  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     // Try specifying the same commit twice indirectly
@@ -167,20 +167,20 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as ztxkyksq 0f7430f2 e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    0f7430f2727a   e
+    ○    0f7430f2727a   e
     ├─╮
-    │ ◉  2181781b4f81   d
-    ◉ │  fa167d18a83a   b
+    │ ○  2181781b4f81   d
+    ○ │  fa167d18a83a   b
     │ │ @    921dde6e55c0   e
     │ │ ├─╮
-    │ │ │ ◉  ebd06dba20ec   d
+    │ │ │ ○  ebd06dba20ec   d
     │ ├───╯
-    │ ◉ │  c0cb3a0b73e7   c
+    │ ○ │  c0cb3a0b73e7   c
     ├─╯ │
-    │   ◉  1394f625cbbd   b
+    │   ○  1394f625cbbd   b
     ├───╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -188,12 +188,12 @@ fn test_duplicate_many() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    921dde6e55c0   e
     ├─╮
-    │ ◉  ebd06dba20ec   d
-    │ ◉  c0cb3a0b73e7   c
-    ◉ │  1394f625cbbd   b
+    │ ○  ebd06dba20ec   d
+    │ ○  c0cb3a0b73e7   c
+    ○ │  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    ◉  000000000000
+    ○  2443ea76b0b1   a
+    ◆  000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @"");
@@ -203,20 +203,20 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as urrlptpw 9bd4389f e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    9bd4389f5d47   e
+    ○    9bd4389f5d47   e
     ├─╮
-    │ ◉  d94e4c55a68b   d
+    │ ○  d94e4c55a68b   d
     │ │ @  921dde6e55c0   e
     ╭───┤
-    │ │ ◉  ebd06dba20ec   d
+    │ │ ○  ebd06dba20ec   d
     │ ├─╯
-    │ ◉  c0cb3a0b73e7   c
-    ◉ │  1394f625cbbd   b
+    │ ○  c0cb3a0b73e7   c
+    ○ │  1394f625cbbd   b
     ├─╯
-    ◉  2443ea76b0b1   a
-    │ ◉  c6f7f8c4512e   a
+    ○  2443ea76b0b1   a
+    │ ○  c6f7f8c4512e   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Check for BUG -- makes too many 'a'-s, etc.
@@ -231,22 +231,22 @@ fn test_duplicate_many() {
     Duplicated 921dde6e55c0 as mvkzkxrl ee8fe64e e
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    ee8fe64ed254   e
+    ○    ee8fe64ed254   e
     ├─╮
-    │ ◉  2f2442db08eb   d
-    │ ◉  df53fa589286   c
-    ◉ │  e13ac0adabdf   b
+    │ ○  2f2442db08eb   d
+    │ ○  df53fa589286   c
+    ○ │  e13ac0adabdf   b
     ├─╯
-    ◉  0fe67a05989e   a
+    ○  0fe67a05989e   a
     │ @    921dde6e55c0   e
     │ ├─╮
-    │ │ ◉  ebd06dba20ec   d
-    │ │ ◉  c0cb3a0b73e7   c
-    │ ◉ │  1394f625cbbd   b
+    │ │ ○  ebd06dba20ec   d
+    │ │ ○  c0cb3a0b73e7   c
+    │ ○ │  1394f625cbbd   b
     │ ├─╯
-    │ ◉  2443ea76b0b1   a
+    │ ○  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -260,7 +260,7 @@ fn test_undo_after_duplicate() {
     create_commit(&test_env, &repo_path, "a", &[]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);
@@ -269,10 +269,10 @@ fn test_undo_after_duplicate() {
     Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  f5cefcbb65a4   a
+    ○  f5cefcbb65a4   a
     │ @  2443ea76b0b1   a
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -280,7 +280,7 @@ fn test_undo_after_duplicate() {
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -297,9 +297,9 @@ fn test_rebase_duplicates() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
     @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
-    ◉  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
-    ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
-    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
+    ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "c"]);
@@ -313,14 +313,14 @@ fn test_rebase_duplicates() {
     Duplicated 7e4fbf4f2759 as znkkpsqq ce5f4eeb c
     "###);
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
-    ◉  ce5f4eeb69d1   c @ 2001-02-03 04:05:16.000 +07:00
-    │ ◉  0ac2063b1bee   c @ 2001-02-03 04:05:15.000 +07:00
+    ○  ce5f4eeb69d1   c @ 2001-02-03 04:05:16.000 +07:00
+    │ ○  0ac2063b1bee   c @ 2001-02-03 04:05:15.000 +07:00
     ├─╯
     │ @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
     ├─╯
-    ◉  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
-    ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
-    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
+    ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "root()"]);
@@ -334,15 +334,15 @@ fn test_rebase_duplicates() {
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.
     insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
-    ◉  b86e9f27d085   c @ 2001-02-03 04:05:16.000 +07:00
-    │ ◉  8033590fe04d   c @ 2001-02-03 04:05:17.000 +07:00
+    ○  b86e9f27d085   c @ 2001-02-03 04:05:16.000 +07:00
+    │ ○  8033590fe04d   c @ 2001-02-03 04:05:17.000 +07:00
     ├─╯
     │ @  ed671a3cbf35   c @ 2001-02-03 04:05:18.000 +07:00
     ├─╯
-    ◉  4c6f1569e2a9   b @ 2001-02-03 04:05:18.000 +07:00
-    │ ◉  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
+    ○  4c6f1569e2a9   b @ 2001-02-03 04:05:18.000 +07:00
+    │ ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ├─╯
-    ◉  000000000000    @ 1970-01-01 00:00:00.000 +00:00
+    ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
     "###);
 }
 

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -47,9 +47,9 @@ fn test_edit() {
     "###);
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  2c910ae2d628 second
+    ○  2c910ae2d628 second
     @  73383c0b6439 first
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(read_file(&repo_path.join("file1")), @"0");
@@ -58,9 +58,9 @@ fn test_edit() {
     std::fs::write(repo_path.join("file2"), "0").unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  b384b2cc1883 second
+    ○  b384b2cc1883 second
     @  ff3f7b0dc386 first
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 descendant commits onto updated working copy

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -57,11 +57,11 @@ fn test_chmod_regular_conflict() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  n
-    ◉ │  x
+    │ ○  n
+    ○ │  x
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
@@ -163,15 +163,15 @@ fn test_chmod_file_dir_deletion_conflicts() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    file_deletion
     ├─╮
-    │ ◉  deletion
-    │ │ ◉  file_dir
+    │ ○  deletion
+    │ │ ×  file_dir
     ╭───┤
-    │ │ ◉  dir
+    │ │ ○  dir
     │ ├─╯
-    ◉ │  file
+    ○ │  file
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     // The file-dir conflict cannot be chmod-ed

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -58,8 +58,8 @@ fn test_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  3e9369cd54227eb88455e1834dbc08aad6a16ac4
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
@@ -71,8 +71,8 @@ fn test_git_colocated() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  4f546c80f30abc0803fb83e5032a4d49fede4d68
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
@@ -83,9 +83,9 @@ fn test_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  0e2301a42b288b9568344e32cfdd8c76d1e56a83
-    ◉  4f546c80f30abc0803fb83e5032a4d49fede4d68 HEAD@git
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
-    ◉  0000000000000000000000000000000000000000
+    ○  4f546c80f30abc0803fb83e5032a4d49fede4d68 HEAD@git
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
@@ -120,7 +120,7 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Stage some change, and check out root. This shouldn't clobber the HEAD.
@@ -139,9 +139,9 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  fcdbbd731496cae17161cd6be9b6cf1f759655a8
-    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
+    │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Staged change shouldn't persist.
     checkout_index();
@@ -167,10 +167,10 @@ fn test_git_colocated_unborn_branch() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  0e14610343ef50775f5c44db5aeef19aee45d9ad
-    ◉  e3e01407bd3539722ae4ffff077700d97c60cb11 HEAD@git
-    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
+    ○  e3e01407bd3539722ae4ffff077700d97c60cb11 HEAD@git
+    │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Staged change shouldn't persist.
     checkout_index();
@@ -196,12 +196,12 @@ fn test_git_colocated_unborn_branch() {
     assert!(git_repo.head().is_err());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  10dd328bb906e15890e55047740eab2812a3b2f7
-    │ ◉  ef75c0b0dcc9b080e00226908c21316acaa84dc6
-    │ ◉  e3e01407bd3539722ae4ffff077700d97c60cb11 master
+    │ ○  ef75c0b0dcc9b080e00226908c21316acaa84dc6
+    │ ○  e3e01407bd3539722ae4ffff077700d97c60cb11 master
     ├─╯
-    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
+    │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // Staged change shouldn't persist.
     checkout_index();
@@ -221,13 +221,13 @@ fn test_git_colocated_unborn_branch() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  101e272377a9daff75358f10dbd078df922fe68c
-    ◉  fc8af9345b0830dcb14716e04cd2af26e2d19f63 HEAD@git
-    │ ◉  ef75c0b0dcc9b080e00226908c21316acaa84dc6
-    │ ◉  e3e01407bd3539722ae4ffff077700d97c60cb11 master
+    ○  fc8af9345b0830dcb14716e04cd2af26e2d19f63 HEAD@git
+    │ ○  ef75c0b0dcc9b080e00226908c21316acaa84dc6
+    │ ○  e3e01407bd3539722ae4ffff077700d97c60cb11 master
     ├─╯
-    │ ◉  993600f1189571af5bbeb492cf657dc7d0fde48a
+    │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -246,7 +246,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "foo"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7 foo
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // The branch gets updated when we modify the working copy, and it should get
@@ -254,7 +254,7 @@ fn test_git_colocated_export_branches_on_snapshot() {
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf foo
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(git_repo
         .find_reference("refs/heads/foo")
@@ -296,8 +296,8 @@ fn test_git_colocated_rebase_on_import() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
     insta::assert_snapshot!(stdout, @r###"
     @  5539e55eb3690b85a7ebd4a37a5e3b57f469ee94
-    ◉  47fe984daf66f7bf3ebf31b9cb3513c995afb857 master HEAD@git add a file
-    ◉  0000000000000000000000000000000000000000
+    ○  47fe984daf66f7bf3ebf31b9cb3513c995afb857 master HEAD@git add a file
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Reset the working copy parent to the new Git HEAD.
@@ -316,10 +316,10 @@ fn test_git_colocated_branches() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-", "-m", "bar"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  3560559274ab431feea00b7b7e0b9250ecce951f bar
-    │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda foo
+    │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda foo
     ├─╯
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Create a branch in jj. It should be exported to Git even though it points to
@@ -350,10 +350,10 @@ fn test_git_colocated_branches() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
     insta::assert_snapshot!(stdout, @r###"
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
-    │ ◉  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
+    │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Abandoned 1 commits that are no longer reachable.
@@ -373,8 +373,8 @@ fn test_git_colocated_branch_forget() {
     test_env.jj_cmd_ok(&workspace_root, &["branch", "create", "foo"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  65b6b74e08973b88d38404430f119c8c79465250 foo
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &workspace_root), @r###"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
@@ -497,10 +497,10 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  149cc31cb08a1589e6c5ee2cb2061559dc758ecb new
-    │ ◉  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
+    │ ○  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
     ├─╯
-    ◉  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  e61b6729ff4292870702f2f72b2a60165679ef37 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -524,12 +524,12 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     test_env.jj_cmd_ok(&clone_path, &["new", "A"]);
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
     @  9c2de797c3c299a40173c5af724329012b77cbdd
-    │ ◉  4a191a9013d3f3398ccf5e172792a61439dbcf3a C_to_move original C
+    │ ○  4a191a9013d3f3398ccf5e172792a61439dbcf3a C_to_move original C
     ├─╯
-    │ ◉  c49ec4fb50844d0e693f1609da970b11878772ee B_to_delete B_to_delete
+    │ ○  c49ec4fb50844d0e693f1609da970b11878772ee B_to_delete B_to_delete
     ├─╯
-    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A HEAD@git A
-    ◉  0000000000000000000000000000000000000000
+    ◆  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A HEAD@git A
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     test_env.jj_cmd_ok(&origin_path, &["branch", "delete", "B_to_delete"]);
@@ -545,11 +545,11 @@ fn test_git_colocated_fetch_deleted_or_moved_branch() {
     // "original C" and "B_to_delete" are abandoned, as the corresponding branches
     // were deleted or moved on the remote (#864)
     insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r###"
-    ◉  4f3d13296f978cbc351c46a43b4619c91b888475 C_to_move moved C
+    ○  4f3d13296f978cbc351c46a43b4619c91b888475 C_to_move moved C
     │ @  9c2de797c3c299a40173c5af724329012b77cbdd
     ├─╯
-    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A HEAD@git A
-    ◉  0000000000000000000000000000000000000000
+    ◆  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A HEAD@git A
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -592,8 +592,8 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  6bad94b10401f5fafc8a91064661224650d10d1b feature??
-    ◉  3230d52258f6de7e9afbd10da8d64503cc7cdca5 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  3230d52258f6de7e9afbd10da8d64503cc7cdca5 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // The working-copy content shouldn't be lost.
@@ -621,10 +621,10 @@ fn test_git_colocated_external_checkout() {
     // Checked out anonymous branch
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f8a23336e41840ed1757ef323402a770427dc89a
-    ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
-    │ ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
+    ○  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
+    │ ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Check out another branch by external command
@@ -635,10 +635,10 @@ fn test_git_colocated_external_checkout() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
     @  8bb9e8d42a37c2a4e8dcfad97fce0b8f49bc7afa
-    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master HEAD@git A
-    │ ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a B
+    ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master HEAD@git A
+    │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Reset the working copy parent to the new Git HEAD.
@@ -648,12 +648,12 @@ fn test_git_colocated_external_checkout() {
     test_env.jj_cmd_ok(&repo_path, &["new", "description(B)"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=C", "--no-edit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
+    ○  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
     @  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
-    ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
-    │ ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
+    ○  eccedddfa5152d99fc8ddd1081b375387a8a382a HEAD@git B
+    │ ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Check out another branch by external command
@@ -663,12 +663,12 @@ fn test_git_colocated_external_checkout() {
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
     insta::assert_snapshot!(stdout, @r###"
     @  ca2a4e32f08688c6fb795c4c034a0a7e09c0d804
-    ◉  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master HEAD@git A
-    │ ◉  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
-    │ ◉  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
-    │ ◉  eccedddfa5152d99fc8ddd1081b375387a8a382a B
+    ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master HEAD@git A
+    │ ○  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
+    │ ○  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
+    │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Reset the working copy parent to the new Git HEAD.
@@ -685,23 +685,23 @@ fn test_git_colocated_squash_undo() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo 9670380ac379
-    ◉  qpvuntsmwlqt a7e4cec4256b A HEAD@git
-    ◉  zzzzzzzzzzzz 000000000000
+    ○  qpvuntsmwlqt a7e4cec4256b A HEAD@git
+    ◆  zzzzzzzzzzzz 000000000000
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr 6ee662324e5a
-    ◉  qpvuntsmwlqt 13ab6b96d82e A HEAD@git
-    ◉  zzzzzzzzzzzz 000000000000
+    ○  qpvuntsmwlqt 13ab6b96d82e A HEAD@git
+    ◆  zzzzzzzzzzzz 000000000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
     insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo 9670380ac379
-    ◉  qpvuntsmwlqt a7e4cec4256b A HEAD@git
-    ◉  zzzzzzzzzzzz 000000000000
+    ○  qpvuntsmwlqt a7e4cec4256b A HEAD@git
+    ◆  zzzzzzzzzzzz 000000000000
     "###);
 }
 
@@ -719,8 +719,8 @@ fn test_git_colocated_undo_head_move() {
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  65b6b74e08973b88d38404430f119c8c79465250
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // HEAD should be unset
@@ -728,7 +728,7 @@ fn test_git_colocated_undo_head_move() {
     assert!(git_repo.head().is_err());
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Create commit on non-root commit
@@ -736,9 +736,9 @@ fn test_git_colocated_undo_head_move() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  69b19f73cf584f162f078fb0d91c55ca39d10bc7
-    ◉  eb08b363bb5ef8ee549314260488980d7bbe8f63 HEAD@git
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ○  eb08b363bb5ef8ee549314260488980d7bbe8f63 HEAD@git
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
@@ -756,8 +756,8 @@ fn test_git_colocated_undo_head_move() {
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  eb08b363bb5ef8ee549314260488980d7bbe8f63
-    ◉  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
-    ◉  0000000000000000000000000000000000000000
+    ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 HEAD@git
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -845,8 +845,8 @@ fn test_git_colocated_unreachable_commits() {
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  66ae47cee4f8c28ee8d7e4f5d9401b03c07e22f2
-    ◉  2ee37513d2b5e549f7478c671a780053614bff19 master HEAD@git initial
-    ◉  0000000000000000000000000000000000000000
+    ○  2ee37513d2b5e549f7478c671a780053614bff19 master HEAD@git initial
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -450,18 +450,18 @@ fn test_git_fetch_all() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Nothing in our repo before the fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
@@ -483,15 +483,15 @@ fn test_git_fetch_all() {
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // ==== Change both repos ====
@@ -499,14 +499,14 @@ fn test_git_fetch_all() {
     let source_log = create_trunk2_and_rebase_branches(&test_env, &source_git_repo_path);
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
-    ◉  babc49226c14 descr_for_b b
-    │ ◉  91e46b4b2653 descr_for_a2 a2
+    ○  babc49226c14 descr_for_b b
+    │ ○  91e46b4b2653 descr_for_a2 a2
     ├─╯
-    │ ◉  0424f6dfc1ff descr_for_a1 a1
+    │ ○  0424f6dfc1ff descr_for_a1 a1
     ├─╯
     @  8f1f14fbbf42 descr_for_trunk2 trunk2
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
     // Change a branch in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -516,15 +516,15 @@ fn test_git_fetch_all() {
 
     // Our repo before and after fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  061eddbb43ab new_descr_for_b_to_create_conflict b*
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  061eddbb43ab new_descr_for_b_to_create_conflict b*
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: nknoxmzm 359a9a02 descr_for_a1
@@ -561,18 +561,18 @@ fn test_git_fetch_all() {
       @origin: umznmzko 8f1f14fb descr_for_trunk2
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  babc49226c14 descr_for_b b?? b@origin
-    │ ◉  91e46b4b2653 descr_for_a2 a2
+    ○  babc49226c14 descr_for_b b?? b@origin
+    │ ○  91e46b4b2653 descr_for_a2 a2
     ├─╯
-    │ ◉  0424f6dfc1ff descr_for_a1 a1
+    │ ○  0424f6dfc1ff descr_for_a1 a1
     ├─╯
-    ◉  8f1f14fbbf42 descr_for_trunk2 trunk2
-    │ ◉  061eddbb43ab new_descr_for_b_to_create_conflict b??
+    ○  8f1f14fbbf42 descr_for_trunk2 trunk2
+    │ ○  061eddbb43ab new_descr_for_b_to_create_conflict b??
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -599,12 +599,12 @@ fn test_git_fetch_some_of_many_branches() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Test an error message
@@ -624,7 +624,7 @@ fn test_git_fetch_some_of_many_branches() {
     // Nothing in our repo before the fetch
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // Fetch one branch...
     let (stdout, stderr) =
@@ -634,11 +634,11 @@ fn test_git_fetch_some_of_many_branches() {
     branch: b@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  c7d4bdcbc215 descr_for_b b
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // ...check what the intermediate state looks like...
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
@@ -656,15 +656,15 @@ fn test_git_fetch_some_of_many_branches() {
     branch: a2@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  decaa3966c83 descr_for_a2 a2
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  decaa3966c83 descr_for_a2 a2
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    │ ◉  c7d4bdcbc215 descr_for_b b
+    │ ○  c7d4bdcbc215 descr_for_b b
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // Fetching the same branch again
     let (stdout, stderr) =
@@ -674,15 +674,15 @@ fn test_git_fetch_some_of_many_branches() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  decaa3966c83 descr_for_a2 a2
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  decaa3966c83 descr_for_a2 a2
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    │ ◉  c7d4bdcbc215 descr_for_b b
+    │ ○  c7d4bdcbc215 descr_for_b b
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // ==== Change both repos ====
@@ -690,14 +690,14 @@ fn test_git_fetch_some_of_many_branches() {
     let source_log = create_trunk2_and_rebase_branches(&test_env, &source_git_repo_path);
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
-    ◉  01d115196c39 descr_for_b b
-    │ ◉  31c7d94b1f29 descr_for_a2 a2
+    ○  01d115196c39 descr_for_b b
+    │ ○  31c7d94b1f29 descr_for_a2 a2
     ├─╯
-    │ ◉  6df2d34cf0da descr_for_a1 a1
+    │ ○  6df2d34cf0da descr_for_a1 a1
     ├─╯
     @  2bb3ebd2bba3 descr_for_trunk2 trunk2
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
     // Change a branch in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -707,15 +707,15 @@ fn test_git_fetch_some_of_many_branches() {
 
     // Our repo before and after fetch of two branches
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
@@ -728,18 +728,18 @@ fn test_git_fetch_some_of_many_branches() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  01d115196c39 descr_for_b b?? b@origin
-    │ ◉  6df2d34cf0da descr_for_a1 a1
+    ○  01d115196c39 descr_for_b b?? b@origin
+    │ ○  6df2d34cf0da descr_for_a1 a1
     ├─╯
-    ◉  2bb3ebd2bba3 descr_for_trunk2
-    │ ◉  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
+    ○  2bb3ebd2bba3 descr_for_trunk2
+    │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
     ├─╯
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // We left a2 where it was before, let's see how `jj branch list` sees this.
@@ -766,18 +766,18 @@ fn test_git_fetch_some_of_many_branches() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  31c7d94b1f29 descr_for_a2 a2
-    │ ◉  01d115196c39 descr_for_b b?? b@origin
+    ○  31c7d94b1f29 descr_for_a2 a2
+    │ ○  01d115196c39 descr_for_b b?? b@origin
     ├─╯
-    │ ◉  6df2d34cf0da descr_for_a1 a1
+    │ ○  6df2d34cf0da descr_for_a1 a1
     ├─╯
-    ◉  2bb3ebd2bba3 descr_for_trunk2
-    │ ◉  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
+    ○  2bb3ebd2bba3 descr_for_trunk2
+    │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b??
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &target_jj_repo_path), @r###"
     a1: ypowunwp 6df2d34c descr_for_a1
@@ -816,12 +816,12 @@ fn test_git_fetch_undo() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Fetch 2 branches
@@ -835,13 +835,13 @@ fn test_git_fetch_undo() {
     branch: b@origin  [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
@@ -849,7 +849,7 @@ fn test_git_fetch_undo() {
     // The undo works as expected
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
     // Now try to fetch just one branch
     let (stdout, stderr) =
@@ -859,11 +859,11 @@ fn test_git_fetch_undo() {
     branch: b@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  c7d4bdcbc215 descr_for_b b
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -891,12 +891,12 @@ fn test_fetch_undo_what() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Initial state we will try to return to after `op restore`. There are no
@@ -911,11 +911,11 @@ fn test_fetch_undo_what() {
     branch: b@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  c7d4bdcbc215 descr_for_b b
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     b: vpupmnsl c7d4bdcb descr_for_b
@@ -1068,12 +1068,12 @@ fn test_git_fetch_removed_branch() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Fetch all branches
@@ -1086,15 +1086,15 @@ fn test_git_fetch_removed_branch() {
     branch: trunk1@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Remove a2 branch in origin
@@ -1108,15 +1108,15 @@ fn test_git_fetch_removed_branch() {
     Nothing changed.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Fetch branches a2 from origin, and check that it has been removed locally
@@ -1128,13 +1128,13 @@ fn test_git_fetch_removed_branch() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  359a9a02457d descr_for_a1 a1
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -1160,12 +1160,12 @@ fn test_git_fetch_removed_parent_branch() {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
-    ◉  000000000000
+    ○  ff36dc55760e descr_for_trunk1 trunk1
+    ◆  000000000000
     "###);
 
     // Fetch all branches
@@ -1178,15 +1178,15 @@ fn test_git_fetch_removed_parent_branch() {
     branch: trunk1@origin [new] tracked
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    │ ◉  359a9a02457d descr_for_a1 a1
+    │ ○  359a9a02457d descr_for_a1 a1
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1 trunk1
+    ○  ff36dc55760e descr_for_trunk1 trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Remove all branches in origin.
@@ -1208,13 +1208,13 @@ fn test_git_fetch_removed_parent_branch() {
     Abandoned 1 commits that are no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    ◉  c7d4bdcbc215 descr_for_b b
-    │ ◉  decaa3966c83 descr_for_a2 a2
+    ○  c7d4bdcbc215 descr_for_b b
+    │ ○  decaa3966c83 descr_for_a2 a2
     ├─╯
-    ◉  ff36dc55760e descr_for_trunk1
+    ○  ff36dc55760e descr_for_trunk1
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -1275,10 +1275,10 @@ fn test_git_fetch_remote_only_branch() {
     test_env.add_config("git.auto-local-branch = false");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  9f01a0e04879 message feature1 feature2@origin
+    ◆  9f01a0e04879 message feature1 feature2@origin
     │ @  230dd059e1b0
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_branch_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -142,8 +142,8 @@ fn test_git_init_external(bare: bool) {
     insta::allow_duplicates! {
         insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
         @  f6950fc115ae
-        ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-        ◉  000000000000
+        ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+        ◆  000000000000
         "###);
     }
 }
@@ -268,17 +268,17 @@ fn test_git_init_colocated_via_git_repo_path() {
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f61b77cd4bb5
-    ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-    ◉  000000000000
+    ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+    ◆  000000000000
     "###);
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f1c7aa7c62d8
-    ◉  f61b77cd4bb5 HEAD@git
-    ◉  8d698d4a8ee1 my-branch My commit message
-    ◉  000000000000
+    ○  f61b77cd4bb5 HEAD@git
+    ○  8d698d4a8ee1 my-branch My commit message
+    ◆  000000000000
     "###);
 }
 
@@ -304,17 +304,17 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f61b77cd4bb5
-    ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-    ◉  000000000000
+    ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+    ◆  000000000000
     "###);
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f1c7aa7c62d8
-    ◉  f61b77cd4bb5 HEAD@git
-    ◉  8d698d4a8ee1 my-branch My commit message
-    ◉  000000000000
+    ○  f61b77cd4bb5 HEAD@git
+    ○  8d698d4a8ee1 my-branch My commit message
+    ◆  000000000000
     "###);
 }
 
@@ -339,17 +339,17 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f61b77cd4bb5
-    ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-    ◉  000000000000
+    ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+    ◆  000000000000
     "###);
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f1c7aa7c62d8
-    ◉  f61b77cd4bb5 HEAD@git
-    ◉  8d698d4a8ee1 my-branch My commit message
-    ◉  000000000000
+    ○  f61b77cd4bb5 HEAD@git
+    ○  8d698d4a8ee1 my-branch My commit message
+    ◆  000000000000
     "###);
 }
 
@@ -377,17 +377,17 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f61b77cd4bb5
-    ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-    ◉  000000000000
+    ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+    ◆  000000000000
     "###);
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f1c7aa7c62d8
-    ◉  f61b77cd4bb5 HEAD@git
-    ◉  8d698d4a8ee1 my-branch My commit message
-    ◉  000000000000
+    ○  f61b77cd4bb5 HEAD@git
+    ○  8d698d4a8ee1 my-branch My commit message
+    ◆  000000000000
     "###);
 }
 
@@ -417,17 +417,17 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f61b77cd4bb5
-    ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-    ◉  000000000000
+    ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+    ◆  000000000000
     "###);
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f1c7aa7c62d8
-    ◉  f61b77cd4bb5 HEAD@git
-    ◉  8d698d4a8ee1 my-branch My commit message
-    ◉  000000000000
+    ○  f61b77cd4bb5 HEAD@git
+    ○  8d698d4a8ee1 my-branch My commit message
+    ◆  000000000000
     "###);
 }
 
@@ -544,10 +544,10 @@ fn test_git_init_colocated_dirty_working_copy() {
     │  A new-staged-file
     │  M some-file
     │  A unstaged-file
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     │  A some-file
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Git index should be consistent with the working copy parent. With the
@@ -583,15 +583,15 @@ fn test_git_init_external_but_git_dir_exists() {
     // The local ".git" repository is unrelated, so no commits should be imported
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  4db490c88528
-    ◉  230dd059e1b0
-    ◉  000000000000
+    ○  230dd059e1b0
+    ◆  000000000000
     "###);
 }
 
@@ -612,17 +612,17 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f61b77cd4bb5
-    ◉  8d698d4a8ee1 my-branch HEAD@git My commit message
-    ◉  000000000000
+    ○  8d698d4a8ee1 my-branch HEAD@git My commit message
+    ◆  000000000000
     "###);
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  f1c7aa7c62d8
-    ◉  f61b77cd4bb5 HEAD@git
-    ◉  8d698d4a8ee1 my-branch My commit message
-    ◉  000000000000
+    ○  f61b77cd4bb5 HEAD@git
+    ○  8d698d4a8ee1 my-branch My commit message
+    ◆  000000000000
     "###);
 }
 
@@ -639,7 +639,7 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     // No HEAD@git ref is available yet
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  230dd059e1b0
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // Create the default branch (create both in case we change the default)
@@ -649,7 +649,7 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     // be created on top.
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
     @  230dd059e1b0 main master
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -561,11 +561,11 @@ fn test_git_push_multiple() {
     insta::assert_snapshot!(stdout, @r###"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 branch2 my-branch c4a3c310
     │  (empty) foo
-    │ ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
+    │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
     ├─╯  (empty) description 2
-    │ ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
+    │ ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 }
 
@@ -1028,13 +1028,13 @@ fn test_git_push_deleted() {
     "###);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  rlzusymt test.user@example.com 2001-02-03 08:05:10 branch2 8476341e
+    ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 branch2 8476341e
     │  (empty) description 2
-    │ ◉  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
+    │ ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     │ @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     ├─╯  (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::assert_snapshot!(stdout, @"");

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -232,7 +232,7 @@ fn test_git_remote_named_git() {
     // @git branch shouldn't be removed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbranches"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  main
+    ○  main
     │
     ~
     "###);

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -125,7 +125,7 @@ fn test_ignore_working_copy() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Modify the file. With --ignore-working-copy, we still get the same commit
@@ -141,7 +141,7 @@ fn test_ignore_working_copy() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 
@@ -351,30 +351,30 @@ fn test_color_config() {
     // Test that --color=always is respected.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that color is used if it's requested in the config file
     test_env.add_config(r#"ui.color="always""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that --color=never overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=never", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Test that --color=auto overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=auto", "log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Test that --config-toml 'ui.color="never"' overrides the config.
@@ -390,7 +390,7 @@ fn test_color_config() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // --color overrides --config-toml 'ui.color=...'.
@@ -408,15 +408,15 @@ fn test_color_config() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Test that NO_COLOR does NOT override the request for color in the config file
     test_env.add_env_var("NO_COLOR", "");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
-    ◉  [38;5;4m0000000000000000000000000000000000000000[39m
+    [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
+    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
     "###);
 
     // Test that per-repo config overrides the user config.
@@ -428,7 +428,7 @@ fn test_color_config() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 }
 

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -30,11 +30,11 @@ fn test_rewrite_immutable_generic() {
     insta::assert_snapshot!(stdout, @r###"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 7adb43e8
     │  c
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main 72e1b68c
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main 72e1b68c
     ├─╯  b
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 b84b821b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 b84b821b
     │  a
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Cannot rewrite a commit in the configured set
@@ -189,12 +189,12 @@ fn test_rewrite_immutable_commands() {
     insta::assert_snapshot!(stdout, @r###"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 65147295
     │  (empty) (no description set)
-    │ ◉  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 1d5af877 conflict
+    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 1d5af877 conflict
     ╭─┤  merge
     │ │
     │ ~
     │
-    ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 72e1b68c
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:10 72e1b68c
     │  b
     ~
     "###);

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -139,7 +139,7 @@ fn test_init_git_external(bare: bool) {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @r###"
-        ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+        ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
         │  My commit message
         ~
         "###);
@@ -207,7 +207,7 @@ fn test_init_git_colocated() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -216,7 +216,7 @@ fn test_init_git_colocated() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -246,7 +246,7 @@ fn test_init_git_colocated_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -255,7 +255,7 @@ fn test_init_git_colocated_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -284,7 +284,7 @@ fn test_init_git_colocated_symlink_directory() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -293,7 +293,7 @@ fn test_init_git_colocated_symlink_directory() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -325,7 +325,7 @@ fn test_init_git_colocated_symlink_directory_without_bare_config() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -334,7 +334,7 @@ fn test_init_git_colocated_symlink_directory_without_bare_config() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -368,7 +368,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     // Check that the Git repo's HEAD got checked out
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
+    ○  mwrttmos git.user@example.com 1970-01-01 11:02:03 my-branch HEAD@git 8d698d4a
     │  My commit message
     ~
     "###);
@@ -377,7 +377,7 @@ fn test_init_git_colocated_symlink_gitlink() {
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
+    ○  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 HEAD@git f61b77cd
     │  (no description set)
     ~
     "###);
@@ -477,14 +477,14 @@ fn test_init_git_external_but_git_dir_exists() {
     // The local ".git" repository is unrelated, so no commits should be imported
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###);

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -71,8 +71,8 @@ fn test_log_with_or_without_diff() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
-    ◉  add a file
-    ◉
+    ○  add a file
+    ◆
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p"]);
@@ -81,10 +81,10 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ◉  add a file
+    ○  add a file
     │  Added regular file file1:
     │          1: foo
-    ◉
+    ◆
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--no-graph"]);
@@ -101,11 +101,11 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ◉  add a file
+    ○  add a file
     │  A file1
     │  Added regular file file1:
     │          1: foo
-    ◉
+    ◆
     "###);
 
     // `-s` for summary, `--git` for git diff (which implies `-p`)
@@ -120,7 +120,7 @@ fn test_log_with_or_without_diff() {
     │  @@ -1,1 +1,2 @@
     │   foo
     │  +bar
-    ◉  add a file
+    ○  add a file
     │  A file1
     │  diff --git a/file1 b/file1
     │  new file mode 100644
@@ -129,7 +129,7 @@ fn test_log_with_or_without_diff() {
     │  +++ b/file1
     │  @@ -1,0 +1,1 @@
     │  +foo
-    ◉
+    ◆
     "###);
 
     // `-p` enables default "summary" output, so `-s` is noop
@@ -147,9 +147,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
     │  M file1
-    ◉  add a file
+    ○  add a file
     │  A file1
-    ◉
+    ◆
     "###);
 
     // `-p` enables default "color-words" diff output, so `--color-words` is noop
@@ -162,10 +162,10 @@ fn test_log_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    ◉  add a file
+    ○  add a file
     │  Added regular file file1:
     │          1: foo
-    ◉
+    ◆
     "###);
 
     // `--git` enables git diff, so `-p` is noop
@@ -218,9 +218,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  a new commit
     │  M file1
-    ◉  add a file
+    ○  add a file
     │  A file1
-    ◉
+    ◆
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -505,7 +505,7 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
         @r###"
-    ◉  Change qpvuntsmwlqt initial e0e22b9fae75 original
+    ○  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
     "###
@@ -523,17 +523,17 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4med[0m[38;5;8me204633421[39m
-    ◉  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mef3[0m[38;5;8md013266cd[39m
-    ◉  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4maf[0m[38;5;8m95b841712d[39m
-    ◉  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m23[0m[38;5;8mc1103d3427[39m
-    ◉  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4mb87[0m[38;5;8maa9b24921[39m
-    ◉  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m1e[0m[38;5;8ma31a205ce9[39m
-    ◉  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m34[0m[38;5;8mbefb94f4eb[39m
-    ◉  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4mcc[0m[38;5;8m0c127948ef[39m
-    ◉  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7b715afc3f[39m
-    ◉  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4me0[0m[38;5;8me22b9fae75[39m [38;5;5moriginal[39m
-    ◉  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4med[0m[38;5;8me204633421[39m
+    ○  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mef3[0m[38;5;8md013266cd[39m
+    ○  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4maf[0m[38;5;8m95b841712d[39m
+    ○  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m23[0m[38;5;8mc1103d3427[39m
+    ○  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4mb87[0m[38;5;8maa9b24921[39m
+    ○  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4m1e[0m[38;5;8ma31a205ce9[39m
+    ○  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m34[0m[38;5;8mbefb94f4eb[39m
+    ○  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4mcc[0m[38;5;8m0c127948ef[39m
+    ○  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7b715afc3f[39m
+    ○  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4me0[0m[38;5;8me22b9fae75[39m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
     "###
     );
     let stdout = test_env.jj_cmd_success(
@@ -549,17 +549,17 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4med[0m[38;5;8me[39m
-    ◉  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mef3[0m
-    ◉  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4maf[0m[38;5;8m9[39m
-    ◉  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m23[0m[38;5;8mc[39m
-    ◉  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4mb87[0m
-    ◉  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m1e[0m[38;5;8ma[39m
-    ◉  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m34[0m[38;5;8mb[39m
-    ◉  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4mcc[0m[38;5;8m0[39m
-    ◉  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7[39m
-    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m[38;5;8me[39m [38;5;5moriginal[39m
-    ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4med[0m[38;5;8me[39m
+    ○  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mef3[0m
+    ○  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4maf[0m[38;5;8m9[39m
+    ○  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m23[0m[38;5;8mc[39m
+    ○  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4mb87[0m
+    ○  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4m1e[0m[38;5;8ma[39m
+    ○  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m34[0m[38;5;8mb[39m
+    ○  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4mcc[0m[38;5;8m0[39m
+    ○  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7[39m
+    ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m[38;5;8me[39m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
     "###
     );
     let stdout = test_env.jj_cmd_success(
@@ -575,17 +575,17 @@ fn test_log_prefix_highlight_styled() {
     );
     insta::assert_snapshot!(stdout,
         @r###"
-    @  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4med[0m
-    ◉  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mef3[0m
-    ◉  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4maf[0m
-    ◉  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m23[0m
-    ◉  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4mb87[0m
-    ◉  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m1e[0m
-    ◉  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m34[0m
-    ◉  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4mcc[0m
-    ◉  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m1b[0m
-    ◉  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m [38;5;5moriginal[39m
-    ◉  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4med[0m
+    ○  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mef3[0m
+    ○  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4maf[0m
+    ○  Change [1m[38;5;5mzn[0m commit6 [1m[38;5;4m23[0m
+    ○  Change [1m[38;5;5myo[0m commit5 [1m[38;5;4mb87[0m
+    ○  Change [1m[38;5;5mvr[0m commit4 [1m[38;5;4m1e[0m
+    ○  Change [1m[38;5;5myq[0m commit3 [1m[38;5;4m34[0m
+    ○  Change [1m[38;5;5mro[0m commit2 [1m[38;5;4mcc[0m
+    ○  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m1b[0m
+    ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
     "###
     );
 }
@@ -621,7 +621,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
         @r###"
     @  Change q[pvuntsmwlqt] initial e0[e22b9fae75] original
-    ◉  Change z[zzzzzzzzzzz] 0[00000000000]
+    ◆  Change z[zzzzzzzzzzz] 0[00000000000]
     "###
     );
 
@@ -637,9 +637,9 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
         test_env.jj_cmd_success(&repo_path, &["log", "-T", prefix_format]),
         @r###"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
-    │ ◉  Change qpv[untsmwlqt] initial e0e[22b9fae75] original
+    │ ○  Change qpv[untsmwlqt] initial e0e[22b9fae75] original
     ├─╯
-    ◉  Change zzz[zzzzzzzzz] 00[0000000000]
+    ◆  Change zzz[zzzzzzzzz] 00[0000000000]
     "###
     );
     insta::assert_snapshot!(
@@ -668,22 +668,22 @@ fn test_log_short_shortest_length_parameter() {
     insta::assert_snapshot!(
         render(r#"commit_id.short(0) ++ "|" ++ commit_id.shortest(0)"#), @r###"
     @  |2
-    ◉  |0
+    ◆  |0
     "###);
     insta::assert_snapshot!(
         render(r#"commit_id.short(-0) ++ "|" ++ commit_id.shortest(-0)"#), @r###"
     @  |2
-    ◉  |0
+    ◆  |0
     "###);
     insta::assert_snapshot!(
         render(r#"commit_id.short(-100) ++ "|" ++ commit_id.shortest(-100)"#), @r###"
     @  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
-    ◉  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
+    ◆  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
     "###);
     insta::assert_snapshot!(
         render(r#"commit_id.short(100) ++ "|" ++ commit_id.shortest(100)"#), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22|230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000|0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000|0000000000000000000000000000000000000000
     "###);
 }
 
@@ -734,7 +734,7 @@ fn test_log_divergence() {
     // No divergence
     insta::assert_snapshot!(stdout, @r###"
     @  description 1
-    ◉
+    ◆
     "###);
 
     // Create divergence
@@ -744,10 +744,10 @@ fn test_log_divergence() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  description 2 !divergence!
+    ○  description 2 !divergence!
     │ @  description 1 !divergence!
     ├─╯
-    ◉
+    ◆
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -765,8 +765,8 @@ fn test_log_reversed() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉
-    ◉  first
+    ◆
+    ○  first
     @  second
     "###);
 
@@ -795,7 +795,7 @@ fn test_log_filtered_by_path() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
     @  second
-    ◉  first
+    ○  first
     │
     ~
     "###);
@@ -811,7 +811,7 @@ fn test_log_filtered_by_path() {
     insta::assert_snapshot!(stdout, @r###"
     @  second
     │  M file1
-    ◉  first
+    ○  first
     │  A file1
     ~
     "###);
@@ -843,7 +843,7 @@ fn test_log_filtered_by_path() {
     @  second
     │  M file1
     │  A file2
-    ◉  first
+    ○  first
     │  A file1
     ~
     "###);
@@ -863,7 +863,7 @@ fn test_log_filtered_by_path() {
     insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
     @  second
     │  M repo/file1
-    ◉  first
+    ○  first
     │  A repo/file1
     ~
     "###);
@@ -908,8 +908,8 @@ fn test_log_limit() {
     insta::assert_snapshot!(stdout, @r###"
     @    d
     ├─╮
-    │ ◉  b
-    ◉ │  c
+    │ ○  b
+    ○ │  c
     ├─╯
     "###);
 
@@ -918,7 +918,7 @@ fn test_log_limit() {
     insta::assert_snapshot!(stdout, @r###"
     @    d
     ├─╮
-    │ ◉  b
+    │ ○  b
     "###);
 
     let stdout = test_env.jj_cmd_success(
@@ -936,10 +936,10 @@ fn test_log_limit() {
         &["log", "-T", "description", "--limit=3", "--reversed"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    ◉
-    ◉    a
+    ◆
+    ○    a
     ├─╮
-    │ ◉  c
+    │ ○  c
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -963,7 +963,7 @@ fn test_log_limit() {
         &["log", "-T", "description", "--limit=1", "b", "c"],
     );
     insta::assert_snapshot!(stdout, @r###"
-    ◉  c
+    ○  c
     │
     ~
     "###);
@@ -1101,7 +1101,7 @@ fn test_multiple_revsets() {
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches", "-rfoo"]),
         @r###"
-    ◉  foo
+    ○  foo
     │
     ~
     "###);
@@ -1109,15 +1109,15 @@ fn test_multiple_revsets() {
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches", "-rfoo", "-rbar", "-rbaz"]),
         @r###"
     @  baz
-    ◉  bar
-    ◉  foo
+    ○  bar
+    ○  foo
     │
     ~
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "branches", "-rfoo", "-rfoo"]),
         @r###"
-    ◉  foo
+    ○  foo
     │
     ~
     "###);
@@ -1148,26 +1148,26 @@ fn test_graph_template_color() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
     @  single line
-    ◉  first line
+    ○  first line
     │  second line
     │  third line
-    ◉
+    ◆
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;2msingle line[0m
-    ◉  [38;5;1mfirst line[39m
+    [1m[38;5;2m@[0m  [1m[38;5;2msingle line[0m
+    ○  [38;5;1mfirst line[39m
     │  [38;5;1msecond line[39m
     │  [38;5;1mthird line[39m
-    ◉
+    [1m[38;5;14m◆[0m
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=debug", "log", "-T", template]);
     insta::assert_snapshot!(stdout, @r###"
-    <<node::@>>  [1m[38;5;2m<<log working_copy description::single line>>[0m
-    <<node::◉>>  [38;5;1m<<log description::first line>>[39m
+    [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;2m<<log working_copy description::single line>>[0m
+    <<node::○>>  [38;5;1m<<log description::first line>>[39m
     │  [38;5;1m<<log description::second line>>[39m
     │  [38;5;1m<<log description::third line>>[39m
-    <<node::◉>>
+    [1m[38;5;14m<<node immutable::◆>>[0m
     "###);
 }
 
@@ -1195,15 +1195,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─╮
-    │ ◉  side branch
+    │ ○  side branch
     │ │  with
     │ │  long
     │ │  description
-    │ ◉  main branch 2
+    │ ○  main branch 2
     ├─╯
-    ◉  main branch 1
-    ◉  initial
-    ◉
+    ○  main branch 1
+    ○  initial
+    ◆
     "###);
 
     // ASCII style
@@ -1220,7 +1220,7 @@ fn test_graph_styles() {
     |/
     o  main branch 1
     o  initial
-    o
+    +
     "###);
 
     // Large ASCII style
@@ -1239,7 +1239,7 @@ fn test_graph_styles() {
     |/
     o  main branch 1
     o  initial
-    o
+    +
     "###);
 
     // Curved style
@@ -1248,15 +1248,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─╮
-    │ ◉  side branch
+    │ ○  side branch
     │ │  with
     │ │  long
     │ │  description
-    │ ◉  main branch 2
+    │ ○  main branch 2
     ├─╯
-    ◉  main branch 1
-    ◉  initial
-    ◉
+    ○  main branch 1
+    ○  initial
+    ◆
     "###);
 
     // Square style
@@ -1265,15 +1265,15 @@ fn test_graph_styles() {
     insta::assert_snapshot!(stdout, @r###"
     @    merge
     ├─┐
-    │ ◉  side branch
+    │ ○  side branch
     │ │  with
     │ │  long
     │ │  description
-    │ ◉  main branch 2
+    │ ○  main branch 2
     ├─┘
-    ◉  main branch 1
-    ◉  initial
-    ◉
+    ○  main branch 1
+    ○  initial
+    ◆
     "###);
 }
 
@@ -1324,7 +1324,7 @@ fn test_log_word_wrap() {
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r###"
-    @  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
     │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12m04[38;5;8m4c0400[39m[0m
     ~  [1m[38;5;10m(empty)[39m merge[0m
     "###);
@@ -1336,18 +1336,18 @@ fn test_log_word_wrap() {
     ├─╮  3 4 5
     │ │  6 7 8
     │ │  9
-    │ ◉  0 1 2
+    │ ○  0 1 2
     │ │  3 4 5
     │ │  6 7 8
     │ │  9
-    │ ◉  0 1 2
+    │ ○  0 1 2
     ├─╯  3 4 5
     │    6 7 8
     │    9
-    ◉  0 1 2 3
+    ○  0 1 2 3
     │  4 5 6 7
     │  8 9
-    ◉  0 1 2 3
+    ◆  0 1 2 3
        4 5 6 7
        8 9
     "###);
@@ -1401,17 +1401,17 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("::"), @r###"
     @    merge
     ├─╮
-    │ ◉  side branch 2
+    │ ○  side branch 2
     │ │
-    │ ◉  side branch 1
+    │ ○  side branch 1
     │ │
-    ◉ │  main branch 2
+    ○ │  main branch 2
     │ │
-    ◉ │  main branch 1
+    ○ │  main branch 1
     ├─╯
-    ◉  initial
+    ○  initial
     │
-    ◉
+    ◆
     "###);
 
     // Elide some commits from each side of the merge. It's unclear that a revision
@@ -1420,11 +1420,11 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
     @    merge
     ├─╮
-    │ ◉  side branch 2
+    │ ○  side branch 2
     │ ╷
-    ◉ ╷  main branch 2
+    ○ ╷  main branch 2
     ├─╯
-    ◉  initial
+    ○  initial
     │
     ~
     "###);
@@ -1432,11 +1432,11 @@ fn test_elided() {
     // Elide shared commits. It's unclear that a revision was skipped on the right
     // side (#1252).
     insta::assert_snapshot!(get_log("@-- | root()"), @r###"
-    ◉  side branch 1
+    ○  side branch 1
     ╷
-    ╷ ◉  main branch 1
+    ╷ ○  main branch 1
     ╭─╯
-    ◉
+    ◆
     "###);
 
     // Now test the same thing with synthetic nodes for elided commits
@@ -1446,14 +1446,14 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
     @    merge
     ├─╮
-    │ ◉  side branch 2
+    │ ○  side branch 2
     │ │
-    │ ◌  (elided revisions)
-    ◉ │  main branch 2
+    │ ~  (elided revisions)
+    ○ │  main branch 2
     │ │
-    ◌ │  (elided revisions)
+    ~ │  (elided revisions)
     ├─╯
-    ◉  initial
+    ○  initial
     │
     ~
     "###);
@@ -1461,14 +1461,14 @@ fn test_elided() {
     // Elide shared commits. To keep the implementation simple, it still gets
     // rendered as two synthetic nodes.
     insta::assert_snapshot!(get_log("@-- | root()"), @r###"
-    ◉  side branch 1
+    ○  side branch 1
     │
-    ◌  (elided revisions)
-    │ ◉  main branch 1
+    ~  (elided revisions)
+    │ ○  main branch 1
     │ │
-    │ ◌  (elided revisions)
+    │ ~  (elided revisions)
     ├─╯
-    ◉
+    ◆
     "###);
 }
 

--- a/cli/tests/test_move_command.rs
+++ b/cli/tests/test_move_command.rs
@@ -56,13 +56,13 @@ fn test_move() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a847ab4967fe f
-    ◉  c2f9de87325d e
-    ◉  e0dac715116f d
-    │ ◉  59597b34a0d8 c
-    │ ◉  12d6103dc0c8 b
+    ○  c2f9de87325d e
+    ○  e0dac715116f d
+    │ ○  59597b34a0d8 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
 
     // Errors out without arguments
@@ -95,12 +95,12 @@ fn test_move() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a45950b1b7ff f
-    ◉  c2f9de87325d e
-    ◉  e0dac715116f d
-    │ ◉  12d6103dc0c8 b c
+    ○  c2f9de87325d e
+    ○  e0dac715116f d
+    │ ○  12d6103dc0c8 b c
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -127,12 +127,12 @@ fn test_move() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  5e5727af3d75 f
-    ◉  ed9c41643a77 e
-    │ ◉  59597b34a0d8 c
-    │ ◉  12d6103dc0c8 b
+    ○  ed9c41643a77 e
+    │ ○  59597b34a0d8 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a d
-    ◉  000000000000
+    ○  b7b767179c44 a d
+    ◆  000000000000
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
@@ -156,12 +156,12 @@ fn test_move() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e21f6bb01bae f
-    ◉  3cf0fa772663 d e
-    │ ◉  59597b34a0d8 c
-    │ ◉  12d6103dc0c8 b
+    ○  3cf0fa772663 d e
+    │ ○  59597b34a0d8 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "d"]);
@@ -200,11 +200,11 @@ fn test_move_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e0dac715116f d
-    │ ◉  087591be5a01 c
-    │ ◉  12d6103dc0c8 b
+    │ ○  087591be5a01 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
 
     let edit_script = test_env.set_up_fake_diff_editor();
@@ -221,10 +221,10 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  987bcfb2eb62 d
-    │ ◉  12d6103dc0c8 b c
+    │ ○  12d6103dc0c8 b c
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -255,11 +255,11 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  576244e87883 d
-    │ ◉  6f486f2f4539 c
-    │ ◉  12d6103dc0c8 b
+    │ ○  6f486f2f4539 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -292,11 +292,11 @@ fn test_move_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  5b407c249fa7 d
-    │ ◉  724d64da1487 c
-    │ ◉  12d6103dc0c8 b
+    │ ○  724d64da1487 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -327,12 +327,12 @@ fn test_move_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  d2a587ae205d c
-    ◉  a53394306362 b
+    ○  d2a587ae205d c
+    ○  a53394306362 b
     │ @  e0dac715116f d
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000
+    ○  b7b767179c44 a
+    ◆  000000000000
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -27,29 +27,29 @@ fn test_new() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
-    ◉  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
-    ◉  0000000000000000000000000000000000000000
+    ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Start a new change off of a specific commit (the root commit in this case).
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "off of root", "root()"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ◉  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
-    │ ◉  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
+    │ ○  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
+    │ ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // --edit is a no-op
     test_env.jj_cmd_ok(&repo_path, &["new", "--edit", "-m", "yet another commit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  101cbec5cae8049cb9850a906ef3675631ed48fa yet another commit
-    ◉  026537ddb96b801b9cb909985d5443aab44616c1 off of root
-    │ ◉  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
-    │ ◉  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
+    ○  026537ddb96b801b9cb909985d5443aab44616c1 off of root
+    │ ○  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
+    │ ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // --edit cannot be used with --no-edit
@@ -80,10 +80,10 @@ fn test_new_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    2f9a61ea1fef257eca52fcee2feec1cbd2e41660
     ├─╮
-    │ ◉  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
+    │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
+    ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @"a");
@@ -98,12 +98,12 @@ fn test_new_merge() {
     Created new commit znkkpsqq 496490a6 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    496490a66cebb31730c4103b7b22a1098d49af91
+    ○    496490a66cebb31730c4103b7b22a1098d49af91
     ├─╮
     │ @  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
+    ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // Same test with `jj merge`
@@ -112,10 +112,10 @@ fn test_new_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    114023233c454e2eca22b8b209f9e42f755eb28c
     ├─╮
-    │ ◉  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
-    ◉ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
+    │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
+    ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
 
     // `jj merge` with less than two arguments is an error
@@ -161,14 +161,14 @@ fn test_new_insert_after() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // --insert-after can be repeated; --after is an alias
@@ -184,18 +184,18 @@ fn test_new_insert_after() {
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉  C
-    │ ◉  F
+    ○  C
+    │ ○  F
     ╭─┤
     @ │    G
     ├───╮
-    │ │ ◉  D
-    ◉ │ │  B
-    ◉ │ │  A
+    │ │ ○  D
+    ○ │ │  B
+    ○ │ │  A
     ├───╯
-    │ ◉  E
+    │ ○  E
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) =
@@ -207,19 +207,19 @@ fn test_new_insert_after() {
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉  C
-    │ ◉  F
+    ○  C
+    │ ○  F
     ╭─┤
-    ◉ │    G
+    ○ │    G
     ├───╮
     │ │ @  H
-    │ │ ◉  D
-    ◉ │ │  B
-    ◉ │ │  A
+    │ │ ○  D
+    ○ │ │  B
+    ○ │ │  A
     ├───╯
-    │ ◉  E
+    │ ○  E
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // --after cannot be used with revisions
@@ -242,14 +242,14 @@ fn test_new_insert_after_children() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // Check that inserting G after A and C doesn't try to rebase B (which is
@@ -276,17 +276,17 @@ fn test_new_insert_after_children() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    G
     ├─╮
-    │ ◉  C
-    │ ◉  B
+    │ ○  C
+    │ ○  B
     ├─╯
-    ◉  A
-    │ ◉    F
+    ○  A
+    │ ○    F
     │ ├─╮
-    │ │ ◉  E
+    │ │ ○  E
     ├───╯
-    │ ◉  D
+    │ ○  D
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 }
 
@@ -299,14 +299,14 @@ fn test_new_insert_before() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -330,18 +330,18 @@ fn test_new_insert_before() {
     Parent commit      : znkkpsqq 41a89ffc E | (empty) E
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉  F
-    │ ◉  C
+    ○  F
+    │ ○  C
     ├─╯
     @      G
     ├─┬─╮
-    │ │ ◉  E
-    │ ◉ │  D
+    │ │ ○  E
+    │ ○ │  D
     │ ├─╯
-    ◉ │  B
-    ◉ │  A
+    ○ │  B
+    ○ │  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     // --before cannot be used with revisions
@@ -364,14 +364,14 @@ fn test_new_insert_before_root_successors() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -393,17 +393,17 @@ fn test_new_insert_before_root_successors() {
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉    F
+    ○    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
-    │ │ ◉  C
-    │ │ ◉  B
-    │ │ ◉  A
+    │ ○  E
+    ○ │  D
+    │ │ ○  C
+    │ │ ○  B
+    │ │ ○  A
     ├───╯
     @ │  G
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 }
 
@@ -418,14 +418,14 @@ fn test_new_insert_before_no_loop() {
     insta::assert_snapshot!(stdout, @r###"
     @    7705d353bf5d F
     ├─╮
-    │ ◉  41a89ffcbba2 E
-    ◉ │  c9257eff5bf9 D
+    │ ○  41a89ffcbba2 E
+    ○ │  c9257eff5bf9 D
     ├─╯
-    │ ◉  83376b270925 C
-    │ ◉  bfd4157e6ea4 B
-    │ ◉  5ef24e4bf2be A
+    │ ○  83376b270925 C
+    │ ○  bfd4157e6ea4 B
+    │ ○  5ef24e4bf2be A
     ├─╯
-    ◉  000000000000 root
+    ◆  000000000000 root
     "###);
 
     let stderr = test_env.jj_cmd_failure(
@@ -454,14 +454,14 @@ fn test_new_insert_before_no_root_merge() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let stderr = test_env.jj_cmd_failure(
@@ -490,14 +490,14 @@ fn test_new_insert_before_root() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let stderr =
@@ -516,14 +516,14 @@ fn test_new_insert_after_before() {
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
     @    F
     ├─╮
-    │ ◉  E
-    ◉ │  D
+    │ ○  E
+    ○ │  D
     ├─╯
-    │ ◉  C
-    │ ◉  B
-    │ ◉  A
+    │ ○  C
+    │ ○  B
+    │ ○  A
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -537,17 +537,17 @@ fn test_new_insert_after_before() {
     Parent commit      : mzvwutvl 83376b27 C | (empty) C
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉      F
+    ○      F
     ├─┬─╮
     │ │ @  G
-    │ │ ◉  C
-    │ │ ◉  B
-    │ │ ◉  A
-    │ ◉ │  E
+    │ │ ○  C
+    │ │ ○  B
+    │ │ ○  A
+    │ ○ │  E
     │ ├─╯
-    ◉ │  D
+    ○ │  D
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -561,20 +561,20 @@ fn test_new_insert_after_before() {
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     "###);
     insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
-    ◉      F
+    ○      F
     ├─┬─╮
-    │ │ ◉  G
-    │ │ ◉  C
-    │ │ ◉    B
+    │ │ ○  G
+    │ │ ○  C
+    │ │ ○    B
     │ │ ├─╮
     │ │ │ @  H
     ├─────╯
-    ◉ │ │  D
-    │ │ ◉  A
+    ○ │ │  D
+    │ │ ○  A
     ├───╯
-    │ ◉  E
+    │ ○  E
     ├─╯
-    ◉  root
+    ◆  root
     "###);
 }
 
@@ -589,14 +589,14 @@ fn test_new_insert_after_before_no_loop() {
     insta::assert_snapshot!(stdout, @r###"
     @    7705d353bf5d F
     ├─╮
-    │ ◉  41a89ffcbba2 E
-    ◉ │  c9257eff5bf9 D
+    │ ○  41a89ffcbba2 E
+    ○ │  c9257eff5bf9 D
     ├─╯
-    │ ◉  83376b270925 C
-    │ ◉  bfd4157e6ea4 B
-    │ ◉  5ef24e4bf2be A
+    │ ○  83376b270925 C
+    │ ○  bfd4157e6ea4 B
+    │ ○  5ef24e4bf2be A
     ├─╯
-    ◉  000000000000 root
+    ◆  000000000000 root
     "###);
 
     let stderr = test_env.jj_cmd_failure(

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -74,10 +74,10 @@ fn test_prev_simple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
@@ -100,11 +100,11 @@ fn test_prev_multiple_without_root() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt
-    ◉  zsuskulnrvyr fourth
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  zsuskulnrvyr fourth
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "2"]);
@@ -146,12 +146,12 @@ fn test_next_parent_has_multiple_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  mzvwutvlkqwt 4
+    ○  mzvwutvlkqwt 4
     @  zsuskulnrvyr 3
-    │ ◉  kkmpptxzrspx 2
-    │ ◉  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    │ ○  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     // --edit is implied since the working copy isn't a leaf commit.
@@ -163,11 +163,11 @@ fn test_next_parent_has_multiple_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt 4
-    ◉  zsuskulnrvyr 3
-    │ ◉  kkmpptxzrspx 2
-    │ ◉  qpvuntsmwlqt 1
+    ○  zsuskulnrvyr 3
+    │ ○  kkmpptxzrspx 2
+    │ ○  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -187,14 +187,14 @@ fn test_next_with_merge_commit_parent() {
     test_env.jj_cmd_ok(&repo_path, &["prev", "0"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  royxmykxtrkr
-    │ ◉  mzvwutvlkqwt 4
+    │ ○  mzvwutvlkqwt 4
     ├─╯
-    ◉    zsuskulnrvyr 3
+    ○    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
@@ -205,13 +205,13 @@ fn test_next_with_merge_commit_parent() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  vruxwmqvtpmx
-    ◉  mzvwutvlkqwt 4
-    ◉    zsuskulnrvyr 3
+    ○  mzvwutvlkqwt 4
+    ○    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -230,13 +230,13 @@ fn test_next_on_merge_commit() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  mzvwutvlkqwt 4
+    ○  mzvwutvlkqwt 4
     @    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     // --edit is implied since the working copy is not a leaf commit.
@@ -248,12 +248,12 @@ fn test_next_on_merge_commit() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt 4
-    ◉    zsuskulnrvyr 3
+    ○    zsuskulnrvyr 3
     ├─╮
-    │ ◉  kkmpptxzrspx 2
-    ◉ │  qpvuntsmwlqt 1
+    │ ○  kkmpptxzrspx 2
+    ○ │  qpvuntsmwlqt 1
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -349,10 +349,10 @@ fn test_prev_on_merge_commit() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    royxmykxtrkr
     ├─╮
-    │ ◉  zsuskulnrvyr right second
-    ◉ │  qpvuntsmwlqt left first
+    │ ○  zsuskulnrvyr right second
+    ○ │  qpvuntsmwlqt left first
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
@@ -398,14 +398,14 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    royxmykxtrkr M
     ├─╮
-    │ ◉  mzvwutvlkqwt 1
-    ◉ │    zsuskulnrvyr z
+    │ ○  mzvwutvlkqwt 1
+    ○ │    zsuskulnrvyr z
     ├───╮
-    │ │ ◉  kkmpptxzrspx y
+    │ │ ○  kkmpptxzrspx y
     │ ├─╯
-    ◉ │  qpvuntsmwlqt x
+    ○ │  qpvuntsmwlqt x
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev"], "2\n");
@@ -455,14 +455,14 @@ fn test_prev_prompts_on_multiple_parents() {
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  vruxwmqvtpmx
-    ◉      yqosqzytrlsw merge
+    ○      yqosqzytrlsw merge
     ├─┬─╮
-    │ │ ◉  qpvuntsmwlqt first
-    │ ◉ │  kkmpptxzrspx second
+    │ │ ○  qpvuntsmwlqt first
+    │ ○ │  kkmpptxzrspx second
     │ ├─╯
-    ◉ │  mzvwutvlkqwt third
+    ○ │  mzvwutvlkqwt third
     ├─╯
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
 
     // Move @ backwards.
@@ -492,11 +492,11 @@ fn test_prev_beyond_root_fails() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  mzvwutvlkqwt
-    ◉  zsuskulnrvyr fourth
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  zsuskulnrvyr fourth
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
     // @- is at "fourth", and there is no parent 5 commits behind it.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "5"]);
@@ -520,10 +520,10 @@ fn test_prev_editing() {
     // Check that the graph looks the way we expect.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr fourth
-    ◉  kkmpptxzrspx third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  kkmpptxzrspx third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit"]);
@@ -587,21 +587,21 @@ fn test_prev_conflict() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  yqosqzytrlsw conflict
-    ◉  royxmykxtrkr conflict fourth
-    ◉  kkmpptxzrspx conflict third
-    ◉  rlvkpnrzqnoo conflict second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ×  royxmykxtrkr conflict fourth
+    ×  kkmpptxzrspx conflict third
+    ×  rlvkpnrzqnoo conflict second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
     test_env.jj_cmd_ok(&repo_path, &["prev", "--conflict"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  yostqsxwqrlt conflict
-    │ ◉  royxmykxtrkr conflict fourth
+    │ ×  royxmykxtrkr conflict fourth
     ├─╯
-    ◉  kkmpptxzrspx conflict third
-    ◉  rlvkpnrzqnoo conflict second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ×  kkmpptxzrspx conflict third
+    ×  rlvkpnrzqnoo conflict second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -623,18 +623,18 @@ fn test_prev_conflict_editing() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  royxmykxtrkr conflict
-    ◉  kkmpptxzrspx conflict third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ×  kkmpptxzrspx conflict third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
     test_env.jj_cmd_ok(&repo_path, &["prev", "--conflict", "--edit"]);
     // We now should be editing the third commit.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  kkmpptxzrspx conflict third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -658,19 +658,19 @@ fn test_next_conflict() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  royxmykxtrkr
-    │ ◉  kkmpptxzrspx conflict third
-    │ ◉  rlvkpnrzqnoo second
+    │ ×  kkmpptxzrspx conflict third
+    │ ○  rlvkpnrzqnoo second
     ├─╯
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
     test_env.jj_cmd_ok(&repo_path, &["next", "--conflict"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  vruxwmqvtpmx conflict
-    ◉  kkmpptxzrspx conflict third
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ×  kkmpptxzrspx conflict third
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -692,17 +692,17 @@ fn test_next_conflict_editing() {
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  kkmpptxzrspx conflict
-    ◉  rlvkpnrzqnoo second
+    ×  kkmpptxzrspx conflict
+    ○  rlvkpnrzqnoo second
     @  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
     test_env.jj_cmd_ok(&repo_path, &["next", "--conflict", "--edit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  kkmpptxzrspx conflict
-    ◉  rlvkpnrzqnoo second
-    ◉  qpvuntsmwlqt first
-    ◉  zzzzzzzzzzzz
+    ○  rlvkpnrzqnoo second
+    ○  qpvuntsmwlqt first
+    ◆  zzzzzzzzzzzz
     "###);
 }
 
@@ -720,7 +720,7 @@ fn test_next_conflict_head() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  rlvkpnrzqnoo conflict
-    ◉  zzzzzzzzzzzz
+    ◆  zzzzzzzzzzzz
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--conflict"]);
     insta::assert_snapshot!(stderr, @r###"

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -31,24 +31,24 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
     "###);
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "obslog"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
     │  [1mmy description[0m
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mc[0m[38;5;8mf73917d[39m [38;5;1mconflict[39m
+    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mc[0m[38;5;8mf73917d[39m [38;5;1mconflict[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m06[0m[38;5;8m8224a7[39m
+    ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m06[0m[38;5;8m8224a7[39m
     │  my description
-    ◉  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m2b[0m[38;5;8m023b5f[39m
+    ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m2b[0m[38;5;8m023b5f[39m
        [38;5;2m(empty)[39m my description
     "###);
 
@@ -66,16 +66,16 @@ fn test_obslog_with_or_without_diff() {
     │     5     : foo
     │     6     : bar
     │     7    1: >>>>>>> Conflict 1 of 1 endsresolved
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 068224a7
     │  my description
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
     "###);
 
@@ -84,7 +84,7 @@ fn test_obslog_with_or_without_diff() {
     insta::assert_snapshot!(stdout, @r###"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
-    ◉  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 cf73917d conflict
     │  my description
     "###);
 
@@ -196,14 +196,14 @@ fn test_obslog_word_wrap() {
     insta::assert_snapshot!(render(&["obslog"], 40, false), @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
     insta::assert_snapshot!(render(&["obslog"], 40, true), @r###"
     @  qpvuntsm test.user@example.com
     │  2001-02-03 08:05:08 fa15625b
     │  (empty) first
-    ◉  qpvuntsm hidden test.user@example.com
+    ○  qpvuntsm hidden test.user@example.com
        2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
@@ -246,41 +246,41 @@ fn test_obslog_squash() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉    qpvuntsm test.user@example.com 2001-02-03 08:05:12 1408a0a7
+    ○    qpvuntsm test.user@example.com 2001-02-03 08:05:12 1408a0a7
     ├─╮  squashed 2
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │     2    2: bar
     │ │          3: baz
-    │ ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:12 7015a42c
+    │ ○  zsuskuln hidden test.user@example.com 2001-02-03 08:05:12 7015a42c
     │ │  third
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │     2    2: bar
     │ │          3: baz
-    │ ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:11 66645763
+    │ ○  zsuskuln hidden test.user@example.com 2001-02-03 08:05:11 66645763
     │ │  (empty) third
-    │ ◉  zsuskuln hidden test.user@example.com 2001-02-03 08:05:10 1c7afcb4
+    │ ○  zsuskuln hidden test.user@example.com 2001-02-03 08:05:10 1c7afcb4
     │    (empty) (no description set)
-    ◉    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:10 e3c2a446
+    ○    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:10 e3c2a446
     ├─╮  squashed 1
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    │ ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 46acd22a
+    │ ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 46acd22a
     │ │  second
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    │ ◉  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 cba41deb
+    │ ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:09 cba41deb
     │    (empty) second
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 766420db
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:09 766420db
     │  first
     │  Added regular file file1:
     │          1: foo
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 fa15625b
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
-    ◉  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
+    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
     "###);
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -39,11 +39,11 @@ fn test_op_log() {
     @  c1851f1c3d90 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     let op_log_lines = stdout.lines().collect_vec();
     let add_workspace_id = op_log_lines[3].split(' ').nth(2).unwrap();
@@ -51,21 +51,21 @@ fn test_op_log() {
 
     // Can load the repo at a specific operation ID
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, initialize_repo_id), @r###"
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, add_workspace_id), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // "@" resolves to the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@"), @r###"
     @  19611c995a342c01f525583e5fcafdd211f6d009
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     // "@-" resolves to the parent of the head operation
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@-"), @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
-    ◉  0000000000000000000000000000000000000000
+    ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "@----"]), @r###"
@@ -212,22 +212,22 @@ fn test_op_log_template() {
 
     insta::assert_snapshot!(render(r#"id ++ "\n""#), @r###"
     @  b51416386f2685fd5493f2b20e8eec3c24a1776d9e1a7cb5ed7e30d2d9c88c0c1e1fe71b0b7358cba60de42533d1228ed9878f2f89817d892c803395ccf9fe92
-    ◉  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
-    ◉  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    ○  9a7d829846af88a2f7a1e348fb46ff58729e49632bc9c6a052aec8501563cb0d10f4a4e6010ffde529f84a2b9b5b3a4c211a889106a41f6c076dfdacc79f6af7
+    ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
                                 time.start(), time.end(), time.duration()) ++ "\n""#), @r###"
     @  b5141 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
-    ◉  9a7d8 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
-    ◉  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
+    ○  9a7d8 false test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+    ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
     "###);
 
     // Negative length shouldn't cause panic.
     insta::assert_snapshot!(render(r#"id.short(-1) ++ "|""#), @r###"
     @  <Error: out of range integral type conversion attempted>|
-    ◉  <Error: out of range integral type conversion attempted>|
-    ◉  <Error: out of range integral type conversion attempted>|
+    ○  <Error: out of range integral type conversion attempted>|
+    ○  <Error: out of range integral type conversion attempted>|
     "###);
 
     // Test the default template, i.e. with relative start time and duration. We
@@ -244,9 +244,9 @@ fn test_op_log_template() {
     insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r###"
     @  b51416386f26 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com NN years ago, lasted less than a microsecond
+    ○  9a7d829846af test-username@host.example.com NN years ago, lasted less than a microsecond
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 }
 
@@ -314,9 +314,9 @@ fn test_op_log_word_wrap() {
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @r###"
     @  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @r###"
     @  b51416386f26
@@ -324,12 +324,12 @@ fn test_op_log_word_wrap() {
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af
+    ○  9a7d829846af
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 }
 
@@ -365,14 +365,14 @@ fn test_op_abandon_ancestors() {
     @  c2878c428b1c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
-    ◉  5d0ab09ab0fa test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  5d0ab09ab0fa test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj commit -m 'commit 1'
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Abandon old operations. The working-copy operation id should be updated.
@@ -389,7 +389,7 @@ fn test_op_abandon_ancestors() {
     @  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Abandon operation range.
@@ -404,10 +404,10 @@ fn test_op_abandon_ancestors() {
     @  d92d0753399f test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit c5f7dd51add0046405055336ef443f882a0a8968
     │  args: jj commit -m 'commit 5'
-    ◉  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Can't abandon the current operation.
@@ -438,10 +438,10 @@ fn test_op_abandon_ancestors() {
     @  0699d720d0ce test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     │  undo operation d92d0753399f732e438bdd88fa7e5214cba2a310d120ec1714028a514c7116bcf04b4a0b26c04dbecf0a917f1d4c8eb05571b8816dd98b0502aaf321e92500b3
     │  args: jj undo
-    ◉  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 
     // Abandon empty range.

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -28,28 +28,28 @@ fn test_parallelize_no_descendants() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  02b7709cc4e9 6 parents: 5
-    ◉  1b2f08d76b66 5 parents: 4
-    ◉  e5c4cf44e237 4 parents: 3
-    ◉  4cd999dfaac0 3 parents: 2
-    ◉  d3902619fade 2 parents: 1
-    ◉  8b64ddff700d 1 parents:
-    ◉  000000000000 parents:
+    ○  1b2f08d76b66 5 parents: 4
+    ○  e5c4cf44e237 4 parents: 3
+    ○  4cd999dfaac0 3 parents: 2
+    ○  d3902619fade 2 parents: 1
+    ○  8b64ddff700d 1 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  4850b4629edb 6 parents:
-    │ ◉  87627fbb7d29 5 parents:
+    │ ○  87627fbb7d29 5 parents:
     ├─╯
-    │ ◉  5b9815e28fae 4 parents:
+    │ ○  5b9815e28fae 4 parents:
     ├─╯
-    │ ◉  bb1bb465ccc2 3 parents:
+    │ ○  bb1bb465ccc2 3 parents:
     ├─╯
-    │ ◉  337eca1ef3a8 2 parents:
+    │ ○  337eca1ef3a8 2 parents:
     ├─╯
-    │ ◉  8b64ddff700d 1 parents:
+    │ ○  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -66,12 +66,12 @@ fn test_parallelize_with_descendants_simple() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  02b7709cc4e9 6 parents: 5
-    ◉  1b2f08d76b66 5 parents: 4
-    ◉  e5c4cf44e237 4 parents: 3
-    ◉  4cd999dfaac0 3 parents: 2
-    ◉  d3902619fade 2 parents: 1
-    ◉  8b64ddff700d 1 parents:
-    ◉  000000000000 parents:
+    ○  1b2f08d76b66 5 parents: 4
+    ○  e5c4cf44e237 4 parents: 3
+    ○  4cd999dfaac0 3 parents: 2
+    ○  d3902619fade 2 parents: 1
+    ○  8b64ddff700d 1 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(
@@ -80,16 +80,16 @@ fn test_parallelize_with_descendants_simple() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9bc057f8b6e3 6 parents: 5
-    ◉        9e36a8afe793 5 parents: 1 2 3 4
+    ○        9e36a8afe793 5 parents: 1 2 3 4
     ├─┬─┬─╮
-    │ │ │ ◉  5b9815e28fae 4 parents:
-    │ │ ◉ │  bb1bb465ccc2 3 parents:
+    │ │ │ ○  5b9815e28fae 4 parents:
+    │ │ ○ │  bb1bb465ccc2 3 parents:
     │ │ ├─╯
-    │ ◉ │  337eca1ef3a8 2 parents:
+    │ ○ │  337eca1ef3a8 2 parents:
     │ ├─╯
-    ◉ │  8b64ddff700d 1 parents:
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -109,14 +109,14 @@ fn test_parallelize_where_interior_has_non_target_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(5)", "-m=6"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  2508ea92308a 6 parents: 5
-    ◉  1b2f08d76b66 5 parents: 4
-    ◉  e5c4cf44e237 4 parents: 3
-    ◉  4cd999dfaac0 3 parents: 2
-    │ ◉  3e7571e62c87 2c parents: 2
+    ○  1b2f08d76b66 5 parents: 4
+    ○  e5c4cf44e237 4 parents: 3
+    ○  4cd999dfaac0 3 parents: 2
+    │ ○  3e7571e62c87 2c parents: 2
     ├─╯
-    ◉  d3902619fade 2 parents: 1
-    ◉  8b64ddff700d 1 parents:
-    ◉  000000000000 parents:
+    ○  d3902619fade 2 parents: 1
+    ○  8b64ddff700d 1 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(
@@ -125,18 +125,18 @@ fn test_parallelize_where_interior_has_non_target_children() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  c9525dff9d03 6 parents: 5
-    ◉        b3ad09518546 5 parents: 1 2 3 4
+    ○        b3ad09518546 5 parents: 1 2 3 4
     ├─┬─┬─╮
-    │ │ │ ◉  3b125ed6a683 4 parents:
-    │ │ ◉ │  1ed8c0c5be30 3 parents:
+    │ │ │ ○  3b125ed6a683 4 parents:
+    │ │ ○ │  1ed8c0c5be30 3 parents:
     │ │ ├─╯
-    │ │ │ ◉  c01d8e85ea96 2c parents: 1 2
+    │ │ │ ○  c01d8e85ea96 2c parents: 1 2
     ╭─┬───╯
-    │ ◉ │  7efea6c89b60 2 parents:
+    │ ○ │  7efea6c89b60 2 parents:
     │ ├─╯
-    ◉ │  8b64ddff700d 1 parents:
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -153,12 +153,12 @@ fn test_parallelize_where_root_has_non_target_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m=4"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9132691e6256 4 parents: 3
-    ◉  4cd999dfaac0 3 parents: 2
-    ◉  d3902619fade 2 parents: 1
-    │ ◉  6c64110df0a5 1c parents: 1
+    ○  4cd999dfaac0 3 parents: 2
+    ○  d3902619fade 2 parents: 1
+    │ ○  6c64110df0a5 1c parents: 1
     ├─╯
-    ◉  8b64ddff700d 1 parents:
-    ◉  000000000000 parents:
+    ○  8b64ddff700d 1 parents:
+    ◆  000000000000 parents:
     "###);
     test_env.jj_cmd_ok(
         &workspace_path,
@@ -167,14 +167,14 @@ fn test_parallelize_where_root_has_non_target_children() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @      3397916989e7 4 parents: 1 2 3
     ├─┬─╮
-    │ │ ◉  1f768c1bc591 3 parents:
-    │ ◉ │  12ef12b4640e 2 parents:
+    │ │ ○  1f768c1bc591 3 parents:
+    │ ○ │  12ef12b4640e 2 parents:
     │ ├─╯
-    │ │ ◉  6c64110df0a5 1c parents: 1
+    │ │ ○  6c64110df0a5 1c parents: 1
     ├───╯
-    ◉ │  8b64ddff700d 1 parents:
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -197,14 +197,14 @@ fn test_parallelize_with_merge_commit_child() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m", "4"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  99ffaf5b3984 4 parents: 3
-    ◉  4cd999dfaac0 3 parents: 2
-    │ ◉  4313cc3b476f 2a-c parents: 2 a
+    ○  4cd999dfaac0 3 parents: 2
+    │ ○  4313cc3b476f 2a-c parents: 2 a
     ╭─┤
-    │ ◉  1eb902150bb9 a parents:
-    ◉ │  d3902619fade 2 parents: 1
-    ◉ │  8b64ddff700d 1 parents:
+    │ ○  1eb902150bb9 a parents:
+    ○ │  d3902619fade 2 parents: 1
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     // After this finishes, child-2a will have three parents: "1", "2", and "a".
@@ -215,16 +215,16 @@ fn test_parallelize_with_merge_commit_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @      3ee9279847a6 4 parents: 1 2 3
     ├─┬─╮
-    │ │ ◉  bb1bb465ccc2 3 parents:
-    │ │ │ ◉  c70ee196514b 2a-c parents: 1 2 a
+    │ │ ○  bb1bb465ccc2 3 parents:
+    │ │ │ ○  c70ee196514b 2a-c parents: 1 2 a
     ╭─┬───┤
-    │ │ │ ◉  1eb902150bb9 a parents:
+    │ │ │ ○  1eb902150bb9 a parents:
     │ │ ├─╯
-    │ ◉ │  337eca1ef3a8 2 parents:
+    │ ○ │  337eca1ef3a8 2 parents:
     │ ├─╯
-    ◉ │  8b64ddff700d 1 parents:
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -240,9 +240,9 @@ fn test_parallelize_disconnected_target_commits() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  4cd999dfaac0 3 parents: 2
-    ◉  d3902619fade 2 parents: 1
-    ◉  8b64ddff700d 1 parents:
-    ◉  000000000000 parents:
+    ○  d3902619fade 2 parents: 1
+    ○  8b64ddff700d 1 parents:
+    ◆  000000000000 parents:
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -255,9 +255,9 @@ fn test_parallelize_disconnected_target_commits() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  4cd999dfaac0 3 parents: 2
-    ◉  d3902619fade 2 parents: 1
-    ◉  8b64ddff700d 1 parents:
-    ◉  000000000000 parents:
+    ○  d3902619fade 2 parents: 1
+    ○  8b64ddff700d 1 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -279,28 +279,28 @@ fn test_parallelize_head_is_a_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    1fb53c45237e merged-head parents: 2 b
     ├─╮
-    │ ◉  a7bf5001cfd8 b parents: a
-    │ ◉  6ca0450a05f5 a parents:
-    ◉ │  1f81bd465ed0 2 parents: 1
-    ◉ │  0c058af014a6 1 parents: 0
-    ◉ │  745bea8029c1 0 parents:
+    │ ○  a7bf5001cfd8 b parents: a
+    │ ○  6ca0450a05f5 a parents:
+    ○ │  1f81bd465ed0 2 parents: 1
+    ○ │  0c058af014a6 1 parents: 0
+    ○ │  745bea8029c1 0 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    82131a679769 merged-head parents: 0 b
     ├─╮
-    │ ◉  a7bf5001cfd8 b parents: a
-    │ ◉  6ca0450a05f5 a parents:
-    │ │ ◉  daef04bc3fae 2 parents: 0
+    │ ○  a7bf5001cfd8 b parents: a
+    │ ○  6ca0450a05f5 a parents:
+    │ │ ○  daef04bc3fae 2 parents: 0
     ├───╯
-    │ │ ◉  0c058af014a6 1 parents: 0
+    │ │ ○  0c058af014a6 1 parents: 0
     ├───╯
-    ◉ │  745bea8029c1 0 parents:
+    ○ │  745bea8029c1 0 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -319,27 +319,27 @@ fn test_parallelize_interior_target_is_a_merge() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  9b77792c77ac 3 parents: 2
-    ◉    1e29145c95fd 2 parents: 1 a
+    ○    1e29145c95fd 2 parents: 1 a
     ├─╮
-    │ ◉  427890ea3f2b a parents:
-    ◉ │  0c058af014a6 1 parents: 0
-    ◉ │  745bea8029c1 0 parents:
+    │ ○  427890ea3f2b a parents:
+    ○ │  0c058af014a6 1 parents: 0
+    ○ │  745bea8029c1 0 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    042fc3f4315c 3 parents: 0 a
     ├─╮
-    │ │ ◉  80603361bb48 2 parents: 0 a
+    │ │ ○  80603361bb48 2 parents: 0 a
     ╭─┬─╯
-    │ ◉  427890ea3f2b a parents:
-    │ │ ◉  0c058af014a6 1 parents: 0
+    │ ○  427890ea3f2b a parents:
+    │ │ ○  0c058af014a6 1 parents: 0
     ├───╯
-    ◉ │  745bea8029c1 0 parents:
+    ○ │  745bea8029c1 0 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -358,13 +358,13 @@ fn test_parallelize_root_is_a_merge() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  cc239b744d01 3 parents: 2
-    ◉  2bf00c2ad44c 2 parents: 1
-    ◉    1c6853121f3c 1 parents: y x
+    ○  2bf00c2ad44c 2 parents: 1
+    ○    1c6853121f3c 1 parents: y x
     ├─╮
-    │ ◉  4035b23c8f72 x parents:
-    ◉ │  ca57511e158f y parents:
+    │ ○  4035b23c8f72 x parents:
+    ○ │  ca57511e158f y parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(
@@ -374,14 +374,14 @@ fn test_parallelize_root_is_a_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    2c7fdfa00b38 3 parents: 1 2
     ├─╮
-    │ ◉    3acbd32944d6 2 parents: y x
+    │ ○    3acbd32944d6 2 parents: y x
     │ ├─╮
-    ◉ │ │  1c6853121f3c 1 parents: y x
+    ○ │ │  1c6853121f3c 1 parents: y x
     ╰─┬─╮
-      │ ◉  4035b23c8f72 x parents:
-      ◉ │  ca57511e158f y parents:
+      │ ○  4035b23c8f72 x parents:
+      ○ │  ca57511e158f y parents:
       ├─╯
-      ◉  000000000000 parents:
+      ◆  000000000000 parents:
     "###);
 }
 
@@ -395,20 +395,20 @@ fn test_parallelize_multiple_heads() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  97d7522f40e8 2 parents: 0
-    │ ◉  0c058af014a6 1 parents: 0
+    │ ○  0c058af014a6 1 parents: 0
     ├─╯
-    ◉  745bea8029c1 0 parents:
-    ◉  000000000000 parents:
+    ○  745bea8029c1 0 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(0)::"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  e84481c26195 2 parents:
-    │ ◉  6270540ee067 1 parents:
+    │ ○  6270540ee067 1 parents:
     ├─╯
-    │ ◉  745bea8029c1 0 parents:
+    │ ○  745bea8029c1 0 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -425,10 +425,10 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  97d7522f40e8 2 parents: 0
-    │ ◉  0c058af014a6 1 parents: 0
+    │ ○  0c058af014a6 1 parents: 0
     ├─╯
-    ◉  745bea8029c1 0 parents:
-    ◉  000000000000 parents:
+    ○  745bea8029c1 0 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(
@@ -436,11 +436,11 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
         &["parallelize", "description(0)", "description(1)"],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    ◉  6270540ee067 1 parents:
+    ○  6270540ee067 1 parents:
     │ @  97d7522f40e8 2 parents: 0
-    │ ◉  745bea8029c1 0 parents:
+    │ ○  745bea8029c1 0 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -458,25 +458,25 @@ fn test_parallelize_multiple_roots() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  34da938ad94a 3 parents: 2
-    ◉    85d5043b881d 2 parents: 1 a
+    ○    85d5043b881d 2 parents: 1 a
     ├─╮
-    │ ◉  6d37472c632c a parents:
-    ◉ │  8b64ddff700d 1 parents:
+    │ ○  6d37472c632c a parents:
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     // Succeeds because the roots have the same parents.
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "root().."]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  3c90598481cd 3 parents:
-    │ ◉  b96aa55582e5 2 parents:
+    │ ○  b96aa55582e5 2 parents:
     ├─╯
-    │ ◉  6d37472c632c a parents:
+    │ ○  6d37472c632c a parents:
     ├─╯
-    │ ◉  8b64ddff700d 1 parents:
+    │ ○  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -494,14 +494,14 @@ fn test_parallelize_multiple_heads_with_different_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=c"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  4bc4dace0e65 parents: c
-    ◉  63b0da9212c0 c parents: b
-    ◉  a7bf5001cfd8 b parents: a
-    ◉  6ca0450a05f5 a parents:
-    │ ◉  4cd999dfaac0 3 parents: 2
-    │ ◉  d3902619fade 2 parents: 1
-    │ ◉  8b64ddff700d 1 parents:
+    ○  63b0da9212c0 c parents: b
+    ○  a7bf5001cfd8 b parents: a
+    ○  6ca0450a05f5 a parents:
+    │ ○  4cd999dfaac0 3 parents: 2
+    │ ○  d3902619fade 2 parents: 1
+    │ ○  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(
@@ -514,18 +514,18 @@ fn test_parallelize_multiple_heads_with_different_children() {
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  f6c9d9ee3db8 parents: c
-    ◉    62661d5f0c77 c parents: a b
+    ○    62661d5f0c77 c parents: a b
     ├─╮
-    │ ◉  c9ea9058f5c7 b parents:
-    ◉ │  6ca0450a05f5 a parents:
+    │ ○  c9ea9058f5c7 b parents:
+    ○ │  6ca0450a05f5 a parents:
     ├─╯
-    │ ◉    dac1be696563 3 parents: 1 2
+    │ ○    dac1be696563 3 parents: 1 2
     │ ├─╮
-    │ │ ◉  7efea6c89b60 2 parents:
+    │ │ ○  7efea6c89b60 2 parents:
     ├───╯
-    │ ◉  8b64ddff700d 1 parents:
+    │ ○  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -546,12 +546,12 @@ fn test_parallelize_multiple_roots_with_different_parents() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    ba4297d53c1a merged-head parents: 2 b
     ├─╮
-    │ ◉  6577defaca2d b parents: a
-    │ ◉  1eb902150bb9 a parents:
-    ◉ │  d3902619fade 2 parents: 1
-    ◉ │  8b64ddff700d 1 parents:
+    │ ○  6577defaca2d b parents: a
+    │ ○  1eb902150bb9 a parents:
+    ○ │  d3902619fade 2 parents: 1
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 
     test_env.jj_cmd_ok(
@@ -561,14 +561,14 @@ fn test_parallelize_multiple_roots_with_different_parents() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    0943ed52b3ed merged-head parents: 1 a
     ├─╮
-    │ │ ◉  6577defaca2d b parents: a
+    │ │ ○  6577defaca2d b parents: a
     │ ├─╯
-    │ ◉  1eb902150bb9 a parents:
-    │ │ ◉  d3902619fade 2 parents: 1
+    │ ○  1eb902150bb9 a parents:
+    │ │ ○  d3902619fade 2 parents: 1
     ├───╯
-    ◉ │  8b64ddff700d 1 parents:
+    ○ │  8b64ddff700d 1 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###);
 }
 
@@ -587,19 +587,19 @@ fn test_parallelize_complex_nonlinear_target() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3c", "description(3)"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  b043eb81416c 3c parents: 3
-    │ ◉    48277ee9afe0 4 parents: 3 2 1
+    │ ○    48277ee9afe0 4 parents: 3 2 1
     ╭─┼─╮
-    ◉ │ │  944922f0c69f 3 parents: 0
-    │ │ │ ◉  9d28e8e38435 2c parents: 2
+    ○ │ │  944922f0c69f 3 parents: 0
+    │ │ │ ○  9d28e8e38435 2c parents: 2
     │ ├───╯
-    │ ◉ │  97d7522f40e8 2 parents: 0
+    │ ○ │  97d7522f40e8 2 parents: 0
     ├─╯ │
-    │ ◉ │  6c82c22a5e35 1c parents: 1
+    │ ○ │  6c82c22a5e35 1c parents: 1
     │ ├─╯
-    │ ◉  0c058af014a6 1 parents: 0
+    │ ○  0c058af014a6 1 parents: 0
     ├─╯
-    ◉  745bea8029c1 0 parents:
-    ◉  000000000000 parents:
+    ○  745bea8029c1 0 parents:
+    ◆  000000000000 parents:
     "###);
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
@@ -614,20 +614,20 @@ fn test_parallelize_complex_nonlinear_target() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    59a216e537c4 3c parents: 0 3
     ├─╮
-    │ ◉  cb9447869bf0 3 parents:
-    │ │ ◉  248ce1ffd76b 2c parents: 0 2
+    │ ○  cb9447869bf0 3 parents:
+    │ │ ○  248ce1ffd76b 2c parents: 0 2
     ╭───┤
-    │ │ ◉  8f4b8ef68676 2 parents:
+    │ │ ○  8f4b8ef68676 2 parents:
     │ ├─╯
-    │ │ ◉  55c626d090e2 1c parents: 0 1
+    │ │ ○  55c626d090e2 1c parents: 0 1
     ╭───┤
-    │ │ ◉  82918d78c984 1 parents:
+    │ │ ○  82918d78c984 1 parents:
     │ ├─╯
-    ◉ │  745bea8029c1 0 parents:
+    ○ │  745bea8029c1 0 parents:
     ├─╯
-    │ ◉  14ca4df576b3 4 parents:
+    │ ○  14ca4df576b3 4 parents:
     ├─╯
-    ◉  000000000000 parents:
+    ◆  000000000000 parents:
     "###)
 }
 

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -182,13 +182,13 @@ fn test_rebase_branch() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ◉  d
-    │ │ ◉  c
+    │ ○  d
+    │ │ ○  c
     │ ├─╯
-    │ ◉  b
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "e"]);
@@ -197,13 +197,13 @@ fn test_rebase_branch() {
     Rebased 3 commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  d
-    │ ◉  c
+    ○  d
+    │ ○  c
     ├─╯
-    ◉  b
+    ○  b
     @  e
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Test rebasing multiple branches at once
@@ -219,13 +219,13 @@ fn test_rebase_branch() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ◉  d
+    │ ○  d
     ├─╯
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  b
-    ◉  a
-    ◉
+    ○  b
+    ○  a
+    ◆
     "###);
 
     // Same test but with more than one revision per argument
@@ -249,13 +249,13 @@ fn test_rebase_branch() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    │ ◉  d
+    │ ○  d
     ├─╯
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  b
-    ◉  a
-    ◉
+    ○  b
+    ○  a
+    ◆
     "###);
 }
 
@@ -274,13 +274,13 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  d
-    │ ◉  c
-    │ │ ◉  b
+    │ ○  d
+    │ ○  c
+    │ │ ○  b
     ├───╯
-    ◉ │  a
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
@@ -295,12 +295,12 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  d
-    │ ◉  c
-    │ ◉  b
+    │ ○  d
+    │ ○  c
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -316,12 +316,12 @@ fn test_rebase_branch_with_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  d
-    │ ◉  c
-    │ ◉  b
+    │ ○  d
+    │ ○  c
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 }
 
@@ -339,13 +339,13 @@ fn test_rebase_single_revision() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    ◉    d
+    ○    d
     ├─╮
-    │ ◉  c
-    ◉ │  b
+    │ ○  c
+    ○ │  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Descendants of the rebased commit "c" should be rebased onto parents. First
@@ -361,14 +361,14 @@ fn test_rebase_single_revision() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e
-    ◉    d
+    ○    d
     ├─╮
-    │ │ ◉  c
+    │ │ ○  c
     ├───╯
-    ◉ │  b
+    ○ │  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -387,13 +387,13 @@ fn test_rebase_single_revision() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    e
     ├─╮
-    │ ◉  c
-    ◉ │  b
+    │ ○  c
+    ○ │  b
     ├─╯
-    │ ◉  d
+    │ ○  d
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 }
 
@@ -411,11 +411,11 @@ fn test_rebase_single_revision_merge_parent() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    d
     ├─╮
-    │ ◉  c
-    │ ◉  b
-    ◉ │  a
+    │ ○  c
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Descendants of the rebased commit should be rebased onto parents, and if
@@ -433,12 +433,12 @@ fn test_rebase_single_revision_merge_parent() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    d
     ├─╮
-    │ ◉  b
-    │ │ ◉  c
+    │ ○  b
+    │ │ ○  c
     ├───╯
-    ◉ │  a
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 }
 
@@ -460,18 +460,18 @@ fn test_rebase_multiple_revisions() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  i
-    │ ◉  h
-    │ ◉  g
+    │ ○  h
+    │ ○  g
     ├─╯
-    ◉    f
+    ○    f
     ├─╮
-    │ ◉  e
-    │ ◉  d
-    ◉ │  c
-    ◉ │  b
+    │ ○  e
+    │ ○  d
+    ○ │  c
+    ○ │  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Test with two non-related non-merge commits.
@@ -487,20 +487,20 @@ fn test_rebase_multiple_revisions() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  i
-    │ ◉  h
-    │ ◉  g
+    │ ○  h
+    │ ○  g
     ├─╯
-    ◉    f
+    ○    f
     ├─╮
-    │ ◉  d
-    ◉ │  b
+    │ ○  d
+    ○ │  b
     ├─╯
-    │ ◉  e
+    │ ○  e
     ├─╯
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -519,19 +519,19 @@ fn test_rebase_multiple_revisions() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  i
-    │ ◉  h
-    │ ◉  g
+    │ ○  h
+    │ ○  g
     ├─╯
-    ◉    f
+    ○    f
     ├─╮
-    │ │ ◉  c
-    │ │ ◉  b
+    │ │ ○  c
+    │ │ ○  b
     │ ├─╯
-    │ ◉  e
-    │ ◉  d
+    │ ○  e
+    │ ○  d
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -551,18 +551,18 @@ fn test_rebase_multiple_revisions() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    i
     ├─╮
-    │ │ ◉  h
+    │ │ ○  h
     ╭─┬─╯
-    │ ◉  d
-    ◉ │  c
-    ◉ │  b
+    │ ○  d
+    ○ │  c
+    ○ │  b
     ├─╯
-    │ ◉  g
-    │ ◉  f
-    │ ◉  e
+    │ ○  g
+    │ ○  f
+    │ ○  e
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -586,18 +586,18 @@ fn test_rebase_multiple_revisions() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    i
     ├─╮
-    │ │ ◉  g
+    │ │ ○  g
     ╭─┬─╯
-    │ ◉  e
-    ◉ │  c
-    │ │ ◉  h
-    │ │ ◉  f
-    │ │ ◉  d
+    │ ○  e
+    ○ │  c
+    │ │ ○  h
+    │ │ ○  f
+    │ │ ○  d
     ├───╯
-    ◉ │  b
+    ○ │  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
@@ -612,19 +612,19 @@ fn test_rebase_multiple_revisions() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  h
-    ◉  g
-    │ ◉  e
-    │ ◉  d
+    ○  h
+    ○  g
+    │ ○  e
+    │ ○  d
     │ @  i
     ├─╯
-    ◉    f
+    ○    f
     ├─╮
-    ◉ │  c
-    ◉ │  b
+    ○ │  c
+    ○ │  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 }
 
@@ -642,11 +642,11 @@ fn test_rebase_revision_onto_descendant() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    merge
     ├─╮
-    │ ◉  a
-    ◉ │  b
+    │ ○  a
+    ○ │  b
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -664,12 +664,12 @@ fn test_rebase_revision_onto_descendant() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    merge
     ├─╮
-    ◉ │  b
-    │ │ ◉  base
+    ○ │  b
+    │ │ ○  base
     │ ├─╯
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     // Now, let's rebase onto the descendant merge
@@ -692,13 +692,13 @@ fn test_rebase_revision_onto_descendant() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  base
+    ○  base
     @    merge
     ├─╮
-    │ ◉  a
-    ◉ │  b
+    │ ○  a
+    ○ │  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     // TODO(ilyagr): These will be good tests for `jj rebase --insert-after` and
@@ -717,11 +717,11 @@ fn test_rebase_multiple_destinations() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    │ ◉  b
+    │ ○  b
     ├─╯
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     let (stdout, stderr) =
@@ -731,12 +731,12 @@ fn test_rebase_multiple_destinations() {
     Rebased 1 commits onto destination
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    a
+    ○    a
     ├─╮
     │ @  c
-    ◉ │  b
+    ○ │  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b|c"]);
@@ -755,12 +755,12 @@ fn test_rebase_multiple_destinations() {
     Rebased 1 commits onto destination
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    a
+    ○    a
     ├─╮
-    │ ◉  b
+    │ ○  b
     @ │  c
     ├─╯
-    ◉
+    ◆
     "###);
 
     // undo and do it again, but with 'ui.always-allow-large-revsets'
@@ -775,12 +775,12 @@ fn test_rebase_multiple_destinations() {
         ],
     );
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    a
+    ○    a
     ├─╮
-    │ ◉  b
+    │ ○  b
     @ │  c
     ├─╯
-    ◉
+    ◆
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
@@ -819,12 +819,12 @@ fn test_rebase_with_descendants() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
@@ -836,12 +836,12 @@ fn test_rebase_with_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Rebase several subtrees at once.
@@ -856,24 +856,24 @@ fn test_rebase_with_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    │ ◉  c
+    │ ○  c
     ├─╯
-    ◉  a
-    │ ◉  b
+    ○  a
+    │ ○  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // Reminder of the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  d
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     // `d` was a descendant of `b`, and both are moved to be direct descendants of
@@ -887,14 +887,14 @@ fn test_rebase_with_descendants() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
+    │ ○  b
     ├─╯
     │ @  d
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     // Same test as above, but with multiple commits per argument
@@ -916,14 +916,14 @@ fn test_rebase_with_descendants() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉    c
+    ○    c
     ├─╮
-    │ ◉  b
+    │ ○  b
     ├─╯
     │ @  d
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 }
 
@@ -969,13 +969,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     // ===================== rebase -s tests =================
@@ -988,13 +988,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -1006,13 +1006,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -1027,13 +1027,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // "base" and "a" as parents as before.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
-    ◉ │  base
-    ◉ │  notroot
+    │ ○  a
+    ○ │  base
+    ○ │  notroot
     ├─╯
-    ◉
+    ◆
     "###);
 
     // ===================== rebase -b tests =================
@@ -1041,13 +1041,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "base"]);
@@ -1059,13 +1059,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -1080,11 +1080,11 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // which means "b" loses its "base" parent
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉  b
-    ◉  a
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  b
+    ○  a
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -1096,13 +1096,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     // ===================== rebase -r tests =================
@@ -1110,13 +1110,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     let (stdout, stderr) =
@@ -1132,14 +1132,14 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // The user would expect unsimplified ancestry here.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  notroot
-    │ ◉  base
+    ○  notroot
+    │ ○  base
     ├─╯
-    ◉
+    ◆
     "###);
 
     // This tests the algorithm for rebasing onto descendants. The result should
@@ -1156,14 +1156,14 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    │ ◉  base
+    │ ○  base
     ├─╯
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  notroot
-    ◉
+    ○  notroot
+    ◆
     "###);
 
     // This tests the algorithm for rebasing onto descendants. The result should
@@ -1180,27 +1180,27 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ │ ◉  base
+    │ │ ○  base
     │ ├─╯
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  notroot
-    ◉
+    ○  notroot
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ====== Reminder of the setup =========
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉    b
+    ○    b
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "root()"]);
@@ -1216,12 +1216,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // ancestry (whether `b` should also be a direct child of the root commit).
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    ◉  b
-    ◉  base
-    ◉  notroot
-    │ ◉  a
+    ○  b
+    ○  base
+    ○  notroot
+    │ ○  a
     ├─╯
-    ◉
+    ◆
     "###);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -1239,13 +1239,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    c
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    │ ◉  b
+    ○  base
+    ○  notroot
+    │ ○  b
     ├─╯
-    ◉
+    ◆
     "###);
 
     // This tests the algorithm for rebasing onto descendants. The result should
@@ -1262,14 +1262,14 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  b
+    ○  b
     @    c
     ├─╮
-    │ ◉  a
+    │ ○  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 
     // In this test, the commit with weird ancestry is not rebased (neither directly
@@ -1285,13 +1285,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  c
-    │ ◉  b
+    │ ○  b
     ╭─┤
-    ◉ │  a
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉  notroot
-    ◉
+    ○  base
+    ○  notroot
+    ◆
     "###);
 }
 
@@ -1313,18 +1313,18 @@ fn test_rebase_revisions_after() {
     // Test the setup
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e4a00798
-    ◉  e  nkmrtpmo  858693f7
-    │ ◉  d  lylxulpl  7d0512e5
+    ○  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -1340,18 +1340,18 @@ fn test_rebase_revisions_after() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e4a00798
-    ◉  e  nkmrtpmo  858693f7
-    │ ◉  d  lylxulpl  7d0512e5
+    ○  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     // Rebasing a commit after itself should be a no-op.
@@ -1363,18 +1363,18 @@ fn test_rebase_revisions_after() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e4a00798
-    ◉  e  nkmrtpmo  858693f7
-    │ ◉  d  lylxulpl  7d0512e5
+    ○  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     // Rebase a commit after another commit. "c" has parents "b2" and "b4", so its
@@ -1389,18 +1389,18 @@ fn test_rebase_revisions_after() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e0e873c8
-    ◉  c  kmkuslsw  754793f3
-    ◉    e  nkmrtpmo  e0d7fb63
+    ○  c  kmkuslsw  754793f3
+    ○    e  nkmrtpmo  e0d7fb63
     ├─╮
-    │ │ ◉  d  lylxulpl  5e9cb58d
+    │ │ ○  d  lylxulpl  5e9cb58d
     ╭─┬─╯
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1415,19 +1415,19 @@ fn test_rebase_revisions_after() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  76ac6464
+    ○  e  nkmrtpmo  76ac6464
     @  f  xznxytkn  9804b742
-    │ ◉  d  lylxulpl  7d0512e5
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1442,19 +1442,19 @@ fn test_rebase_revisions_after() {
     Added 0 files, modified 0 files, removed 5 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  cee7a197
-    │ ◉  d  lylxulpl  1eb960ec
+    ○  e  nkmrtpmo  cee7a197
+    │ ○  d  lylxulpl  1eb960ec
     ├─╯
-    ◉    c  kmkuslsw  305a7803
+    ○    c  kmkuslsw  305a7803
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  526481b4
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  526481b4
     @ │  f  xznxytkn  80c27408
-    ◉ │  b1  zsuskuln  072d5ae1
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1469,19 +1469,19 @@ fn test_rebase_revisions_after() {
     Added 0 files, modified 0 files, removed 4 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  3162ac52
-    │ ◉  d  lylxulpl  6f7f3b2a
+    ○  e  nkmrtpmo  3162ac52
+    │ ○  d  lylxulpl  6f7f3b2a
     ├─╯
-    ◉    c  kmkuslsw  d33f69f1
+    ○    c  kmkuslsw  d33f69f1
     ├─╮
     │ @  f  xznxytkn  ebbc24b1
-    │ ◉  b2  royxmykx  2b8e1148
-    │ ◉  b1  zsuskuln  072d5ae1
-    ◉ │  b4  znkkpsqq  a52a83a4
-    ◉ │  b3  vruxwmqv  523e6a8b
+    │ ○  b2  royxmykx  2b8e1148
+    │ ○  b1  zsuskuln  072d5ae1
+    ○ │  b4  znkkpsqq  a52a83a4
+    ○ │  b3  vruxwmqv  523e6a8b
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1498,19 +1498,19 @@ fn test_rebase_revisions_after() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  03ade273
-    │ ◉  d  lylxulpl  8bccbeda
+    ○  e  nkmrtpmo  03ade273
+    │ ○  d  lylxulpl  8bccbeda
     ├─╯
     @  f  xznxytkn  8f8c91d3
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1530,18 +1530,18 @@ fn test_rebase_revisions_after() {
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @    f  xznxytkn  7784e5a0
     ├─╮
-    │ ◉  d  lylxulpl  7d0512e5
-    ◉ │  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
+    ○ │  e  nkmrtpmo  858693f7
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1560,19 +1560,19 @@ fn test_rebase_revisions_after() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  0b53613e
-    ◉    c  kmkuslsw  193687bb
+    ○    c  kmkuslsw  193687bb
     ├─╮
-    │ ◉  b4  znkkpsqq  e8d0f57b
-    │ ◉    b3  vruxwmqv  cb48344c
+    │ ○  b4  znkkpsqq  e8d0f57b
+    │ ○    b3  vruxwmqv  cb48344c
     │ ├─╮
-    ◉ │ │  b2  royxmykx  535f779d
-    ◉ │ │  b1  zsuskuln  693186c0
+    ○ │ │  b2  royxmykx  535f779d
+    ○ │ │  b1  zsuskuln  693186c0
     ╰─┬─╮
-      │ ◉  e  nkmrtpmo  2bb4e0b6
-      ◉ │  d  lylxulpl  0b921a1c
+      │ ○  e  nkmrtpmo  2bb4e0b6
+      ○ │  d  lylxulpl  0b921a1c
       ├─╯
-      ◉  a  rlvkpnrz  2443ea76
-      ◉    zzzzzzzz  00000000
+      ○  a  rlvkpnrz  2443ea76
+      ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1591,21 +1591,21 @@ fn test_rebase_revisions_after() {
     Added 0 files, modified 0 files, removed 3 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉    d  lylxulpl  16060da9
+    ○    d  lylxulpl  16060da9
     ├─╮
-    │ │ ◉    c  kmkuslsw  ef5ead27
+    │ │ ○    c  kmkuslsw  ef5ead27
     │ │ ├─╮
-    │ │ │ ◉  b4  znkkpsqq  9c884b94
-    │ │ ◉ │  b2  royxmykx  bdfea21d
+    │ │ │ ○  b4  znkkpsqq  9c884b94
+    │ │ ○ │  b2  royxmykx  bdfea21d
     │ │ ├─╯
     │ │ @  f  xznxytkn  eaf1d6b8
-    │ │ ◉  e  nkmrtpmo  0d7e4ce9
+    │ │ ○  e  nkmrtpmo  0d7e4ce9
     ╭─┬─╯
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1622,17 +1622,17 @@ fn test_rebase_revisions_after() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  084e0629
-    ◉  e  nkmrtpmo  563d78c6
-    ◉  d  lylxulpl  e67ba5c9
-    ◉  c  kmkuslsw  049aa109
-    ◉  b2  royxmykx  7af3d6cd
-    ◉    b1  zsuskuln  cd84b343
+    ○  e  nkmrtpmo  563d78c6
+    ○  d  lylxulpl  e67ba5c9
+    ○  c  kmkuslsw  049aa109
+    ○  b2  royxmykx  7af3d6cd
+    ○    b1  zsuskuln  cd84b343
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1652,18 +1652,18 @@ fn test_rebase_revisions_after() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  4fb2bb60
-    │ ◉  e  nkmrtpmo  1ea93588
-    │ ◉  b2  royxmykx  064e3bcb
-    │ ◉  d  lylxulpl  b46a9d31
+    │ ○  e  nkmrtpmo  1ea93588
+    │ ○  b2  royxmykx  064e3bcb
+    │ ○  d  lylxulpl  b46a9d31
     ├─╯
-    ◉    c  kmkuslsw  cebde86a
+    ○    c  kmkuslsw  cebde86a
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1695,18 +1695,18 @@ fn test_rebase_revisions_before() {
     // Test the setup
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e4a00798
-    ◉  e  nkmrtpmo  858693f7
-    │ ◉  d  lylxulpl  7d0512e5
+    ○  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -1722,18 +1722,18 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e4a00798
-    ◉  e  nkmrtpmo  858693f7
-    │ ◉  d  lylxulpl  7d0512e5
+    ○  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     // Rebasing a commit before itself should be a no-op.
@@ -1745,18 +1745,18 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  e4a00798
-    ◉  e  nkmrtpmo  858693f7
-    │ ◉  d  lylxulpl  7d0512e5
+    ○  e  nkmrtpmo  858693f7
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     // Rebasing a commit before the root commit should error.
@@ -1777,18 +1777,18 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  24335685
-    ◉    e  nkmrtpmo  e9a28d4b
+    ○    e  nkmrtpmo  e9a28d4b
     ├─╮
-    │ │ ◉  d  lylxulpl  6609e9c6
+    │ │ ○  d  lylxulpl  6609e9c6
     ╭─┬─╯
-    │ ◉  b4  znkkpsqq  4b39b18c
-    │ ◉  b3  vruxwmqv  39f79dcc
-    ◉ │  b2  royxmykx  ffcf6038
-    ◉ │  b1  zsuskuln  85e90af6
+    │ ○  b4  znkkpsqq  4b39b18c
+    │ ○  b3  vruxwmqv  39f79dcc
+    ○ │  b2  royxmykx  ffcf6038
+    ○ │  b1  zsuskuln  85e90af6
     ├─╯
-    ◉  a  rlvkpnrz  318ea816
-    ◉  c  kmkuslsw  5f99791e
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  318ea816
+    ○  c  kmkuslsw  5f99791e
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1803,19 +1803,19 @@ fn test_rebase_revisions_before() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  41706bd9
+    ○  e  nkmrtpmo  41706bd9
     @  f  xznxytkn  8e3b728a
-    │ ◉  d  lylxulpl  7d0512e5
+    │ ○  d  lylxulpl  7d0512e5
     ├─╯
-    ◉    c  kmkuslsw  cd86b3e4
+    ○    c  kmkuslsw  cd86b3e4
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1830,19 +1830,19 @@ fn test_rebase_revisions_before() {
     Added 0 files, modified 0 files, removed 5 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  7cad61fd
-    │ ◉  d  lylxulpl  526b6ab6
+    ○  e  nkmrtpmo  7cad61fd
+    │ ○  d  lylxulpl  526b6ab6
     ├─╯
-    ◉    c  kmkuslsw  445f6927
+    ○    c  kmkuslsw  445f6927
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  972bfeb7
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  972bfeb7
     @ │  f  xznxytkn  2b4f48f8
-    ◉ │  b1  zsuskuln  072d5ae1
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1857,19 +1857,19 @@ fn test_rebase_revisions_before() {
     Added 0 files, modified 0 files, removed 6 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  9d5fa6a2
-    │ ◉  d  lylxulpl  ca323694
+    ○  e  nkmrtpmo  9d5fa6a2
+    │ ○  d  lylxulpl  ca323694
     ├─╯
-    ◉    c  kmkuslsw  07426e1a
+    ○    c  kmkuslsw  07426e1a
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  55376058
-    ◉ │  b1  zsuskuln  cd5b1d04
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  55376058
+    ○ │  b1  zsuskuln  cd5b1d04
     @ │  f  xznxytkn  488ebb95
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1887,19 +1887,19 @@ fn test_rebase_revisions_before() {
     Added 0 files, modified 0 files, removed 2 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  0ea67093
-    │ ◉  d  lylxulpl  c079568d
+    ○  e  nkmrtpmo  0ea67093
+    │ ○  d  lylxulpl  c079568d
     ├─╯
-    ◉  c  kmkuslsw  6371742b
+    ○  c  kmkuslsw  6371742b
     @    f  xznxytkn  aae1bc10
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  2b8e1148
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  2b8e1148
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1917,18 +1917,18 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  8268ec4d
-    ◉  e  nkmrtpmo  fd26fbd4
-    │ ◉  d  lylxulpl  21da64b4
+    ○  e  nkmrtpmo  fd26fbd4
+    │ ○  d  lylxulpl  21da64b4
     ├─╯
-    ◉  b1  zsuskuln  83e9b8ac
-    ◉    c  kmkuslsw  a89354fc
+    ○  b1  zsuskuln  83e9b8ac
+    ○    c  kmkuslsw  a89354fc
     ├─╮
-    │ ◉  b4  znkkpsqq  a52a83a4
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b2  royxmykx  b7f03180
+    │ ○  b4  znkkpsqq  a52a83a4
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b2  royxmykx  b7f03180
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1948,21 +1948,21 @@ fn test_rebase_revisions_before() {
     Added 0 files, modified 0 files, removed 4 files
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
-    ◉  e  nkmrtpmo  9436134a
-    │ ◉  d  lylxulpl  534be1ee
+    ○  e  nkmrtpmo  9436134a
+    │ ○  d  lylxulpl  534be1ee
     ├─╯
-    ◉    c  kmkuslsw  bc3ed9f8
+    ○    c  kmkuslsw  bc3ed9f8
     ├─╮
-    │ ◉  b4  znkkpsqq  3e59611b
-    ◉ │  b2  royxmykx  148d7e50
+    │ ○  b4  znkkpsqq  3e59611b
+    ○ │  b2  royxmykx  148d7e50
     ├─╯
     @    f  xznxytkn  7ba8014f
     ├─╮
-    │ ◉  b3  vruxwmqv  523e6a8b
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b3  vruxwmqv  523e6a8b
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1981,20 +1981,20 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  fabd8dd7
-    ◉  e  nkmrtpmo  b5933877
-    │ ◉  d  lylxulpl  6b91dd66
+    ○  e  nkmrtpmo  b5933877
+    │ ○  d  lylxulpl  6b91dd66
     ├─╯
-    ◉    c  kmkuslsw  d873acf7
+    ○    c  kmkuslsw  d873acf7
     ├─╮
-    │ ◉  b3  vruxwmqv  1fd332d8
-    ◉ │  b1  zsuskuln  8e39430f
+    │ ○  b3  vruxwmqv  1fd332d8
+    ○ │  b1  zsuskuln  8e39430f
     ├─╯
-    ◉    a  rlvkpnrz  414580f5
+    ○    a  rlvkpnrz  414580f5
     ├─╮
-    │ ◉  b4  znkkpsqq  ae3d5bdb
-    ◉ │  b2  royxmykx  a225236e
+    │ ○  b4  znkkpsqq  ae3d5bdb
+    ○ │  b2  royxmykx  a225236e
     ├─╯
-    ◉    zzzzzzzz  00000000
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2012,20 +2012,20 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  cbe2be58
-    ◉  e  nkmrtpmo  e31053d1
-    ◉    c  kmkuslsw  23155860
+    ○  e  nkmrtpmo  e31053d1
+    ○    c  kmkuslsw  23155860
     ├─╮
-    │ ◉    b4  znkkpsqq  e50520ad
+    │ ○    b4  znkkpsqq  e50520ad
     │ ├─╮
-    ◉ │ │  b2  royxmykx  54f03b06
+    ○ │ │  b2  royxmykx  54f03b06
     ╰─┬─╮
-    ◉ │ │  d  lylxulpl  0c74206e
+    ○ │ │  d  lylxulpl  0c74206e
     ╰─┬─╮
-      │ ◉  b3  vruxwmqv  523e6a8b
-      ◉ │  b1  zsuskuln  072d5ae1
+      │ ○  b3  vruxwmqv  523e6a8b
+      ○ │  b1  zsuskuln  072d5ae1
       ├─╯
-      ◉  a  rlvkpnrz  2443ea76
-      ◉    zzzzzzzz  00000000
+      ○  a  rlvkpnrz  2443ea76
+      ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2044,18 +2044,18 @@ fn test_rebase_revisions_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  xznxytkn  1c48b514
-    │ ◉  d  lylxulpl  4dbbc808
+    │ ○  d  lylxulpl  4dbbc808
     ├─╯
-    ◉    c  kmkuslsw  c0fd979a
+    ○    c  kmkuslsw  c0fd979a
     ├─╮
-    │ ◉  b4  znkkpsqq  4d5c61f4
-    │ ◉  b3  vruxwmqv  d5699c24
-    ◉ │  b2  royxmykx  e23ab998
+    │ ○  b4  znkkpsqq  4d5c61f4
+    │ ○  b3  vruxwmqv  d5699c24
+    ○ │  b2  royxmykx  e23ab998
     ├─╯
-    ◉  a  rlvkpnrz  076f0094
-    ◉  e  nkmrtpmo  20d1f131
-    ◉  b1  zsuskuln  11db739a
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  076f0094
+    ○  e  nkmrtpmo  20d1f131
+    ○  b1  zsuskuln  11db739a
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2085,16 +2085,16 @@ fn test_rebase_revisions_after_before() {
     // Test the setup
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     let setup_opid = test_env.current_operation_id(&repo_path);
 
@@ -2114,15 +2114,15 @@ fn test_rebase_revisions_after_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  fe3d8c30
-    ◉  d  znkkpsqq  cca70ee1
-    ◉  e  kmkuslsw  48dd9e3f
-    ◉    c  vruxwmqv  c41e416e
+    ○  d  znkkpsqq  cca70ee1
+    ○  e  kmkuslsw  48dd9e3f
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2144,16 +2144,16 @@ fn test_rebase_revisions_after_before() {
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @    f  lylxulpl  22f0323c
     ├─╮
-    │ ◉  d  znkkpsqq  61388bb6
-    ◉ │  e  kmkuslsw  48dd9e3f
-    ◉ │    c  vruxwmqv  c41e416e
+    │ ○  d  znkkpsqq  61388bb6
+    ○ │  e  kmkuslsw  48dd9e3f
+    ○ │    c  vruxwmqv  c41e416e
     ├───╮
-    │ │ ◉  b2  royxmykx  903ab0d6
+    │ │ ○  b2  royxmykx  903ab0d6
     │ ├─╯
-    ◉ │  b1  zsuskuln  072d5ae1
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2175,16 +2175,16 @@ fn test_rebase_revisions_after_before() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  e37682c5
-    ◉      e  kmkuslsw  9bbc9e53
+    ○      e  kmkuslsw  9bbc9e53
     ├─┬─╮
-    │ │ ◉  c  vruxwmqv  e11c7c95
-    │ │ ◉  d  znkkpsqq  37869bd5
+    │ │ ○  c  vruxwmqv  e11c7c95
+    │ │ ○  d  znkkpsqq  37869bd5
     ╭─┬─╯
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2212,16 +2212,16 @@ fn test_rebase_revisions_after_before() {
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @        f  lylxulpl  868f6c61
     ├─┬─┬─╮
-    │ │ │ ◉  e  kmkuslsw  a55a6779
-    │ │ ◉ │  d  znkkpsqq  ae6181e6
+    │ │ │ ○  e  kmkuslsw  a55a6779
+    │ │ ○ │  d  znkkpsqq  ae6181e6
     │ │ ├─╯
-    │ │ ◉  c  vruxwmqv  22540859
-    │ ◉ │  b2  royxmykx  903ab0d6
+    │ │ ○  c  vruxwmqv  22540859
+    │ ○ │  b2  royxmykx  903ab0d6
     │ ├─╯
-    ◉ │  b1  zsuskuln  072d5ae1
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2251,12 +2251,12 @@ fn test_rebase_skip_emptied() {
     // Test the setup
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
     @  also already empty
-    ◉  already empty
-    ◉  will become empty
-    │ ◉  b
+    ○  already empty
+    ○  will become empty
+    │ ○  b
     ├─╯
-    ◉  a
-    ◉
+    ○  a
+    ◆
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=b", "--skip-emptied"]);
@@ -2271,10 +2271,10 @@ fn test_rebase_skip_emptied() {
     // were kept
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
     @  also already empty
-    ◉  already empty
-    ◉  b
-    ◉  a
-    ◉
+    ○  already empty
+    ○  b
+    ○  a
+    ◆
     "###);
 }
 
@@ -2294,16 +2294,16 @@ fn test_rebase_skip_if_on_destination() {
     // Test the setup
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "a"]);
@@ -2314,16 +2314,16 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) =
@@ -2335,16 +2335,16 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d", "-d", "c"]);
@@ -2356,16 +2356,16 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  88f778c5
-    ◉  e  kmkuslsw  48dd9e3f
-    │ ◉  d  znkkpsqq  92438fc9
+    ○  e  kmkuslsw  48dd9e3f
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e", "-d", "c"]);
@@ -2380,17 +2380,17 @@ fn test_rebase_skip_if_on_destination() {
     "###);
     insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
     @  f  lylxulpl  77cb229f
-    │ ◉  e  kmkuslsw  48dd9e3f
+    │ ○  e  kmkuslsw  48dd9e3f
     ├─╯
-    │ ◉  d  znkkpsqq  92438fc9
+    │ ○  d  znkkpsqq  92438fc9
     ├─╯
-    ◉    c  vruxwmqv  c41e416e
+    ○    c  vruxwmqv  c41e416e
     ├─╮
-    │ ◉  b2  royxmykx  903ab0d6
-    ◉ │  b1  zsuskuln  072d5ae1
+    │ ○  b2  royxmykx  903ab0d6
+    ○ │  b1  zsuskuln  072d5ae1
     ├─╯
-    ◉  a  rlvkpnrz  2443ea76
-    ◉    zzzzzzzz  00000000
+    ○  a  rlvkpnrz  2443ea76
+    ◆    zzzzzzzz  00000000
     "###);
 }
 

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -56,11 +56,11 @@ fn test_resolution() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -395,11 +395,11 @@ fn test_normal_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -436,11 +436,11 @@ fn test_baseless_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -638,11 +638,11 @@ fn test_edit_delete_conflict_input_files() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
     @r###"
@@ -681,11 +681,11 @@ fn test_file_vs_dir() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -731,13 +731,13 @@ fn test_description_with_dir_and_deletion() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @      conflict
     ├─┬─╮
-    │ │ ◉  del
-    │ ◉ │  dir
+    │ │ ○  del
+    │ ○ │  dir
     │ ├─╯
-    ◉ │  edit
+    ○ │  edit
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
@@ -814,11 +814,11 @@ fn test_multiple_conflicts() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap()

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -162,11 +162,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    conflict
     ├─╮
-    │ ◉  b
-    ◉ │  a
+    │ ○  b
+    ○ │  a
     ├─╯
-    ◉  base
-    ◉
+    ○  base
+    ◆
     "###);
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -352,12 +352,12 @@ fn test_alias() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root() & syntax-error"]);
@@ -492,7 +492,7 @@ fn test_bad_alias_decl() {
     // Invalid declaration should be warned and ignored.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "my-root"]);
     insta::assert_snapshot!(stdout, @r###"
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Warning: Failed to load "revset-aliases."bad"":  --> 1:1
@@ -535,7 +535,7 @@ fn test_all_modifier() {
     insta::assert_snapshot!(stdout, @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     // Command that accepts only single revision
@@ -555,7 +555,7 @@ fn test_all_modifier() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tself.contained_in('all:all()')"]);
     insta::assert_snapshot!(stdout, @r###"
     @  true
-    ◉  true
+    ◆  true
     "###);
 
     // Typo

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -38,7 +38,7 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  qpvuntsmwlqt false
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
     insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r###"
     Author date:  2001-02-03 04:05:08.000 +07:00
@@ -72,8 +72,8 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
-    ◉  qpvuntsmwlqt false
-    ◉  zzzzzzzzzzzz true
+    ○  qpvuntsmwlqt false
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // The author dates of the new commits should be inherited from the commit being
@@ -111,9 +111,9 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
-    ◉  znkkpsqqskkl true
-    ◉  qpvuntsmwlqt false
-    ◉  zzzzzzzzzzzz true
+    ○  znkkpsqqskkl true
+    ○  qpvuntsmwlqt false
+    ◆  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@--"]);
@@ -139,9 +139,9 @@ fn test_split_by_paths() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
-    ◉  lylxulplsnyw false
-    ◉  qpvuntsmwlqt true
-    ◉  zzzzzzzzzzzz true
+    ○  lylxulplsnyw false
+    ○  qpvuntsmwlqt true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
@@ -206,8 +206,8 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  kkmpptxzrspx false part 2
-    ◉  qpvuntsmwlqt false part 1
-    ◉  zzzzzzzzzzzz true
+    ○  qpvuntsmwlqt false part 1
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -259,8 +259,8 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     assert!(!test_env.env_root().join("editor2").exists());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  kkmpptxzrspx false test_branch
-    ◉  qpvuntsmwlqt false TESTED=TODO
-    ◉  zzzzzzzzzzzz true
+    ○  qpvuntsmwlqt false TESTED=TODO
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -282,10 +282,10 @@ fn test_split_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ◉  kkmpptxzrspx false a
-    ◉ │  qpvuntsmwlqt true 1
+    │ ○  kkmpptxzrspx false a
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // Set up the editor and do the split.
@@ -309,11 +309,11 @@ fn test_split_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ◉  royxmykxtrkr false Add file2
-    │ ◉  kkmpptxzrspx false Add file1
-    ◉ │  qpvuntsmwlqt true 1
+    │ ○  royxmykxtrkr false Add file2
+    │ ○  kkmpptxzrspx false Add file1
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 
@@ -334,7 +334,7 @@ fn test_split_siblings_no_descendants() {
     test_env.jj_cmd_ok(&workspace_path, &["branch", "create", "test_branch"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  qpvuntsmwlqt false test_branch
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     let edit_script = test_env.set_up_fake_editor();
@@ -354,9 +354,9 @@ fn test_split_siblings_no_descendants() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  zsuskulnrvyr false test_branch
-    │ ◉  qpvuntsmwlqt false TESTED=TODO
+    │ ○  qpvuntsmwlqt false TESTED=TODO
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // Since the commit being split has no description, the user will only be
@@ -401,10 +401,10 @@ fn test_split_siblings_with_descendants() {
     test_env.jj_cmd_ok(&workspace_path, &["prev", "--edit"]);
     test_env.jj_cmd_ok(&workspace_path, &["prev", "--edit"]);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    ◉  kkmpptxzrspx false Add file4
-    ◉  rlvkpnrzqnoo false Add file3
+    ○  kkmpptxzrspx false Add file4
+    ○  rlvkpnrzqnoo false Add file3
     @  qpvuntsmwlqt false Add file1 & file2
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // Set up the editor and do the split.
@@ -432,13 +432,13 @@ fn test_split_siblings_with_descendants() {
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    ◉  kkmpptxzrspx false Add file4
-    ◉    rlvkpnrzqnoo false Add file3
+    ○  kkmpptxzrspx false Add file4
+    ○    rlvkpnrzqnoo false Add file3
     ├─╮
     │ @  vruxwmqvtpmx false Add file2
-    ◉ │  qpvuntsmwlqt false Add file1
+    ○ │  qpvuntsmwlqt false Add file1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // The commit we're splitting has a description, so the user will be
@@ -485,10 +485,10 @@ fn test_split_siblings_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ◉  kkmpptxzrspx false a
-    ◉ │  qpvuntsmwlqt true 1
+    │ ○  kkmpptxzrspx false a
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 
     // Set up the editor and do the split.
@@ -515,12 +515,12 @@ fn test_split_siblings_with_merge_child() {
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @      zsuskulnrvyr true 2
     ├─┬─╮
-    │ │ ◉  royxmykxtrkr false Add file2
-    │ ◉ │  kkmpptxzrspx false Add file1
+    │ │ ○  royxmykxtrkr false Add file2
+    │ ○ │  kkmpptxzrspx false Add file1
     │ ├─╯
-    ◉ │  qpvuntsmwlqt true 1
+    ○ │  qpvuntsmwlqt true 1
     ├─╯
-    ◉  zzzzzzzzzzzz true
+    ◆  zzzzzzzzzzzz true
     "###);
 }
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -33,9 +33,9 @@ fn test_squash() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  382c9bad7d42 c
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000 (empty)
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000 (empty)
     "###);
 
     // Squashes the working copy into the parent by default
@@ -47,9 +47,9 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  f7bb78d8da62 (empty)
-    ◉  59f4446070a0 b c
-    ◉  184ddbcce5a9 a
-    ◉  000000000000 (empty)
+    ○  59f4446070a0 b c
+    ○  184ddbcce5a9 a
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -67,8 +67,8 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  1d70f50afa6d c
-    ◉  9146bcc8d996 a b
-    ◉  000000000000 (empty)
+    ○  9146bcc8d996 a b
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -91,12 +91,12 @@ fn test_squash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    41219719ab5f e (empty)
     ├─╮
-    │ ◉  f86e2b3af3e3 d
-    ◉ │  382c9bad7d42 c
+    │ ○  f86e2b3af3e3 d
+    ○ │  382c9bad7d42 c
     ├─╯
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000 (empty)
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000 (empty)
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -114,14 +114,14 @@ fn test_squash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b50b843d8555 (empty)
-    ◉    338cbc05e4e6 e
+    ○    338cbc05e4e6 e
     ├─╮
-    │ ◉  f86e2b3af3e3 d
-    ◉ │  382c9bad7d42 c
+    │ ○  f86e2b3af3e3 d
+    ○ │  382c9bad7d42 c
     ├─╯
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000 (empty)
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "e"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -149,9 +149,9 @@ fn test_squash_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a0b1a272ebc4 c
-    ◉  d117da276a0f b
-    ◉  54d3c1c0e9fd a
-    ◉  000000000000 (empty)
+    ○  d117da276a0f b
+    ○  54d3c1c0e9fd a
+    ◆  000000000000 (empty)
     "###);
 
     // If we don't make any changes in the diff-editor, the whole change is moved
@@ -182,8 +182,8 @@ fn test_squash_partial() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  3c6332267ea8 c
-    ◉  38ffd8b98578 a b
-    ◉  000000000000 (empty)
+    ○  38ffd8b98578 a b
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -202,9 +202,9 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  57c3cf20d0b1 c
-    ◉  c4925e01d298 b
-    ◉  1fc159063ed3 a
-    ◉  000000000000 (empty)
+    ○  c4925e01d298 b
+    ○  1fc159063ed3 a
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -236,9 +236,9 @@ fn test_squash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  64d7ad7c43c1 c
-    ◉  60a264527aee b
-    ◉  7314692d32e3 a
-    ◉  000000000000 (empty)
+    ○  60a264527aee b
+    ○  7314692d32e3 a
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -293,9 +293,9 @@ fn test_squash_keep_emptied() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  382c9bad7d42 c
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000 (empty)
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000 (empty)
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "--keep-emptied"]);
@@ -308,9 +308,9 @@ fn test_squash_keep_emptied() {
     // With --keep-emptied, b remains even though it is now empty.
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  7ee7f18a5223 c
-    ◉  9490bd7f1e6a b (empty)
-    ◉  53bf93080518 a
-    ◉  000000000000 (empty)
+    ○  9490bd7f1e6a b (empty)
+    ○  53bf93080518 a
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -358,13 +358,13 @@ fn test_squash_from_to() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a847ab4967fe f
-    ◉  c2f9de87325d e
-    ◉  e0dac715116f d
-    │ ◉  59597b34a0d8 c
-    │ ◉  12d6103dc0c8 b
+    ○  c2f9de87325d e
+    ○  e0dac715116f d
+    │ ○  59597b34a0d8 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
 
     // Errors out if source and destination are the same
@@ -383,12 +383,12 @@ fn test_squash_from_to() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b902d1dd59d9 f
-    ◉  c2f9de87325d e
-    ◉  e0dac715116f d
-    │ ◉  12d6103dc0c8 b c
+    ○  c2f9de87325d e
+    ○  e0dac715116f d
+    │ ○  12d6103dc0c8 b c
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -413,12 +413,12 @@ fn test_squash_from_to() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  cfc5eb876eb1 f
-    ◉  4dc7c27994bd e
-    │ ◉  59597b34a0d8 c
-    │ ◉  12d6103dc0c8 b
+    ○  4dc7c27994bd e
+    │ ○  59597b34a0d8 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a d
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a d
+    ◆  000000000000 (empty)
     "###);
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
@@ -441,12 +441,12 @@ fn test_squash_from_to() {
     // became empty and was abandoned)
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  6de62c22fa07 f
-    ◉  32196a117ee3 d e
-    │ ◉  59597b34a0d8 c
-    │ ◉  12d6103dc0c8 b
+    ○  32196a117ee3 d e
+    │ ○  59597b34a0d8 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "d"]);
@@ -485,11 +485,11 @@ fn test_squash_from_to_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e0dac715116f d
-    │ ◉  087591be5a01 c
-    │ ◉  12d6103dc0c8 b
+    │ ○  087591be5a01 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
 
     let edit_script = test_env.set_up_fake_diff_editor();
@@ -504,10 +504,10 @@ fn test_squash_from_to_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  987bcfb2eb62 d
-    │ ◉  12d6103dc0c8 b c
+    │ ○  12d6103dc0c8 b c
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -536,11 +536,11 @@ fn test_squash_from_to_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  576244e87883 d
-    │ ◉  6f486f2f4539 c
-    │ ◉  12d6103dc0c8 b
+    │ ○  6f486f2f4539 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -571,11 +571,11 @@ fn test_squash_from_to_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  5b407c249fa7 d
-    │ ◉  724d64da1487 c
-    │ ◉  12d6103dc0c8 b
+    │ ○  724d64da1487 c
+    │ ○  12d6103dc0c8 b
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
@@ -606,12 +606,12 @@ fn test_squash_from_to_partial() {
     Rebased 1 descendant commits
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
-    ◉  d2a587ae205d c
-    ◉  a53394306362 b
+    ○  d2a587ae205d c
+    ○  a53394306362 b
     │ @  e0dac715116f d
     ├─╯
-    ◉  b7b767179c44 a
-    ◉  000000000000 (empty)
+    ○  b7b767179c44 a
+    ◆  000000000000 (empty)
     "###);
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
@@ -669,15 +669,15 @@ fn test_squash_from_multiple() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  94e57ecb8d4f f
-    ◉      78ed28eb87b8 e
+    ○      78ed28eb87b8 e
     ├─┬─╮
-    │ │ ◉  35e764e4357c b
-    │ ◉ │  02a128cd4344 c
+    │ │ ○  35e764e4357c b
+    │ ○ │  02a128cd4344 c
     │ ├─╯
-    ◉ │  aaf7b53a1b64 d
+    ○ │  aaf7b53a1b64 d
     ├─╯
-    ◉  3b1673b6370c a
-    ◉  000000000000 (empty)
+    ○  3b1673b6370c a
+    ◆  000000000000 (empty)
     "###);
 
     // Squash a few commits sideways
@@ -698,12 +698,12 @@ fn test_squash_from_multiple() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  3e25ee211f3f f
-    ◉    abb5a4ea1222 e
+    ○    abb5a4ea1222 e
     ├─╮
-    ◉ │  98759debcee5 d
+    × │  98759debcee5 d
     ├─╯
-    ◉  3b1673b6370c a b c
-    ◉  000000000000 (empty)
+    ○  3b1673b6370c a b c
+    ◆  000000000000 (empty)
     "###);
     // The changes from the sources have been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file"]);
@@ -731,12 +731,12 @@ fn test_squash_from_multiple() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  6a670d1ac76e (empty)
-    ◉    c1293ff7be51 e f
+    ○    c1293ff7be51 e f
     ├─╮
-    ◉ │  aaf7b53a1b64 d
+    ○ │  aaf7b53a1b64 d
     ├─╯
-    ◉  3b1673b6370c a b c
-    ◉  000000000000 (empty)
+    ○  3b1673b6370c a b c
+    ◆  000000000000 (empty)
     "###);
     // The changes from the sources have been applied to the destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file"]);
@@ -794,15 +794,15 @@ fn test_squash_from_multiple_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  30980b9045f7 f
-    ◉      5326a04aac1f e
+    ○      5326a04aac1f e
     ├─┬─╮
-    │ │ ◉  d117da276a0f b
-    │ ◉ │  93a7bfff61e7 c
+    │ │ ○  d117da276a0f b
+    │ ○ │  93a7bfff61e7 c
     │ ├─╯
-    ◉ │  763809ca0131 d
+    ○ │  763809ca0131 d
     ├─╯
-    ◉  54d3c1c0e9fd a
-    ◉  000000000000 (empty)
+    ○  54d3c1c0e9fd a
+    ◆  000000000000 (empty)
     "###);
 
     // Partially squash a few commits sideways
@@ -823,15 +823,15 @@ fn test_squash_from_multiple_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  056dc38bf286 f
-    ◉      450694753699 e
+    ○      450694753699 e
     ├─┬─╮
-    │ │ ◉  450d1499c1ae b
-    │ ◉ │  14b44bf0473c c
+    │ │ ○  450d1499c1ae b
+    │ ○ │  14b44bf0473c c
     │ ├─╯
-    ◉ │  b91b11575906 d
+    × │  b91b11575906 d
     ├─╯
-    ◉  54d3c1c0e9fd a
-    ◉  000000000000 (empty)
+    ○  54d3c1c0e9fd a
+    ◆  000000000000 (empty)
     "###);
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
@@ -875,15 +875,15 @@ fn test_squash_from_multiple_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  3b7559b89a57 f
-    ◉      a3b1714cdfb2 e
+    ○      a3b1714cdfb2 e
     ├─┬─╮
-    │ │ ◉  867efb38e801 b
-    │ ◉ │  84dcb3d4b3eb c
+    │ │ ○  867efb38e801 b
+    │ ○ │  84dcb3d4b3eb c
     │ ├─╯
-    ◉ │  763809ca0131 d
+    ○ │  763809ca0131 d
     ├─╯
-    ◉  54d3c1c0e9fd a
-    ◉  000000000000 (empty)
+    ○  54d3c1c0e9fd a
+    ◆  000000000000 (empty)
     "###);
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
@@ -935,12 +935,12 @@ fn test_squash_from_multiple_partial_no_op() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b37ca1ee3306 d
-    │ ◉  f40b442af3e8 c
+    │ ○  f40b442af3e8 c
     ├─╯
-    │ ◉  b73077b08c59 b
+    │ ○  b73077b08c59 b
     ├─╯
-    ◉  2443ea76b0b1 a
-    ◉  000000000000 (empty)
+    ○  2443ea76b0b1 a
+    ◆  000000000000 (empty)
     "###);
 
     // Source commits that didn't match the paths are not rewritten
@@ -956,10 +956,10 @@ fn test_squash_from_multiple_partial_no_op() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  e178068add8c d
-    │ ◉  f40b442af3e8 c
+    │ ○  f40b442af3e8 c
     ├─╯
-    ◉  2443ea76b0b1 a
-    ◉  000000000000 (empty)
+    ○  2443ea76b0b1 a
+    ◆  000000000000 (empty)
     "###);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -972,10 +972,10 @@ fn test_squash_from_multiple_partial_no_op() {
     insta::assert_snapshot!(stdout, @r###"
     @    e178068add8c d
     ├─╮
-    │ ◉  b73077b08c59 b
-    │ ◉  a786561e909f b
-    ◉  b37ca1ee3306 d
-    ◉  1d9eb34614c9 d
+    │ ○  b73077b08c59 b
+    │ ○  a786561e909f b
+    ○  b37ca1ee3306 d
+    ○  1d9eb34614c9 d
     "###);
 
     // If no source commits match the paths, then the whole operation is a no-op
@@ -990,12 +990,12 @@ fn test_squash_from_multiple_partial_no_op() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b37ca1ee3306 d
-    │ ◉  f40b442af3e8 c
+    │ ○  f40b442af3e8 c
     ├─╯
-    │ ◉  b73077b08c59 b
+    │ ○  b73077b08c59 b
     ├─╯
-    ◉  2443ea76b0b1 a
-    ◉  000000000000 (empty)
+    ○  2443ea76b0b1 a
+    ◆  000000000000 (empty)
     "###);
 }
 
@@ -1161,18 +1161,18 @@ fn test_squash_use_destination_message() {
     // Test the setup
     insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
     @  8aac283daeac c
-    ◉  017c7f689ed7 b
-    ◉  d8d5f980a897 a
-    ◉  000000000000
+    ○  017c7f689ed7 b
+    ○  d8d5f980a897 a
+    ◆  000000000000
     "###);
 
     // Squash the current revision using the short name for the option.
     test_env.jj_cmd_ok(&repo_path, &["squash", "-u"]);
     insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
     @  fd33e4bc332b
-    ◉  3a17aa5dcce9 b
-    ◉  d8d5f980a897 a
-    ◉  000000000000
+    ○  3a17aa5dcce9 b
+    ○  d8d5f980a897 a
+    ◆  000000000000
     "###);
 
     // Undo and squash again, but this time squash both "b" and "c" into "a".
@@ -1190,8 +1190,8 @@ fn test_squash_use_destination_message() {
     );
     insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
     @  7c832accbf60
-    ◉  688660377651 a
-    ◉  000000000000
+    ○  688660377651 a
+    ◆  000000000000
     "###);
 }
 

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -148,17 +148,17 @@ fn test_status_display_rebase_instructions() {
     insta::assert_snapshot!(stdout, @r###"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 65143fef conflict
     │  (empty) boom-cont-2
-    ◉  royxmykx test.user@example.com 2001-02-03 08:05:12 a4e88714 conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 a4e88714 conflict
     │  (empty) boom-cont
-    ◉    mzvwutvl test.user@example.com 2001-02-03 08:05:11 538415e7 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 538415e7 conflict
     ├─╮  (empty) boom
-    │ ◉  kkmpptxz test.user@example.com 2001-02-03 08:05:10 1e8c2956
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 1e8c2956
     │ │  First part of conflicting change
-    ◉ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 2c8b19fd
+    ○ │  zsuskuln test.user@example.com 2001-02-03 08:05:11 2c8b19fd
     ├─╯  Second part of conflicting change
-    ◉  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
-    ◉  zzzzzzzz root() 00000000
+    ◆  zzzzzzzz root() 00000000
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -148,6 +148,8 @@ fn test_templater_alias() {
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
     'coalesce(x, y)' = 'if(x, x, y)'
+    'builtin_log_node' = '"#"'
+    'builtin_op_log_node' = '"#"'
     "###,
     );
 

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -31,8 +31,8 @@ fn test_undo_rewrite_with_child() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  child
-    ◉  modified
-    ◉
+    ○  modified
+    ◆
     "###);
     test_env.jj_cmd_ok(&repo_path, &["undo", &op_id_hex]);
 
@@ -41,8 +41,8 @@ fn test_undo_rewrite_with_child() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
     @  child
-    ◉  initial
-    ◉
+    ○  initial
+    ◆
     "###);
 }
 

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -33,9 +33,9 @@ fn test_unsquash() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  382c9bad7d42 c
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000
     "###);
 
     // Unsquashes into the working copy from its parent by default
@@ -47,8 +47,8 @@ fn test_unsquash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  9177132cfbb9 c
-    ◉  184ddbcce5a9 a b
-    ◉  000000000000
+    ○  184ddbcce5a9 a b
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -66,8 +66,8 @@ fn test_unsquash() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  b353b29c423d c
-    ◉  27772b156771 b
-    ◉  000000000000 a
+    ○  27772b156771 b
+    ◆  000000000000 a
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -90,12 +90,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    b780e7469252 e
     ├─╮
-    │ ◉  f86e2b3af3e3 d
-    ◉ │  382c9bad7d42 c
+    │ ○  f86e2b3af3e3 d
+    ○ │  382c9bad7d42 c
     ├─╯
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -115,12 +115,12 @@ fn test_unsquash() {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    bd05eb698d1e
     ├─╮
-    │ ◉  f86e2b3af3e3 d e??
-    ◉ │  382c9bad7d42 c e??
+    │ ○  f86e2b3af3e3 d e??
+    ○ │  382c9bad7d42 c e??
     ├─╯
-    ◉  d5d59175b481 b
-    ◉  184ddbcce5a9 a
-    ◉  000000000000
+    ○  d5d59175b481 b
+    ○  184ddbcce5a9 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -148,9 +148,9 @@ fn test_unsquash_partial() {
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a0b1a272ebc4 c
-    ◉  d117da276a0f b
-    ◉  54d3c1c0e9fd a
-    ◉  000000000000
+    ○  d117da276a0f b
+    ○  54d3c1c0e9fd a
+    ◆  000000000000
     "###);
 
     // If we don't make any changes in the diff-editor, the whole change is moved
@@ -180,9 +180,9 @@ fn test_unsquash_partial() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  8802263dbd92 c
-    ◉  5bd83140fd47 b
-    ◉  c93de9257191 a
-    ◉  000000000000
+    ○  5bd83140fd47 b
+    ○  c93de9257191 a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -200,9 +200,9 @@ fn test_unsquash_partial() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  a896ffdebb85 c
-    ◉  904111b4d3c4 b
-    ◉  54d3c1c0e9fd a
-    ◉  000000000000
+    ○  904111b4d3c4 b
+    ○  54d3c1c0e9fd a
+    ◆  000000000000
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -47,18 +47,18 @@ fn test_workspaces_add_second_workspace() {
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  5ed2222c28e2 second@
+    ○  5ed2222c28e2 second@
     │ @  8183d0fcaa4c default@
     ├─╯
-    ◉  751b12b7b981
-    ◉  000000000000
+    ○  751b12b7b981
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  5ed2222c28e2 second@
-    │ ◉  8183d0fcaa4c default@
+    │ ○  8183d0fcaa4c default@
     ├─╯
-    ◉  751b12b7b981
-    ◉  000000000000
+    ○  751b12b7b981
+    ◆  000000000000
     "###);
 
     // Both workspaces show up when we list them
@@ -117,14 +117,14 @@ fn test_workspaces_add_second_workspace_on_merge() {
 
     // The new workspace's working-copy commit shares all parents with the old one.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉    7013a493bd09 second@
+    ○    7013a493bd09 second@
     ├─╮
     │ │ @  35e47bff781e default@
     ╭─┬─╯
-    │ ◉  444b77e99d43
-    ◉ │  1694f2ddf8ec
+    │ ○  444b77e99d43
+    ○ │  1694f2ddf8ec
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -169,20 +169,20 @@ fn test_workspaces_add_workspace_at_revision() {
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  e374e74aa0c8 second@
+    ○  e374e74aa0c8 second@
     │ @  dadeedb493e8 default@
-    │ ◉  c420244c6398
+    │ ○  c420244c6398
     ├─╯
-    ◉  f6097c2f7cac
-    ◉  000000000000
+    ○  f6097c2f7cac
+    ◆  000000000000
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  e374e74aa0c8 second@
-    │ ◉  dadeedb493e8 default@
-    │ ◉  c420244c6398
+    │ ○  dadeedb493e8 default@
+    │ ○  c420244c6398
     ├─╯
-    ◉  f6097c2f7cac
-    ◉  000000000000
+    ○  f6097c2f7cac
+    ◆  000000000000
     "###);
 }
 
@@ -208,13 +208,13 @@ fn test_workspaces_add_workspace_multiple_revisions() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  5b36783cd11c
-    │ ◉  6c843d62ca29
+    │ ○  6c843d62ca29
     ├─╯
-    │ ◉  544cd61f2d26
+    │ ○  544cd61f2d26
     ├─╯
-    │ ◉  f6097c2f7cac
+    │ ○  f6097c2f7cac
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     let (_, stderr) = test_env.jj_cmd_ok(
@@ -239,16 +239,16 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉      f4fa64f40944 merge@
+    ○      f4fa64f40944 merge@
     ├─┬─╮
-    │ │ ◉  f6097c2f7cac
-    │ ◉ │  544cd61f2d26
+    │ │ ○  f6097c2f7cac
+    │ ○ │  544cd61f2d26
     │ ├─╯
-    ◉ │  6c843d62ca29
+    ○ │  6c843d62ca29
     ├─╯
     │ @  5b36783cd11c default@
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 }
 
@@ -267,11 +267,11 @@ fn test_workspaces_conflicting_edits() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  3224de8ae048 secondary@
+    ○  3224de8ae048 secondary@
     │ @  06b57f44a3ca default@
     ├─╯
-    ◉  506f4ec3c2c6
-    ◉  000000000000
+    ○  506f4ec3c2c6
+    ◆  000000000000
     "###);
 
     // Make changes in both working copies
@@ -290,10 +290,10 @@ fn test_workspaces_conflicting_edits() {
     // The secondary workspace's working-copy commit was updated
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  a58c9a9b19ce default@
-    │ ◉  e82cd4ee8faa secondary@
+    │ ○  e82cd4ee8faa secondary@
     ├─╯
-    ◉  d41244767d45
-    ◉  000000000000
+    ○  d41244767d45
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -321,25 +321,25 @@ fn test_workspaces_conflicting_edits() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ◉  a28c85ce128b (divergent)
-    │ ◉  a58c9a9b19ce default@
+    ×  a28c85ce128b (divergent)
+    │ ○  a58c9a9b19ce default@
     ├─╯
     │ @  e82cd4ee8faa secondary@ (divergent)
     ├─╯
-    ◉  d41244767d45
-    ◉  000000000000
+    ○  d41244767d45
+    ◆  000000000000
     "###);
     // The stale working copy should have been resolved by the previous command
     let stdout = get_log_output(&test_env, &secondary_path);
     assert!(!stdout.starts_with("The working copy is stale"));
     insta::assert_snapshot!(stdout, @r###"
-    ◉  a28c85ce128b (divergent)
-    │ ◉  a58c9a9b19ce default@
+    ×  a28c85ce128b (divergent)
+    │ ○  a58c9a9b19ce default@
     ├─╯
     │ @  e82cd4ee8faa secondary@ (divergent)
     ├─╯
-    ◉  d41244767d45
-    ◉  000000000000
+    ○  d41244767d45
+    ◆  000000000000
     "###);
 }
 
@@ -357,11 +357,11 @@ fn test_workspaces_updated_by_other() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../secondary"]);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  3224de8ae048 secondary@
+    ○  3224de8ae048 secondary@
     │ @  06b57f44a3ca default@
     ├─╯
-    ◉  506f4ec3c2c6
-    ◉  000000000000
+    ○  506f4ec3c2c6
+    ◆  000000000000
     "###);
 
     // Rewrite the check-out commit in one workspace.
@@ -377,10 +377,10 @@ fn test_workspaces_updated_by_other() {
     // The secondary workspace's working-copy commit was updated.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  a58c9a9b19ce default@
-    │ ◉  e82cd4ee8faa secondary@
+    │ ○  e82cd4ee8faa secondary@
     ├─╯
-    ◉  d41244767d45
-    ◉  000000000000
+    ○  d41244767d45
+    ◆  000000000000
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -398,11 +398,11 @@ fn test_workspaces_updated_by_other() {
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
-    ◉  a58c9a9b19ce default@
+    ○  a58c9a9b19ce default@
     │ @  e82cd4ee8faa secondary@
     ├─╯
-    ◉  d41244767d45
-    ◉  000000000000
+    ○  d41244767d45
+    ◆  000000000000
     "###);
 }
 
@@ -456,15 +456,15 @@ fn test_workspaces_current_op_discarded_by_other() {
     );
     insta::assert_snapshot!(stdout, @r###"
     @  8e5ea0fbda abandon commit 3540d386892997a2a927078635a2d933e37499fb8691938a2f540c25bccffd9e8a60b2d5a8cb94bb3eeab17e1c56f96aafa2bcb66fa1e4eb96911d093d7a579e
-    ◉  f336f5b6e8 Create initial working-copy commit in workspace secondary
-    ◉  aacb3bda7d add workspace 'secondary'
-    ◉  46bcf7d75e new empty commit
-    ◉  4d2f5d7cbf snapshot working copy
-    ◉  2f863a1573 new empty commit
-    ◉  f01631d976 snapshot working copy
-    ◉  17dbb2fe40 add workspace 'default'
-    ◉  cecfee9647 initialize repo
-    ◉  0000000000
+    ○  f336f5b6e8 Create initial working-copy commit in workspace secondary
+    ○  aacb3bda7d add workspace 'secondary'
+    ○  46bcf7d75e new empty commit
+    ○  4d2f5d7cbf snapshot working copy
+    ○  2f863a1573 new empty commit
+    ○  f01631d976 snapshot working copy
+    ○  17dbb2fe40 add workspace 'default'
+    ○  cecfee9647 initialize repo
+    ○  0000000000
     "###);
 
     // Abandon ops, including the one the secondary workspace is currently on.
@@ -473,10 +473,10 @@ fn test_workspaces_current_op_discarded_by_other() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  cc0b087cb874 default@
-    │ ◉  376eee1462a7 secondary@
+    │ ○  376eee1462a7 secondary@
     ├─╯
-    ◉  7788883a847c
-    ◉  000000000000
+    ○  7788883a847c
+    ◆  000000000000
     "###);
 
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
@@ -494,12 +494,12 @@ fn test_workspaces_current_op_discarded_by_other() {
     insta::assert_snapshot!(stdout, @"");
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  a8f7db7868c1 secondary@
-    ◉  376eee1462a7
+    ○  a8f7db7868c1 secondary@
+    ○  376eee1462a7
     │ @  cc0b087cb874 default@
     ├─╯
-    ◉  7788883a847c
-    ◉  000000000000
+    ○  7788883a847c
+    ◆  000000000000
     "###);
 
     // The sparse patterns should remain
@@ -530,7 +530,7 @@ fn test_workspaces_current_op_discarded_by_other() {
     insta::assert_snapshot!(stdout, @r###"
     @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ a8f7db78
     │  (no description set)
-    ◉  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 68033549
+    ○  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 68033549
        (empty) (no description set)
     "###);
 }
@@ -559,8 +559,8 @@ fn test_workspaces_update_stale_noop() {
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "-Tdescription"]);
     insta::assert_snapshot!(stdout, @r###"
     @  add workspace 'default'
-    ◉  initialize repo
-    ◉
+    ○  initialize repo
+    ○
     "###);
 }
 
@@ -591,11 +591,11 @@ fn test_workspaces_update_stale_snapshot() {
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
     @  e672fd8fefac secondary@
-    │ ◉  ea37b073f5ab default@
-    │ ◉  b13c81dedc64
+    │ ○  ea37b073f5ab default@
+    │ ○  b13c81dedc64
     ├─╯
-    ◉  e6e9989f1179
-    ◉  000000000000
+    ○  e6e9989f1179
+    ◆  000000000000
     "###);
 }
 
@@ -632,9 +632,9 @@ fn test_workspaces_forget() {
     // there's only one workspace. We should show it when the command is not run
     // from that workspace.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  18463f438cc9
-    ◉  4e8f9d2be039
-    ◉  000000000000
+    ○  18463f438cc9
+    ○  4e8f9d2be039
+    ◆  000000000000
     "###);
 
     // Revision "@" cannot be used
@@ -734,37 +734,37 @@ fn test_workspaces_forget_abandon_commits() {
     third: uuqppmxq 57d63245 (empty) (no description set)
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  57d63245a308 fourth@ second@ third@
+    ○  57d63245a308 fourth@ second@ third@
     │ @  4e8f9d2be039 default@
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // delete the default workspace (should not abandon commit since not empty)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "default"]);
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  57d63245a308 fourth@ second@ third@
-    │ ◉  4e8f9d2be039
+    ○  57d63245a308 fourth@ second@ third@
+    │ ○  4e8f9d2be039
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // delete the second workspace (should not abandon commit since other workspaces
     // still have commit checked out)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "second"]);
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  57d63245a308 fourth@ third@
-    │ ◉  4e8f9d2be039
+    ○  57d63245a308 fourth@ third@
+    │ ○  4e8f9d2be039
     ├─╯
-    ◉  000000000000
+    ◆  000000000000
     "###);
 
     // delete the last 2 workspaces (commit should be abandoned now even though
     // forgotten in same tx)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "third", "fourth"]);
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    ◉  4e8f9d2be039
-    ◉  000000000000
+    ○  4e8f9d2be039
+    ◆  000000000000
     "###);
 }
 
@@ -851,11 +851,11 @@ fn test_debug_snapshot() {
     @  e1e762d39b39 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
@@ -863,14 +863,14 @@ fn test_debug_snapshot() {
     @  9ac6e7144e8a test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
-    ◉  e1e762d39b39 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  e1e762d39b39 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ◉  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  b51416386f26 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    ◉  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  9a7d829846af test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  initialize repo
-    ◉  000000000000 root()
+    ○  000000000000 root()
     "###);
 }
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -236,16 +236,16 @@ impl UserSettings {
     pub fn commit_node_template(&self) -> String {
         self.node_template_for_key(
             "templates.log_node",
-            r#"if(self, if(current_working_copy, "@", "◉"), "◌")"#,
-            r#"if(self, if(current_working_copy, "@", "o"), ".")"#,
+            "builtin_log_node",
+            "builtin_log_node_ascii",
         )
     }
 
     pub fn op_node_template(&self) -> String {
         self.node_template_for_key(
             "templates.op_log_node",
-            r#"if(current_operation, "@", "◉")"#,
-            r#"if(current_operation, "@", "o")"#,
+            "builtin_op_log_node",
+            "builtin_op_log_node_ascii",
         )
     }
 


### PR DESCRIPTION
It's been tested in various places now, so this is probably mature enough to be the default.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
