### PR TITLE
bookmark: add "b" alias

### DIFF
--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -2,6 +2,7 @@
 # all aliases from here.
 [aliases]
 amend = ["squash"]
+b = ["bookmark"]
 co = ["checkout"]
 unamend = ["unsquash"]
 

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -24,9 +24,9 @@ fn test_alias_basic() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.add_config(r#"aliases.b = ["log", "-r", "@", "-T", "bookmarks"]"#);
+    test_env.add_config(r#"aliases.bk = ["log", "-r", "@", "-T", "bookmarks"]"#);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["bk"]);
     insta::assert_snapshot!(stdout, @r###"
     @  my-bookmark
     │
@@ -41,9 +41,9 @@ fn test_alias_legacy_section() {
     let repo_path = test_env.env_root().join("repo");
 
     // Can define aliases in [alias] section
-    test_env.add_config(r#"alias.b = ["log", "-r", "@", "-T", "bookmarks"]"#);
+    test_env.add_config(r#"alias.bk = ["log", "-r", "@", "-T", "bookmarks"]"#);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
-    let stdout = test_env.jj_cmd_success(&repo_path, &["b"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["bk"]);
     insta::assert_snapshot!(stdout, @r###"
     @  my-bookmark
     │
@@ -51,10 +51,10 @@ fn test_alias_legacy_section() {
     "###);
 
     // The same alias (name) in both [alias] and [aliases] sections is an error
-    test_env.add_config(r#"aliases.b = ["bookmark", "list"]"#);
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["b"]);
+    test_env.add_config(r#"aliases.bk = ["bookmark", "list"]"#);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["bk"]);
     insta::assert_snapshot!(stderr, @r###"
-    Error: Alias "b" is defined in both [aliases] and [alias]
+    Error: Alias "bk" is defined in both [aliases] and [alias]
     Hint: [aliases] is the preferred section for aliases. Please remove the alias from [alias].
     "###);
 }

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -218,4 +218,13 @@ To resolve a conflicted state in a remote bookmark (e.g. `main@origin`), simply
 pull from the remote (e.g. `jj git fetch`). The conflict resolution will also
 propagate to the local bookmark (which was presumably also conflicted).
 
+## Ease of use
+
+The use of bookmarks is frequent in some workflows, for example, when
+interacting with Git repositories containing branches. To this end,
+one-letter shortcuts have been implemented, both for the `jj bookmark`
+command itself through an alias (as `jj b`), and for its subcommands.
+For example, `jj bookmark create BOOKMARK-NAME` can be abbreviated as
+`jj b c BOOKMARK-NAME`.
+
 [design]: design/tracking-branches.md


### PR DESCRIPTION
`jj bookmark` is a frequently used command. Its subcommands already have one letter aliases. Defining `jj b` as an alias for `jj bookmarks` make bookmarks really easy to use.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
