### PR TITLE
cargo: build with crt-static on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# NOTE: on Windows, build with the static CRT, so that produced .exe files don't
+# depend on vcruntime140.dll; otherwise the user requires visual studio if they
+# download a raw .exe
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj diff --git` no longer shows the contents of binary files.
 
+* Windows binaries no longer require `vcruntime140.dll` to be installed
+  (normally through Visual Studio.)
+
 ## [0.19.0] - 2024-07-03
 
 ### Breaking changes


### PR DESCRIPTION
Avoids a runtime dependency on vcruntime140.dll.

Closes #4005.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
