### PR TITLE
cli: reorder updating and reporting for consistency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* Fixing #4239 means the ordering of some messages have changed.
+
 * Invalid `ui.graph.style` configuration is now an error.
 
 * The builtin template `branch_list` has been renamed to `bookmark_list` as part
@@ -68,6 +70,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   author of given commit.
 
 ### Fixed bugs
+
+ * Update working copy before reporting changes. This prevents errors during reporting
+   from leaving the working copy in a stale state.
 
  * `jj git fetch -b <remote-git-branch-name>` will now warn if the branch(es)
    can not be found in any of the specified/configured remotes.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1715,8 +1715,10 @@ See https://martinvonz.github.io/jj/latest/working-copy/#stale-working-copy \
         }
 
         self.user_repo = ReadonlyUserRepo::new(tx.commit(description));
-        self.report_repo_changes(ui, &old_repo)?;
 
+        // Update working copy before reporting repo changes, so that
+        // potential errors while reporting changes (broken pipe, etc)
+        // don't leave the working copy in a stale state.
         if self.may_update_working_copy {
             if let Some(new_commit) = &maybe_new_wc_commit {
                 self.update_working_copy(ui, maybe_old_wc_commit.as_ref(), new_commit)?;
@@ -1725,6 +1727,8 @@ See https://martinvonz.github.io/jj/latest/working-copy/#stale-working-copy \
                 // update it.
             }
         }
