### PR TITLE
cli: make default log revset work without working-copy commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Editing a hidden commit now makes it visible.
 
+* The `present()` revset now suppresses missing working copy error. For example,
+  `present(@)` evaluates to `none()` if the current workspace has no
+  working-copy commit.
+
 ## [0.21.0] - 2024-09-04
 
 ### Breaking changes

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -46,9 +46,10 @@ use crate::ui::Ui;
 /// rendered as a synthetic node labeled "(elided revisions)".
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
-    /// Which revisions to show. If no paths nor revisions are specified, this
-    /// defaults to the `revsets.log` setting, or `@ |
-    /// ancestors(immutable_heads().., 2) | trunk()` if it is not set.
+    /// Which revisions to show
+    ///
+    /// If no paths nor revisions are specified, this defaults to the
+    /// `revsets.log` setting.
     #[arg(long, short)]
     revisions: Vec<RevisionArg>,
     /// Show revisions modifying the given paths

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -389,7 +389,7 @@
                 "log": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",
-                    "default": "@ | ancestors(immutable_heads().., 2) | trunk()"
+                    "default": "present(@) | ancestors(immutable_heads().., 2) | trunk()"
                 },
                 "short-prefixes": {
                     "type": "string",

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -3,7 +3,7 @@
 
 [revsets]
 fix = "reachable(@, mutable())"
-log = "@ | ancestors(immutable_heads().., 2) | trunk()"
+log = "present(@) | ancestors(immutable_heads().., 2) | trunk()"
 
 [revset-aliases]
 'trunk()' = '''

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1221,7 +1221,9 @@ Spans of revisions that are not included in the graph per `--revisions` are rend
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVISIONS>` — Which revisions to show. If no paths nor revisions are specified, this defaults to the `revsets.log` setting, or `@ | ancestors(immutable_heads().., 2) | trunk()` if it is not set
+* `-r`, `--revisions <REVISIONS>` — Which revisions to show
+
+   If no paths nor revisions are specified, this defaults to the `revsets.log` setting.
 * `--reversed` — Show revisions in the opposite order (older revisions first)
 * `-n`, `--limit <LIMIT>` — Limit number of revisions to show
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -218,6 +218,19 @@ fn test_log_default() {
 }
 
 #[test]
+fn test_log_default_without_working_copy() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.jj_cmd_ok(&repo_path, &["workspace", "forget"]);
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
+    insta::assert_snapshot!(stdout, @r#"
+    ◆  zzzzzzzz root() 00000000
+    "#);
+}
+
+#[test]
 fn test_log_builtin_templates() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);

--- a/docs/config.md
+++ b/docs/config.md
@@ -289,7 +289,8 @@ You can configure the revisions `jj log` would show when neither `-r` nor any pa
 revsets.log = "main@origin.."
 ```
 
-The default value for `revsets.log` is `'@ | ancestors(immutable_heads().., 2) | trunk()'`.
+The default value for `revsets.log` is
+`'present(@) | ancestors(immutable_heads().., 2) | trunk()'`.
 
 ### Graph style
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1866,11 +1866,11 @@ fn resolve_symbols(
             RevsetExpression::Present(candidates) => {
                 resolve_symbols(repo, candidates.clone(), symbol_resolver)
                     .or_else(|err| match err {
-                        RevsetResolutionError::NoSuchRevision { .. } => {
+                        RevsetResolutionError::NoSuchRevision { .. }
+                        | RevsetResolutionError::WorkspaceMissingWorkingCopy { .. } => {
                             Ok(RevsetExpression::none())
                         }
-                        RevsetResolutionError::WorkspaceMissingWorkingCopy { .. }
-                        | RevsetResolutionError::EmptyString
+                        RevsetResolutionError::EmptyString
                         | RevsetResolutionError::AmbiguousCommitIdPrefix(_)
                         | RevsetResolutionError::AmbiguousChangeIdPrefix(_)
                         | RevsetResolutionError::StoreError(_)

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -14,6 +14,7 @@
 
 use std::iter;
 use std::path::Path;
+use std::rc::Rc;
 
 use assert_matches::assert_matches;
 use chrono::DateTime;
@@ -388,6 +389,18 @@ fn test_resolve_working_copy() {
         RevsetExpression::working_copy(ws1.clone())
             .resolve_user_expression(mut_repo, &FailingSymbolResolver),
         Err(RevsetResolutionError::WorkspaceMissingWorkingCopy { name }) if name == "ws1"
+    );
+
+    // The error can be suppressed by present()
+    assert_eq!(
+        Rc::new(RevsetExpression::Present(RevsetExpression::working_copy(
+            ws1.clone()
+        )))
+        .evaluate_programmatic(mut_repo)
+        .unwrap()
+        .iter()
+        .collect_vec(),
+        vec![]
     );
 
     // Add some workspaces


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
