### PR TITLE
cli: change default inline threshold of color-words diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   includes information about copies and moves.
 
 * Color-words diff has gained [an option to display complex changes as separate
-  lines](docs/config.md#color-words-diff-options).
+  lines](docs/config.md#color-words-diff-options). It's enabled by default. To
+  restore the old behavior, set `diff.color-words.max-inline-alternation = -1`.
 
 * A tilde (`~`) at the start of the path will now be expanded to the user's home
   directory when configuring a `signing.key` for SSH commit signing.

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1376,7 +1376,7 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
                     // TODO: load defaults from UserSettings?
                     let options = diff_util::ColorWordsOptions {
                         context: context.unwrap_or(diff_util::DEFAULT_CONTEXT_LINES),
-                        max_inline_alternation: None,
+                        max_inline_alternation: Some(3),
                     };
                     diff.into_formatted(move |formatter, store, tree_diff| {
                         diff_util::show_color_words_diff(

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -286,7 +286,8 @@
                     "properties": {
                         "max-inline-alternation": {
                             "type": "integer",
-                            "description": "Maximum number of removed/added word alternation to inline"
+                            "description": "Maximum number of removed/added word alternation to inline",
+                            "default": 3
                         }
                     }
                 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -6,7 +6,7 @@ co = ["checkout"]
 unamend = ["unsquash"]
 
 [diff.color-words]
-max-inline-alternation = -1
+max-inline-alternation = 3
 
 [ui]
 # TODO: delete ui.allow-filesets in jj 0.26+

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -853,9 +853,55 @@ fn test_diff_color_words_inlining_threshold() {
     )
     .unwrap();
 
-    // inline all by default
+    // default
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
     insta::assert_snapshot!(stdout, @r###"
+    Modified regular file file1-single-line:
+       1    1: == adds ==
+       2    2: a X b Y Z c
+       3    3: == removes ==
+       4    4: a b c d e f g
+       5    5: == adds + removes ==
+       6    6: a X b c d e
+       7    7: == adds + removes + adds ==
+       8    8: a X b c d eY
+       9    9: == adds + removes + adds + removes ==
+      10     : a b c d e f g
+           10: X a Y b d Z e
+    Modified regular file file2-multiple-lines-in-single-hunk:
+       1    1: == adds; removes; adds + removes ==
+       2    2: a X b Y Z c
+       3    3: a b c d e f g
+       4    4: a X b c d e
+       5    5: == adds + removes + adds; adds + removes + adds + removes ==
+       6     : a b c d e
+       7     : a b c d e f g
+            6: a X b d Y
+            7: X a Y b d Z e
+    Modified regular file file3-changes-across-lines:
+       1    1: == adds ==
+       2    2: a X b
+       2    3: Y Z c
+       3    4: == removes ==
+       4    5: a b c d
+       5    5: e f g
+       6    6: == adds + removes ==
+       7    7: a
+       7    8: X b c
+       8    8: d e
+       9    9: == adds + removes + adds ==
+      10   10: a X b c
+      11   10: d e
+      11   11: Y
+      12   12: == adds + removes + adds + removes ==
+      13     : a b
+      14     : c d e f g
+           13: X a Y b d
+           14: Z e
+    "###);
+
+    // -1: inline all
+    insta::assert_snapshot!(render_diff(-1, &[]), @r###"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c

--- a/docs/config.md
+++ b/docs/config.md
@@ -214,7 +214,9 @@ threshold to switch to traditional separate-line format.
   * `0`: disable inlining, making `--color-words` more similar to `--git`
   * `1`: inline removes-only or adds-only lines
   * `2`, `3`, ..: inline up to `2`, `3`, .. alternation
-  * `-1`: inline all lines (default)
+  * `-1`: inline all lines
+
+  The default is `3`.
 
   **This parameter is experimental.** The definition is subject to change.
 


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
