### PR TITLE
cli: fix/disable workspace-creation commands with `--at-op`/`--ignore-working-copy`

### DIFF
--- a/cli/examples/custom-command/main.rs
+++ b/cli/examples/custom-command/main.rs
@@ -46,7 +46,7 @@ fn run_custom_command(
                 .rewrite_commit(command_helper.settings(), &commit)
                 .set_description("Frobnicated!")
                 .write()?;
-            tx.finish(ui, "Frobnicate")?;
+            tx.finish(ui, "frobnicate")?;
             writeln!(
                 ui.status(),
                 "Frobnicated revision: {}",

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -378,7 +378,8 @@ impl CommandHelper {
         workspace: Workspace,
         repo: Arc<ReadonlyRepo>,
     ) -> Result<WorkspaceCommandHelper, CommandError> {
-        WorkspaceCommandHelper::new(ui, self, workspace, repo)
+        let loaded_at_head = self.global_args.at_operation == "@";
+        WorkspaceCommandHelper::new(ui, self, workspace, repo, loaded_at_head)
     }
 }
 
@@ -499,13 +500,13 @@ impl WorkspaceCommandHelper {
         command: &CommandHelper,
         workspace: Workspace,
         repo: Arc<ReadonlyRepo>,
+        loaded_at_head: bool,
     ) -> Result<Self, CommandError> {
         let settings = command.settings.clone();
         let commit_summary_template_text =
             settings.config().get_string("templates.commit_summary")?;
         let revset_aliases_map = revset_util::load_revset_aliases(ui, &command.layered_configs)?;
         let template_aliases_map = command.load_template_aliases(ui)?;
-        let loaded_at_head = command.global_args.at_operation == "@";
         let may_update_working_copy = loaded_at_head && !command.global_args.ignore_working_copy;
         let working_copy_shared_with_git = is_colocated_git_workspace(&workspace, &repo);
         let path_converter = RepoPathUiConverter::Fs {

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -195,7 +195,7 @@ fn do_git_clone(
         r#"Fetching into new repo in "{}""#,
         wc_path.display()
     )?;
-    let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;
+    let mut workspace_command = command.for_workable_repo(ui, workspace, repo)?;
     maybe_add_gitignore(&workspace_command)?;
     git_repo.remote(remote_name, source).unwrap();
     let mut fetch_tx = workspace_command.start_transaction();

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -22,7 +22,7 @@ use jj_lib::str_util::StringPattern;
 use jj_lib::workspace::Workspace;
 
 use crate::cli_util::{CommandHelper, WorkspaceCommandHelper};
-use crate::command_error::{user_error, user_error_with_message, CommandError};
+use crate::command_error::{cli_error, user_error, user_error_with_message, CommandError};
 use crate::commands::git::{map_git_error, maybe_add_gitignore};
 use crate::config::{write_config_value_to_file, ConfigNamePathBuf};
 use crate::git_util::{get_git_repo, print_git_import_stats, with_remote_git_callbacks};
@@ -85,6 +85,9 @@ pub fn cmd_git_clone(
     command: &CommandHelper,
     args: &GitCloneArgs,
 ) -> Result<(), CommandError> {
+    if command.global_args().at_operation != "@" {
+        return Err(cli_error("--at-op is not respected"));
+    }
     let remote_name = "origin";
     let source = absolute_git_source(command.cwd(), &args.source);
     let wc_path_str = args

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -149,7 +149,7 @@ pub fn do_init(
         GitInitMode::Colocate => {
             let (workspace, repo) =
                 Workspace::init_colocated_git(command.settings(), workspace_root)?;
-            let workspace_command = command.for_loaded_repo(ui, workspace, repo)?;
+            let workspace_command = command.for_workable_repo(ui, workspace, repo)?;
             maybe_add_gitignore(&workspace_command)?;
         }
         GitInitMode::External(git_repo_path) => {
@@ -159,7 +159,7 @@ pub fn do_init(
             // chronological order.
             let colocated = is_colocated_git_workspace(&workspace, &repo);
             let repo = init_git_refs(ui, command, repo, colocated)?;
-            let mut workspace_command = command.for_loaded_repo(ui, workspace, repo)?;
+            let mut workspace_command = command.for_workable_repo(ui, workspace, repo)?;
             maybe_add_gitignore(&workspace_command)?;
             workspace_command.maybe_snapshot(ui)?;
             maybe_set_repository_level_trunk_alias(ui, workspace_command.repo())?;

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -22,7 +22,9 @@ use jj_lib::workspace::Workspace;
 use jj_lib::{file_util, git};
 
 use crate::cli_util::{print_trackable_remote_branches, start_repo_transaction, CommandHelper};
-use crate::command_error::{user_error_with_hint, user_error_with_message, CommandError};
+use crate::command_error::{
+    cli_error, user_error_with_hint, user_error_with_message, CommandError,
+};
 use crate::commands::git::maybe_add_gitignore;
 use crate::config::{write_config_value_to_file, ConfigNamePathBuf};
 use crate::git_util::{
@@ -71,6 +73,12 @@ pub fn cmd_git_init(
     command: &CommandHelper,
     args: &GitInitArgs,
 ) -> Result<(), CommandError> {
+    if command.global_args().ignore_working_copy {
+        return Err(cli_error("--ignore-working-copy is not respected"));
+    }
+    if command.global_args().at_operation != "@" {
+        return Err(cli_error("--at-op is not respected"));
+    }
     let cwd = command.cwd();
     let wc_path = cwd.join(&args.destination);
     let wc_path = file_util::create_or_reuse_dir(&wc_path)

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -21,7 +21,9 @@ use tracing::instrument;
 
 use super::git;
 use crate::cli_util::CommandHelper;
-use crate::command_error::{user_error_with_hint, user_error_with_message, CommandError};
+use crate::command_error::{
+    cli_error, user_error_with_hint, user_error_with_message, CommandError,
+};
 use crate::ui::Ui;
 
 /// Create a new repo in the given directory
@@ -50,6 +52,12 @@ pub(crate) fn cmd_init(
     command: &CommandHelper,
     args: &InitArgs,
 ) -> Result<(), CommandError> {
+    if command.global_args().ignore_working_copy {
+        return Err(cli_error("--ignore-working-copy is not respected"));
+    }
+    if command.global_args().at_operation != "@" {
+        return Err(cli_error("--at-op is not respected"));
+    }
     let cwd = command.cwd();
     let wc_path = cwd.join(&args.destination);
     let wc_path = file_util::create_or_reuse_dir(&wc_path)

--- a/cli/src/commands/operation/abandon.rs
+++ b/cli/src/commands/operation/abandon.rs
@@ -21,7 +21,7 @@ use jj_lib::op_walk;
 use jj_lib::operation::Operation;
 
 use crate::cli_util::{short_operation_hash, CommandHelper};
-use crate::command_error::{user_error, user_error_with_hint, CommandError};
+use crate::command_error::{cli_error, user_error, user_error_with_hint, CommandError};
 use crate::ui::Ui;
 
 /// Abandon operation history
@@ -55,7 +55,7 @@ pub fn cmd_op_abandon(
     // with the current head.
     let head_op_str = &command.global_args().at_operation;
     if head_op_str != "@" {
-        return Err(user_error("--at-op is not respected"));
+        return Err(cli_error("--at-op is not respected"));
     }
     let current_head_op = op_walk::resolve_op_for_load(repo_loader, head_op_str)?;
     let resolve_op = |op_str| op_walk::resolve_op_at(op_store, &current_head_op, op_str);

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -91,7 +91,7 @@ pub fn cmd_op_diff(
 
     // Create a new transaction starting from `to_repo`.
     let mut workspace_command =
-        command.for_loaded_repo(ui, command.load_workspace()?, to_repo.clone())?;
+        command.for_temporary_repo(ui, command.load_workspace()?, to_repo.clone())?;
     let mut tx = workspace_command.start_transaction();
     // Merge index from `from_repo` to `to_repo`, so commits in `from_repo` are
     // accessible.

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -59,7 +59,8 @@ pub fn cmd_op_show(
     let parent_repo = repo_loader.load_at(&parent_op)?;
     let repo = repo_loader.load_at(&op)?;
 
-    let workspace_command = command.for_loaded_repo(ui, command.load_workspace()?, repo.clone())?;
+    let workspace_command =
+        command.for_temporary_repo(ui, command.load_workspace()?, repo.clone())?;
     let commit_summary_template = workspace_command.commit_summary_template();
 
     let with_content_format = LogContentFormat::new(ui, command.settings())?;

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -173,9 +173,7 @@ fn cmd_workspace_add(
     )?;
 
     // Copy sparse patterns from workspace where the command was run
-    let loaded_at_head = true;
-    let mut new_workspace_command =
-        WorkspaceCommandHelper::new(ui, command, new_workspace, repo, loaded_at_head)?;
+    let mut new_workspace_command = command.for_workable_repo(ui, new_workspace, repo)?;
     let (mut locked_ws, _wc_commit) = new_workspace_command.start_working_copy_mutation()?;
     let sparse_patterns = old_workspace_command
         .working_copy()
@@ -374,7 +372,7 @@ fn for_stale_working_copy(
             Err(e) => return Err(e.into()),
         }
     };
-    Ok((command.for_loaded_repo(ui, workspace, repo)?, recovered))
+    Ok((command.for_workable_repo(ui, workspace, repo)?, recovered))
 }
 
 #[instrument(skip_all)]

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -223,7 +223,7 @@ fn cmd_workspace_add(
     tx.edit(&new_wc_commit)?;
     tx.finish(
         ui,
-        format!("Create initial working-copy commit in workspace {}", &name),
+        format!("create initial working-copy commit in workspace {name}"),
     )?;
     Ok(())
 }

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -173,7 +173,9 @@ fn cmd_workspace_add(
     )?;
 
     // Copy sparse patterns from workspace where the command was run
-    let mut new_workspace_command = WorkspaceCommandHelper::new(ui, command, new_workspace, repo)?;
+    let loaded_at_head = true;
+    let mut new_workspace_command =
+        WorkspaceCommandHelper::new(ui, command, new_workspace, repo, loaded_at_head)?;
     let (mut locked_ws, _wc_commit) = new_workspace_command.start_working_copy_mutation()?;
     let sparse_patterns = old_workspace_command
         .working_copy()

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -485,15 +485,12 @@ fn test_git_clone_at_operation() {
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
     set_up_non_empty_git_repo(&git_repo);
 
-    // TODO: just error out? no operation should exist
-    let (_stdout, stderr) = test_env.jj_cmd_ok(
+    let stderr = test_env.jj_cmd_cli_error(
         test_env.env_root(),
         &["git", "clone", "--at-op=@-", "source", "clone"],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Fetching into new repo in "$TEST_ENV/clone"
-    branch: main@origin [new] untracked
-    Setting the revset alias "trunk()" to "main@origin"
+    Error: --at-op is not respected
     "###);
 }
 

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -101,21 +101,11 @@ fn test_git_init_internal_ignore_working_copy() {
     std::fs::create_dir(&workspace_root).unwrap();
     std::fs::write(workspace_root.join("file1"), "").unwrap();
 
-    // No snapshot should be taken
-    let (_stdout, stderr) =
-        test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--ignore-working-copy"]);
+    let stderr =
+        test_env.jj_cmd_cli_error(&workspace_root, &["git", "init", "--ignore-working-copy"]);
     insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "."
+    Error: --ignore-working-copy is not respected
     "###);
-
-    let (stdout, stderr) =
-        test_env.jj_cmd_ok(&workspace_root, &["status", "--ignore-working-copy"]);
-    insta::assert_snapshot!(stdout, @r###"
-    The working copy is clean
-    Working copy : qpvuntsm 230dd059 (empty) (no description set)
-    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(stderr, @"");
 }
 
 #[test]
@@ -124,10 +114,9 @@ fn test_git_init_internal_at_operation() {
     let workspace_root = test_env.env_root().join("repo");
     std::fs::create_dir(&workspace_root).unwrap();
 
-    // TODO: just error out? no operation should exist
-    let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--at-op=@-"]);
+    let stderr = test_env.jj_cmd_cli_error(&workspace_root, &["git", "init", "--at-op=@-"]);
     insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "."
+    Error: --at-op is not respected
     "###);
 }
 
@@ -254,7 +243,7 @@ fn test_git_init_external_ignore_working_copy() {
     std::fs::write(workspace_root.join("file1"), "").unwrap();
 
     // No snapshot should be taken
-    let (_stdout, stderr) = test_env.jj_cmd_ok(
+    let stderr = test_env.jj_cmd_cli_error(
         &workspace_root,
         &[
             "git",
@@ -265,25 +254,7 @@ fn test_git_init_external_ignore_working_copy() {
         ],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Done importing changes from the underlying Git repo.
-    Initialized repo in "."
-    "###);
-
-    let (stdout, stderr) =
-        test_env.jj_cmd_ok(&workspace_root, &["status", "--ignore-working-copy"]);
-    insta::assert_snapshot!(stdout, @r###"
-    The working copy is clean
-    Working copy : sqpuoqvx f6950fc1 (empty) (no description set)
-    Parent commit: mwrttmos 8d698d4a my-branch | My commit message
-    "###);
-    insta::assert_snapshot!(stderr, @"");
-
-    // TODO: Correct, but might be better to check out the root commit?
-    let stderr = test_env.jj_cmd_failure(&workspace_root, &["status"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation b51416386f26).
-    Hint: Run `jj workspace update-stale` to update it.
-    See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
+    Error: --ignore-working-copy is not respected
     "###);
 }
 
@@ -295,8 +266,7 @@ fn test_git_init_external_at_operation() {
     let workspace_root = test_env.env_root().join("repo");
     std::fs::create_dir(&workspace_root).unwrap();
 
-    // TODO: just error out? no operation should exist
-    let (_stdout, stderr) = test_env.jj_cmd_ok(
+    let stderr = test_env.jj_cmd_cli_error(
         &workspace_root,
         &[
             "git",
@@ -307,8 +277,7 @@ fn test_git_init_external_at_operation() {
         ],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Done importing changes from the underlying Git repo.
-    Initialized repo in "."
+    Error: --at-op is not respected
     "###);
 }
 
@@ -676,35 +645,13 @@ fn test_git_init_colocated_ignore_working_copy() {
     init_git_repo(&workspace_root, false);
     std::fs::write(workspace_root.join("file1"), "").unwrap();
 
-    // No snapshot should be taken
-    let (_stdout, stderr) = test_env.jj_cmd_ok(
+    let stderr = test_env.jj_cmd_cli_error(
         &workspace_root,
         &["git", "init", "--ignore-working-copy", "--colocate"],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Done importing changes from the underlying Git repo.
-    Initialized repo in "."
+    Error: --ignore-working-copy is not respected
     "###);
-
-    // FIXME: wrong HEAD, but fixing this would result in stale working copy
-    let (stdout, stderr) =
-        test_env.jj_cmd_ok(&workspace_root, &["status", "--ignore-working-copy"]);
-    insta::assert_snapshot!(stdout, @r###"
-    The working copy is clean
-    Working copy : qpvuntsm 230dd059 (empty) (no description set)
-    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(stderr, @"");
-
-    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
-    Working copy changes:
-    A file1
-    D some-file
-    Working copy : kkmpptxz 7864ea63 (no description set)
-    Parent commit: mwrttmos 8d698d4a my-branch | My commit message
-    "###);
-    insta::assert_snapshot!(stderr, @"");
 }
 
 #[test]
@@ -713,14 +660,12 @@ fn test_git_init_colocated_at_operation() {
     let workspace_root = test_env.env_root().join("repo");
     init_git_repo(&workspace_root, false);
 
-    // TODO: just error out? no operation should exist
-    let (_stdout, stderr) = test_env.jj_cmd_ok(
+    let stderr = test_env.jj_cmd_cli_error(
         &workspace_root,
         &["git", "init", "--at-op=@-", "--colocate"],
     );
     insta::assert_snapshot!(stderr, @r###"
-    Done importing changes from the underlying Git repo.
-    Initialized repo in "."
+    Error: --at-op is not respected
     "###);
 }
 

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -546,4 +546,17 @@ fn test_init_local() {
     assert!(store_path.join("files").is_dir());
     assert!(store_path.join("symlinks").is_dir());
     assert!(store_path.join("conflicts").is_dir());
+
+    let stderr = test_env.jj_cmd_cli_error(
+        test_env.env_root(),
+        &["init", "--ignore-working-copy", "repo2"],
+    );
+    insta::assert_snapshot!(stderr, @r###"
+    Error: --ignore-working-copy is not respected
+    "###);
+
+    let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["init", "--at-op=@-", "repo3"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Error: --at-op is not respected
+    "###);
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -418,7 +418,7 @@ fn test_op_abandon_ancestors() {
     "###);
 
     // Can't create concurrent abandoned operations explicitly.
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["op", "abandon", "--at-op=@-", "@"]);
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &["op", "abandon", "--at-op=@-", "@"]);
     insta::assert_snapshot!(stderr, @r###"
     Error: --at-op is not respected
     "###);

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -333,14 +333,14 @@ fn test_workspaces_conflicting_edits() {
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation f46ea702e886).
+    Error: The working copy is stale (not updated since operation 0da24da631e3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
     "###);
     // Same error on second run, and from another command
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["log"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation f46ea702e886).
+    Error: The working copy is stale (not updated since operation 0da24da631e3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
     "###);
@@ -420,7 +420,7 @@ fn test_workspaces_updated_by_other() {
     "###);
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: The working copy is stale (not updated since operation f46ea702e886).
+    Error: The working copy is stale (not updated since operation 0da24da631e3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-working-copy for more information.
     "###);
@@ -491,8 +491,8 @@ fn test_workspaces_current_op_discarded_by_other() {
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
-    @  8e5ea0fbda abandon commit 3540d386892997a2a927078635a2d933e37499fb8691938a2f540c25bccffd9e8a60b2d5a8cb94bb3eeab17e1c56f96aafa2bcb66fa1e4eb96911d093d7a579e
-    ○  f336f5b6e8 Create initial working-copy commit in workspace secondary
+    @  78e49a9ae1 abandon commit 3540d386892997a2a927078635a2d933e37499fb8691938a2f540c25bccffd9e8a60b2d5a8cb94bb3eeab17e1c56f96aafa2bcb66fa1e4eb96911d093d7a579e
+    ○  083b1fe855 create initial working-copy commit in workspace secondary
     ○  aacb3bda7d add workspace 'secondary'
     ○  46bcf7d75e new empty commit
     ○  4d2f5d7cbf snapshot working copy
@@ -524,7 +524,7 @@ fn test_workspaces_current_op_discarded_by_other() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     insta::assert_snapshot!(stderr, @r###"
-    Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object f336f5b6e83bb901dce6d05d83193f7d0cad2b6375a9910d586c844a479feb130c30d417bdf3030f980d9bacca117584a654e9bdf74b41b30021651e28fbfc8c of type operation not found
+    Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 083b1fe855c23361b504fc78eb827aaa6099067d5ccba28b4e8cd89ed35d850be68ea557f03aaeaa37a09cc91b185c03c7ac638fff1fd8234b2e2a9cc62dc2cf of type operation not found
     Created and checked out recovery commit 6803354995e6
     "###);
     insta::assert_snapshot!(stdout, @"");
@@ -728,7 +728,7 @@ fn test_workspaces_forget_multi_transaction() {
     // the op log should have multiple workspaces forgotten in a single tx
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(stdout, @r###"
-    @  f91852cb278f test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  b7ab9f1c16cc test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third
     "###);

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -168,17 +168,18 @@ fn test_workspaces_add_at_operation() {
     Parent commit      : rlvkpnrz 0dbaa19a 2
     "###);
 
-    // FIXME: --at-op should disable snapshot in the main workspace, but the
-    // newly created workspace should still be writable.
+    // --at-op should disable snapshot in the main workspace, but the newly
+    // created workspace should still be writable.
     std::fs::write(main_path.join("file3"), "").unwrap();
-    let stderr = test_env.jj_cmd_failure(
+    let (_stdout, stderr) = test_env.jj_cmd_ok(
         &main_path,
         &["workspace", "add", "--at-op=@-", "../secondary"],
     );
     insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
     Created workspace in "../secondary"
-    Error: This command must be able to update the working copy.
-    Hint: Don't use --at-op.
+    Working copy now at: rzvqmyuk a4d1cbc9 (empty) (no description set)
+    Parent commit      : qpvuntsm 3364a7ed 1
+    Added 1 files, modified 0 files, removed 0 files
     "###);
     let secondary_path = test_env.env_root().join("secondary");
 
@@ -188,8 +189,8 @@ fn test_workspaces_add_at_operation() {
     insta::assert_snapshot!(stdout, @r###"
     Working copy changes:
     A file4
-    Working copy : zsuskuln 7df5cfc8 (no description set)
-    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    Working copy : rzvqmyuk 2ba74f85 (no description set)
+    Parent commit: qpvuntsm 3364a7ed 1
     "###);
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
@@ -201,6 +202,7 @@ fn test_workspaces_add_at_operation() {
     ○    resolve concurrent operations
     ├─╮
     ○ │  commit cd06097124e3e5860867e35c2bb105902c28ea38
+    │ ○  create initial working-copy commit in workspace secondary
     │ ○  add workspace 'secondary'
     ├─╯
     ○  snapshot working copy


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
