### PR TITLE
codespell.yml: allow a proper name in our changelog

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,4 +19,6 @@ jobs:
           check_filenames: true
           check_hidden: true
           skip: ./target,./.jj,*.lock
-          ignore_words_list: crate,NotIn
+          # `Wirth` is the proper name of one of our contributors in the changelog.
+          # It seems Codespell does not allow per-file ignore_word_list.
+          ignore_words_list: crate,NotIn,Wirth


### PR DESCRIPTION
See e.g. https://github.com/martinvonz/jj/actions/runs/11148768488 for the failure this fixes.

