### PR TITLE
revset: fix copy-paste error in conflict() deprecation message

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -843,7 +843,7 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
         // TODO: Remove in jj 0.28+
         if function.name != "conflicts" {
             diagnostics.add_warning(RevsetParseError::expression(
-                "file() is deprecated; use files() instead",
+                "conflict() is deprecated; use conflicts() instead",
                 function.name_span,
             ));
         }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
