### PR TITLE
squash: accept -k as a shorthand for --keep-emptied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj op undo` now reports information on the operation that has been undone.
 
+* `jj squash`: the `-k` flag can be used as a shorthand for `--keep-emptied`.
+
 ### Fixed bugs
 
  * Fixed panic when parsing invalid conflict markers of a particular form.

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -82,7 +82,7 @@ pub(crate) struct SquashArgs {
     #[arg(conflicts_with_all = ["interactive", "tool"], value_hint = clap::ValueHint::AnyPath)]
     paths: Vec<String>,
     /// The source revision will not be abandoned
-    #[arg(long)]
+    #[arg(long, short)]
     keep_emptied: bool,
 }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1925,7 +1925,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 * `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
-* `--keep-emptied` — The source revision will not be abandoned
+* `-k`, `--keep-emptied` — The source revision will not be abandoned
 
 
 


### PR DESCRIPTION
This eases the workflow in which a commit in the middle of the tree is repeatedly squashed into its parent.

The issue came while discussing #4468.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