+
+        self.report_repo_changes(ui, &old_repo)?;
 
         let settings = self.settings();
         if settings.user_name().is_empty() || settings.user_email().is_empty() {

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -215,7 +215,13 @@ fn test_chmod_file_dir_deletion_conflicts() {
         &["file", "chmod", "x", "file", "-r=file_deletion"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
+    Working copy now at: kmkuslsw 1b2ef84c file_deletion | (conflict) file_deletion
+    Parent commit      : zsuskuln c51c9c55 file | file
+    Parent commit      : royxmykx 6b18b3c1 deletion | deletion
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion and an executable
     New conflicts appeared in these commits:
       kmkuslsw 1b2ef84c file_deletion | (conflict) file_deletion
     To resolve the conflicts, start by updating to it:
@@ -223,13 +229,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kmkuslsw 1b2ef84c file_deletion | (conflict) file_deletion
-    Parent commit      : zsuskuln c51c9c55 file | file
-    Parent commit      : royxmykx 6b18b3c1 deletion | deletion
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file    2-sided conflict including 1 deletion and an executable
-    "#);
+    "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout,
     @r###"

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -30,8 +30,13 @@ fn test_report_conflicts() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Rebased 3 commits
+    Working copy now at: zsuskuln aa73e2ae (conflict) (empty) (no description set)
+    Parent commit      : kkmpptxz 64bdec0c (conflict) C
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     New conflicts appeared in these commits:
       kkmpptxz 64bdec0c (conflict) C
       rlvkpnrz 10a5fd45 (conflict) B
@@ -40,23 +45,18 @@ fn test_report_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: zsuskuln aa73e2ae (conflict) (empty) (no description set)
-    Parent commit      : kkmpptxz 64bdec0c (conflict) C
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file    2-sided conflict including 1 deletion
-    "#);
+    "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 3 commits
-    Existing conflicts were resolved or abandoned from these commits:
-      kkmpptxz hidden 64bdec0c (conflict) C
-      rlvkpnrz hidden 10a5fd45 (conflict) B
     Working copy now at: zsuskuln d70c003d (empty) (no description set)
     Parent commit      : kkmpptxz 43e94449 C
     Added 0 files, modified 1 files, removed 0 files
+    Existing conflicts were resolved or abandoned from these commits:
+      kkmpptxz hidden 64bdec0c (conflict) C
+      rlvkpnrz hidden 10a5fd45 (conflict) B
     "###);
 
     // Can get hint about multiple root commits
@@ -66,6 +66,11 @@ fn test_report_conflicts() {
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
+    Working copy now at: zsuskuln 99fb9018 (conflict) (empty) (no description set)
+    Parent commit      : kkmpptxz 17c72220 (conflict) C
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict
     New conflicts appeared in these commits:
       kkmpptxz 17c72220 (conflict) C
       rlvkpnrz eb93a73d (conflict) B
@@ -75,11 +80,6 @@ fn test_report_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: zsuskuln 99fb9018 (conflict) (empty) (no description set)
-    Parent commit      : kkmpptxz 17c72220 (conflict) C
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file    2-sided conflict
     "###);
 
     // Resolve one of the conflicts by (mostly) following the instructions
@@ -96,10 +96,10 @@ fn test_report_conflicts() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
-    Existing conflicts were resolved or abandoned from these commits:
-      rlvkpnrz hidden eb93a73d (conflict) B
     Working copy now at: yostqsxw f5a0cf8c (empty) (no description set)
     Parent commit      : rlvkpnrz 87370844 B
+    Existing conflicts were resolved or abandoned from these commits:
+      rlvkpnrz hidden eb93a73d (conflict) B
     "###);
 }
 
@@ -121,9 +121,14 @@ fn test_report_conflicts_with_divergent_commits() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits
+    Working copy now at: zsuskuln?? 97ce1783 (conflict) C2
+    Parent commit      : kkmpptxz eb93a73d (conflict) B
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     New conflicts appeared in these commits:
       zsuskuln?? b535189c (conflict) C3
       zsuskuln?? 97ce1783 (conflict) C2
@@ -133,32 +138,32 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: zsuskuln?? 97ce1783 (conflict) C2
-    Parent commit      : kkmpptxz eb93a73d (conflict) B
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file    2-sided conflict including 1 deletion
-    "#);
+    "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 3 commits
+    Working copy now at: zsuskuln?? f2d7a228 C2
+    Parent commit      : kkmpptxz db069a22 B
+    Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from these commits:
       zsuskuln hidden b535189c (conflict) C3
       zsuskuln hidden 97ce1783 (conflict) C2
       kkmpptxz hidden eb93a73d (conflict) B
-    Working copy now at: zsuskuln?? f2d7a228 C2
-    Parent commit      : kkmpptxz db069a22 B
-    Added 0 files, modified 1 files, removed 0 files
     "###);
 
     // Same thing when rebasing the divergent commits one at a time
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(C2)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Rebased 1 commits
+    Working copy now at: zsuskuln?? b15416ac (conflict) C2
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict including 1 deletion
     New conflicts appeared in these commits:
       zsuskuln?? b15416ac (conflict) C2
     To resolve the conflicts, start by updating to it:
@@ -166,12 +171,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: zsuskuln?? b15416ac (conflict) C2
-    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file    2-sided conflict including 1 deletion
-    "#);
+    "###);
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(C3)", "-d=root()"]);
@@ -194,11 +194,11 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Rebased 1 commits
-    Existing conflicts were resolved or abandoned from these commits:
-      zsuskuln hidden b15416ac (conflict) C2
     Working copy now at: zsuskuln?? 1f9680bd C2
     Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
+    Existing conflicts were resolved or abandoned from these commits:
+      zsuskuln hidden b15416ac (conflict) C2
     "###);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -235,8 +235,14 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Resolving conflicts in: file
+    Working copy now at: vruxwmqv 7699b9c3 conflict | (conflict) conflict
+    Parent commit      : zsuskuln aa493daf a | a
+    Parent commit      : royxmykx db6a4daf b | b
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file    2-sided conflict
     New conflicts appeared in these commits:
       vruxwmqv 7699b9c3 conflict | (conflict) conflict
     To resolve the conflicts, start by updating to it:
@@ -244,13 +250,7 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: vruxwmqv 7699b9c3 conflict | (conflict) conflict
-    Parent commit      : zsuskuln aa493daf a | a
-    Parent commit      : royxmykx db6a4daf b | b
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file    2-sided conflict
-    "#);
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
     <<<<<<< Conflict 1 of 1
@@ -590,15 +590,8 @@ fn test_simplify_conflict_sides() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Resolving conflicts in: fileB
-    New conflicts appeared in these commits:
-      nkmrtpmo 4b14662a conflict | (conflict) conflict
-    To resolve the conflicts, start by updating to it:
-      jj new nkmrtpmo
-    Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
-    Then run `jj squash` to move the resolution into the conflicted commit.
     Working copy now at: nkmrtpmo 4b14662a conflict | (conflict) conflict
     Parent commit      : kmkuslsw 18c1fb00 conflictA | (conflict) (empty) conflictA
     Parent commit      : lylxulpl d11c92eb conflictB | (conflict) (empty) conflictB
@@ -606,7 +599,14 @@ fn test_simplify_conflict_sides() {
     There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict
-    "#);
+    New conflicts appeared in these commits:
+      nkmrtpmo 4b14662a conflict | (conflict) conflict
+    To resolve the conflicts, start by updating to it:
+      jj new nkmrtpmo
+    Then use `jj resolve`, or edit the conflict markers in the file directly.
+    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Then run `jj squash` to move the resolution into the conflicted commit.
+    "###);
     insta::assert_snapshot!(std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
@@ -860,8 +860,14 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "another_file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Resolving conflicts in: another_file
+    Working copy now at: vruxwmqv 6a90e546 conflict | (conflict) conflict
+    Parent commit      : zsuskuln de7553ef a | a
+    Parent commit      : royxmykx f68bc2f0 b | b
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    this_file_has_a_very_long_name_to_test_padding 2-sided conflict
     New conflicts appeared in these commits:
       vruxwmqv 6a90e546 conflict | (conflict) conflict
     To resolve the conflicts, start by updating to it:
@@ -869,13 +875,7 @@ fn test_multiple_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: vruxwmqv 6a90e546 conflict | (conflict) conflict
-    Parent commit      : zsuskuln de7553ef a | a
-    Parent commit      : royxmykx f68bc2f0 b | b
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    this_file_has_a_very_long_name_to_test_padding 2-sided conflict
-    "#);
+    "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
     @r###"
     diff --git a/another_file b/another_file

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -58,9 +58,14 @@ fn test_restore() {
     "###);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Created rlvkpnrz b9b6011e (empty) (no description set)
     Rebased 1 descendant commits
+    Working copy now at: kkmpptxz d05c4d2a (conflict) (no description set)
+    Parent commit      : rlvkpnrz b9b6011e (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    There are unresolved conflicts at these paths:
+    file2    2-sided conflict including 1 deletion
     New conflicts appeared in these commits:
       kkmpptxz d05c4d2a (conflict) (no description set)
     To resolve the conflicts, start by updating to it:
@@ -68,12 +73,7 @@ fn test_restore() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kkmpptxz d05c4d2a (conflict) (no description set)
-    Parent commit      : rlvkpnrz b9b6011e (empty) (no description set)
-    Added 0 files, modified 1 files, removed 0 files
-    There are unresolved conflicts at these paths:
-    file2    2-sided conflict including 1 deletion
-    "#);
+    "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
     insta::assert_snapshot!(stdout, @"");
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -686,8 +686,10 @@ fn test_squash_from_multiple() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b", "--from=c", "--into=d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
+    Working copy now at: kpqxywon 3e25ee21 f | (no description set)
+    Parent commit      : yostqsxw abb5a4ea e | (no description set)
     New conflicts appeared in these commits:
       yqosqzyt 98759deb d | (conflict) (no description set)
     To resolve the conflicts, start by updating to it:
@@ -695,9 +697,7 @@ fn test_squash_from_multiple() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kpqxywon 3e25ee21 f | (no description set)
-    Parent commit      : yostqsxw abb5a4ea e | (no description set)
-    "#);
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  3e25ee211f3f f
     ○    abb5a4ea1222 e
@@ -811,8 +811,10 @@ fn test_squash_from_multiple_partial() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c", "--into=d", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Rebased 2 descendant commits
+    Working copy now at: kpqxywon 056dc38b f | (no description set)
+    Parent commit      : yostqsxw 45069475 e | (no description set)
     New conflicts appeared in these commits:
       yqosqzyt b91b1157 d | (conflict) (no description set)
     To resolve the conflicts, start by updating to it:
@@ -820,9 +822,7 @@ fn test_squash_from_multiple_partial() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    Working copy now at: kpqxywon 056dc38b f | (no description set)
-    Parent commit      : yostqsxw 45069475 e | (no description set)
-    "#);
+    "###);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  056dc38bf286 f
     ○      450694753699 e


### PR DESCRIPTION
* See #4239 for details.
* For now, update working copy before reporting repo changes, so that potential errors in reporting changes don't leave the repo in a stale state.

Fixes: #4239

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
