### PR TITLE
Expose some internal constructors

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -604,6 +604,26 @@ pub struct RepoLoader {
 }
 
 impl RepoLoader {
+    pub fn new(
+        repo_path: PathBuf,
+        repo_settings: RepoSettings,
+        store: Arc<Store>,
+        op_store: Arc<dyn OpStore>,
+        op_heads_store: Arc<dyn OpHeadsStore>,
+        index_store: Arc<dyn IndexStore>,
+        submodule_store: Arc<dyn SubmoduleStore>,
+    ) -> Self {
+        Self {
+            repo_path,
+            repo_settings,
+            store,
+            op_store,
+            op_heads_store,
+            index_store,
+            submodule_store,
+        }
+    }
+
     pub fn init(
         user_settings: &UserSettings,
         repo_path: &Path,

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -131,17 +131,29 @@ fn init_working_copy(
 }
 
 impl Workspace {
-    fn new(
+    pub fn new(
         workspace_root: &Path,
         working_copy: Box<dyn WorkingCopy>,
         repo_loader: RepoLoader,
     ) -> Result<Workspace, PathError> {
         let workspace_root = workspace_root.canonicalize().context(workspace_root)?;
-        Ok(Workspace {
+        Ok(Self::new_no_canonicalize(
+            workspace_root,
+            working_copy,
+            repo_loader,
+        ))
+    }
+
+    pub fn new_no_canonicalize(
+        workspace_root: PathBuf,
+        working_copy: Box<dyn WorkingCopy>,
+        repo_loader: RepoLoader,
+    ) -> Self {
+        Self {
             workspace_root,
             repo_loader,
             working_copy,
-        })
+        }
     }
 
     pub fn init_local(


### PR DESCRIPTION
Many places in jj_cli assume a working std::fs for interrogating repo storage types before loading the repos.  Rather than abstract all of that away and introduce complexity, let's expose a couple simple constructor methods to allow a determined client to bypass std::fs interactions in environments that don't support them (for instance, when the repo is stored in a cloud filesystem that isn't mounted locally).

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
