### PR TITLE
id_prefix: fix crash on hidden change id disambiguation

### DIFF
--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -176,10 +176,12 @@ impl IdPrefixContext {
                 .change_index
                 .resolve_prefix_to_key(&*indexes.commit_change_ids, prefix);
             if let PrefixResolution::SingleMatch(change_id) = resolution {
-                // There may be more commits with this change id outside the narrower sets.
-                return PrefixResolution::SingleMatch(repo.resolve_change_id(&change_id).expect(
-                    "Change ids present in narrower search set should be present globally.",
-                ));
+                return match repo.resolve_change_id(&change_id) {
+                    // There may be more commits with this change id outside the narrower sets.
+                    Some(commit_ids) => PrefixResolution::SingleMatch(commit_ids),
+                    // The disambiguation set may contain hidden commits.
+                    None => PrefixResolution::NoMatch,
+                };
             }
         }
         repo.resolve_change_id_prefix(prefix)


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
