### PR TITLE
cli: make paths to auto-track configurable, add `jj track`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* The new config option `snapshot.auto-track` lets you automatically track only
+  the specified paths (all paths by default). Use the new `jj file track`
+  command to manually tracks path that were not automatically tracked. There is
+  no way to list untracked files yet. Use `git status` in a colocated workspace
+  as a workaround.
+  [#323](https://github.com/martinvonz/jj/issues/323)
+
 * `jj fix` now allows fixing unchanged files with the `--include-unchanged-files` flag. This
   can be used to more easily introduce automatic formatting changes in a new
   commit separate from other changes.

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -15,6 +15,7 @@
 pub mod chmod;
 pub mod list;
 pub mod show;
+pub mod track;
 pub mod untrack;
 
 use crate::cli_util::CommandHelper;
@@ -27,6 +28,7 @@ pub enum FileCommand {
     Chmod(chmod::FileChmodArgs),
     List(list::FileListArgs),
     Show(show::FileShowArgs),
+    Track(track::FileTrackArgs),
     Untrack(untrack::FileUntrackArgs),
 }
 
@@ -39,6 +41,7 @@ pub fn cmd_file(
         FileCommand::Chmod(args) => chmod::cmd_file_chmod(ui, command, args),
         FileCommand::List(args) => list::cmd_file_list(ui, command, args),
         FileCommand::Show(args) => show::cmd_file_show(ui, command, args),
+        FileCommand::Track(args) => track::cmd_file_track(ui, command, args),
         FileCommand::Untrack(args) => untrack::cmd_file_untrack(ui, command, args),
     }
 }

