### PR TITLE
Add new command `jj config unset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Add a new template alias `bultin_log_compact_full_description()`.
 
+* New command `jj config unset` that unsets config values. For example,
+  `jj config unset --user user.name`.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -17,6 +17,7 @@ mod get;
 mod list;
 mod path;
 mod set;
+mod unset;
 
 use tracing::instrument;
 
@@ -30,6 +31,8 @@ use self::path::cmd_config_path;
 use self::path::ConfigPathArgs;
 use self::set::cmd_config_set;
 use self::set::ConfigSetArgs;
+use self::unset::cmd_config_unset;
+use self::unset::ConfigUnsetArgs;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::config::ConfigSource;
@@ -82,6 +85,8 @@ pub(crate) enum ConfigCommand {
     Path(ConfigPathArgs),
     #[command(visible_alias("s"))]
     Set(ConfigSetArgs),
+    #[command(visible_alias("u"))]
+    Unset(ConfigUnsetArgs),
 }
 
 #[instrument(skip_all)]
@@ -96,5 +101,6 @@ pub(crate) fn cmd_config(
         ConfigCommand::List(args) => cmd_config_list(ui, command, args),
         ConfigCommand::Path(args) => cmd_config_path(ui, command, args),
         ConfigCommand::Set(args) => cmd_config_set(ui, command, args),
+        ConfigCommand::Unset(args) => cmd_config_unset(ui, command, args),
     }
 }

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tracing::instrument;
+
+use super::ConfigLevelArgs;
+use crate::cli_util::get_new_config_file_path;
+use crate::cli_util::CommandHelper;
+use crate::command_error::user_error;
+use crate::command_error::CommandError;
+use crate::config::remove_config_value_from_file;
+use crate::config::ConfigNamePathBuf;
+use crate::ui::Ui;
+
+/// Update config file to unset the given option.
+#[derive(clap::Args, Clone, Debug)]
+pub struct ConfigUnsetArgs {
+    #[arg(required = true)]
+    name: ConfigNamePathBuf,
+    #[command(flatten)]
+    level: ConfigLevelArgs,
+}
+
+#[instrument(skip_all)]
+pub fn cmd_config_unset(
+    _ui: &mut Ui,
+    command: &CommandHelper,
+    args: &ConfigUnsetArgs,
+) -> Result<(), CommandError> {
+    let config_path = get_new_config_file_path(&args.level.expect_source_kind(), command)?;
+    if config_path.is_dir() {
+        return Err(user_error(format!(
+            "Can't set config in path {path} (dirs not supported)",
+            path = config_path.display()
+        )));
+    }
+
+    remove_config_value_from_file(&args.name, &config_path)
+}

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -30,6 +30,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj config list`↴](#jj-config-list)
 * [`jj config path`↴](#jj-config-path)
 * [`jj config set`↴](#jj-config-set)
+* [`jj config unset`↴](#jj-config-unset)
 * [`jj describe`↴](#jj-describe)
 * [`jj diff`↴](#jj-diff)
 * [`jj diffedit`↴](#jj-diffedit)
@@ -479,6 +480,7 @@ For file locations, supported config options, and other details about jj config,
 * `list` — List variables set in config file, along with their values
 * `path` — Print the path to the config file
 * `set` — Update config file to set the given option to a given value
+* `unset` — Update config file to unset the given option
 
 
 
@@ -572,6 +574,23 @@ Update config file to set the given option to a given value
 
 * `<NAME>`
 * `<VALUE>`
+
+###### **Options:**
+
+* `--user` — Target the user-level config
+* `--repo` — Target the repo-level config
+
+
+
+## `jj config unset`
+
+Update config file to unset the given option
+
+**Usage:** `jj config unset <--user|--repo> <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>`
 
 ###### **Options:**
 


### PR DESCRIPTION
Allow unsetting config values similar to `git config unset`.

```bash
$ jj config set --user some-key some-val
$ jj config get some-key
some-val
$ jj config unset --user some-key
$ jj config get some-key
Config error: configuration property "some-key" not found
For help, see https://martinvonz.github.io/jj/latest/config/.
```

Unsetting a key, which is part of a table, might leave that table empty. For now we do not delete such empty tables, as there may be cases where an empty table is semantically meaningful (https://github.com/martinvonz/jj/issues/4458#issuecomment-2407109269).

For example:

```toml
[table]
key = "value"

[another-table]
key = "value"
```

Running `jj config unset --user table.key` will leave us with `table` being empty:
```toml
[table]

[another-table]
key = "value"
```

---

Closes #4458

# Checklist
If applicable:

- [x] I have updated CHANGELOG.md
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes