### PR TITLE
revset: fix crash on "log --at-op 00000000 -r 'root()'"

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1798,7 +1798,18 @@ fn resolve_commit_ref(
             Ok(wc_commits)
         }
         RevsetCommitRef::VisibleHeads => Ok(repo.view().heads().iter().cloned().collect_vec()),
-        RevsetCommitRef::Root => Ok(vec![repo.store().root_commit_id().clone()]),
+        RevsetCommitRef::Root => {
+            let commit_id = repo.store().root_commit_id();
+            if repo.index().has_id(commit_id) {
+                Ok(vec![commit_id.clone()])
+            } else {
+                // The root commit doesn't exist at the root operation.
+                Err(RevsetResolutionError::NoSuchRevision {
+                    name: "root()".to_owned(),
+                    candidates: vec![],
+                })
+            }
+        }
         RevsetCommitRef::Bookmarks(pattern) => {
             let commit_ids = repo
                 .view()


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
