### PR TITLE
RFC: cargo: add vendored-libgit2 feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -115,6 +115,7 @@ bench = ["dep:criterion"]
 packaging = []
 test-fakes = ["jj-lib/testing"]
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
+vendored-libgit2 = ["git2/vendored-libgit2", "jj-lib/vendored-libgit2"]
 watchman = ["jj-lib/watchman"]
 
 [package.metadata.binstall]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -95,5 +95,6 @@ tokio = { workspace = true, features = ["full"] }
 default = ["git"]
 git = ["dep:git2", "dep:gix", "dep:gix-filter"]
 vendored-openssl = ["git2/vendored-openssl"]
+vendored-libgit2 = ["git2/vendored-libgit2"]
 watchman = ["dep:tokio", "dep:watchman_client"]
 testing = ["git"]


### PR DESCRIPTION
It is only active if enabled manually at this point.

It seems to work insofar as `otool -L` stops listing libgit2 as a dynamic dependency when `--feature vendored-libgit2` is used.

I'm not 100% sure, but perhaps we could recommend that Homebrew uses `--feature vendored-libgit2` and maybe `--feature-vendoredopenssl`. We could also use it in our builds.