### PR TITLE
cargo: bump tokio to 1.39.1 as previous version is yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,9 +3264,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.0"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3318c4fc7126c339a40fbc025927d0328ca32259f68bfe4321660644c1f626"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ test-case = "3.3.1"
 textwrap = "0.16.1"
 thiserror = "1.0.63"
 timeago = { version = "0.4.2", default-features = false }
-tokio = { version = "1.39.0" }
+tokio = { version = "1.39.1" }
 toml_edit = { version = "0.19.15", features = ["serde"] }
 tracing = "0.1.40"
 tracing-chrome = "0.7.2"


### PR DESCRIPTION
```
error[yanked]: detected yanked crate (try `cargo update -p tokio`)
    ┌─ /github/workspace/Cargo.lock:316:1
    │
316 │ tokio 1.39.0 registry+https://github.com/rust-lang/crates.io-index
    │ ------------------------------------------------------------------ yanked version
```

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
