### PR TITLE
cli: get author timestamp of description template in consistent way

### DIFF
--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -155,7 +155,7 @@ pub(crate) fn cmd_describe(
                     let new_author = Signature {
                         name,
                         email,
-                        timestamp: commit.author().timestamp,
+                        timestamp: commit_builder.author().timestamp,
                     };
                     commit_builder.set_author(new_author);
                 }

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -568,7 +568,7 @@ fn test_describe_author() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
 
-    JJ: Author: Super Seeder <super.seeder@example.com> (2001-02-03 08:05:10)
+    JJ: Author: Super Seeder <super.seeder@example.com> (2001-02-03 08:05:12)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:12)
 
     JJ: 0 files changed, 0 insertions(+), 0 deletions(-)


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
