### PR TITLE
revset: use generic GraphEdge type in default graph iterator

### DIFF
--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -29,38 +29,8 @@ use crate::backend::CommitId;
 use crate::graph::GraphEdge;
 use crate::graph::GraphEdgeType;
 
-/// Like `RevsetGraphEdge`, but stores `IndexPosition` instead.
-///
-/// This can be cheaply allocated and hashed compared to `CommitId`-based type.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct IndexGraphEdge {
-    target: IndexPosition,
-    edge_type: GraphEdgeType,
-}
-
-impl IndexGraphEdge {
-    fn missing(target: IndexPosition) -> Self {
-        let edge_type = GraphEdgeType::Missing;
-        IndexGraphEdge { target, edge_type }
-    }
-
-    fn direct(target: IndexPosition) -> Self {
-        let edge_type = GraphEdgeType::Direct;
-        IndexGraphEdge { target, edge_type }
-    }
-
-    fn indirect(target: IndexPosition) -> Self {
-        let edge_type = GraphEdgeType::Indirect;
-        IndexGraphEdge { target, edge_type }
-    }
-
-    fn to_revset_edge(self, index: &CompositeIndex) -> GraphEdge<CommitId> {
-        GraphEdge {
-            target: index.entry_by_pos(self.target).commit_id(),
-            edge_type: self.edge_type,
-        }
-    }
-}
+// This can be cheaply allocated and hashed compared to `CommitId`-based type.
+type IndexGraphEdge = GraphEdge<IndexPosition>;
 
 /// Given a `RevWalk` over some set of revisions, yields the same revisions with
 /// associated edge types.
@@ -349,7 +319,7 @@ impl RevWalk<CompositeIndex> for RevsetGraphWalk<'_> {
         }
         let edges = edges
             .iter()
-            .map(|edge| edge.to_revset_edge(index))
+            .map(|edge| edge.map(|pos| index.entry_by_pos(pos).commit_id()))
             .collect();
         Some((entry.commit_id(), edges))
     }

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::hash::Hash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct GraphEdge<N> {
     pub target: N,
     pub edge_type: GraphEdgeType,
@@ -44,6 +44,13 @@ impl<N> GraphEdge<N> {
         Self {
             target,
             edge_type: GraphEdgeType::Indirect,
+        }
+    }
+
+    pub fn map<M>(self, f: impl FnOnce(N) -> M) -> GraphEdge<M> {
+        GraphEdge {
+            target: f(self.target),
+            edge_type: self.edge_type,
         }
     }
 }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
