### PR TITLE
Be more specific when warning the user about missing identity configs

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1613,13 +1613,31 @@ See https://martinvonz.github.io/jj/latest/working-copy/#stale-working-copy \
         }
 
         let settings = self.settings();
-        if settings.user_name().is_empty() || settings.user_email().is_empty() {
+        let missing_user_name = settings.user_name().is_empty();
+        let missing_user_mail = settings.user_email().is_empty();
+        if missing_user_name || missing_user_mail {
+            let mut writer = ui.warning_default();
+            let not_configured_msg = match (missing_user_name, missing_user_mail) {
+                (true, true) => "Name and email not configured.",
+                (true, false) => "Name not configured.",
+                (false, true) => "Email not configured.",
+                _ => unreachable!(),
+            };
+            write!(writer, "{not_configured_msg} ")?;
             writeln!(
-                ui.warning_default(),
-                r#"Name and email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
-  jj config set --user user.name "Some One"
-  jj config set --user user.email "someone@example.com""#
+                writer,
+                "Until configured, your commits will be created with the empty identity, and \
+                 can't be pushed to remotes. To configure, run:",
             )?;
+            if missing_user_name {
+                writeln!(writer, r#"  jj config set --user user.name "Some One""#)?;
+            }
+            if missing_user_mail {
+                writeln!(
+                    writer,
+                    r#"  jj config set --user user.email "someone@example.com""#
+                )?;
+            }
         }
         Ok(())
     }

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -568,9 +568,8 @@ fn test_no_user_configured() {
     insta::assert_snapshot!(get_stderr_string(&assert), @r###"
     Working copy now at: qpvuntsm 7a7d6016 (empty) without name
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    Warning: Name and email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
+    Warning: Name not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
       jj config set --user user.name "Some One"
-      jj config set --user user.email "someone@example.com"
     "###);
     let assert = test_env
         .jj_cmd(&repo_path, &["describe", "-m", "without email"])
@@ -579,6 +578,18 @@ fn test_no_user_configured() {
         .success();
     insta::assert_snapshot!(get_stderr_string(&assert), @r###"
     Working copy now at: qpvuntsm 906f8b89 (empty) without email
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    Warning: Email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
+      jj config set --user user.email "someone@example.com"
+    "###);
+    let assert = test_env
+        .jj_cmd(&repo_path, &["describe", "-m", "without name and email"])
+        .env_remove("JJ_USER")
+        .env_remove("JJ_EMAIL")
+        .assert()
+        .success();
+    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    Working copy now at: qpvuntsm 57d3a489 (empty) without name and email
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Warning: Name and email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
       jj config set --user user.name "Some One"


### PR DESCRIPTION
Typoed `user.name` as `user.nane` and got confused why my entire user didn't get recognized, warning on each command. 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
