### PR TITLE
config: expand tilde in ssh key filepaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The following diff formats now include information about copies and moves:
   `--color-words`, `--summary`
 
+* A tilde (`~`) at the start of the path will now be expanded to the user's home
+  directory when configuring a `signing.key` for SSH commit signing.
+
 ### Fixed bugs
 
 ## [0.20.0] - 2024-08-07

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -73,7 +73,7 @@ use jj_lib::workspace::{
     default_working_copy_factories, LockedWorkspace, WorkingCopyFactories, Workspace,
     WorkspaceLoadError, WorkspaceLoader,
 };
-use jj_lib::{dag_walk, fileset, git, op_heads_store, op_walk, revset};
+use jj_lib::{dag_walk, file_util, fileset, git, op_heads_store, op_walk, revset};
 use once_cell::unsync::OnceCell;
 use tracing::instrument;
 use tracing_chrome::ChromeLayerBuilder;
@@ -806,7 +806,7 @@ impl WorkspaceCommandHelper {
             if let Some(value) = config.string("core.excludesFile") {
                 let path = str::from_utf8(&value)
                     .ok()
-                    .map(crate::git_util::expand_git_path)?;
+                    .map(file_util::expand_home_path)?;
                 // The configured path is usually absolute, but if it's relative,
                 // the "git" command would read the file at the work-tree directory.
                 Some(self.workspace_root().join(path))

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -419,13 +419,3 @@ export or their "parent" branches."#,
     }
     Ok(())
 }
-
-/// Expands "~/" to "$HOME/" as Git seems to do for e.g. core.excludesFile.
-pub fn expand_git_path(path_str: &str) -> PathBuf {
-    if let Some(remainder) = path_str.strip_prefix("~/") {
-        if let Ok(home_dir_str) = std::env::var("HOME") {
-            return PathBuf::from(home_dir_str).join(remainder);
-        }
-    }
-    PathBuf::from(path_str)
-}

--- a/docs/config.md
+++ b/docs/config.md
@@ -784,7 +784,7 @@ sign-all = true
 backend = "ssh"
 key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h"
 ## You can also use a path instead of embedding the key
-# key = "/home/me/.ssh/id_for_signing.pub"
+# key = "~/.ssh/id_for_signing.pub"
 ```
 
 By default the ssh backend will look for a `ssh-keygen` binary on your path. If you want

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -69,6 +69,16 @@ pub fn remove_dir_contents(dirname: &Path) -> Result<(), PathError> {
     Ok(())
 }
 
+/// Expands "~/" to "$HOME/".
+pub fn expand_home_path(path_str: &str) -> PathBuf {
+    if let Some(remainder) = path_str.strip_prefix("~/") {
+        if let Ok(home_dir_str) = std::env::var("HOME") {
+            return PathBuf::from(home_dir_str).join(remainder);
+        }
+    }
+    PathBuf::from(path_str)
+}
+
 /// Turns the given `to` path into relative path starting from the `from` path.
 ///
 /// Both `from` and `to` paths are supposed to be absolute and normalized in the

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -81,8 +81,8 @@ fn run_command(command: &mut Command, stdin: &[u8]) -> SshResult<Vec<u8>> {
 fn ensure_key_as_file(key: &str) -> SshResult<Either<PathBuf, tempfile::TempPath>> {
     let is_inlined_ssh_key = key.starts_with("ssh-");
     if !is_inlined_ssh_key {
-        let key_path = Path::new(key);
-        return Ok(either::Left(key_path.to_path_buf()));
+        let key_path = crate::file_util::expand_home_path(key);
+        return Ok(either::Left(key_path));
     }
 
     let mut pub_key_file = tempfile::Builder::new()


### PR DESCRIPTION
Add home directory expansion for SSH key filepaths. This allows the `signing.key` configuration value to work more universally across both Linux and macOS without requiring an absolute path.

This moved and renamed the previous `expand_git_path` function to a more generic location, and the prior use was updated accordingly.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
