### PR TITLE
cli: Warn if specified remote branch not found for `jj git fetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+ * `jj git fetch -b <remote-git-branch-name>` will now warn if the branch(es)
+   can not be found in any of the specified/configured remotes.
+
  * Fixed panic when parsing invalid conflict markers of a particular form.
    ([#2611](https://github.com/martinvonz/jj/pull/2611))
 


### PR DESCRIPTION
* First fetch from remote.
* Then check tx.{base_repo(),repo}.view().remote_bookmarks_matching(<branch>, <remote>).
  This has to happen after the fetch has been done so the tx.repo() is updated.
* Warn if a branch is not found in any of the remotes used in the fetch. Note that the remotes
  used in the fetch can be a subset of the remotes configured for the repo, so the language
  of the warning tries to point that out.

Fixes: #4293

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
