### PR TITLE
cli: add pointer to the documentation in case of fileset syntax error

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -613,6 +613,10 @@ fn file_pattern_parse_error_hint(err: &FilePatternParseError) -> Option<String> 
 
 fn fileset_parse_error_hint(err: &FilesetParseError) -> Option<String> {
     match err.kind() {
+        FilesetParseErrorKind::SyntaxError => Some(String::from(
+            "See https://martinvonz.github.io/jj/latest/filesets/ for filesets syntax, or for how \
+             to match file paths.",
+        )),
         FilesetParseErrorKind::NoSuchFunction {
             name: _,
             candidates,
@@ -620,7 +624,6 @@ fn fileset_parse_error_hint(err: &FilesetParseError) -> Option<String> {
         FilesetParseErrorKind::InvalidArguments { .. } | FilesetParseErrorKind::Expression(_) => {
             find_source_parse_error_hint(&err)
         }
-        _ => None,
     }
 }
 

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -141,7 +141,7 @@ fn test_bad_function_call() {
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "files(not::a-fileset)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: Failed to parse revset: In fileset expression
     Caused by:
     1:  --> 1:7
@@ -156,7 +156,8 @@ fn test_bad_function_call() {
       |     ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    "###);
+    Hint: See https://martinvonz.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
+    "#);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"files(foo:"bar")"#]);
     insta::assert_snapshot!(stderr, @r###"


### PR DESCRIPTION
Inspired by #4509.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
