### PR TITLE
Follow ups on post #4282 submission comments.

### DIFF
--- a/cli/src/commands/next.rs
+++ b/cli/src/commands/next.rs
@@ -14,7 +14,7 @@
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
-use crate::movement_util::{move_to_commit, Direction};
+use crate::movement_util::{move_to_commit, Direction, MovementArgs};
 use crate::ui::Ui;
 
 /// Move the working-copy commit to the child revision
@@ -64,6 +64,16 @@ pub(crate) struct NextArgs {
     conflict: bool,
 }
 
+impl From<&NextArgs> for MovementArgs {
+    fn from(val: &NextArgs) -> Self {
+        MovementArgs {
+            offset: val.offset,
+            edit: val.edit,
+            conflict: val.conflict,
+        }
+    }
+}
+
 pub(crate) fn cmd_next(
     ui: &mut Ui,
     command: &CommandHelper,
@@ -73,9 +83,7 @@ pub(crate) fn cmd_next(
     move_to_commit(
         ui,
         &mut workspace_command,
-        &Direction::Next,
-        args.edit,
-        args.conflict,
-        args.offset,
+        Direction::Next,
+        &MovementArgs::from(args),
     )
 }

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -14,7 +14,7 @@
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
-use crate::movement_util::{move_to_commit, Direction};
+use crate::movement_util::{move_to_commit, Direction, MovementArgs};
 use crate::ui::Ui;
 /// Change the working copy revision relative to the parent revision
 ///
@@ -60,6 +60,16 @@ pub(crate) struct PrevArgs {
     conflict: bool,
 }
 
+impl From<&PrevArgs> for MovementArgs {
+    fn from(val: &PrevArgs) -> Self {
+        MovementArgs {
+            offset: val.offset,
+            edit: val.edit,
+            conflict: val.conflict,
+        }
+    }
+}
+
 pub(crate) fn cmd_prev(
     ui: &mut Ui,
     command: &CommandHelper,
@@ -69,9 +79,7 @@ pub(crate) fn cmd_prev(
     move_to_commit(
         ui,
         &mut workspace_command,
-        &Direction::Prev,
-        args.edit,
-        args.conflict,
-        args.offset,
+        Direction::Prev,
+        &MovementArgs::from(args),
     )
 }


### PR DESCRIPTION
Follow up on post-submission comments in #4282.

* Derive a bunch of standard and useful traits for `movement_util::Direction`
  as it is a simple type. Importantly `Copy`.
* Return `&'static str` from Direction.cmd()
* Refactor out `MovementArgs` to reduce the number of arguments
  to `movement_util::move_to_commit`.
* Implement `From<&NextArgs/&PrevArgs>` for MovementArgs

Part of #3947


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
