### PR TITLE
cli: make "op abandon" not fail with multiple op heads

### DIFF
--- a/cli/src/commands/operation/abandon.rs
+++ b/cli/src/commands/operation/abandon.rs
@@ -57,7 +57,8 @@ pub fn cmd_op_abandon(
         return Err(cli_error("--at-op is not respected"));
     }
     let current_head_op = op_walk::resolve_op_for_load(repo_loader, "@")?;
-    let resolve_op = |op_str| op_walk::resolve_op_at(op_store, &current_head_op, op_str);
+    let resolve_op =
+        |op_str| op_walk::resolve_op_at(op_store, slice::from_ref(&current_head_op), op_str);
     let (abandon_root_op, abandon_head_op) =
         if let Some((root_op_str, head_op_str)) = args.operation.split_once("..") {
             let root_op = if root_op_str.is_empty() {

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -250,7 +250,7 @@ pub fn walk_ancestors(head_ops: &[Operation]) -> impl Iterator<Item = OpStoreRes
 /// Stats about `reparent_range()`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReparentStats {
-    /// New head operation ids.
+    /// New head operation ids in order of the old `head_ops`.
     pub new_head_ids: Vec<OperationId>,
     /// The number of rewritten operations.
     pub rewritten_count: usize,


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
