### PR TITLE
cli: fix: add --include-unchanged-files flag to allow fixing as yet unchanged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj fix` now allows fixing unchanged files with the `--include-unchanged-files` flag. This
+  can be used to more easily introduce automatic formatting changes in a new
+  commit separate from other changes.
+
 ### Fixed bugs
 
 ## [0.21.0] - 2024-09-04

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -864,6 +864,7 @@ will be removed in a future version.
 ###### **Options:**
 
 * `-s`, `--source <SOURCE>` — Fix files in the specified revision(s) and their descendants. If no revisions are specified, this defaults to the `revsets.fix` setting, or `reachable(@, mutable())` if it is not set
+* `--include-unchanged-files` — Fix unchanged files in addition to changed ones. If no paths are specified, all files in the repo will be fixed
 
 
 


### PR DESCRIPTION
This enables workflows like "insert a commit that reformats the code in one of my project directories".

`jj fix --include-unchanged-files` is an easy way to fix everything in the repo.

`jj fix --include-unchanged-files <file...>` fixes all of the `<files>` even if they are unchanged.

This is mostly orthogonal to other features, so not many tests are added.

This is a significant and simple enough improvement that I think it's appropriate to make it here instead of waiting for a `jj run`-based solution.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

`jj diff -r tumtymnsotvq` shows the change a bit more clearly than Github.