### PR TITLE
Downgrade once_cell to 1.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 dependencies = [
  "parking_lot_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ libc = { version = "0.2.158" }
 maplit = "1.0.2"
 minus = { version = "5.6.1", features = ["dynamic_output", "search"] }
 num_cpus = "1.16.0"
-once_cell = "1.20.0"
+once_cell = "1.19.0"
 pest = "2.7.12"
 pest_derive = "2.7.12"
 pollster = "0.3.0"


### PR DESCRIPTION
1.20.0 was yanked: https://github.com/matklad/once_cell/issues/264
