### PR TITLE
 cli: obslog: show diffs from all predecessors, not first predecessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj --at-op=@` no longer merges concurrent operations if explicitly specified.
 
+* `jj obslog -p` no longer shows diffs at non-partial squash operations.
+  Previously, it showed the same diffs as the second predecessor.
+
 ### Deprecations
 
 * The original configuration syntax for `jj fix` is now deprecated in favor of

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::slice;
+
 use clap::ArgGroup;
 use jj_lib::rewrite::rebase_to_dest_parent;
 use tracing::instrument;
@@ -53,7 +55,11 @@ pub(crate) fn cmd_interdiff(
         workspace_command.resolve_single_rev(args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
     let to = workspace_command.resolve_single_rev(args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
 
-    let from_tree = rebase_to_dest_parent(workspace_command.repo().as_ref(), &from, &to)?;
+    let from_tree = rebase_to_dest_parent(
+        workspace_command.repo().as_ref(),
+        slice::from_ref(&from),
+        &to,
+    )?;
     let to_tree = to.tree()?;
     let matcher = workspace_command
         .parse_file_patterns(&args.paths)?

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -190,12 +190,8 @@ fn show_predecessor_patch(
     commit: &Commit,
     width: usize,
 ) -> Result<(), CommandError> {
-    let mut predecessors = commit.predecessors();
-    let predecessor = match predecessors.next() {
-        Some(predecessor) => predecessor?,
-        None => return Ok(()),
-    };
-    let predecessor_tree = rebase_to_dest_parent(repo, &predecessor, commit)?;
+    let predecessors: Vec<_> = commit.predecessors().try_collect()?;
+    let predecessor_tree = rebase_to_dest_parent(repo, &predecessors, commit)?;
     let tree = commit.tree()?;
     renderer.show_diff(
         ui,

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -556,7 +556,9 @@ fn show_change_diff(
     width: usize,
 ) -> Result<(), CommandError> {
     match (&*change.removed_commits, &*change.added_commits) {
-        (predecessors @ [_], [commit]) => {
+        (predecessors @ ([] | [_]), [commit]) => {
+            // New or modified change. If the modification involved a rebase,
+            // show diffs from the rebased tree.
             let predecessor_tree = rebase_to_dest_parent(repo, predecessors, commit)?;
             let tree = commit.tree()?;
             diff_renderer.show_diff(
@@ -567,9 +569,6 @@ fn show_change_diff(
                 &EverythingMatcher,
                 width,
             )?;
-        }
-        ([], [commit]) => {
-            diff_renderer.show_patch(ui, formatter, commit, &EverythingMatcher, width)?;
         }
         ([commit], []) => {
             // TODO: Should we show a reverse diff?

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -556,8 +556,8 @@ fn show_change_diff(
     width: usize,
 ) -> Result<(), CommandError> {
     match (&*change.removed_commits, &*change.added_commits) {
-        ([predecessor], [commit]) => {
-            let predecessor_tree = rebase_to_dest_parent(repo, predecessor, commit)?;
+        (predecessors @ [_], [commit]) => {
+            let predecessor_tree = rebase_to_dest_parent(repo, predecessors, commit)?;
             let tree = commit.tree()?;
             diff_renderer.show_diff(
                 ui,

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -234,7 +234,7 @@ fn test_obslog_squash() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "second"]);
     std::fs::write(repo_path.join("file1"), "foo\nbar\n").unwrap();
 
-    // full
+    // not partial
     test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "squashed 1"]);
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "third"]);
@@ -267,10 +267,6 @@ fn test_obslog_squash() {
     insta::assert_snapshot!(stdout, @r###"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 d49749bf
     ├─┬─╮  squashed 3
-    │ │ │  Added regular file file4:
-    │ │ │          1: foo4
-    │ │ │  Added regular file file5:
-    │ │ │          1: foo5
     │ │ ○  vruxwmqv hidden test.user@example.com 2001-02-03 08:05:15 8f2ae2b5
     │ │ │  fifth
     │ │ │  Added regular file file5:
@@ -285,10 +281,10 @@ fn test_obslog_squash() {
     │    (empty) fourth
     ○    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:12 1408a0a7
     ├─╮  squashed 2
-    │ │  Modified regular file file1:
-    │ │     1    1: foo
-    │ │     2    2: bar
-    │ │          3: baz
+    │ │  Removed regular file file2:
+    │ │     1     : foo2
+    │ │  Removed regular file file3:
+    │ │     1     : foo3
     │ ○  zsuskuln hidden test.user@example.com 2001-02-03 08:05:12 c9460789
     │ │  third
     │ │  Modified regular file file1:
@@ -305,9 +301,6 @@ fn test_obslog_squash() {
     │    (empty) (no description set)
     ○    qpvuntsm hidden test.user@example.com 2001-02-03 08:05:10 e3c2a446
     ├─╮  squashed 1
-    │ │  Modified regular file file1:
-    │ │     1    1: foo
-    │ │          2: bar
     │ ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 46acd22a
     │ │  second
     │ │  Modified regular file file1:

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -225,7 +225,7 @@ fn test_obslog_word_wrap() {
 
 #[test]
 fn test_obslog_squash() {
-    let mut test_env = TestEnvironment::default();
+    let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
@@ -234,15 +234,12 @@ fn test_obslog_squash() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "second"]);
     std::fs::write(repo_path.join("file1"), "foo\nbar\n").unwrap();
 
-    let edit_script = test_env.set_up_fake_editor();
-    std::fs::write(&edit_script, "write\nsquashed 1").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["squash"]);
+    test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "squashed 1"]);
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "third"]);
     std::fs::write(repo_path.join("file1"), "foo\nbar\nbaz\n").unwrap();
 
-    std::fs::write(&edit_script, "write\nsquashed 2").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["squash"]);
+    test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "squashed 2"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["obslog", "-p", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
