### PR TITLE
Update `jj edit <commit>` to add commit into view heads if not already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Fixed panic when parsing invalid conflict markers of a particular form.
    ([#2611](https://github.com/martinvonz/jj/pull/2611))
 
+ * Editing a hidden commit now makes it visible.
+
 ## [0.21.0] - 2024-09-04
 
 ### Breaking changes

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1375,6 +1375,7 @@ impl MutableRepo {
         commit: &Commit,
     ) -> Result<(), EditCommitError> {
         self.maybe_abandon_wc_commit(&workspace_id)?;
+        self.add_head(commit)?;
         self.set_wc_commit(workspace_id, commit.id().clone())
             .map_err(|RewriteRootCommit| EditCommitError::RewriteRootCommit)
     }


### PR DESCRIPTION
`jj new <commit>` automatically adds the checked out commits into the view head ids. However, `jj edit` does not.

To reproduce:
```
jj git init test
cd test
jj commit -m "my commit"
jj log -r @- -T commit_id # Save the id
jj abandon -r @-
jj edit <saved_id>

jj log -r :: # Does not show the currently editing commit 
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
