### PR TITLE
config: add color for renamed and copied in summary

### DIFF
--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -82,6 +82,8 @@
 "diff added" = { fg = "green" }
 "diff token" = { underline = true }
 "diff modified" = "cyan"
+"diff renamed" = "cyan"
+"diff copied" = "green"
 "diff access-denied" = { bg = "red" }
 
 "op_log id" = "blue"

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1017,7 +1017,7 @@ fn test_log_diff_predefined_formats() {
     === summary ===
     [38;5;6mM file1[39m
     [38;5;6mM file2[39m
-    R {rename-source => rename-target}
+    [38;5;6mR {rename-source => rename-target}[39m
     "###);
 
     // color labels
@@ -1063,7 +1063,7 @@ fn test_log_diff_predefined_formats() {
     <<log::=== summary ===>>
     [38;5;6m<<log diff summary modified::M file1>>[39m
     [38;5;6m<<log diff summary modified::M file2>>[39m
-    <<log diff summary renamed::R {rename-source => rename-target}>>
+    [38;5;6m<<log diff summary renamed::R {rename-source => rename-target}>>[39m
     "###);
 
     // cwd != workspace root


### PR DESCRIPTION
Right now, renamed and copied files don't have any color in the output of `jj status`, and it makes them stand out. I think it's reasonable to color renamed files the same as modified files, since renaming is like modifying the path, and to color copied files the same as added files, since they're basically just added files that happen to have similar contents to an existing file.

Before this change:

![No color](https://github.com/user-attachments/assets/7822265d-c6bb-4640-a3d7-403e43dd1980)

After this change (I couldn't get copied to show up):

![Color on renamed](https://github.com/user-attachments/assets/edb167a0-216f-44a4-9392-e373b0bd9444)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
