### PR TITLE
workspace: warn if destination doesn't contain path separator

### DIFF
--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -171,6 +171,15 @@ fn cmd_workspace_add(
         "Created workspace in \"{}\"",
         file_util::relative_path(command.cwd(), &destination_path).display()
     )?;
+    // Show a warning if the user passed a path without a separator, since they
+    // may have intended the argument to only be the name for the workspace.
+    if !args.destination.contains(std::path::is_separator) {
+        writeln!(
+            ui.warning_default(),
+            r#"Workspace created inside current directory. If this was unintentional, delete the "{}" directory and run `jj workspace forget {name}` to remove it."#,
+            args.destination
+        )?;
+    }
 
     // Copy sparse patterns from workspace where the command was run
     let mut new_workspace_command = command.for_workable_repo(ui, new_workspace, repo)?;

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -136,30 +136,31 @@ fn test_immutable_heads_set_to_working_copy() {
 #[test]
 fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     let test_env = TestEnvironment::default();
-    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init"]);
-    test_env.jj_cmd_ok(test_env.env_root(), &["branch", "create", "main"]);
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "main"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
-    test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
-    test_env.jj_cmd_ok(test_env.env_root(), &["workspace", "add", "workspace1"]);
+    test_env.jj_cmd_ok(&repo_path, &["new", "-m=a"]);
+    test_env.jj_cmd_ok(&repo_path, &["workspace", "add", "../workspace1"]);
     let workspace1_envroot = test_env.env_root().join("workspace1");
-    test_env.jj_cmd_ok(workspace1_envroot.as_path(), &["edit", "default@"]);
-    let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["branch", "set", "main"]);
+    test_env.jj_cmd_ok(&workspace1_envroot, &["edit", "default@"]);
+    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["branch", "set", "main"]);
     insta::assert_snapshot!(stderr, @r###"
-    Moved 1 branches to kkmpptxz 40cbbd52 main | a
+    Moved 1 branches to kkmpptxz 7796c4df main | (empty) a
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
-    Working copy now at: royxmykx 5bcb7da6 (empty) (no description set)
-    Parent commit      : kkmpptxz 40cbbd52 main | a
+    Working copy now at: royxmykx 896465c4 (empty) (no description set)
+    Parent commit      : kkmpptxz 7796c4df main | (empty) a
     "###);
-    test_env.jj_cmd_ok(workspace1_envroot.as_path(), &["workspace", "update-stale"]);
-    let (stdout, _) = test_env.jj_cmd_ok(workspace1_envroot.as_path(), &["log", "--no-graph"]);
+    test_env.jj_cmd_ok(&workspace1_envroot, &["workspace", "update-stale"]);
+    let (stdout, _) = test_env.jj_cmd_ok(&workspace1_envroot, &["log", "--no-graph"]);
     insta::assert_snapshot!(stdout, @r###"
-    nppvrztz test.user@example.com 2001-02-03 08:05:11 workspace1@ 44082ceb
+    nppvrztz test.user@example.com 2001-02-03 08:05:11 workspace1@ ee0671fd
     (empty) (no description set)
-    royxmykx test.user@example.com 2001-02-03 08:05:12 default@ 5bcb7da6
+    royxmykx test.user@example.com 2001-02-03 08:05:12 default@ 896465c4
     (empty) (no description set)
-    kkmpptxz test.user@example.com 2001-02-03 08:05:12 main 40cbbd52
-    a
+    kkmpptxz test.user@example.com 2001-02-03 08:05:09 main 7796c4df
+    (empty) a
     zzzzzzzz root() 00000000
     "###);
 }


### PR DESCRIPTION
Users may try to run `jj workspace add <name>` without specifying a path, which results in the workspace being created in the current directory. This can be confusing, since the workspace contents will also be snapshotted in the original workspace if it is not sparse. Adding a warning should reduce confusion in this case.

Resolves #865.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
