### PR TITLE
cli: op show: remove visible alias for positional arg

### DIFF
--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -25,7 +25,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub struct OperationShowArgs {
     /// Show repository changes in this operation, compared to its parent(s)
-    #[arg(visible_alias = "op", default_value = "@")]
+    #[arg(default_value = "@")]
     operation: String,
     /// Don't show the graph, show a flat list of modified changes
     #[arg(long)]


### PR DESCRIPTION
The alias has no effect for positional arguments AFAIK, this makes it more consistent with `jj show`.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
