### PR TITLE
cli_util: add missing word in conflict resolution instructions

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1545,7 +1545,7 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             writeln!(
                 fmt,
                 r#"Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit."#,
             )?;
             fmt.pop_label()?;

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -221,7 +221,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     To resolve the conflicts, start by updating to it:
       jj new kmkuslswpqwq
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: kmkuslsw 1b2ef84c file_deletion | (conflict) file_deletion
     Parent commit      : zsuskuln c51c9c55 file | file

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -38,7 +38,7 @@ fn test_report_conflicts() {
     To resolve the conflicts, start by updating to the first one:
       jj new rlvkpnrzqnoo
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: zsuskuln aa73e2ae (conflict) (empty) (no description set)
     Parent commit      : kkmpptxz 64bdec0c (conflict) C
@@ -73,7 +73,7 @@ fn test_report_conflicts() {
       jj new kkmpptxzrspx
       jj new rlvkpnrzqnoo
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: zsuskuln 99fb9018 (conflict) (empty) (no description set)
     Parent commit      : kkmpptxz 17c72220 (conflict) C
@@ -131,7 +131,7 @@ fn test_report_conflicts_with_divergent_commits() {
     To resolve the conflicts, start by updating to the first one:
       jj new kkmpptxzrspx
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: zsuskuln?? 97ce1783 (conflict) C2
     Parent commit      : kkmpptxz eb93a73d (conflict) B
@@ -164,7 +164,7 @@ fn test_report_conflicts_with_divergent_commits() {
     To resolve the conflicts, start by updating to it:
       jj new zsuskulnrvyr
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: zsuskuln?? b15416ac (conflict) C2
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
@@ -183,7 +183,7 @@ fn test_report_conflicts_with_divergent_commits() {
     To resolve the conflicts, start by updating to it:
       jj new zsuskulnrvyr
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     "###);
 

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -242,7 +242,7 @@ fn test_resolution() {
     To resolve the conflicts, start by updating to it:
       jj new vruxwmqvtpmx
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: vruxwmqv 7699b9c3 conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -597,7 +597,7 @@ fn test_simplify_conflict_sides() {
     To resolve the conflicts, start by updating to it:
       jj new nkmrtpmomlro
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: nkmrtpmo 4b14662a conflict | (conflict) conflict
     Parent commit      : kmkuslsw 18c1fb00 conflictA | (conflict) (empty) conflictA
@@ -867,7 +867,7 @@ fn test_multiple_conflicts() {
     To resolve the conflicts, start by updating to it:
       jj new vruxwmqvtpmx
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: vruxwmqv 6a90e546 conflict | (conflict) conflict
     Parent commit      : zsuskuln de7553ef a | a

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -66,7 +66,7 @@ fn test_restore() {
     To resolve the conflicts, start by updating to it:
       jj new kkmpptxzrspx
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: kkmpptxz d05c4d2a (conflict) (no description set)
     Parent commit      : rlvkpnrz b9b6011e (empty) (no description set)

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -691,7 +691,7 @@ fn test_squash_from_multiple() {
     To resolve the conflicts, start by updating to it:
       jj new yqosqzytrlsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: kpqxywon 3e25ee21 f | (no description set)
     Parent commit      : yostqsxw abb5a4ea e | (no description set)
@@ -816,7 +816,7 @@ fn test_squash_from_multiple_partial() {
     To resolve the conflicts, start by updating to it:
       jj new yqosqzytrlsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: kpqxywon 056dc38b f | (no description set)
     Parent commit      : yostqsxw 45069475 e | (no description set)

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -172,7 +172,7 @@ fn test_status_display_rebase_instructions() {
     To resolve the conflicts, start by updating to the first one:
       jj new mzvwutvlkqwt
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     "###);
 }
@@ -220,7 +220,7 @@ fn test_status_simplify_conflict_sides() {
       jj new lylxulplsnyw
       jj new kmkuslswpqwq
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     "###);
 }

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -117,7 +117,7 @@ working copy. Any further changes in the working copy will then amend the
 commit. Whether you choose to create a new change and squash, or to edit,
 typically depends on how done you are with the change; if the change is almost
 done, it makes sense to use `jj new` so you can easily review your adjustments
-with `jj diff` before running `jj squash`. 
+with `jj diff` before running `jj squash`.
 
 To view how a change has evolved over time, we can use `jj obslog` to see each
 recorded change for the current commit. This records changes to the working
@@ -233,7 +233,7 @@ New conflicts appeared in these commits:
 To resolve the conflicts, start by updating to the first one:
   jj new puqltuttzvly
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 Working copy now at: qzvqqupx 1978b534 (conflict) C
 Parent commit      : puqltutt f7fb5943 (conflict) B2
@@ -360,7 +360,7 @@ New conflicts appeared in these commits:
 To resolve the conflicts, start by updating to the first one:
   jj new puqltuttzvly
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 Working copy now at: zxoosnnp 63874fe6 (no description set)
 Parent commit      : puqltutt f7fb5943 (conflict) B2
@@ -485,7 +485,7 @@ New conflicts appeared in these commits:
 To resolve the conflicts, start by updating to it:
   jj new mrxqplykmyqv
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 Working copy now at: mrxqplyk 1c72cd50 (conflict) ABCD
 Parent commit      : kwtuwqnm 70985eaa (empty) ABC


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Added a missing 'to' and updated the docs as well.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
