### PR TITLE
docs: minor fix to Markdown formatting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -303,8 +303,8 @@ ui.graph.style = "square"
 The symbols used to represent commits or operations can be customized via
 templates.
 
-  * `templates.log_node` for commits (with `Option<Commit>` keywords)
-  * `templates.op_log_node` for operations (with `Operation` keywords)
+- `templates.log_node` for commits (with `Option<Commit>` keywords)
+- `templates.op_log_node` for operations (with `Operation` keywords)
 
 For example:
 ```toml


### PR DESCRIPTION
MkDocs did not render this list in
https://martinvonz.github.io/jj/prerelease/config/#node-style properly before.

I don't understand the reason; we have other lists that are formatted similarly to how this one was, and they look fine in MkDocs. This might be a bug in one of the MkDocs extensions for lists that we use.

**Update:** For a laugh, here's the relevant portion of the config. I made that, but I'm not touching it with a 10-ft pole unless I'm forced to :). Weird old Markdown parser is one of the major downsides of MkDocs.

https://github.com/martinvonz/jj/blob/52499e84cca5f72162d1f954ef18de73ccaed2c3/mkdocs.yml#L58-L72
