### PR TITLE
branch: ignore git tracking branches for rename warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Windows binaries no longer require `vcruntime140.dll` to be installed
   (normally through Visual Studio.)
 
+* `jj branch rename` no longer shows a warning in colocated repos.
+
 ## [0.19.0] - 2024-07-03
 
 ### Breaking changes

--- a/cli/src/commands/branch/mod.rs
+++ b/cli/src/commands/branch/mod.rs
@@ -24,6 +24,7 @@ mod untrack;
 
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
+use jj_lib::git;
 use jj_lib::op_store::{RefTarget, RemoteRef};
 use jj_lib::repo::Repo;
 use jj_lib::str_util::StringPattern;
@@ -163,6 +164,7 @@ fn find_remote_branches<'a>(
 /// local branch.)
 fn has_tracked_remote_branches(view: &View, branch: &str) -> bool {
     view.remote_branches_matching(&StringPattern::exact(branch), &StringPattern::everything())
+        .filter(|&((_, remote_name), _)| remote_name != git::REMOTE_NAME_FOR_LOCAL_GIT_REPO)
         .any(|(_, remote_ref)| remote_ref.is_tracking())
 }
 

--- a/cli/tests/test_branch_command.rs
+++ b/cli/tests/test_branch_command.rs
@@ -449,6 +449,21 @@ fn test_branch_rename() {
 }
 
 #[test]
+fn test_branch_rename_colocated() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo", "--colocate"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-0"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "blocal"]);
+
+    // Make sure that git tracking branches don't cause a warning
+    let (_stdout, stderr) =
+        test_env.jj_cmd_ok(&repo_path, &["branch", "rename", "blocal", "blocal1"]);
+    insta::assert_snapshot!(stderr, @"");
+}
+
+#[test]
 fn test_branch_forget_glob() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);


### PR DESCRIPTION
Prevents a warning from being printed when renaming branches in a colocated repo, since git tracking branches were being considered as remote tracking branches.

Resolves #4111.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
