### PR TITLE
cli, lib: inline grammar definitions into `.rs` files

### DIFF
--- a/cli/src/grammars/mod.rs
+++ b/cli/src/grammars/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2021-2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Grammars for parsing Jujutsu formats.
+
+pub mod template;

--- a/cli/src/grammars/template.rs
+++ b/cli/src/grammars/template.rs
@@ -1,22 +1,23 @@
-// Copyright 2020 The Jujutsu Authors
-// 
+// Copyright 2021-2024 The Jujutsu Authors
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Example:
-// "commit: " ++ short(commit_id) ++ "\n"
-// predecessors.map(|p| "predecessor: " ++ p.commit_id)
-// parents.map(|p| p.commit_id ++ " is a parent of " ++ commit_id)
+#![allow(missing_docs)]
 
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar_inline = r###"
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
@@ -87,3 +88,5 @@ function_alias_declaration = {
 alias_declaration = _{
   SOI ~ (function_alias_declaration | identifier) ~ EOI
 }
+"###]
+pub struct TemplateParser;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -25,6 +25,7 @@ pub mod diff_util;
 pub mod formatter;
 pub mod generic_templater;
 pub mod git_util;
+pub mod grammars;
 pub mod graphlog;
 pub mod merge_tools;
 pub mod movement_util;

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -37,12 +37,9 @@ use pest::pratt_parser::Assoc;
 use pest::pratt_parser::Op;
 use pest::pratt_parser::PrattParser;
 use pest::Parser;
-use pest_derive::Parser;
 use thiserror::Error;
 
-#[derive(Parser)]
-#[grammar = "template.pest"]
-struct TemplateParser;
+use crate::grammars::template::*;
 
 const STRING_LITERAL_PARSER: StringLiteralParser<Rule> = StringLiteralParser {
     content_rule: Rule::string_content,

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -23,16 +23,12 @@ use pest::pratt_parser::Assoc;
 use pest::pratt_parser::Op;
 use pest::pratt_parser::PrattParser;
 use pest::Parser;
-use pest_derive::Parser;
 use thiserror::Error;
 
 use crate::dsl_util;
 use crate::dsl_util::InvalidArguments;
 use crate::dsl_util::StringLiteralParser;
-
-#[derive(Parser)]
-#[grammar = "fileset.pest"]
-struct FilesetParser;
+use crate::grammars::fileset::*;
 
 const STRING_LITERAL_PARSER: StringLiteralParser<Rule> = StringLiteralParser {
     content_rule: Rule::string_content,

--- a/lib/src/grammars/fileset.rs
+++ b/lib/src/grammars/fileset.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar_inline = r###"
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 // XID_CONTINUE: https://www.unicode.org/reports/tr31/#Default_Identifier_Syntax
@@ -86,3 +92,5 @@ program_or_bare_string = _{
         | bare_string_pattern ~ EOI
         | bare_string ~ EOI )
 }
+"###]
+pub struct FilesetParser;

--- a/lib/src/grammars/mod.rs
+++ b/lib/src/grammars/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2021-2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Grammars for parsing Jujutsu formats.
+
+pub mod fileset;
+pub mod revset;

--- a/lib/src/grammars/revset.rs
+++ b/lib/src/grammars/revset.rs
@@ -1,17 +1,23 @@
-// Copyright 2021 The Jujutsu Authors
-// 
+// Copyright 2021-2024 The Jujutsu Authors
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar_inline = r###"
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
 identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
@@ -116,3 +122,5 @@ function_alias_declaration = {
 alias_declaration = _{
   SOI ~ (function_alias_declaration | identifier) ~ EOI
 }
+"###]
+pub struct RevsetParser;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -51,6 +51,7 @@ pub mod git;
 pub mod git_backend;
 pub mod gitignore;
 pub mod gpg_signing;
+pub mod grammars;
 pub mod graph;
 pub mod hex_util;
 pub mod id_prefix;

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -27,7 +27,6 @@ use pest::pratt_parser::Assoc;
 use pest::pratt_parser::Op;
 use pest::pratt_parser::PrattParser;
 use pest::Parser;
-use pest_derive::Parser;
 use thiserror::Error;
 
 use crate::dsl_util;
@@ -44,10 +43,7 @@ use crate::dsl_util::FoldableExpression;
 use crate::dsl_util::InvalidArguments;
 use crate::dsl_util::KeywordArgument;
 use crate::dsl_util::StringLiteralParser;
-
-#[derive(Parser)]
-#[grammar = "revset.pest"]
-struct RevsetParser;
+use crate::grammars::revset::*;
 
 const STRING_LITERAL_PARSER: StringLiteralParser<Rule> = StringLiteralParser {
     content_rule: Rule::string_content,


### PR DESCRIPTION
When building Jujutsu crates as a dependency in a Buck project, the usage of `#[grammar]` requires the `.pest` files in the code to be in the `$PWD` relative to where the Rust compiler is invoked on the crate; which isn't identical to how it is done by Cargo, causing a build failure ("file not found").

Rather than special case a Buck build path into the codebase for this (only used by downstream consumers in other projects), inlining the grammar definition into a new Rust file makes this go away.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
