### PR TITLE
working_copy: delete `path()` method from trait

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1543,10 +1543,6 @@ impl WorkingCopy for LocalWorkingCopy {
         Self::name()
     }
 
-    fn path(&self) -> &Path {
-        &self.working_copy_path
-    }
-
     fn workspace_id(&self) -> &WorkspaceId {
         &self.checkout_state().workspace_id
     }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -17,7 +17,7 @@
 
 use std::any::Any;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -39,9 +39,6 @@ pub trait WorkingCopy: Send {
     /// The name/id of the implementation. Used for choosing the right
     /// implementation when loading a working copy.
     fn name(&self) -> &str;
-
-    /// The working copy's root directory.
-    fn path(&self) -> &Path;
 
     /// The working copy's workspace ID.
     fn workspace_id(&self) -> &WorkspaceId;

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -103,7 +103,7 @@ fn test_sparse_checkout() {
     // Reload the state to check that it was persisted
     let wc = LocalWorkingCopy::load(
         repo.store().clone(),
-        wc.path().to_path_buf(),
+        ws.workspace_root().to_path_buf(),
         wc.state_path().to_path_buf(),
     );
     assert_eq!(


### PR DESCRIPTION
We don't currently use the `path()` method. Not all working copies even have a relevant path. For example, working copies on Google's server don't.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
