### PR TITLE
config: do not parse TOML value expression by write_config_value_to_file()

### DIFF
--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -17,7 +17,9 @@ use tracing::instrument;
 use super::ConfigLevelArgs;
 use crate::cli_util::{get_new_config_file_path, CommandHelper};
 use crate::command_error::{user_error, CommandError};
-use crate::config::{write_config_value_to_file, ConfigNamePathBuf};
+use crate::config::{
+    parse_toml_value_or_bare_string, write_config_value_to_file, ConfigNamePathBuf,
+};
 use crate::ui::Ui;
 
 /// Update config file to set the given option to a given value.
@@ -44,5 +46,7 @@ pub fn cmd_config_set(
             path = config_path.display()
         )));
     }
-    write_config_value_to_file(&args.name, &args.value, &config_path)
+    // TODO(#531): Infer types based on schema (w/ --type arg to override).
+    let value = parse_toml_value_or_bare_string(&args.value);
+    write_config_value_to_file(&args.name, value, &config_path)
 }

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -149,7 +149,7 @@ pub fn cmd_git_clone(
         let config_path = workspace_command.repo().repo_path().join("config.toml");
         write_config_value_to_file(
             &ConfigNamePathBuf::from_iter(["revset-aliases", "trunk()"]),
-            &format!("{default_branch}@{remote_name}"),
+            format!("{default_branch}@{remote_name}").into(),
             &config_path,
         )?;
         writeln!(

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -238,7 +238,7 @@ pub fn maybe_set_repository_level_trunk_alias(
                 let config_path = repo.repo_path().join("config.toml");
                 write_config_value_to_file(
                     &ConfigNamePathBuf::from_iter(["revset-aliases", "trunk()"]),
-                    &format!("{default_branch}@origin"),
+                    format!("{default_branch}@origin").into(),
                     &config_path,
                 )?;
                 writeln!(


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
