### PR TITLE
diffedit: add --restore-descendants flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj commit` and `jj describe` now accept `--author` option allowing to quickly change
   author of given commit.
 
+* `jj diffedit` now accepts a `--restore-descendants` flag. When used,
+  descendants of the edited commit will keep their original content.
+
 ### Fixed bugs
 
  * Update working copy before reporting changes. This prevents errors during reporting

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -655,7 +655,7 @@ With the `--from` and/or `--to` options, starts a [diff editor] comparing the "f
 
 [diff editor]: https://martinvonz.github.io/jj/latest/config/#editing-diffs
 
-Edit the right side of the diff until it looks the way you want. Once you close the editor, the revision specified with `-r` or `--to` will be updated. Descendants will be rebased on top as usual, which may result in conflicts.
+Edit the right side of the diff until it looks the way you want. Once you close the editor, the revision specified with `-r` or `--to` will be updated. Unless `--restore-descendants` is used, descendants will be rebased on top as usual, which may result in conflicts.
 
 See `jj restore` if you want to move entire files from one revision to another. See `jj squash -i` or `jj unsquash -i` if you instead want to move changes into or out of the parent revision.
 
@@ -673,6 +673,9 @@ See `jj restore` if you want to move entire files from one revision to another. 
 
    Defaults to @ if --from is specified.
 * `--tool <NAME>` — Specify diff editor to be used
+* `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
+
+   When rebasing a descendant on top of the rewritten revision, its diff compared to its parent(s) is normally preserved, i.e. the same way that descendants are always rebased. This flag makes it so the content/state is preserved instead of preserving the diff.
 
 
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -602,6 +602,7 @@ fn test_help() {
           --from <FROM>          Show changes from this revision
           --to <TO>              Edit changes in this revision
           --tool <NAME>          Specify diff editor to be used
+          --restore-descendants  Preserve the content (not the diff) when rebasing descendants
       -h, --help                 Print help (see more with '--help')
 
     Global Options:

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1314,6 +1314,11 @@ impl MutableRepo {
         result
     }
 
+    /// Rebase descendants of the rewritten commits.
+    ///
+    /// The descendants of the commits registered in `self.parent_mappings` will
+    /// be recursively rebased onto the new version of their parents.
+    /// Returns the number of rebased descendants.
     pub fn rebase_descendants(&mut self, settings: &UserSettings) -> BackendResult<usize> {
         let roots = self.parent_mapping.keys().cloned().collect_vec();
         let mut num_rebased = 0;


### PR DESCRIPTION
This adds to `diffedit` something that `unsquash` could do and `squash` could not. This would ease the deprecation of `unsquash` (see #4479).

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
