### PR TITLE
diff: add option to display complex color-words diffs without inlining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--color-words`, `--git`, `--stat`, `--summary`, `--types`, and external diff
   tools in file-by-file mode.
 
+* Color-words diff has gained [an option to display complex changes as separate
+  lines](docs/config.md#color-words-diff-options).
+
 * A tilde (`~`) at the start of the path will now be expanded to the user's home
   directory when configuring a `signing.key` for SSH commit signing.
   

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1345,14 +1345,16 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
             let path_converter = language.path_converter;
             let template = (self_property, context_property)
                 .map(move |(diff, context)| {
-                    let context = context.unwrap_or(diff_util::DEFAULT_CONTEXT_LINES);
+                    let options = diff_util::ColorWordsOptions {
+                        context: context.unwrap_or(diff_util::DEFAULT_CONTEXT_LINES),
+                    };
                     diff.into_formatted(move |formatter, store, tree_diff| {
                         diff_util::show_color_words_diff(
                             formatter,
                             store,
                             tree_diff,
                             path_converter,
-                            context,
+                            &options,
                         )
                     })
                 })

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1345,8 +1345,10 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
             let path_converter = language.path_converter;
             let template = (self_property, context_property)
                 .map(move |(diff, context)| {
+                    // TODO: load defaults from UserSettings?
                     let options = diff_util::ColorWordsOptions {
                         context: context.unwrap_or(diff_util::DEFAULT_CONTEXT_LINES),
+                        max_inline_alternation: None,
                     };
                     diff.into_formatted(move |formatter, store, tree_diff| {
                         diff_util::show_color_words_diff(

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -276,6 +276,22 @@
                 ]
             }
         },
+        "diff": {
+            "type": "object",
+            "description": "Builtin diff formats settings",
+            "properties": {
+                "color-words": {
+                    "type": "object",
+                    "description": "Options for color-words diffs",
+                    "properties": {
+                        "max-inline-alternation": {
+                            "type": "integer",
+                            "description": "Maximum number of removed/added word alternation to inline"
+                        }
+                    }
+                }
+            }
+        },
         "git": {
             "type": "object",
             "description": "Settings for git behavior (when using git backend)",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -5,6 +5,9 @@ amend = ["squash"]
 co = ["checkout"]
 unamend = ["unsquash"]
 
+[diff.color-words]
+max-inline-alternation = -1
+
 [ui]
 # TODO: delete ui.allow-filesets in jj 0.26+
 allow-filesets = true

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -111,7 +111,7 @@ pub fn diff_formats_for(
 ) -> Result<Vec<DiffFormat>, config::ConfigError> {
     let formats = diff_formats_from_args(settings, args)?;
     if formats.is_empty() {
-        Ok(vec![default_diff_format(settings, args.context)?])
+        Ok(vec![default_diff_format(settings, args)?])
     } else {
         Ok(formats)
     }
@@ -127,7 +127,7 @@ pub fn diff_formats_for_log(
     let mut formats = diff_formats_from_args(settings, args)?;
     // --patch implies default if no format other than --summary is specified
     if patch && matches!(formats.as_slice(), [] | [DiffFormat::Summary]) {
-        formats.push(default_diff_format(settings, args.context)?);
+        formats.push(default_diff_format(settings, args)?);
         formats.dedup();
     }
     Ok(formats)
@@ -168,7 +168,7 @@ fn diff_formats_from_args(
 
 fn default_diff_format(
     settings: &UserSettings,
-    num_context_lines: Option<usize>,
+    args: &DiffFormatArgs,
 ) -> Result<DiffFormat, config::ConfigError> {
     let config = settings.config();
     if let Some(args) = config.get("ui.diff.tool").optional()? {
@@ -193,10 +193,10 @@ fn default_diff_format(
         "types" => Ok(DiffFormat::Types),
         "name-only" => Ok(DiffFormat::NameOnly),
         "git" => Ok(DiffFormat::Git {
-            context: num_context_lines.unwrap_or(DEFAULT_CONTEXT_LINES),
+            context: args.context.unwrap_or(DEFAULT_CONTEXT_LINES),
         }),
         "color-words" => Ok(DiffFormat::ColorWords {
-            context: num_context_lines.unwrap_or(DEFAULT_CONTEXT_LINES),
+            context: args.context.unwrap_or(DEFAULT_CONTEXT_LINES),
         }),
         "stat" => Ok(DiffFormat::Stat),
         _ => Err(config::ConfigError::Message(format!(

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -137,27 +137,27 @@ fn diff_formats_from_args(
     settings: &UserSettings,
     args: &DiffFormatArgs,
 ) -> Result<Vec<DiffFormat>, config::ConfigError> {
-    let mut formats = [
-        (args.summary, DiffFormat::Summary),
-        (args.types, DiffFormat::Types),
-        (args.name_only, DiffFormat::NameOnly),
-        (
-            args.git,
-            DiffFormat::Git {
-                context: args.context.unwrap_or(DEFAULT_CONTEXT_LINES),
-            },
-        ),
-        (
-            args.color_words,
-            DiffFormat::ColorWords {
-                context: args.context.unwrap_or(DEFAULT_CONTEXT_LINES),
-            },
-        ),
-        (args.stat, DiffFormat::Stat),
-    ]
-    .into_iter()
-    .filter_map(|(arg, format)| arg.then_some(format))
-    .collect_vec();
+    let mut formats = Vec::new();
+    if args.summary {
+        formats.push(DiffFormat::Summary);
+    }
+    if args.types {
+        formats.push(DiffFormat::Types);
+    }
+    if args.name_only {
+        formats.push(DiffFormat::NameOnly);
+    }
+    if args.git {
+        let context = args.context.unwrap_or(DEFAULT_CONTEXT_LINES);
+        formats.push(DiffFormat::Git { context });
+    }
+    if args.color_words {
+        let context = args.context.unwrap_or(DEFAULT_CONTEXT_LINES);
+        formats.push(DiffFormat::ColorWords { context });
+    }
+    if args.stat {
+        formats.push(DiffFormat::Stat);
+    }
     if let Some(name) = &args.tool {
         let tool = merge_tools::get_external_tool_config(settings, name)?
             .unwrap_or_else(|| ExternalMergeTool::with_program(name));

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -533,34 +533,43 @@ fn show_color_words_context_lines(
     Ok((line_number, num_skipped > 0))
 }
 
-fn show_color_words_diff_line(
+fn show_color_words_line_number(
     formatter: &mut dyn Formatter,
-    diff_line: &DiffLine,
+    left_line_number: Option<u32>,
+    right_line_number: Option<u32>,
 ) -> io::Result<()> {
-    if diff_line.has_left_content() {
+    if let Some(line_number) = left_line_number {
         formatter.with_label("removed", |formatter| {
-            write!(
-                formatter.labeled("line_number"),
-                "{:>4}",
-                diff_line.line_number.left
-            )
+            write!(formatter.labeled("line_number"), "{line_number:>4}")
         })?;
         write!(formatter, " ")?;
     } else {
         write!(formatter, "     ")?;
     }
-    if diff_line.has_right_content() {
+    if let Some(line_number) = right_line_number {
         formatter.with_label("added", |formatter| {
-            write!(
-                formatter.labeled("line_number"),
-                "{:>4}",
-                diff_line.line_number.right
-            )
+            write!(formatter.labeled("line_number"), "{line_number:>4}",)
         })?;
         write!(formatter, ": ")?;
     } else {
         write!(formatter, "    : ")?;
     }
+    Ok(())
+}
+
+fn show_color_words_diff_line(
+    formatter: &mut dyn Formatter,
+    diff_line: &DiffLine,
+) -> io::Result<()> {
+    show_color_words_line_number(
+        formatter,
+        diff_line
+            .has_left_content()
+            .then_some(diff_line.line_number.left),
+        diff_line
+            .has_right_content()
+            .then_some(diff_line.line_number.right),
+    )?;
     for (side, data) in &diff_line.hunks {
         let label = match side {
             DiffLineHunkSide::Both => None,

--- a/docs/config.md
+++ b/docs/config.md
@@ -200,6 +200,29 @@ can override the default style with the following keys:
 ui.diff.format = "git"
 ```
 
