### PR TITLE
changelog: `conflict()` and `file()` deprecations are yet unreleased.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `git.push-branch-prefix` config has been deprecated in favor of
   `git.push-bookmark-prefix`.
 
+* `conflict()` and `file()` revsets have been renamed to `conflicts()` and `files()`
+  respectively. The old names are still around and will be removed in a future
+  release.
+
 ### New features
 
 * The new config option `snapshot.auto-track` lets you automatically track only
@@ -93,10 +97,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `next/prev` will no longer infer when to go into edit mode when moving from
   commit to commit. It now either follows the flags `--edit|--no-edit` or it
   gets the mode from `ui.movement.edit`.
-
-* `conflict()` and `file()` revsets have been renamed to `conflicts()` and `files()`
-  respectively. With this, all revsets that could potentially return multiple
-  results are named in the plural.
 
 ### Deprecations
 


### PR DESCRIPTION
Move this update under `Unreleased`. I started the change before the last release and after rebasing, forgot to move it. Fixing it now thanks to @yuja catching this on time.

Issue: #4122
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
