### PR TITLE
git: add --remote option to clone command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj op log` gained an option to include operation diffs.
 
+* `jj git clone` now accepts a `--remote <REMOTE NAME>` option, which
+  allows to set a name for the remote instead of using the default
+  `origin`.
+
 ### Fixed bugs
 
  * Fixed panic when parsing invalid conflict markers of a particular form.

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -54,6 +54,9 @@ pub struct GitCloneArgs {
     /// doesn't exist.
     #[arg(value_hint = clap::ValueHint::DirPath)]
     destination: Option<String>,
+    /// Name of the newly created remote
+    #[arg(long = "remote", default_value = "origin")]
+    remote_name: String,
     /// Whether or not to colocate the Jujutsu repo with the git repo
     #[arg(long)]
     colocate: bool,
@@ -97,10 +100,10 @@ pub fn cmd_git_clone(
     command: &CommandHelper,
     args: &GitCloneArgs,
 ) -> Result<(), CommandError> {
+    let remote_name = &args.remote_name;
     if command.global_args().at_operation.is_some() {
         return Err(cli_error("--at-op is not respected"));
     }
-    let remote_name = "origin";
     let source = absolute_git_source(command.cwd(), &args.source);
     let wc_path_str = args
         .destination

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -957,6 +957,9 @@ The Git repo will be a bare git repo stored inside the `.jj/` directory.
 
 ###### **Options:**
 
+* `--remote <REMOTE_NAME>` — Name of the newly created remote
+
+  Default value: `origin`
 * `--colocate` — Whether or not to colocate the Jujutsu repo with the git repo
 
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -498,6 +498,30 @@ fn test_git_clone_at_operation() {
     "###);
 }
 
+#[test]
+fn test_git_clone_with_remote_name() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.auto-local-branch = true");
+    let git_repo_path = test_env.env_root().join("source");
+    let git_repo = git2::Repository::init(git_repo_path).unwrap();
+    set_up_non_empty_git_repo(&git_repo);
+
+    // Clone with relative source path and a non-default remote name
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        test_env.env_root(),
+        &["git", "clone", "source", "clone", "--remote", "upstream"],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r#"
+    Fetching into new repo in "$TEST_ENV/clone"
+    bookmark: main@upstream [new] tracked
+    Setting the revset alias "trunk()" to "main@upstream"
+    Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
+    Parent commit      : mzyxwzks 9f01a0e0 main | message
+    Added 1 files, modified 0 files, removed 0 files
+    "#);
+}
+
 fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes"])
 }

--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -105,9 +105,9 @@ parent.
     </tr>
     <tr>
       <td>Clone an existing repo</td>
-      <td><code>jj git clone &lt;source&gt; &lt;destination&gt;</code> (there is no support
+      <td><code>jj git clone &lt;source&gt; &lt;destination&gt; [--remote &lt;remote name&gt;]</code> (there is no support
           for cloning non-Git repos yet)</td>
-      <td><code>git clone &lt;source&gt; &lt;destination&gt;</code></td>
+      <td><code>git clone &lt;source&gt; &lt;destination&gt; [--origin &lt;remote name&gt;]</code></td>
     </tr>
     <tr>
       <td>Update the local repo with all bookmarks from a remote</td>

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -94,6 +94,9 @@ To create a Jujutsu repo from a remote Git URL, use `jj git clone <URL>
 https://github.com/octocat/Hello-World` will clone GitHub's "Hello-World" repo
 into a directory by the same name.
 
+By default, the remote repository will be named `origin`. You can use
+a name of your choice by adding `--remote <remote name>` to the `jj
+git clone` command.
 
 ## Co-located Jujutsu/Git repos
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -253,11 +253,22 @@ the [tutorial][tut].
 It is common to use several remotes when contributing to a shared repository.
 For example, "upstream" can designate the remote where the changes will be
 merged through a pull-request while "origin" is your private fork of the
-project. In this case, you might want to `jj git fetch` from "upstream" and to
-`jj git push` to "origin".
+project.
 
-You can configure the default remotes to fetch from and push to in your
-configuration file (for example `.jj/repo/config.toml`):
+```shell
+$ jj git clone --remote upstream https://github.com/upstream-org/repo
+$ cd repo
+$ jj git remote add origin git@github.com:your-org/your-repo-fork
+```
+
+This will automatically setup your repository to track the main
+bookmark from the upstream repository, typically `main@upstream`
+or `master@upstream`.
+
+You might want to `jj git fetch` from "upstream" and to `jj git push`
+to "origin". You can configure the default remotes to fetch from and
+push to in your configuration file (for example,
+`.jj/repo/config.toml`):
 
 ```toml
 [git]
@@ -266,3 +277,13 @@ push = "origin"
 ```
 
 The default for both `git.fetch` and `git.push` is "origin".
+
+If you usually work on a project from several computers, you may
+configure `jj` to fetch from both repositories by default, in order to
+keep your own bookmarks synchronized through your `origin` repository:
+
+```toml
+[git]
+fetch = ["upstream", "origin"]
+push = "origin"
+```


### PR DESCRIPTION
This feature is discussed in https://github.com/martinvonz/jj/discussions/4447.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [X] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