+#### Color-words diff options
+
+In color-words diffs, changed words are displayed inline by default. Because
+it's difficult to read a diff line with many removed/added words, there's a
+threshold to switch to traditional separate-line format.
+
+* `max-inline-alternation`: Maximum number of removed/added word alternation to
+  inline. For example, `<added> ... <added>` sequence has 1 alternation, so the
+  line will be inline if `max-inline-alternation >= 1`. `<added> ... <removed>
+  ... <added>` sequence has 3 alternation.
+
+  * `0`: disable inlining, making `--color-words` more similar to `--git`
+  * `1`: inline removes-only or adds-only lines
+  * `2`, `3`, ..: inline up to `2`, `3`, .. alternation
+  * `-1`: inline all lines (default)
+
+  **This parameter is experimental.** The definition is subject to change.
+
+```toml
+[diff.color-words]
+max-inline-alternation = 3
+```
+
 ### Generating diffs by external command
 
 If `ui.diff.tool` is set, the specified diff command will be called instead of


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

---

original (inline everything):
![image](https://github.com/user-attachments/assets/52540794-4390-47fe-8404-2fb1de943153)

`max-inline-alternation = 3`:
![image](https://github.com/user-attachments/assets/6d96b041-7b4d-4626-acc5-2a586cb2e74b)
