### PR TITLE
diff_util: add copy records tracking to `DiffRenderer::show_patch`

### DIFF
--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -349,13 +349,21 @@ impl<'a> DiffRenderer<'a> {
     ) -> Result<(), DiffRenderError> {
         let from_tree = commit.parent_tree(self.repo)?;
         let to_tree = commit.tree()?;
+        let mut copy_records = CopyRecords::default();
+        for parent_id in commit.parent_ids() {
+            copy_records.add_records(self.repo.store().get_copy_records(
+                None,
+                parent_id,
+                commit.id(),
+            )?)?;
+        }
         self.show_diff(
             ui,
             formatter,
             &from_tree,
             &to_tree,
             matcher,
-            &Default::default(),
+            &copy_records,
             width,
         )
     }

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -62,8 +62,7 @@ fn test_show_basic() {
        1    1: foo
             2: bar
        2    3: baz quxquux
-    Added regular file file3:
-            1: foo
+    Modified regular file file3 (file1 => file3):
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--context=0"]);
@@ -81,8 +80,7 @@ fn test_show_basic() {
        1    1: foo
             2: bar
        2    3: baz quxquux
-    Added regular file file3:
-            1: foo
+    Modified regular file file3 (file1 => file3):
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--color=debug"]);
@@ -100,8 +98,7 @@ fn test_show_basic() {
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: foo>>
     <<diff::     >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::bar>>[24m[39m
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   3>>[39m<<diff::: baz >>[4m[38;5;1m<<diff removed token::qux>>[38;5;2m<<diff added token::quux>>[24m[39m<<diff::>>
-    [38;5;3m<<diff header::Added regular file file3:>>[39m
-    <<diff::     >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::foo>>[24m[39m
+    [38;5;3m<<diff header::Modified regular file file3 (file1 => file3):>>[39m
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s"]);
@@ -113,9 +110,8 @@ fn test_show_basic() {
 
         (no description set)
 
-    D file1
     M file2
-    A file3
+    R {file1 => file3}
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--types"]);
@@ -242,9 +238,8 @@ fn test_show_basic() {
 
         (no description set)
 
-    D file1
     M file2
-    A file3
+    R {file1 => file3}
     diff --git a/file1 b/file1
     deleted file mode 100644
     index 257cc5642c..0000000000
@@ -279,10 +274,9 @@ fn test_show_basic() {
 
         (no description set)
 
-    file1 | 1 -
-    file2 | 3 ++-
-    file3 | 1 +
-    3 files changed, 3 insertions(+), 2 deletions(-)
+    file2            | 3 ++-
+    {file1 => file3} | 0
+    2 files changed, 2 insertions(+), 1 deletion(-)
     "###);
 }
 


### PR DESCRIPTION
This allow `jj show --summary` and other commands to include copy tracking information.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
