### PR TITLE
test_git_push: make tests work on newer libgit2-s

### DIFF
--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -38,7 +38,8 @@ fn set_up() -> (TestEnvironment, PathBuf) {
             "git",
             "clone",
             "--config-toml=git.auto-local-branch=true",
-            origin_git_repo_path.to_str().unwrap(),
+            // Git and libgit2 > 1.8 do not allow backslashes in remote names
+            &origin_git_repo_path.to_str().unwrap().replace("\\", "/"),
             "local",
         ],
     );


### PR DESCRIPTION
This should make it unnecessary to disable a test
in #4080.

See also CI run in #4183 

This is a messy fix, I should probably add a TODO for doing something more reasonable when `jj git clone` gets passed a path with backslahshes. 

**Update:** The CI seems slow, but I'll mark this as ready for review. Hopefully, the CI will recover on its own.

**Update 2:** I don't think this is urgent, so I'll see about a more complete fix with a better error message when `jj git clone` or `git remote add` get an invalid remote name.
