### PR TITLE
docs: Fix example with Git conflicts markers

### DIFF
--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -62,15 +62,15 @@ style](https://git-scm.com/docs/git-merge#_how_conflicts_are_presented):
   apple
   grapefruit
   orange
-  ======= base
+  ||||||| base
   apple
   grape
   orange
-  ||||||| right
+  =======
   APPLE
   GRAPE
   ORANGE
-  >>>>>>>
+  >>>>>>> right
 ```
 
 In this example, the left side changed "grape" to "grapefruit", and the right


### PR DESCRIPTION
Example of Git conflict in "diff3" syntax was incorrect - base should start with `|||||||` marker and split marker `=======` should have no label (see linked documentation for examples: https://git-scm.com/docs/git-merge#_how_conflicts_are_presented).

As a way to test - Visual Studio Code correctly renders updated example (while old version didn't have conflict markers rendered).

<img width="695" alt="image" src="https://github.com/user-attachments/assets/4f558786-c5c0-4990-9b58-5d7d00e29360">


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
