### PR TITLE
lib: do not snapshot dirs containing `CACHEDIR.TAG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Assuming that a directory contains a valid `CACHEDIR.TAG` file that follows
+  the [Cache Directory Tagging Specification](https://bford.info/cachedir/),
+  `jj` will now ignore the contents of the directory when building snapshots.
+  This means that many build tools such as `cargo` will automatically have their
+  build directories ignored with no need to use `.gitignore` files.
+
 ### Fixed bugs
 
  * Fixed panic when parsing invalid conflict markers of a particular form.

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::common::get_stdout_string;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -50,5 +51,73 @@ fn test_snapshot_large_file() {
         This will increase the maximum file size allowed for new files, in this repository only.
       - Run `jj --config-toml 'snapshot.max-new-file-size=11264' st`
         This will increase the maximum file size allowed for new files, for this command only.
+    "###);
+}
+
+#[test]
+fn test_snapshot_cachedir_tag_file() {
+    // ensure that a CACHEDIR.TAG file and all the files in its tree are not
+    // snapshotted: https://bford.info/cachedir/
+    let sig = r#"Signature: 8a477f597d28d172789f06886806bc55
+    # Some of these CACHEDIR files have comments after the first 43 bytes,
+    # so add one here to make sure the test accounts for it
+    "#;
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // things are normal
+    std::fs::write(repo_path.join("a"), "").unwrap();
+    std::fs::write(repo_path.join("b"), "").unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy changes:
+    A a
+    A b
+    Working copy : qpvuntsm b6ccb224 (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    "###);
+
+    // oops, we accidentally snapshotted the buck-out/ directory
+    std::fs::create_dir_all(repo_path.join("buck-out").join("dir")).unwrap();
+    std::fs::write(repo_path.join("buck-out/c"), "").unwrap();
+    std::fs::write(repo_path.join("buck-out/dir/d"), "").unwrap();
+    let assert = test_env.jj_cmd(&repo_path, &["status"]).assert().code(0);
+    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy changes:
+    A a
+    A b
+    A buck-out/c
+    A buck-out/dir/d
+    Working copy : qpvuntsm 9172549e (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    "###);
+
+    // write an invalid CACHEDIR.TAG file, and we should see the bad
+    // outcome again
+    std::fs::write(repo_path.join("buck-out/CACHEDIR.TAG"), "").unwrap();
+    let assert = test_env.jj_cmd(&repo_path, &["status"]).assert().code(0);
+    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy changes:
+    A a
+    A b
+    A buck-out/CACHEDIR.TAG
+    A buck-out/c
+    A buck-out/dir/d
+    Working copy : qpvuntsm f1bf2de4 (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    "###);
+
+    // fixed
+    std::fs::write(repo_path.join("buck-out/CACHEDIR.TAG"), sig).unwrap();
+    let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Working copy changes:
+    A a
+    A b
+    Working copy : qpvuntsm eca4b62b (no description set)
+    Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     "###);
 }


### PR DESCRIPTION
The "Cache Directory Tagging Specification"[0] is a (fairly old) specification for a specific file, named `CACHEDIR.TAG`, to be created within a directory, with some exact contents, in the event that:

- Your program uses a directory
- It has a bunch of useless junk in it
- So it shouldn't be backed up, copied, or cloned by other programs

This specification is used by tools like `cargo` for its `target/` directory and `buck2` for its `buck-out/` directory, among many others.

This solves a very practical problem I kept running into, where:

- I would work on the `buck2` branch
- Run lots of builds, accumulate a big `buck-out/` directory
- Switch branches to do other work
- `.gitignore` entry for `buck-out/` only exists on the branch
- Run `jj st`
- Snapshot the entire `buck-out/` directory
- Pain ensues

This exact problem happens with Cargo too if you don't have a properly specified `.gitignore` file. It's pretty bad to snapshot GiBs of small files only to fall over at the end anyway due to file size guardrails.

Alternative solutions to all this aren't that good:

- Add a `.gitignore` file under `buck-out/`? Really?
- Or add it to `.git/info/exclude`? When?
- Submit a patch upstream? For every project on earth?
- Just live with it I guess?

While not _every_ tool uses `CACHEDIR.TAG`, the ones that do (buck2, cargo) almost certainly do so exactly for these reasons. So we should just exclude these files.

[0] https://bford.info/cachedir/

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
