### PR TITLE
op log: add --op-diff option to embed operation diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (inherit from parent; default), `full` (full working copy), or `empty` (the
   empty working copy).
 
+* `jj op log` gained an option to include operation diffs.
+
 ### Fixed bugs
 
  * Fixed panic when parsing invalid conflict markers of a particular form.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -902,6 +902,10 @@ impl WorkspaceCommandHelper {
         self.workspace.repo_path()
     }
 
+    pub fn workspace(&self) -> &Workspace {
+        &self.workspace
+    }
+
     pub fn working_copy(&self) -> &dyn WorkingCopy {
         self.workspace.working_copy()
     }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2359,18 +2359,19 @@ impl LogContentFormat {
     }
 
     /// Writes content which will optionally be wrapped at the current width.
-    pub fn write(
+    pub fn write<E: From<io::Error>>(
         &self,
         formatter: &mut dyn Formatter,
-        content_fn: impl FnOnce(&mut dyn Formatter) -> std::io::Result<()>,
-    ) -> std::io::Result<()> {
+        content_fn: impl FnOnce(&mut dyn Formatter) -> Result<(), E>,
+    ) -> Result<(), E> {
         if self.word_wrap {
             let mut recorder = FormatRecorder::new();
             content_fn(&mut recorder)?;
-            text_util::write_wrapped(formatter, &recorder, self.width)
+            text_util::write_wrapped(formatter, &recorder, self.width)?;
         } else {
-            content_fn(formatter)
+            content_fn(formatter)?;
         }
+        Ok(())
     }
 }
 

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -222,7 +222,9 @@ pub fn show_op_diff(
 
     if !ordered_change_ids.is_empty() {
         writeln!(formatter)?;
-        writeln!(formatter, "Changed commits:")?;
+        with_content_format.write(formatter, |formatter| {
+            writeln!(formatter, "Changed commits:")
+        })?;
         if let Some(graph_style) = graph_style {
             let mut graph = get_graphlog(graph_style, formatter.raw());
 
@@ -281,14 +283,16 @@ pub fn show_op_diff(
         } else {
             for change_id in ordered_change_ids {
                 let modified_change = changes.get(&change_id).unwrap();
-                write_modified_change_summary(
-                    formatter,
-                    commit_summary_template,
-                    &change_id,
-                    modified_change,
-                )?;
+                with_content_format.write(formatter, |formatter| {
+                    write_modified_change_summary(
+                        formatter,
+                        commit_summary_template,
+                        &change_id,
+                        modified_change,
+                    )
+                })?;
                 if let Some(diff_renderer) = &diff_renderer {
-                    let width = ui.term_width();
+                    let width = with_content_format.width();
                     show_change_diff(ui, formatter, diff_renderer, modified_change, width)?;
                 }
             }
@@ -302,25 +306,29 @@ pub fn show_op_diff(
     .collect_vec();
     if !changed_local_bookmarks.is_empty() {
         writeln!(formatter)?;
-        writeln!(formatter, "Changed local branches:")?;
+        with_content_format.write(formatter, |formatter| {
+            writeln!(formatter, "Changed local branches:")
+        })?;
         for (name, (from_target, to_target)) in changed_local_bookmarks {
-            writeln!(formatter, "{}:", name)?;
-            write_ref_target_summary(
-                formatter,
-                current_repo,
-                commit_summary_template,
-                to_target,
-                true,
-                None,
-            )?;
-            write_ref_target_summary(
-                formatter,
-                current_repo,
-                commit_summary_template,
-                from_target,
-                false,
-                None,
-            )?;
+            with_content_format.write(formatter, |formatter| {
+                writeln!(formatter, "{}:", name)?;
+                write_ref_target_summary(
+                    formatter,
+                    current_repo,
+                    commit_summary_template,
+                    to_target,
+                    true,
+                    None,
+                )?;
+                write_ref_target_summary(
+                    formatter,
+                    current_repo,
+                    commit_summary_template,
+                    from_target,
+                    false,
+                    None,
+                )
+            })?;
         }
     }
 
@@ -328,25 +336,27 @@ pub fn show_op_diff(
         diff_named_ref_targets(from_repo.view().tags(), to_repo.view().tags()).collect_vec();
     if !changed_tags.is_empty() {
         writeln!(formatter)?;
-        writeln!(formatter, "Changed tags:")?;
+        with_content_format.write(formatter, |formatter| writeln!(formatter, "Changed tags:"))?;
         for (name, (from_target, to_target)) in changed_tags {
-            writeln!(formatter, "{}:", name)?;
-            write_ref_target_summary(
-                formatter,
-                current_repo,
-                commit_summary_template,
-                to_target,
-                true,
-                None,
-            )?;
-            write_ref_target_summary(
-                formatter,
-                current_repo,
-                commit_summary_template,
-                from_target,
-                false,
-                None,
-            )?;
+            with_content_format.write(formatter, |formatter| {
+                writeln!(formatter, "{}:", name)?;
+                write_ref_target_summary(
+                    formatter,
+                    current_repo,
+                    commit_summary_template,
+                    to_target,
+                    true,
+                    None,
+                )?;
+                write_ref_target_summary(
+                    formatter,
+                    current_repo,
+                    commit_summary_template,
+                    from_target,
+                    false,
+                    None,
+                )
+            })?;
         }
         writeln!(formatter)?;
     }
@@ -361,29 +371,33 @@ pub fn show_op_diff(
     .collect_vec();
     if !changed_remote_branches.is_empty() {
         writeln!(formatter)?;
-        writeln!(formatter, "Changed remote branches:")?;
+        with_content_format.write(formatter, |formatter| {
+            writeln!(formatter, "Changed remote branches:")
+        })?;
         let get_remote_ref_prefix = |remote_ref: &RemoteRef| match remote_ref.state {
             RemoteRefState::New => "untracked",
             RemoteRefState::Tracking => "tracked",
         };
         for ((name, remote_name), (from_ref, to_ref)) in changed_remote_branches {
-            writeln!(formatter, "{}@{}:", name, remote_name)?;
-            write_ref_target_summary(
-                formatter,
-                current_repo,
-                commit_summary_template,
-                &to_ref.target,
-                true,
-                Some(get_remote_ref_prefix(to_ref)),
-            )?;
-            write_ref_target_summary(
-                formatter,
-                current_repo,
-                commit_summary_template,
-                &from_ref.target,
-                false,
-                Some(get_remote_ref_prefix(from_ref)),
-            )?;
+            with_content_format.write(formatter, |formatter| {
+                writeln!(formatter, "{}@{}:", name, remote_name)?;
+                write_ref_target_summary(
+                    formatter,
+                    current_repo,
+                    commit_summary_template,
+                    &to_ref.target,
+                    true,
+                    Some(get_remote_ref_prefix(to_ref)),
+                )?;
+                write_ref_target_summary(
+                    formatter,
+                    current_repo,
+                    commit_summary_template,
+                    &from_ref.target,
+                    false,
+                    Some(get_remote_ref_prefix(from_ref)),
+                )
+            })?;
         }
     }
 

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -244,33 +244,28 @@ pub fn show_op_diff(
                     .iter()
                     .map(|edge| Edge::Direct(edge.target.clone()))
                     .collect_vec();
-                let graph_width = || graph.width(&change_id, &edges);
 
                 let mut buffer = vec![];
-                with_content_format.write_graph_text(
-                    ui.new_formatter(&mut buffer).as_mut(),
-                    |formatter| {
-                        write_modified_change_summary(
-                            formatter,
-                            commit_summary_template,
-                            &change_id,
-                            modified_change,
-                        )
-                    },
-                    graph_width,
-                )?;
+                let within_graph = with_content_format.sub_width(graph.width(&change_id, &edges));
+                within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
+                    write_modified_change_summary(
+                        formatter,
+                        commit_summary_template,
+                        &change_id,
+                        modified_change,
+                    )
+                })?;
                 if !buffer.ends_with(b"\n") {
                     buffer.push(b'\n');
                 }
                 if let Some(diff_renderer) = &diff_renderer {
                     let mut formatter = ui.new_formatter(&mut buffer);
-                    let width = usize::saturating_sub(ui.term_width(), graph_width());
                     show_change_diff(
                         ui,
                         formatter.as_mut(),
                         diff_renderer,
                         modified_change,
-                        width,
+                        within_graph.width(),
                     )?;
                 }
 

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -134,11 +134,10 @@ fn do_op_log(
                 edges.push(Edge::Direct(id.clone()));
             }
             let mut buffer = vec![];
-            with_content_format.write_graph_text(
-                ui.new_formatter(&mut buffer).as_mut(),
-                |formatter| template.format(&op, formatter),
-                || graph.width(op.id(), &edges),
-            )?;
+            let within_graph = with_content_format.sub_width(graph.width(op.id(), &edges));
+            within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
+                template.format(&op, formatter)
+            })?;
             if !buffer.ends_with(b"\n") {
                 buffer.push(b'\n');
             }

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -14,16 +14,24 @@
 
 use std::slice;
 
+use itertools::Itertools as _;
 use jj_lib::op_walk;
 use jj_lib::operation::Operation;
+use jj_lib::repo::RepoLoader;
 use jj_lib::settings::ConfigResultExt as _;
 use jj_lib::settings::UserSettings;
 
+use super::diff::show_op_diff;
 use crate::cli_util::format_template;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::WorkspaceCommandEnvironment;
 use crate::command_error::CommandError;
+use crate::commit_templater::CommitTemplateLanguage;
+use crate::diff_util::diff_formats_for_log;
+use crate::diff_util::DiffFormatArgs;
+use crate::diff_util::DiffRenderer;
+use crate::formatter::Formatter;
 use crate::graphlog::get_graphlog;
 use crate::graphlog::Edge;
 use crate::graphlog::GraphStyle;
@@ -56,6 +64,18 @@ pub struct OperationLogArgs {
     /// For the syntax, see https://martinvonz.github.io/jj/latest/templates/
     #[arg(long, short = 'T')]
     template: Option<String>,
+    /// Show changes to the repository at each operation
+    #[arg(long)]
+    op_diff: bool,
+    /// Show patch of modifications to changes (implies --op-diff)
+    ///
+    /// If the previous version has different parents, it will be temporarily
+    /// rebased to the parents of the new version, so the diff is not
+    /// contaminated by unrelated changes.
+    #[arg(long, short = 'p')]
+    patch: bool,
+    #[command(flatten)]
+    diff_format: DiffFormatArgs,
 }
 
 pub fn cmd_op_log(
@@ -66,27 +86,28 @@ pub fn cmd_op_log(
     if command.is_working_copy_writable() {
         let workspace_command = command.workspace_helper(ui)?;
         let current_op = workspace_command.repo().operation();
-        do_op_log(ui, workspace_command.env(), current_op, args)
+        let repo_loader = workspace_command.workspace().repo_loader();
+        do_op_log(ui, workspace_command.env(), repo_loader, current_op, args)
     } else {
         // Don't load the repo so that the operation history can be inspected
         // even with a corrupted repo state. For example, you can find the first
         // bad operation id to be abandoned.
         let workspace = command.load_workspace()?;
         let workspace_env = command.workspace_environment(ui, &workspace)?;
+        let repo_loader = workspace.repo_loader();
         let current_op = command.resolve_operation(ui, workspace.repo_loader())?;
-        do_op_log(ui, &workspace_env, &current_op, args)
+        do_op_log(ui, &workspace_env, repo_loader, &current_op, args)
     }
 }
 
 fn do_op_log(
     ui: &mut Ui,
     workspace_env: &WorkspaceCommandEnvironment,
+    repo_loader: &RepoLoader,
     current_op: &Operation,
     args: &OperationLogArgs,
 ) -> Result<(), CommandError> {
     let settings = workspace_env.settings();
-    let op_store = current_op.op_store();
-
     let graph_style = GraphStyle::from_settings(settings)?;
     let with_content_format = LogContentFormat::new(ui, settings)?;
 
@@ -94,7 +115,7 @@ fn do_op_log(
     let op_node_template;
     {
         let language = OperationTemplateLanguage::new(
-            op_store.root_operation_id(),
+            repo_loader.op_store().root_operation_id(),
             Some(current_op.id()),
             workspace_env.operation_template_extensions(),
         );
@@ -113,6 +134,49 @@ fn do_op_log(
             )?
             .labeled("node");
     }
+
+    let diff_formats = diff_formats_for_log(settings, &args.diff_format, args.patch)?;
+    let maybe_show_op_diff = if args.op_diff || !diff_formats.is_empty() {
+        let template_text = settings.config().get_string("templates.commit_summary")?;
+        let show = move |ui: &Ui,
+                         formatter: &mut dyn Formatter,
+                         op: &Operation,
+                         with_content_format: &LogContentFormat| {
+            let parents: Vec<_> = op.parents().try_collect()?;
+            let parent_op = repo_loader.merge_operations(settings, parents, None)?;
+            let parent_repo = repo_loader.load_at(&parent_op)?;
+            let repo = repo_loader.load_at(op)?;
+
+            let id_prefix_context = workspace_env.new_id_prefix_context();
+            let commit_summary_template = {
+                let language =
+                    workspace_env.commit_template_language(repo.as_ref(), &id_prefix_context);
+                workspace_env.parse_template(
+                    &language,
+                    &template_text,
+                    CommitTemplateLanguage::wrap_commit,
+                )?
+            };
+            let path_converter = workspace_env.path_converter();
+            let diff_renderer = (!diff_formats.is_empty())
+                .then(|| DiffRenderer::new(repo.as_ref(), path_converter, diff_formats.clone()));
+
+            show_op_diff(
+                ui,
+                formatter,
+                repo.as_ref(),
+                &parent_repo,
+                &repo,
+                &commit_summary_template,
+                (!args.no_graph).then_some(graph_style),
+                with_content_format,
+                diff_renderer.as_ref(),
+            )
+        };
+        Some(show)
+    } else {
+        None
+    };
 
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
@@ -141,6 +205,10 @@ fn do_op_log(
             if !buffer.ends_with(b"\n") {
                 buffer.push(b'\n');
             }
+            if let Some(show) = &maybe_show_op_diff {
+                let mut formatter = ui.new_formatter(&mut buffer);
+                show(ui, formatter.as_mut(), &op, &within_graph)?;
+            }
             let node_symbol = format_template(ui, &op, &op_node_template);
             graph.add_node(
                 op.id(),
@@ -153,6 +221,9 @@ fn do_op_log(
         for op in iter {
             let op = op?;
             with_content_format.write(formatter, |formatter| template.format(&op, formatter))?;
+            if let Some(show) = &maybe_show_op_diff {
+                show(ui, formatter, &op, &with_content_format)?;
+            }
         }
     }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1390,6 +1390,22 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 * `-T`, `--template <TEMPLATE>` — Render each operation using the given template
 
    For the syntax, see https://martinvonz.github.io/jj/latest/templates/
+* `--op-diff` — Show changes to the repository at each operation
+* `-p`, `--patch` — Show patch of modifications to changes (implies --op-diff)
+
+   If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.
+* `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
+* `--stat` — Show a histogram of the changes
+* `--types` — For each path, show only its type before and after
+
+   The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
+* `--name-only` — For each path, show only its path
+
+   Typically useful for shell commands like: `jj diff -r @- --name_only | xargs perl -pi -e's/OLD/NEW/g`
+* `--git` — Show a Git-format diff
+* `--color-words` — Show a word-level diff with changes indicated only by color
+* `--tool <TOOL>` — Generate diff by external command
+* `--context <CONTEXT>` — Number of lines of context to show
 
 
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
