### PR TITLE
git: restore support for `git.push-branch-prefix` config but deprecate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   that describes them better, and they also behave similar to Mercurial's 
   bookmarks. 
 
+* The `git.push-branch-prefix` config has been deprecated in favor of
+  `git.push-bookmark-prefix`.
+
 ### New features
 
 * The new config option `snapshot.auto-track` lets you automatically track only

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -679,6 +679,25 @@ fn test_git_push_changes() {
     Bookmark changes to push to origin:
       Add bookmark test-yostqsxwqrlt to 38cb417ce3a6
     "###);
+
+    // Test deprecation warning for `git.push-branch-prefix`
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &workspace_root,
+        &[
+            "git",
+            "push",
+            "--config-toml",
+            r"git.push-branch-prefix='branch-'",
+            "--change=@",
+        ],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r###"
+  Warning: Config git.push-branch-prefix is deprecated. Please switch to git.push-bookmark-prefix
+  Creating bookmark branch-yostqsxwqrlt for revision yostqsxwqrlt
+  Bookmark changes to push to origin:
+    Add bookmark branch-yostqsxwqrlt to 38cb417ce3a6
+  "###);
 }
 
 #[test]

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -196,6 +196,10 @@ impl UserSettings {
             .unwrap_or_else(|_| "push-".to_string())
     }
 
+    pub fn push_branch_prefix(&self) -> Option<String> {
+        self.config.get_string("git.push-branch-prefix").ok()
+    }
+
     pub fn default_description(&self) -> String {
         self.config()
             .get_string("ui.default-description")


### PR DESCRIPTION

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
