### PR TITLE
merged_tree: remove .diff() method in favor of .diff_stream()

### DIFF
--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -308,19 +308,10 @@ impl MergedTree {
         TreeEntriesIterator::new(self.clone(), matcher)
     }
 
-    /// Iterate over the differences between this tree and another tree.
+    /// Stream of the differences between this tree and another tree.
     ///
     /// The files in a removed tree will be returned before a file that replaces
     /// it.
-    pub fn diff<'matcher>(
-        &self,
-        other: &MergedTree,
-        matcher: &'matcher dyn Matcher,
-    ) -> TreeDiffIterator<'matcher> {
-        TreeDiffIterator::new(self.clone(), other.clone(), matcher)
-    }
-
-    /// Stream of the differences between this tree and another tree.
     pub fn diff_stream<'matcher>(
         &self,
         other: &MergedTree,

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -777,10 +777,11 @@ fn test_diff_resolved() {
     let before_merged = MergedTree::new(Merge::resolved(before.clone()));
     let after_merged = MergedTree::new(Merge::resolved(after.clone()));
 
-    let diff = before_merged
-        .diff(&after_merged, &EverythingMatcher)
+    let diff: Vec<_> = before_merged
+        .diff_stream(&after_merged, &EverythingMatcher)
         .map(|(path, diff)| (path, diff.unwrap()))
-        .collect_vec();
+        .collect()
+        .block_on();
     assert_eq!(diff.len(), 3);
     assert_eq!(
         diff[0].clone(),
@@ -886,10 +887,11 @@ fn test_diff_conflicted() {
     ));
 
     // Test the forwards diff
-    let actual_diff = left_merged
-        .diff(&right_merged, &EverythingMatcher)
+    let actual_diff: Vec<_> = left_merged
+        .diff_stream(&right_merged, &EverythingMatcher)
         .map(|(path, diff)| (path, diff.unwrap()))
-        .collect_vec();
+        .collect()
+        .block_on();
     let expected_diff = [path2, path3, path4]
         .iter()
         .map(|&path| {
@@ -905,10 +907,11 @@ fn test_diff_conflicted() {
     assert_eq!(actual_diff, expected_diff);
     diff_stream_equals_iter(&left_merged, &right_merged, &EverythingMatcher);
     // Test the reverse diff
-    let actual_diff = right_merged
-        .diff(&left_merged, &EverythingMatcher)
+    let actual_diff: Vec<_> = right_merged
+        .diff_stream(&left_merged, &EverythingMatcher)
         .map(|(path, diff)| (path, diff.unwrap()))
-        .collect_vec();
+        .collect()
+        .block_on();
     let expected_diff = [path2, path3, path4]
         .iter()
         .map(|&path| {
@@ -1022,10 +1025,11 @@ fn test_diff_dir_file() {
 
     // Test the forwards diff
     {
-        let actual_diff = left_merged
-            .diff(&right_merged, &EverythingMatcher)
+        let actual_diff: Vec<_> = left_merged
+            .diff_stream(&right_merged, &EverythingMatcher)
             .map(|(path, diff)| (path, diff.unwrap()))
-            .collect_vec();
+            .collect()
+            .block_on();
         let expected_diff = vec![
             // path1: file1 -> directory1
             (path1.to_owned(), (left_value(path1), Merge::absent())),
@@ -1066,10 +1070,11 @@ fn test_diff_dir_file() {
 
     // Test the reverse diff
     {
-        let actual_diff = right_merged
-            .diff(&left_merged, &EverythingMatcher)
+        let actual_diff: Vec<_> = right_merged
+            .diff_stream(&left_merged, &EverythingMatcher)
             .map(|(path, diff)| (path, diff.unwrap()))
-            .collect_vec();
+            .collect()
+            .block_on();
         let expected_diff = vec![
             // path1: file1 -> directory1
             (
@@ -1111,10 +1116,11 @@ fn test_diff_dir_file() {
     // Diff while filtering by `path1` (file1 -> directory1) as a file
     {
         let matcher = FilesMatcher::new([&path1]);
-        let actual_diff = left_merged
-            .diff(&right_merged, &matcher)
+        let actual_diff: Vec<_> = left_merged
+            .diff_stream(&right_merged, &matcher)
             .map(|(path, diff)| (path, diff.unwrap()))
-            .collect_vec();
+            .collect()
+            .block_on();
         let expected_diff = vec![
             // path1: file1 -> directory1
             (path1.to_owned(), (left_value(path1), Merge::absent())),
@@ -1126,10 +1132,11 @@ fn test_diff_dir_file() {
     // Diff while filtering by `path1/file` (file1 -> directory1) as a file
     {
         let matcher = FilesMatcher::new([path1.join(file)]);
-        let actual_diff = left_merged
-            .diff(&right_merged, &matcher)
+        let actual_diff: Vec<_> = left_merged
+            .diff_stream(&right_merged, &matcher)
             .map(|(path, diff)| (path, diff.unwrap()))
-            .collect_vec();
+            .collect()
+            .block_on();
         let expected_diff = vec![
             // path1: file1 -> directory1
             (
@@ -1144,10 +1151,11 @@ fn test_diff_dir_file() {
     // Diff while filtering by `path1` (file1 -> directory1) as a prefix
     {
         let matcher = PrefixMatcher::new([&path1]);
-        let actual_diff = left_merged
-            .diff(&right_merged, &matcher)
+        let actual_diff: Vec<_> = left_merged
+            .diff_stream(&right_merged, &matcher)
             .map(|(path, diff)| (path, diff.unwrap()))
-            .collect_vec();
+            .collect()
+            .block_on();
         let expected_diff = vec![
             (path1.to_owned(), (left_value(path1), Merge::absent())),
             (
@@ -1165,10 +1173,11 @@ fn test_diff_dir_file() {
     // side.
     {
         let matcher = FilesMatcher::new([&path6]);
-        let actual_diff = left_merged
-            .diff(&right_merged, &matcher)
+        let actual_diff: Vec<_> = left_merged
+            .diff_stream(&right_merged, &matcher)
             .map(|(path, diff)| (path, diff.unwrap()))
-            .collect_vec();
+            .collect()
+            .block_on();
         let expected_diff = vec![(path6.to_owned(), (Merge::absent(), right_value(path6)))];
         assert_eq!(actual_diff, expected_diff);
         diff_stream_equals_iter(&left_merged, &right_merged, &matcher);


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
