### PR TITLE
github: build on macos-13 for x86_64

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos-aarch64, win-x86_64]
+        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos-x86_64, macos-aarch64, win-x86_64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -27,6 +27,9 @@ jobs:
         - build: linux-aarch64-gnu
           os: ubuntu-24.04
           target: aarch64-unknown-linux-gnu
+        - build: macos-x86_64
+          os: macos-13
+          target: x86_64-apple-darwin
         - build: macos-aarch64
           os: macos-14
           target: aarch64-apple-darwin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        # macos-13 is x86; macos-14 is ARM
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
         cargo_flags: [""]
         include:
         - os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           os: ubuntu-24.04
           target: aarch64-unknown-linux-musl
         - build: macos-x86_64
-          os: macos-11
+          os: macos-13
           target: x86_64-apple-darwin
         - build: macos-aarch64
           os: macos-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Release binaries for Intel Macs have been restored. They were previously
+  broken due to using a sunset version of GitHub's macOS runners (but nobody had
+  previously complained.)
+
 ## [0.20.0] - 2024-08-07
 
 ### Note to packagers


### PR DESCRIPTION
We all noticed that x86 macOS binaries are no longer being provided on release, due to `macos-11` runners going the way of the Dodo a while back. Nobody alterted us to this, funny enough.

After some quick discussion, we concluded some things:

- x86 macOS runners are likely oversubscribed, and hurt CI latency badly
- `macos-12` is also deprecated; `macos-13` is the best x86 runner available
- GitHub probably isn't going to expand macOS runner capacity; `macos-13` will one day go away
- Some people are still using `jj` on Intel Macs. We didn't get alerted because they do their own builds for now, but may not always do that.
- We can just try to build on `macos-13` and make it optional for merges.

So that's what this does. It might be mergeable outright, but we can also use it to measure build latency impacts.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
