### PR TITLE
Update CHANGELOG to mention deprecation of `file()` for `files()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   commit to commit. It now either follows the flags `--edit|--no-edit` or it
   gets the mode from `ui.movement.edit`.
 
-* `conflict` revset has been renamed to `conflicts`. With this, all revsets that
-  could potentially return multiple results are named in the plural.
+* `conflict()` and `file()` revsets have been renamed to `conflicts()` and `files()`
+  respectively. With this, all revsets that could potentially return multiple
+  results are named in the plural.
 
 ### Deprecations
 


### PR DESCRIPTION
I missed this update in #4334.

Issue: #4122

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