--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use jj_lib::working_copy::SnapshotOptions;
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Start tracking specified paths in the working copy
+///
+/// Without arguments, all paths that are not ignored will be tracked.
+///
+/// New files in the working copy can be automatically tracked.  
+/// You can configure which paths to automatically track by setting
+/// `snapshot.auto-track` (e.g. to `"none()"` or `"glob:**/*.rs"`). Files that
+/// don't match the pattern can be manually tracked using this command. The
+/// default pattern is `all()` and this command has no effect.
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct FileTrackArgs {
+    /// Paths to track
+    #[arg(required = true, value_hint = clap::ValueHint::AnyPath)]
+    paths: Vec<String>,
+}
+
+#[instrument(skip_all)]
+pub(crate) fn cmd_file_track(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &FileTrackArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+    let matcher = workspace_command
+        .parse_file_patterns(&args.paths)?
+        .to_matcher();
+
+    let mut tx = workspace_command.start_transaction().into_inner();
+    let base_ignores = workspace_command.base_ignores()?;
+    let (mut locked_ws, _wc_commit) = workspace_command.start_working_copy_mutation()?;
+    locked_ws.locked_wc().snapshot(&SnapshotOptions {
+        base_ignores,
+        fsmonitor_settings: command.settings().fsmonitor_settings()?,
+        progress: None,
+        start_tracking_matcher: &matcher,
+        max_new_file_size: command.settings().max_new_file_size()?,
+    })?;
+    let num_rebased = tx.repo_mut().rebase_descendants(command.settings())?;
+    if num_rebased > 0 {
+        writeln!(ui.status(), "Rebased {num_rebased} descendant commits")?;
+    }
+    let repo = tx.commit("track paths");
+    locked_ws.finish(repo.op_id().clone())?;
+    Ok(())
+}

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -51,6 +51,7 @@ pub(crate) fn cmd_file_untrack(
 
     let mut tx = workspace_command.start_transaction().into_inner();
     let base_ignores = workspace_command.base_ignores()?;
+    let auto_tracking_matcher = workspace_command.auto_tracking_matcher()?;
     let (mut locked_ws, wc_commit) = workspace_command.start_working_copy_mutation()?;
     // Create a new tree without the unwanted files
     let mut tree_builder = MergedTreeBuilder::new(wc_commit.tree_id().clone());
@@ -72,6 +73,7 @@ pub(crate) fn cmd_file_untrack(
         base_ignores,
         fsmonitor_settings: command.settings().fsmonitor_settings()?,
         progress: None,
+        start_tracking_matcher: &auto_tracking_matcher,
         max_new_file_size: command.settings().max_new_file_size()?,
     })?;
     if wc_tree_id != *new_commit.tree_id() {

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -24,3 +24,4 @@ edit = false
 
 [snapshot]
 max-new-file-size = "1MiB"
+auto-track = "all()"

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -12,6 +12,7 @@ use jj_lib::fsmonitor::FsmonitorSettings;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::local_working_copy::TreeState;
 use jj_lib::local_working_copy::TreeStateError;
+use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::Matcher;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree::TreeDiffEntry;
@@ -286,6 +287,7 @@ diff editing in mind and be a little inaccurate.
             base_ignores,
             fsmonitor_settings: FsmonitorSettings::None,
             progress: None,
+            start_tracking_matcher: &EverythingMatcher,
             max_new_file_size: u64::MAX,
         })?;
         Ok(output_tree_state.current_tree_id().clone())

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -40,6 +40,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj file chmod`↴](#jj-file-chmod)
 * [`jj file list`↴](#jj-file-list)
 * [`jj file show`↴](#jj-file-show)
+* [`jj file track`↴](#jj-file-track)
 * [`jj file untrack`↴](#jj-file-untrack)
 * [`jj fix`↴](#jj-fix)
 * [`jj git`↴](#jj-git)
@@ -739,6 +740,7 @@ File operations
 * `chmod` — Sets or removes the executable bit for paths in the repo
 * `list` — List files in a revision
 * `show` — Print contents of files in a revision
+* `track` — Start tracking specified paths in the working copy
 * `untrack` — Stop tracking specified paths in the working copy
 
 
@@ -806,6 +808,22 @@ If the given path is a directory, files in the directory will be visited recursi
 * `-r`, `--revision <REVISION>` — The revision to get the file contents from
 
   Default value: `@`
+
+
+
+## `jj file track`
+
+Start tracking specified paths in the working copy
+
+Without arguments, all paths that are not ignored will be tracked.
+
+New files in the working copy can be automatically tracked. You can configure which paths to automatically track by setting `snapshot.auto-track` (e.g. to `"none()"` or `"glob:**/*.rs"`). Files that don't match the pattern can be manually tracked using this command. The default pattern is `all()` and this command has no effect.
+
+**Usage:** `jj file track <PATHS>...`
+
+###### **Arguments:**
+
+* `<PATHS>` — Paths to track
 
 
 

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -30,7 +30,7 @@ mod test_edit_command;
 mod test_evolog_command;
 mod test_file_chmod_command;
 mod test_file_print_command;
-mod test_file_untrack_command;
+mod test_file_track_untrack_commands;
 mod test_fix_command;
 mod test_generate_md_cli_help;
 mod test_git_clone;

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -51,4 +51,9 @@ fn test_snapshot_large_file() {
       - Run `jj --config-toml 'snapshot.max-new-file-size=11264' st`
         This will increase the maximum file size allowed for new files, for this command only.
     "###);
+
+    // No error if we disable auto-tracking of the path
+    test_env.add_config(r#"snapshot.auto-track = 'none()'"#);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
+    insta::assert_snapshot!(stdout, @"");
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -101,6 +101,10 @@ To squash or split commits, use `jj squash` and `jj split`.
 
 ### How can I keep my scratch files in the repository without committing them?
 
+You can set `snapshot.auto-track` to only start tracking new files matching the
+configured pattern (e.g. `"none()"`). Changes to already tracked files will
+still be snapshotted by every command.
+
 You can keep your notes and other scratch files in the repository, if you add
 a wildcard pattern to either the repo's `gitignore` or your global `gitignore`.
 Something like `*.scratch` or `*.scratchpad` should do, after that rename the

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -12,12 +12,19 @@ working-copy contents when they have changed. Most `jj` commands you run will
 commit the working-copy changes if they have changed. The resulting revision
 will replace the previous working-copy revision.
 
-Also unlike most other VCSs, added files are implicitly tracked. That means that
-if you add a new file to the working copy, it will be automatically committed
-once you run e.g. `jj st`. Similarly, if you remove a file from the working
-copy, it will implicitly be untracked. To untrack a file while keeping it in
-the working copy, first make sure it's [ignored](#ignored-files) and then run
-`jj file untrack <path>`.
+Also unlike most other VCSs, added files are implicitly tracked by default. That
+means that if you add a new file to the working copy, it will be automatically
+committed once you run e.g. `jj st`. Similarly, if you remove a file from the
+working copy, it will implicitly be untracked.
+
+The `snapshot.auto-track` config option controls which paths get automatically
+tracked when they're added to the working copy. See the
+[fileset documentation](filesets.md) for the syntax. Files with paths matching
+[ignore files](#ignored-files) are never tracked automatically
+
+You can use `jj file untrack` to untrack a file while keeping it in the working
+copy. However, first [ignore](#ignored-files) them or remove them from the
+`snapshot.auto-track` patterns; otherwise they will be immediately tracked again.
 
 
 ## Conflicts
@@ -58,6 +65,14 @@ control. You can tell Jujutsu to not automatically track certain files by using
 See https://git-scm.com/docs/gitignore for details about the format.
 `.gitignore` files are supported in any directory in the working copy, as well
 as in `$HOME/.gitignore` and `$GIT_DIR/info/exclude`.
+
+Ignored files are never tracked automatically (regardless of the value of
+`snapshot.auto-track`), but they can still end up being tracked for a few reasons:
+
+* if they were tracked in the parent commit
+* because of an explicit `jj file track` command
+
+You can untrack such files with the jj file untrack command.
 
 
 ## Workspaces

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -28,6 +28,8 @@ use crate::commit::Commit;
 use crate::fsmonitor::FsmonitorSettings;
 use crate::gitignore::GitIgnoreError;
 use crate::gitignore::GitIgnoreFile;
+use crate::matchers::EverythingMatcher;
+use crate::matchers::Matcher;
 use crate::op_store::OperationId;
 use crate::op_store::WorkspaceId;
 use crate::repo_path::RepoPath;
@@ -194,6 +196,9 @@ pub struct SnapshotOptions<'a> {
     pub fsmonitor_settings: FsmonitorSettings,
     /// A callback for the UI to display progress.
     pub progress: Option<&'a SnapshotProgress<'a>>,
+    /// For new files that are not already tracked, start tracking them if they
+    /// match this.
+    pub start_tracking_matcher: &'a dyn Matcher,
     /// The size of the largest file that should be allowed to become tracked
     /// (already tracked files are always snapshotted). If there are larger
     /// files in the working copy, then `LockedWorkingCopy::snapshot()` may
@@ -209,6 +214,7 @@ impl SnapshotOptions<'_> {
             base_ignores: GitIgnoreFile::empty(),
             fsmonitor_settings: FsmonitorSettings::None,
             progress: None,
+            start_tracking_matcher: &EverythingMatcher,
             max_new_file_size: u64::MAX,
         }
     }


### PR DESCRIPTION
#323

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
