### PR TITLE
cli: implement `workspace add --sparse-patterns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   can be used to more easily introduce automatic formatting changes in a new
   commit separate from other changes.
 
+* `jj workspace add` now accepts a `--sparse-patterns=<MODE>` option, which
+  allows control of the sparse patterns for a newly created workspace: `copy`
+  (inherit from parent; default), `full` (full working copy), or `empty` (the
+  empty working copy).
+
 ### Fixed bugs
 
  * Fixed panic when parsing invalid conflict markers of a particular form.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2118,7 +2118,7 @@ Each workspace also has own sparse patterns.
 
 Add a workspace
 
-Sparse patterns will be copied over from the current workspace.
+By default, the new workspace inherits the sparse patterns of the current workspace. You can override this with the `--sparse-patterns` option.
 
 **Usage:** `jj workspace add [OPTIONS] <DESTINATION>`
 
@@ -2136,6 +2136,18 @@ Sparse patterns will be copied over from the current workspace.
    If no revisions are specified, the new workspace will be created, and its working-copy commit will exist on top of the parent(s) of the working-copy commit in the current workspace, i.e. they will share the same parent(s).
 
    If any revisions are specified, the new workspace will be created, and the new working-copy commit will be created with all these revisions as parents, i.e. the working-copy commit will exist as if you had run `jj new r1 r2 r3 ...`.
+* `--sparse-patterns <SPARSE_PATTERNS>` — How to handle sparse patterns when creating a new workspace
+
+  Default value: `copy`
+
+  Possible values:
+  - `copy`:
+    Copy all sparse patterns from the current workspace
+  - `full`:
+    Include all files in the new workspace
+  - `empty`:
+    Clear all files from the workspace (it will be empty)
+
 
 
 

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -77,6 +77,9 @@ fn test_workspaces_sparse_patterns() {
     let ws1_path = test_env.env_root().join("ws1");
     let ws2_path = test_env.env_root().join("ws2");
     let ws3_path = test_env.env_root().join("ws3");
+    let ws4_path = test_env.env_root().join("ws4");
+    let ws5_path = test_env.env_root().join("ws5");
+    let ws6_path = test_env.env_root().join("ws6");
 
     test_env.jj_cmd_ok(&ws1_path, &["sparse", "set", "--clear", "--add=foo"]);
     test_env.jj_cmd_ok(&ws1_path, &["workspace", "add", "../ws2"]);
@@ -91,6 +94,30 @@ fn test_workspaces_sparse_patterns() {
     bar
     foo
     "###);
+    // --sparse-patterns behavior
+    test_env.jj_cmd_ok(
+        &ws3_path,
+        &["workspace", "add", "--sparse-patterns=copy", "../ws4"],
+    );
+    let stdout = test_env.jj_cmd_success(&ws4_path, &["sparse", "list"]);
+    insta::assert_snapshot!(stdout, @r###"
+    bar
+    foo
+    "###);
+    test_env.jj_cmd_ok(
+        &ws3_path,
+        &["workspace", "add", "--sparse-patterns=full", "../ws5"],
+    );
+    let stdout = test_env.jj_cmd_success(&ws5_path, &["sparse", "list"]);
+    insta::assert_snapshot!(stdout, @r###"
+    .
+    "###);
+    test_env.jj_cmd_ok(
+        &ws3_path,
+        &["workspace", "add", "--sparse-patterns=empty", "../ws6"],
+    );
+    let stdout = test_env.jj_cmd_success(&ws6_path, &["sparse", "list"]);
+    insta::assert_snapshot!(stdout, @"");
 }
 
 /// Test adding a second workspace while the current workspace is editing a


### PR DESCRIPTION
This flag implements three modes:

- `copy`: copy sparse patterns from parent
- `none`: do not copy sparse patterns from parent
- `empty`: clear all paths, equal to `set --clear`

This is useful for various tooling like tools that want to run a parallel
process that queries the build system (without running into locks/blocking.)

I think continuing to copy sparse patterns makes sense as the default behavior.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
