### PR TITLE
polish/4147: Change conflict hint if decendants resolves conflict.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj status` will show different messages in a conflicted tree, depending
+  on the state of the working commit. In particular, if a child commit fixes
+  a conflict in the parent, this will be reflected in the hint provided
+  by `jj status`
+
 * `jj diff --git` no longer shows the contents of binary files.
 
 * Windows binaries no longer require `vcruntime140.dll` to be installed

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -92,21 +92,36 @@ pub(crate) fn cmd_status(
             writeln!(formatter)?;
         }
 
-        let wc_revset = RevsetExpression::commit(wc_commit.id().clone());
-        // Ancestors with conflicts, excluding the current working copy commit.
-        let ancestors_conflicts = workspace_command
-            .attach_revset_evaluator(
-                wc_revset
-                    .parents()
-                    .ancestors()
-                    .filtered(RevsetFilterPredicate::HasConflict)
-                    .minus(&revset_util::parse_immutable_expression(
-                        &workspace_command.revset_parse_context(),
-                    )?),
-            )?
-            .evaluate_to_commit_ids()?
-            .collect();
-        workspace_command.report_repo_conflicts(formatter, repo, ancestors_conflicts)?;
+        if wc_commit.has_conflict()? {
+            let wc_revset = RevsetExpression::commit(wc_commit.id().clone());
+
+            // Ancestors with conflicts, excluding the current working copy commit.
+            let ancestors_conflicts = workspace_command
+                .attach_revset_evaluator(
+                    wc_revset
+                        .parents()
+                        .ancestors()
+                        .filtered(RevsetFilterPredicate::HasConflict)
+                        .minus(&revset_util::parse_immutable_expression(
+                            &workspace_command.revset_parse_context(),
+                        )?),
+                )?
+                .evaluate_to_commit_ids()?
+                .collect();
+
+            workspace_command.report_repo_conflicts(formatter, repo, ancestors_conflicts)?;
+        } else {
+            for parent in wc_commit.parents() {
+                let parent = parent?;
+                if parent.has_conflict()? {
+                    writeln!(
+                        formatter.labeled("hint"),
+                        "Conflict in parent commit has been resolved in working copy"
+                    )?;
+                    break;
+                }
+            }
+        }
     } else {
         writeln!(formatter, "No working copy")?;
     }


### PR DESCRIPTION
Fixes #4147 

Change behaviour to consider the state of the working commit, instead of the state of the tree. In particular:

* If working commit has conflicts: Print the existing message we print today.                                                                                                                                                                                
* If working commit has no conflicts:                                                                                                             
  * If any parent has conflicts, print: "Conflict in parent is resolved in working copy"                                                                 
  * If no parent has any conflicts: no message  

This behaviour resolves the issue raised in #4147.                                                                                                  
                                                                                                                                                 
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
