### PR TITLE
workspace: use cwd for printing relative path

### DIFF
--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -169,8 +169,7 @@ fn cmd_workspace_add(
     writeln!(
         ui.status(),
         "Created workspace in \"{}\"",
-        file_util::relative_path(old_workspace_command.workspace_root(), &destination_path)
-            .display()
+        file_util::relative_path(command.cwd(), &destination_path).display()
     )?;
 
     // Copy sparse patterns from workspace where the command was run


### PR DESCRIPTION
The user probably would expect the path to be relative to their current directory rather than the workspace root. For instance, if the user is in a child directory and runs `jj workspace add ../../name`, then they might be surprised if we printed `"../name"` instead of `"../../name"`.

Noticed while implementing #4128, but it seems independent so I'm putting it in a separate PR.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
