### PR TITLE
split: do not prevent all changes from going into the parent commit, and a fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj git fetch -b <remote-git-branch-name>` will now warn if the branch(es)
    can not be found in any of the specified/configured remotes.
 
+* `jj split` now lets the user select all changes in interactive mode. This may be used
+  to keeping all changes into the first commit while keeping the current commit
+  description for the second commit (the newly created empty one).
+
 ### Fixed bugs
 
 * Update working copy before reporting changes. This prevents errors during reporting

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -99,8 +99,7 @@ You are splitting a commit into two: {}
 The diff initially shows the changes in the commit you're splitting.
 
 Adjust the right side until it shows the contents you want for the first commit.
-The remainder will be in the second commit. If you don't make any changes, then
-the operation will be aborted.
+The remainder will be in the second commit.
 ",
             tx.format_commit_summary(&commit)
         )
@@ -109,12 +108,13 @@ the operation will be aborted.
     // Prompt the user to select the changes they want for the first commit.
     let selected_tree_id =
         diff_selector.select(&base_tree, &end_tree, matcher.as_ref(), format_instructions)?;
-    if &selected_tree_id == commit.tree_id() && diff_selector.is_interactive() {
+    if &selected_tree_id == commit.tree_id() {
         // The user selected everything from the original commit.
-        writeln!(ui.status(), "Nothing changed.")?;
-        return Ok(());
-    }
-    if selected_tree_id == base_tree.id() {
+        writeln!(
+            ui.warning_default(),
+            "All changes have been selected, so the second commit will be empty"
+        )?;
+    } else if selected_tree_id == base_tree.id() {
         // The user selected nothing, so the first commit will be empty.
         writeln!(
             ui.warning_default(),

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -118,8 +118,7 @@ the operation will be aborted.
         // The user selected nothing, so the first commit will be empty.
         writeln!(
             ui.warning_default(),
-            "The given paths do not match any file: {}",
-            args.paths.join(" ")
+            "No changes have been selected, so the first commit will be empty"
         )?;
     }
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -102,13 +102,14 @@ fn test_split_by_paths() {
     test_env.set_up_fake_editor();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: All changes have been selected, so the second commit will be empty
     Rebased 1 descendant commits
     First part: qpvuntsm 9da0eea0 (no description set)
     Second part: znkkpsqq 5b5714a3 (empty) (no description set)
     Working copy now at: zsuskuln 0c798ee7 (no description set)
     Parent commit      : znkkpsqq 5b5714a3 (empty) (no description set)
-    "###);
+    "#);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
@@ -576,15 +577,14 @@ fn test_split_interactive() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split"]);
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r#"
     You are splitting a commit into two: qpvuntsm 44af2155 (no description set)
 
     The diff initially shows the changes in the commit you're splitting.
 
     Adjust the right side until it shows the contents you want for the first commit.
-    The remainder will be in the second commit. If you don't make any changes, then
-    the operation will be aborted.
-    "###);
+    The remainder will be in the second commit.
+    "#);
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -129,14 +129,14 @@ fn test_split_by_paths() {
     test_env.set_up_fake_editor();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: The given paths do not match any file: nonexistent
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: No changes have been selected, so the first commit will be empty
     Rebased 1 descendant commits
     First part: qpvuntsm bd42f95a (empty) (no description set)
     Second part: lylxulpl ed55c86b (no description set)
     Working copy now at: zsuskuln 1e1ed741 (no description set)
     Parent commit      : lylxulpl ed55c86b (no description set)
-    "###);
+    "#);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false


### PR DESCRIPTION
Allowing to put everything into the first commit closes #4533.

**Question:** should we suggest using `jj undo` if everything was put into one of the two commits in case the user didn't want to do this? Or, do we want this only if, in addition, the empty commit has an empty description, because there should be no reason to create an empty commit?

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
