### PR TITLE
New flag: `abandon --restore-descendants`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj diffedit` now accepts a `--restore-descendants` flag. When used,
   descendants of the edited commit will keep their original content.
 
+* `jj abandon` now accepts a `--restore-descendants` flag. When used,
+  descendants of the abandoned commits will keep their original content.
+
 ### Fixed bugs
 
  * Update working copy before reporting changes. This prevents errors during reporting

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -43,6 +43,9 @@ pub(crate) struct AbandonArgs {
     /// Ignored (but lets you pass `-r` for consistency with other commands)
     #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
     unused_revision: u8,
+    /// Do not modify the content of the children of the abandoned commits
+    #[arg(long)]
+    restore_descendants: bool,
 }
 
 #[instrument(skip_all)]
@@ -66,7 +69,14 @@ pub(crate) fn cmd_abandon(
     for commit in &to_abandon {
         tx.repo_mut().record_abandoned_commit(commit.id().clone());
     }
-    let num_rebased = tx.repo_mut().rebase_descendants(command.settings())?;
+    let (num_rebased, extra_msg) = if args.restore_descendants {
+        (
+            tx.repo_mut().reparent_descendants(command.settings())?,
+            " (while preserving their content)",
+        )
+    } else {
+        (tx.repo_mut().rebase_descendants(command.settings())?, "")
+    };
 
     if let Some(mut formatter) = ui.status_formatter() {
         if to_abandon.len() == 1 {
@@ -88,7 +98,8 @@ pub(crate) fn cmd_abandon(
         if num_rebased > 0 {
             writeln!(
                 formatter,
-                "Rebased {num_rebased} descendant commits onto parents of abandoned commits"
+                "Rebased {num_rebased} descendant commits{extra_msg} onto parents of abandoned \
+                 commits",
             )?;
         }
     }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -207,6 +207,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 ###### **Options:**
 
 * `-s`, `--summary` — Do not print every abandoned commit on a separate line
+* `--restore-descendants` — Do not modify the content of the children of the abandoned commits
 
 
 


### PR DESCRIPTION
This factors out the code to emit an extra message "(while preserving their content)" when descendant commits have been reparented instead of rebased, and adds the `--restore-descendants` option to `abandon`, akin to `diffedit --restore-descendants`

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
