### PR TITLE
Color signature names yellow within the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to keeping all changes into the first commit while keeping the current commit
   description for the second commit (the newly created empty one).
 
+* Color author and committer names yellow
+
 ### Fixed bugs
 
 * Update working copy before reporting changes. This prevents errors during reporting

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -21,8 +21,8 @@
 "divergent prefix" = { fg = "red", underline = true }
 "hidden prefix" = "default"
 
-"email" = "yellow"
-"username" = "yellow"
+"author" = "yellow"
+"committer" = "yellow"
 "timestamp" = "cyan"
 "working_copies" = "green"
 "bookmark" = "magenta"
@@ -54,7 +54,8 @@
 "working_copy change_id" = "bright magenta"
 # We do not use bright yellow because of how it looks on xterm's default theme.
 # https://github.com/martinvonz/jj/issues/528
-"working_copy email" = "yellow"
+"working_copy author" = "yellow"
+"working_copy committer" = "yellow"
 "working_copy timestamp" = "bright cyan"
 "working_copy working_copies" = "bright green"
 "working_copy bookmark" = "bright magenta"

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -346,8 +346,8 @@ fn test_log_builtin_templates_colored() {
     │
     ○  Commit ID: [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     │  Change ID: [38;5;5mqpvuntsmwlqtpsluzzsnyyzlmlwvmlnu[39m
-    │  Author: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
-    │  Committer: Test User <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
+    │  Author: [38;5;3mTest User[39m <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
+    │  Committer: [38;5;3mTest User[39m <[38;5;3mtest.user@example.com[39m> ([38;5;6m2001-02-03 08:05:07[39m)
     │
     │  [38;5;2m    (no description set)[39m
     │
@@ -415,8 +415,8 @@ fn test_log_builtin_templates_colored_debug() {
     │  <<log::>>
     <<node::○>>  <<log::Commit ID: >>[38;5;4m<<log commit_id::230dd059e1b059aefc0da06a2e5a7dbf22362f22>>[39m<<log::>>
     │  <<log::Change ID: >>[38;5;5m<<log change_id::qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu>>[39m<<log::>>
-    │  <<log::Author: >><<log author name::Test User>><<log:: <>>[38;5;3m<<log author email::test.user@example.com>>[39m<<log::> (>>[38;5;6m<<log author timestamp local format::2001-02-03 08:05:07>>[39m<<log::)>>
-    │  <<log::Committer: >><<log committer name::Test User>><<log:: <>>[38;5;3m<<log committer email::test.user@example.com>>[39m<<log::> (>>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log::)>>
+    │  <<log::Author: >>[38;5;3m<<log author name::Test User>>[39m<<log:: <>>[38;5;3m<<log author email::test.user@example.com>>[39m<<log::> (>>[38;5;6m<<log author timestamp local format::2001-02-03 08:05:07>>[39m<<log::)>>
+    │  <<log::Committer: >>[38;5;3m<<log committer name::Test User>>[39m<<log:: <>>[38;5;3m<<log committer email::test.user@example.com>>[39m<<log::> (>>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log::)>>
     │  <<log::>>
     │  [38;5;2m<<log empty description placeholder::    (no description set)>>[39m<<log::>>
     │  <<log::>>

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -80,11 +80,11 @@ fn test_show_basic() {
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     Commit ID: [38;5;4m<<commit_id::e34f04317a81edc6ba41fef239c0d0180f10656f>>[39m
     Change ID: [38;5;5m<<change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m
-    Author: <<author name::Test User>> <[38;5;3m<<author email::test.user@example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
-    Committer: <<committer name::Test User>> <[38;5;3m<<committer email::test.user@example.com>>[39m> ([38;5;6m<<committer timestamp local format::2001-02-03 08:05:09>>[39m)
+    Author: [38;5;3m<<author name::Test User>>[39m <[38;5;3m<<author email::test.user@example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
+    Committer: [38;5;3m<<committer name::Test User>>[39m <[38;5;3m<<committer email::test.user@example.com>>[39m> ([38;5;6m<<committer timestamp local format::2001-02-03 08:05:09>>[39m)
 
     [38;5;3m<<description placeholder::    (no description set)>>[39m
 
@@ -93,7 +93,7 @@ fn test_show_basic() {
     <<diff::     >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::bar>>[24m[39m
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   3>>[39m<<diff::: baz >>[4m[38;5;1m<<diff removed token::qux>>[38;5;2m<<diff added token::quux>>[24m[39m<<diff::>>
     [38;5;3m<<diff header::Modified regular file file3 (file1 => file3):>>[39m
-    "###);
+    "#);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -167,11 +167,11 @@ fn test_show_basic() {
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     Commit ID: [38;5;4m<<commit_id::e34f04317a81edc6ba41fef239c0d0180f10656f>>[39m
     Change ID: [38;5;5m<<change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m
-    Author: <<author name::Test User>> <[38;5;3m<<author email::test.user@example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
-    Committer: <<committer name::Test User>> <[38;5;3m<<committer email::test.user@example.com>>[39m> ([38;5;6m<<committer timestamp local format::2001-02-03 08:05:09>>[39m)
+    Author: [38;5;3m<<author name::Test User>>[39m <[38;5;3m<<author email::test.user@example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
+    Committer: [38;5;3m<<committer name::Test User>>[39m <[38;5;3m<<committer email::test.user@example.com>>[39m> ([38;5;6m<<committer timestamp local format::2001-02-03 08:05:09>>[39m)
 
     [38;5;3m<<description placeholder::    (no description set)>>[39m
 
@@ -187,7 +187,7 @@ fn test_show_basic() {
     [1m<<diff file_header::diff --git a/file1 b/file3>>[0m
     [1m<<diff file_header::rename from file1>>[0m
     [1m<<diff file_header::rename to file3>>[0m
-    "###);
+    "#);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s", "--git"]);
     insta::assert_snapshot!(stdout, @r###"


### PR DESCRIPTION
Included the details in the commit message. There is probably a better way to do this, but I've been running with these changes in my local config.toml and seem to be working well with no other color conflicts. Suggestions welcome.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
