### PR TITLE
Fix macOS x86_64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           os: ubuntu-24.04
           target: aarch64-unknown-linux-musl
         - build: macos-x86_64
-          os: macos-11
+          os: macos-13
           target: x86_64-apple-darwin
         - build: macos-aarch64
           os: macos-14


### PR DESCRIPTION
Seems like this broke for the v0.19 release and later.

`macos-11` is no longer supported: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

`macos-13` is the last x86_64 macOS version