### PR TITLE
changelog: make indentation consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,18 +88,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   flag. When used, descendants of the edited or deleted commits will keep their original
   content.
 
- * `jj git fetch -b <remote-git-branch-name>` will now warn if the branch(es)
+* `jj git fetch -b <remote-git-branch-name>` will now warn if the branch(es)
    can not be found in any of the specified/configured remotes.
 
 ### Fixed bugs
 
- * Update working copy before reporting changes. This prevents errors during reporting
-   from leaving the working copy in a stale state.
+* Update working copy before reporting changes. This prevents errors during reporting
+  from leaving the working copy in a stale state.
 
- * Fixed panic when parsing invalid conflict markers of a particular form.
-   ([#2611](https://github.com/martinvonz/jj/pull/2611))
+* Fixed panic when parsing invalid conflict markers of a particular form.
+  ([#2611](https://github.com/martinvonz/jj/pull/2611))
 
- * Editing a hidden commit now makes it visible.
+* Editing a hidden commit now makes it visible.
 
 ## [0.21.0] - 2024-09-04
 


### PR DESCRIPTION
The space inconsistencies between the "New features" and "Fixed bugs" sections of the upcoming release even led me to introduce one more when moving an item in a previous change.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
