### PR TITLE
describe: warn user of limitations of describing multiple commits interface

### DIFF
--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 
 use bstr::ByteVec as _;
 use indexmap::IndexMap;
+use indoc::indoc;
 use itertools::Itertools;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
@@ -58,6 +59,10 @@ pub fn edit_multiple_descriptions(
     let mut commits_map = IndexMap::new();
     let mut bulk_message = String::new();
 
+    bulk_message.push_str(indoc! {r#"
+    JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
+    
+    "#});
     for (commit_id, temp_commit) in commits.iter() {
         let commit_hash = short_commit_hash(commit_id);
         bulk_message.push_str("JJ: describe ");

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -60,8 +60,11 @@ pub fn edit_multiple_descriptions(
     let mut bulk_message = String::new();
 
     bulk_message.push_str(indoc! {r#"
-    JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
-    
+        JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
+        JJ: Warning:
+        JJ: - The text you enter will be lost on a syntax error.
+        JJ: - The syntax of the separator lines may change in the future.
+
     "#});
     for (commit_id, temp_commit) in commits.iter() {
         let commit_hash = short_commit_hash(commit_id);

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -224,6 +224,9 @@ fn test_describe_multiple_commits() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
+    JJ: Warning:
+    JJ: - The text you enter will be lost on a syntax error.
+    JJ: - The syntax of the separator lines may change in the future.
 
     JJ: describe 8d650510daad -------
 
@@ -238,6 +241,10 @@ fn test_describe_multiple_commits() {
         &edit_script,
         indoc! {"
             write
+            JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
+
+            JJ: More header tests. Library tests verify parsing in other situations.
+
             JJ: describe 8d650510daad -------
             description from editor of @-
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -223,6 +223,8 @@ fn test_describe_multiple_commits() {
     "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+    JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
+
     JJ: describe 8d650510daad -------
 
     JJ: describe 41659b846096 -------


### PR DESCRIPTION
This follows up on #3828, cc @bnjmnt4n (and thanks again for implementing this!). It also includes an additional line of explanation.

Calling this an "experimental feature" seems appropriate to me, but let me know if this feels excessive.

I don't think we will or should try to fix all the slightly rough edges by the Wednesday release.

Ultimately, I wonder if we can make this work smoothly with some form of `rebase --interactive`, including things like squashing and reordering commits.

**Update:** I also added a third commit with a new test. This ended up leading me to add `op restore` to the existing tests as well. Let me know if this should be a separate discussion in a separate PR, or I could just drop it.
