### PR TITLE
cli/build-rs: remove metadata command dependency in favor of env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,38 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,7 +1821,6 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "bstr",
- "cargo_metadata",
  "chrono",
  "clap",
  "clap-markdown",
@@ -2831,15 +2798,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ async-trait = "0.1.82"
 backoff = "0.4.0"
 blake2 = "0.10.6"
 bstr = "1.10.0"
-cargo_metadata = "0.17.0"
 clap = { version = "4.5.16", features = [
     "derive",
     "deprecated",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,9 +47,6 @@ required-features = ["test-fakes"]
 [[test]]
 name = "runner"
 
-[build-dependencies]
-cargo_metadata = { workspace = true }
-
 [dependencies]
 bstr = { workspace = true }
 chrono = { workspace = true }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -16,20 +16,11 @@ use std::path::Path;
 use std::process::Command;
 use std::str;
 
-use cargo_metadata::MetadataCommand;
-
 const GIT_HEAD_PATH: &str = "../.git/HEAD";
 const JJ_OP_HEADS_PATH: &str = "../.jj/repo/op_heads/heads";
 
 fn main() -> std::io::Result<()> {
-    let path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let meta = MetadataCommand::new()
-        .manifest_path("./Cargo.toml")
-        .current_dir(&path)
-        .exec()
-        .unwrap();
-    let root = meta.root_package().unwrap();
-    let version = &root.version;
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap();
 
     if Path::new(GIT_HEAD_PATH).exists() {
         // In colocated repo, .git/HEAD should reflect the working-copy parent.


### PR DESCRIPTION
When building this project with [Nix/Crane](https://github.com/ipetkov/crane/discussions/693), if the `jj-cli` dependency is specified in `Cargo.toml` as a git-based crate, `cargo vendor` splits this workspace up into sub-crate directories, which causes `cargo metadata` to fail when searching for relative deps in the workspace root. 

This PR simply changes how the crate version is determined, using Cargo's built-in environment variable [`CARGO_PKG_VERSION`](https://doc.rust-lang.org/cargo/reference/environment-variables.html)

Let me know if this is problematic change! 

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
