### PR TITLE
docs: document how to compile a statically linked binary on Mac

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -95,9 +95,33 @@ brew install jj
 
 ### Mac
 
-#### From Source
+#### From Source, Vendored OpenSSL
 
-You may need to run some or all of these:
+You may need to run:
+
+```shell
+xcode-select --install
+```
+
+Now run either:
+
+```shell
+# To install the *prerelease* version from the main branch
+cargo install --git https://github.com/martinvonz/jj.git \
+     --features vendored-openssl --locked --bin jj jj-cli
+```
+
+or:
+
+```shell
+# To install the latest release
+cargo install --features vendored-openssl -locked --bin jj jj-cli
+```
+
+#### From Source, Homebrew OpenSSL
+
+You will need [Homebrew](https://brew.sh/) installed. You may then need to run
+some or all of these:
 
 ```shell
 xcode-select --install


### PR DESCRIPTION
I feel like this is worth documenting, as it shouldn't require Homebrew.

~~TODO: I need to double-check that this works (planning to do this in a VM) and to check for typos.~~ **Update:** this works fine. Also, `--bin jj` is no longer necessary, but maybe it's helpful in emphasizing that the package is `jj-cli` rather than `jj`. 