### PR TITLE
copy-tracking: plumb copy tracking through diff detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* The following diff formats now include information about copies and moves:
+  `--color-words`, `--summary`
+
 ### Fixed bugs
 
 ## [0.20.0] - 2024-08-07

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -178,10 +178,10 @@ impl Backend for JitBackend {
     fn get_copy_records(
         &self,
         paths: &[RepoPathBuf],
-        roots: &[CommitId],
-        heads: &[CommitId],
+        root: &CommitId,
+        head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {
-        self.inner.get_copy_records(paths, roots, heads)
+        self.inner.get_copy_records(paths, root, head)
     }
 
     fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -177,7 +177,7 @@ impl Backend for JitBackend {
 
     fn get_copy_records(
         &self,
-        paths: &[RepoPathBuf],
+        paths: Option<&[RepoPathBuf]>,
         root: &CommitId,
         head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {

--- a/cli/src/commands/debug/copy_detection.rs
+++ b/cli/src/commands/debug/copy_detection.rs
@@ -43,7 +43,7 @@ pub fn cmd_debug_copy_detection(
     let commit = ws.resolve_single_rev(&args.revision)?;
     for parent_id in commit.parent_ids() {
         for CopyRecord { target, source, .. } in
-            block_on_stream(git.get_copy_records(&[], parent_id, commit.id())?)
+            block_on_stream(git.get_copy_records(None, parent_id, commit.id())?)
                 .filter_map(|r| r.ok())
         {
             writeln!(

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -14,14 +14,11 @@
 
 use itertools::Itertools;
 use jj_lib::backend::CopyRecords;
-use jj_lib::commit::Commit;
 use jj_lib::repo::Repo;
 use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;
 
-use crate::cli_util::{
-    print_unmatched_explicit_paths, CommandHelper, RevisionArg, WorkspaceCommandHelper,
-};
+use crate::cli_util::{print_unmatched_explicit_paths, CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
 use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -175,6 +175,7 @@ pub(crate) fn cmd_fix(
         let mut diff_stream = parent_tree.diff_stream(&tree, &matcher);
         async {
             while let Some(TreeDiffEntry {
+                source: _, // TODO handle copy tracking
                 target: repo_path,
                 value: diff,
             }) = diff_stream.next().await

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -172,7 +172,8 @@ pub(crate) fn cmd_fix(
         // Also fix any new paths that were changed in this commit.
         let tree = commit.tree()?;
         let parent_tree = commit.parent_tree(tx.repo())?;
-        let mut diff_stream = parent_tree.diff_stream(&tree, &matcher);
+        let copy_records = Default::default();
+        let mut diff_stream = parent_tree.diff_stream(&tree, &matcher, &copy_records);
         async {
             while let Some(TreeDiffEntry {
                 source: _, // TODO handle copy tracking

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -72,6 +72,7 @@ pub(crate) fn cmd_interdiff(
         &from_tree,
         &to_tree,
         matcher.as_ref(),
+        &Default::default(),
         ui.term_width(),
     )?;
     Ok(())

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -199,6 +199,7 @@ fn show_predecessor_patch(
         &predecessor_tree,
         &tree,
         &EverythingMatcher,
+        &Default::default(),
         width,
     )?;
     Ok(())

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -567,6 +567,7 @@ fn show_change_diff(
                 &predecessor_tree,
                 &tree,
                 &EverythingMatcher,
+                &Default::default(),
                 width,
             )?;
         }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -67,7 +67,15 @@ pub(crate) fn cmd_status(
             writeln!(formatter, "Working copy changes:")?;
             let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
             let width = ui.term_width();
-            diff_renderer.show_diff(ui, formatter, &parent_tree, &tree, &matcher, width)?;
+            diff_renderer.show_diff(
+                ui,
+                formatter,
+                &parent_tree,
+                &tree,
+                &matcher,
+                &Default::default(),
+                width,
+            )?;
         }
 
         // TODO: Conflicts should also be filtered by the `matcher`. See the related

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -19,7 +19,7 @@ use std::io;
 use std::rc::Rc;
 
 use itertools::Itertools as _;
-use jj_lib::backend::{BackendResult, ChangeId, CommitId};
+use jj_lib::backend::{BackendResult, ChangeId, CommitId, CopyRecords};
 use jj_lib::commit::Commit;
 use jj_lib::extensions_map::ExtensionsMap;
 use jj_lib::fileset::{self, FilesetExpression};
@@ -1278,6 +1278,7 @@ pub struct TreeDiff {
     from_tree: MergedTree,
     to_tree: MergedTree,
     matcher: Rc<dyn Matcher>,
+    copy_records: CopyRecords,
 }
 
 impl TreeDiff {
@@ -1290,11 +1291,13 @@ impl TreeDiff {
             from_tree: commit.parent_tree(repo)?,
             to_tree: commit.tree()?,
             matcher,
+            copy_records: Default::default(),
         })
     }
 
     fn diff_stream(&self) -> TreeDiffStream<'_> {
-        self.from_tree.diff_stream(&self.to_tree, &*self.matcher)
+        self.from_tree
+            .diff_stream(&self.to_tree, &*self.matcher, &self.copy_records)
     }
 
     fn into_formatted<F, E>(self, show: F) -> TreeDiffFormatted<F>

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1394,8 +1394,15 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
             let path_converter = language.path_converter;
             let template = self_property
                 .map(move |diff| {
+                    let to_tree = diff.to_tree.clone();
                     diff.into_formatted(move |formatter, _store, tree_diff| {
-                        diff_util::show_diff_summary(formatter, tree_diff, path_converter)
+                        diff_util::show_diff_summary(
+                            formatter,
+                            tree_diff,
+                            path_converter,
+                            &Default::default(),
+                            &to_tree,
+                        )
                     })
                 })
                 .into_template();

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -20,7 +20,7 @@ use std::{io, mem};
 
 use futures::StreamExt;
 use itertools::Itertools;
-use jj_lib::backend::{BackendError, TreeValue};
+use jj_lib::backend::{BackendError, CopyRecords, TreeValue};
 use jj_lib::commit::Commit;
 use jj_lib::conflicts::{materialized_diff_stream, MaterializedTreeValue};
 use jj_lib::diff::{Diff, DiffHunk};
@@ -245,10 +245,19 @@ impl<'a> DiffRenderer<'a> {
         from_tree: &MergedTree,
         to_tree: &MergedTree,
         matcher: &dyn Matcher,
+        copy_records: &CopyRecords,
         width: usize,
     ) -> Result<(), DiffRenderError> {
         formatter.with_label("diff", |formatter| {
-            self.show_diff_inner(ui, formatter, from_tree, to_tree, matcher, width)
+            self.show_diff_inner(
+                ui,
+                formatter,
+                from_tree,
+                to_tree,
+                matcher,
+                copy_records,
+                width,
+            )
         })
     }
 
@@ -259,6 +268,7 @@ impl<'a> DiffRenderer<'a> {
         from_tree: &MergedTree,
         to_tree: &MergedTree,
         matcher: &dyn Matcher,
+        _copy_records: &CopyRecords,
         width: usize,
     ) -> Result<(), DiffRenderError> {
         let store = self.repo.store();
@@ -324,7 +334,15 @@ impl<'a> DiffRenderer<'a> {
     ) -> Result<(), DiffRenderError> {
         let from_tree = commit.parent_tree(self.repo)?;
         let to_tree = commit.tree()?;
-        self.show_diff(ui, formatter, &from_tree, &to_tree, matcher, width)
+        self.show_diff(
+            ui,
+            formatter,
+            &from_tree,
+            &to_tree,
+            matcher,
+            &Default::default(),
+            width,
+        )
     }
 }
 

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1111,6 +1111,7 @@ pub fn show_diff_summary(
 ) -> io::Result<()> {
     async {
         while let Some(TreeDiffEntry {
+            source: _, // TODO handle copy tracking
             target: repo_path,
             value: diff,
         }) = tree_diff.next().await
@@ -1246,6 +1247,7 @@ pub fn show_types(
 ) -> io::Result<()> {
     async {
         while let Some(TreeDiffEntry {
+            source: _, // TODO handle copy tracking
             target: repo_path,
             value: diff,
         }) = tree_diff.next().await

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -27,7 +27,7 @@ use jj_lib::diff::{Diff, DiffHunk};
 use jj_lib::files::DiffLine;
 use jj_lib::matchers::Matcher;
 use jj_lib::merge::MergedTreeValue;
-use jj_lib::merged_tree::{MergedTree, TreeDiffStream};
+use jj_lib::merged_tree::{MergedTree, TreeDiffEntry, TreeDiffStream};
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::{RepoPath, RepoPathUiConverter};
@@ -1110,7 +1110,11 @@ pub fn show_diff_summary(
     path_converter: &RepoPathUiConverter,
 ) -> io::Result<()> {
     async {
-        while let Some((repo_path, diff)) = tree_diff.next().await {
+        while let Some(TreeDiffEntry {
+            target: repo_path,
+            value: diff,
+        }) = tree_diff.next().await
+        {
             let (before, after) = diff.unwrap();
             let ui_path = path_converter.format_file_path(&repo_path);
             if before.is_present() && after.is_present() {
@@ -1241,7 +1245,11 @@ pub fn show_types(
     path_converter: &RepoPathUiConverter,
 ) -> io::Result<()> {
     async {
-        while let Some((repo_path, diff)) = tree_diff.next().await {
+        while let Some(TreeDiffEntry {
+            target: repo_path,
+            value: diff,
+        }) = tree_diff.next().await
+        {
             let (before, after) = diff.unwrap();
             writeln!(
                 formatter.labeled("modified"),
@@ -1275,7 +1283,10 @@ pub fn show_names(
     path_converter: &RepoPathUiConverter,
 ) -> io::Result<()> {
     async {
-        while let Some((repo_path, _)) = tree_diff.next().await {
+        while let Some(TreeDiffEntry {
+            target: repo_path, ..
+        }) = tree_diff.next().await
+        {
             writeln!(formatter, "{}", path_converter.format_file_path(&repo_path))?;
         }
         Ok(())

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -240,6 +240,7 @@ impl<'a> DiffRenderer<'a> {
     }
 
     /// Generates diff between `from_tree` and `to_tree`.
+    #[allow(clippy::too_many_arguments)]
     pub fn show_diff(
         &self,
         ui: &Ui, // TODO: remove Ui dependency if possible
@@ -263,6 +264,7 @@ impl<'a> DiffRenderer<'a> {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn show_diff_inner(
         &self,
         ui: &Ui,
@@ -278,33 +280,41 @@ impl<'a> DiffRenderer<'a> {
         for format in &self.formats {
             match format {
                 DiffFormat::Summary => {
-                    let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                    let no_copy_tracking = Default::default();
+                    let tree_diff = from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                     show_diff_summary(formatter, tree_diff, path_converter)?;
                 }
                 DiffFormat::Stat => {
-                    let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                    let no_copy_tracking = Default::default();
+                    let tree_diff = from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                     show_diff_stat(formatter, store, tree_diff, path_converter, width)?;
                 }
                 DiffFormat::Types => {
-                    let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                    let no_copy_tracking = Default::default();
+                    let tree_diff = from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                     show_types(formatter, tree_diff, path_converter)?;
                 }
                 DiffFormat::NameOnly => {
-                    let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                    let no_copy_tracking = Default::default();
+                    let tree_diff = from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                     show_names(formatter, tree_diff, path_converter)?;
                 }
                 DiffFormat::Git { context } => {
-                    let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                    let no_copy_tracking = Default::default();
+                    let tree_diff = from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                     show_git_diff(formatter, store, tree_diff, *context)?;
                 }
                 DiffFormat::ColorWords { context } => {
-                    let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                    let no_copy_tracking = Default::default();
+                    let tree_diff = from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                     show_color_words_diff(formatter, store, tree_diff, path_converter, *context)?;
                 }
                 DiffFormat::Tool(tool) => {
                     match tool.diff_invocation_mode {
                         DiffToolMode::FileByFile => {
-                            let tree_diff = from_tree.diff_stream(to_tree, matcher);
+                            let no_copy_tracking = Default::default();
+                            let tree_diff =
+                                from_tree.diff_stream(to_tree, matcher, &no_copy_tracking);
                             show_file_by_file_diff(
                                 ui,
                                 formatter,
@@ -1052,7 +1062,7 @@ pub fn show_git_diff(
         {
             let path_string = path.as_internal_file_string();
             let (left_value, right_value) = diff?;
-            let left_part = git_digf_part(&path, left_value)?;
+            let left_part = git_diff_part(&path, left_value)?;
             let right_part = git_diff_part(&path, right_value)?;
             formatter.with_label("file_header", |formatter| {
                 writeln!(formatter, "diff --git a/{path_string} b/{path_string}")?;

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -498,6 +498,7 @@ pub fn edit_diff_builtin(
         .diff_stream(right_tree, matcher)
         .map(
             |TreeDiffEntry {
+                 source: _, // TODO handle copy tracking
                  target: path,
                  value: diff,
              }| diff.map(|_| path),

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -495,7 +495,7 @@ pub fn edit_diff_builtin(
 ) -> Result<MergedTreeId, BuiltinToolError> {
     let store = left_tree.store().clone();
     let changed_files: Vec<_> = left_tree
-        .diff_stream(right_tree, matcher)
+        .diff_stream(right_tree, matcher, &Default::default())
         .map(
             |TreeDiffEntry {
                  source: _, // TODO handle copy tracking

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -10,7 +10,7 @@ use jj_lib::diff::{Diff, DiffHunk};
 use jj_lib::files::{self, ContentHunk, MergeResult};
 use jj_lib::matchers::Matcher;
 use jj_lib::merge::Merge;
-use jj_lib::merged_tree::{MergedTree, MergedTreeBuilder};
+use jj_lib::merged_tree::{MergedTree, MergedTreeBuilder, TreeDiffEntry};
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo_path::{RepoPath, RepoPathBuf};
 use jj_lib::store::Store;
@@ -496,7 +496,12 @@ pub fn edit_diff_builtin(
     let store = left_tree.store().clone();
     let changed_files: Vec<_> = left_tree
         .diff_stream(right_tree, matcher)
-        .map(|(path, diff)| diff.map(|_| path))
+        .map(
+            |TreeDiffEntry {
+                 target: path,
+                 value: diff,
+             }| diff.map(|_| path),
+        )
         .try_collect()
         .block_on()?;
     let files = make_diff_files(&store, left_tree, right_tree, &changed_files)?;

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -10,7 +10,7 @@ use jj_lib::fsmonitor::FsmonitorSettings;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::local_working_copy::{TreeState, TreeStateError};
 use jj_lib::matchers::Matcher;
-use jj_lib::merged_tree::MergedTree;
+use jj_lib::merged_tree::{MergedTree, TreeDiffEntry};
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::store::Store;
 use jj_lib::working_copy::{CheckoutError, SnapshotOptions};
@@ -132,7 +132,7 @@ pub(crate) fn check_out_trees(
 ) -> Result<DiffWorkingCopies, DiffCheckoutError> {
     let changed_files: Vec<_> = left_tree
         .diff_stream(right_tree, matcher)
-        .map(|(path, _diff)| path)
+        .map(|TreeDiffEntry { target, .. }| target)
         .collect()
         .block_on();
 

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -131,7 +131,7 @@ pub(crate) fn check_out_trees(
     output_is: Option<DiffSide>,
 ) -> Result<DiffWorkingCopies, DiffCheckoutError> {
     let changed_files: Vec<_> = left_tree
-        .diff_stream(right_tree, matcher)
+        .diff_stream(right_tree, matcher, &Default::default())
         .map(|TreeDiffEntry { target, .. }| target)
         .collect()
         .block_on();

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -217,6 +217,11 @@ impl CopyRecords {
     pub fn for_target(&self, target: &RepoPath) -> Option<&CopyRecord> {
         self.targets.get(target).and_then(|&i| self.records.get(i))
     }
+
+    /// Gets all copy records.
+    pub fn iter(&self) -> impl Iterator<Item = &CopyRecord> + '_ {
+        self.records.iter()
+    }
 }
 
 /// Error that may occur during backend initialization.

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -337,6 +337,7 @@ pub fn materialized_diff_stream<'a>(
     tree_diff
         .map(
             |TreeDiffEntry {
+                 source: _, // TODO handle copy tracking
                  target: path,
                  value: diff,
              }| async {

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -34,6 +34,7 @@ use crate::conflicts::{materialized_diff_stream, MaterializedTreeValue};
 use crate::default_index::{AsCompositeIndex, CompositeIndex, IndexPosition};
 use crate::graph::GraphEdge;
 use crate::matchers::{Matcher, Visit};
+use crate::merged_tree::TreeDiffEntry;
 use crate::repo_path::RepoPath;
 use crate::revset::{
     ResolvedExpression, ResolvedPredicateExpression, Revset, RevsetEvaluationError,
@@ -1148,8 +1149,10 @@ fn has_diff_from_parent(
     let mut tree_diff = from_tree.diff_stream(&to_tree, matcher);
     async {
         match tree_diff.next().await {
-            Some((_, Ok(_))) => Ok(true),
-            Some((_, Err(err))) => Err(err),
+            Some(TreeDiffEntry { value: Ok(_), .. }) => Ok(true),
+            Some(TreeDiffEntry {
+                value: Err(err), ..
+            }) => Err(err),
             None => Ok(false),
         }
     }

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1148,7 +1148,8 @@ fn has_diff_from_parent(
     let from_tree =
         rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents)?.resolve()?;
     let to_tree = commit.tree()?;
-    let mut tree_diff = from_tree.diff_stream(&to_tree, matcher);
+    let copy_records = Default::default();
+    let mut tree_diff = from_tree.diff_stream(&to_tree, matcher, &copy_records);
     async {
         match tree_diff.next().await {
             Some(TreeDiffEntry { value: Ok(_), .. }) => Ok(true),
@@ -1168,11 +1169,12 @@ fn matches_diff_from_parent(
     text_pattern: &StringPattern,
     files_matcher: &dyn Matcher,
 ) -> BackendResult<bool> {
+    let copy_records = Default::default();
     let parents: Vec<_> = commit.parents().try_collect()?;
     let from_tree =
         rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents)?.resolve()?;
     let to_tree = commit.tree()?;
-    let tree_diff = from_tree.diff_stream(&to_tree, files_matcher);
+    let tree_diff = from_tree.diff_stream(&to_tree, files_matcher, &copy_records);
     // Conflicts are compared in materialized form. Alternatively, conflict
     // pairs can be compared one by one. #4062
     let mut diff_stream = materialized_diff_stream(store, tree_diff);

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1255,7 +1255,7 @@ impl Backend for GitBackend {
 
     fn get_copy_records(
         &self,
-        paths: &[RepoPathBuf],
+        paths: Option<&[RepoPathBuf]>,
         root_id: &CommitId,
         head_id: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {
@@ -1285,7 +1285,7 @@ impl Backend for GitBackend {
                     .map_err(|err| to_invalid_utf8_err(err, head_id))?;
 
                 let target = RepoPathBuf::from_internal_string(dest);
-                if !paths.is_empty() && !paths.contains(&target) {
+                if !paths.map_or(true, |paths| paths.contains(&target)) {
                     return Ok(None);
                 }
 

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -304,7 +304,7 @@ impl Backend for LocalBackend {
 
     fn get_copy_records(
         &self,
-        _paths: &[RepoPathBuf],
+        _paths: Option<&[RepoPathBuf]>,
         _root: &CommitId,
         _head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -305,8 +305,8 @@ impl Backend for LocalBackend {
     fn get_copy_records(
         &self,
         _paths: &[RepoPathBuf],
-        _roots: &[CommitId],
-        _heads: &[CommitId],
+        _root: &CommitId,
+        _head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {
         Err(BackendError::Unsupported("get_copy_records".into()))
     }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1355,6 +1355,7 @@ impl TreeState {
                 .diff_stream(new_tree, matcher)
                 .map(
                     |TreeDiffEntry {
+                         source: _, // TODO handle copy tracking
                          target: path,
                          value: diff,
                      }| async {
@@ -1454,6 +1455,7 @@ impl TreeState {
         let mut deleted_files = HashSet::new();
         let mut diff_stream = old_tree.diff_stream(new_tree, matcher.as_ref());
         while let Some(TreeDiffEntry {
+            source: _, // TODO handle copy tracking
             target: path,
             value: diff,
         }) = diff_stream.next().await

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -56,7 +56,7 @@ use crate::matchers::{
     DifferenceMatcher, EverythingMatcher, FilesMatcher, IntersectionMatcher, Matcher, PrefixMatcher,
 };
 use crate::merge::{Merge, MergeBuilder, MergedTreeValue};
-use crate::merged_tree::{MergedTree, MergedTreeBuilder};
+use crate::merged_tree::{MergedTree, MergedTreeBuilder, TreeDiffEntry};
 use crate::object_id::ObjectId;
 use crate::op_store::{OperationId, WorkspaceId};
 use crate::repo_path::{RepoPath, RepoPathBuf, RepoPathComponent};
@@ -1353,15 +1353,21 @@ impl TreeState {
         let mut diff_stream = Box::pin(
             old_tree
                 .diff_stream(new_tree, matcher)
-                .map(|(path, diff)| async {
-                    match diff {
-                        Ok((before, after)) => {
-                            let result = materialize_tree_value(&self.store, &path, after).await;
-                            (path, result.map(|value| (before.is_present(), value)))
+                .map(
+                    |TreeDiffEntry {
+                         target: path,
+                         value: diff,
+                     }| async {
+                        match diff {
+                            Ok((before, after)) => {
+                                let result =
+                                    materialize_tree_value(&self.store, &path, after).await;
+                                (path, result.map(|value| (before.is_present(), value)))
+                            }
+                            Err(err) => (path, Err(err)),
                         }
-                        Err(err) => (path, Err(err)),
-                    }
-                })
+                    },
+                )
                 .buffered(self.store.concurrency().max(1)),
         );
         while let Some((path, data)) = diff_stream.next().await {
@@ -1447,7 +1453,11 @@ impl TreeState {
         let mut changed_file_states = Vec::new();
         let mut deleted_files = HashSet::new();
         let mut diff_stream = old_tree.diff_stream(new_tree, matcher.as_ref());
-        while let Some((path, diff)) = diff_stream.next().await {
+        while let Some(TreeDiffEntry {
+            target: path,
+            value: diff,
+        }) = diff_stream.next().await
+        {
             let (_before, after) = diff?;
             if after.is_absent() {
                 deleted_files.insert(path);

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1340,6 +1340,7 @@ impl TreeState {
         new_tree: &MergedTree,
         matcher: &dyn Matcher,
     ) -> Result<CheckoutStats, CheckoutError> {
+        let copy_records = Default::default();
         // TODO: maybe it's better not include the skipped counts in the "intended"
         // counts
         let mut stats = CheckoutStats {
@@ -1352,7 +1353,7 @@ impl TreeState {
         let mut deleted_files = HashSet::new();
         let mut diff_stream = Box::pin(
             old_tree
-                .diff_stream(new_tree, matcher)
+                .diff_stream(new_tree, matcher, &copy_records)
                 .map(
                     |TreeDiffEntry {
                          source: _, // TODO handle copy tracking
@@ -1451,9 +1452,10 @@ impl TreeState {
         })?;
 
         let matcher = self.sparse_matcher();
+        let copy_records = Default::default();
         let mut changed_file_states = Vec::new();
         let mut deleted_files = HashSet::new();
-        let mut diff_stream = old_tree.diff_stream(new_tree, matcher.as_ref());
+        let mut diff_stream = old_tree.diff_stream(new_tree, matcher.as_ref(), &copy_records);
         while let Some(TreeDiffEntry {
             source: _, // TODO handle copy tracking
             target: path,

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -323,7 +323,8 @@ impl MergedTree {
 
 /// A single entry in a tree diff.
 pub struct TreeDiffEntry {
-    // pub source: RepoPathBuf,
+    /// The source path.
+    pub source: RepoPathBuf,
     /// The target path.
     pub target: RepoPathBuf,
     /// The resolved tree values if available.
@@ -712,6 +713,7 @@ impl Iterator for TreeDiffIterator<'_> {
                 TreeDiffItem::File(..) => {
                     if let TreeDiffItem::File(path, before, after) = self.stack.pop().unwrap() {
                         return Some(TreeDiffEntry {
+                            source: path.clone(),
                             target: path,
                             value: Ok((before, after)),
                         });
@@ -731,12 +733,14 @@ impl Iterator for TreeDiffIterator<'_> {
                     (Ok(before_tree), Ok(after_tree)) => (before_tree, after_tree),
                     (Err(before_err), _) => {
                         return Some(TreeDiffEntry {
+                            source: path.clone(),
                             target: path,
                             value: Err(before_err),
                         })
                     }
                     (_, Err(after_err)) => {
                         return Some(TreeDiffEntry {
+                            source: path.clone(),
                             target: path,
                             value: Err(after_err),
                         })
@@ -752,6 +756,7 @@ impl Iterator for TreeDiffIterator<'_> {
             if !tree_before && tree_after {
                 if before.is_present() {
                     return Some(TreeDiffEntry {
+                        source: path.clone(),
                         target: path,
                         value: Ok((before, Merge::absent())),
                     });
@@ -765,6 +770,7 @@ impl Iterator for TreeDiffIterator<'_> {
                 }
             } else if !tree_before && !tree_after {
                 return Some(TreeDiffEntry {
+                    source: path.clone(),
                     target: path,
                     value: Ok((before, after)),
                 });
@@ -999,10 +1005,12 @@ impl Stream for TreeDiffStreamImpl<'_> {
                     let (key, result) = entry.remove_entry();
                     Poll::Ready(Some(match result {
                         Err(err) => TreeDiffEntry {
+                            source: key.path.clone(),
                             target: key.path,
                             value: Err(err),
                         },
                         Ok((before, after)) => TreeDiffEntry {
+                            source: key.path.clone(),
                             target: key.path,
                             value: Ok((before, after)),
                         },
@@ -1013,10 +1021,12 @@ impl Stream for TreeDiffStreamImpl<'_> {
                     let (key, result) = entry.remove_entry();
                     Poll::Ready(Some(match result {
                         Err(err) => TreeDiffEntry {
+                            source: key.path.clone(),
                             target: key.path,
                             value: Err(err),
                         },
                         Ok((before, after)) => TreeDiffEntry {
+                            source: key.path.clone(),
                             target: key.path,
                             value: Ok((before, after)),
                         },

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -89,6 +89,7 @@ pub fn restore_tree(
         async {
             let mut diff_stream = source.diff_stream(destination, matcher);
             while let Some(TreeDiffEntry {
+                source: _, // TODO handle copy tracking
                 target: repo_path,
                 value: diff,
             }) = diff_stream.next().await

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -86,8 +86,9 @@ pub fn restore_tree(
         // TODO: We should be able to not traverse deeper in the diff if the matcher
         // matches an entire subtree.
         let mut tree_builder = MergedTreeBuilder::new(destination.id().clone());
+        let copy_records = Default::default();
         async {
-            let mut diff_stream = source.diff_stream(destination, matcher);
+            let mut diff_stream = source.diff_stream(destination, matcher, &copy_records);
             while let Some(TreeDiffEntry {
                 source: _, // TODO handle copy tracking
                 target: repo_path,

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -27,7 +27,7 @@ use crate::commit::Commit;
 use crate::commit_builder::CommitBuilder;
 use crate::index::Index;
 use crate::matchers::{Matcher, Visit};
-use crate::merged_tree::{MergedTree, MergedTreeBuilder};
+use crate::merged_tree::{MergedTree, MergedTreeBuilder, TreeDiffEntry};
 use crate::repo::{MutableRepo, Repo};
 use crate::repo_path::RepoPath;
 use crate::settings::UserSettings;
@@ -88,7 +88,11 @@ pub fn restore_tree(
         let mut tree_builder = MergedTreeBuilder::new(destination.id().clone());
         async {
             let mut diff_stream = source.diff_stream(destination, matcher);
-            while let Some((repo_path, diff)) = diff_stream.next().await {
+            while let Some(TreeDiffEntry {
+                target: repo_path,
+                value: diff,
+            }) = diff_stream.next().await
+            {
                 let (source_value, _destination_value) = diff?;
                 tree_builder.set_or_remove(repo_path, source_value);
             }

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -171,10 +171,10 @@ impl Backend for SecretBackend {
     fn get_copy_records(
         &self,
         paths: &[RepoPathBuf],
-        roots: &[CommitId],
-        heads: &[CommitId],
+        root: &CommitId,
+        head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {
-        self.inner.get_copy_records(paths, roots, heads)
+        self.inner.get_copy_records(paths, root, head)
     }
 
     fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -170,7 +170,7 @@ impl Backend for SecretBackend {
 
     fn get_copy_records(
         &self,
-        paths: &[RepoPathBuf],
+        paths: Option<&[RepoPathBuf]>,
         root: &CommitId,
         head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -86,10 +86,10 @@ impl Store {
     pub fn get_copy_records(
         &self,
         paths: &[RepoPathBuf],
-        roots: &[CommitId],
-        heads: &[CommitId],
+        root: &CommitId,
+        head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {
-        self.backend.get_copy_records(paths, roots, heads)
+        self.backend.get_copy_records(paths, root, head)
     }
 
     pub fn commit_id_length(&self) -> usize {

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -85,7 +85,7 @@ impl Store {
 
     pub fn get_copy_records(
         &self,
-        paths: &[RepoPathBuf],
+        paths: Option<&[RepoPathBuf]>,
         root: &CommitId,
         head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -27,9 +27,9 @@ use testutils::{assert_rebased_onto, create_tree, CommitGraphBuilder, TestRepo, 
 fn diff_paths(from_tree: &MergedTree, to_tree: &MergedTree) -> Vec<RepoPathBuf> {
     from_tree
         .diff_stream(to_tree, &EverythingMatcher)
-        .map(|(path, diff)| {
-            let _ = diff.unwrap();
-            path
+        .map(|diff| {
+            let _ = diff.value.unwrap();
+            diff.target
         })
         .collect()
         .block_on()

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -26,7 +26,7 @@ use testutils::{assert_rebased_onto, create_tree, CommitGraphBuilder, TestRepo, 
 
 fn diff_paths(from_tree: &MergedTree, to_tree: &MergedTree) -> Vec<RepoPathBuf> {
     from_tree
-        .diff_stream(to_tree, &EverythingMatcher)
+        .diff_stream(to_tree, &EverythingMatcher, &Default::default())
         .map(|diff| {
             let _ = diff.value.unwrap();
             diff.target

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -51,7 +51,7 @@ fn collect_no_gc_refs(git_repo_path: &Path) -> HashSet<CommitId> {
 
 fn get_copy_records(
     store: &Store,
-    paths: &[RepoPathBuf],
+    paths: Option<&[RepoPathBuf]>,
     a: &Commit,
     b: &Commit,
 ) -> HashMap<String, String> {
@@ -262,23 +262,27 @@ fn test_copy_detection() {
 
     let store = repo.store();
     assert_eq!(
-        get_copy_records(store, paths, &commit_a, &commit_b),
+        get_copy_records(store, Some(paths), &commit_a, &commit_b),
         HashMap::from([("file1".to_string(), "file0".to_string())])
     );
     assert_eq!(
-        get_copy_records(store, paths, &commit_b, &commit_c),
+        get_copy_records(store, Some(paths), &commit_b, &commit_c),
         HashMap::from([("file2".to_string(), "file1".to_string())])
     );
     assert_eq!(
-        get_copy_records(store, paths, &commit_a, &commit_c),
+        get_copy_records(store, Some(paths), &commit_a, &commit_c),
         HashMap::from([("file2".to_string(), "file0".to_string())])
     );
     assert_eq!(
-        get_copy_records(store, &[paths[1].clone()], &commit_a, &commit_c),
+        get_copy_records(store, None, &commit_a, &commit_c),
+        HashMap::from([("file2".to_string(), "file0".to_string())])
+    );
+    assert_eq!(
+        get_copy_records(store, Some(&[paths[1].clone()]), &commit_a, &commit_c),
         HashMap::default(),
     );
     assert_eq!(
-        get_copy_records(store, paths, &commit_c, &commit_c),
+        get_copy_records(store, Some(paths), &commit_c, &commit_c),
         HashMap::default(),
     );
 }

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -201,7 +201,7 @@ fn test_sparse_commit() {
         .collect()
         .block_on();
     assert_eq!(diff.len(), 1);
-    assert_eq!(diff[0].0.as_ref(), dir1_file1_path);
+    assert_eq!(diff[0].target.as_ref(), dir1_file1_path);
 
     // Set sparse patterns to also include dir2/
     let mut locked_ws = test_workspace
@@ -223,8 +223,8 @@ fn test_sparse_commit() {
         .collect()
         .block_on();
     assert_eq!(diff.len(), 2);
-    assert_eq!(diff[0].0.as_ref(), dir1_file1_path);
-    assert_eq!(diff[1].0.as_ref(), dir2_file1_path);
+    assert_eq!(diff[0].target.as_ref(), dir1_file1_path);
+    assert_eq!(diff[1].target.as_ref(), dir2_file1_path);
 }
 
 #[test]

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -197,7 +197,7 @@ fn test_sparse_commit() {
     // tree.
     let modified_tree = test_workspace.snapshot().unwrap();
     let diff: Vec<_> = tree
-        .diff_stream(&modified_tree, &EverythingMatcher)
+        .diff_stream(&modified_tree, &EverythingMatcher, &Default::default())
         .collect()
         .block_on();
     assert_eq!(diff.len(), 1);
@@ -219,7 +219,7 @@ fn test_sparse_commit() {
     // updated in the tree.
     let modified_tree = test_workspace.snapshot().unwrap();
     let diff: Vec<_> = tree
-        .diff_stream(&modified_tree, &EverythingMatcher)
+        .diff_stream(&modified_tree, &EverythingMatcher, &Default::default())
         .collect()
         .block_on();
     assert_eq!(diff.len(), 2);

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -303,7 +303,7 @@ impl Backend for TestBackend {
 
     fn get_copy_records(
         &self,
-        _paths: &[RepoPathBuf],
+        _paths: Option<&[RepoPathBuf]>,
         _root: &CommitId,
         _head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -304,8 +304,8 @@ impl Backend for TestBackend {
     fn get_copy_records(
         &self,
         _paths: &[RepoPathBuf],
-        _roots: &[CommitId],
-        _heads: &[CommitId],
+        _root: &CommitId,
+        _head: &CommitId,
     ) -> BackendResult<BoxStream<BackendResult<CopyRecord>>> {
         Err(BackendError::Unsupported("get_copy_records".into()))
     }


### PR DESCRIPTION
Re-approach copy tracking with a simpler signature.  Push through end-to-end copy for `diff -s`.

This is not ready to submit, but is complete enough that I would like feedback on the direction.  Remaining things to do:

- [x] update design doc
- [x] update `CHANGELOG.md`
- [x] plumb through all other diff commands
- [x] update the documentation?
- [x] update the config schema? (cli/src/config-schema.json)
