### PR TITLE
Enforce selected clippy lints, and small style fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ testutils = { path = "lib/testutils" }
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"
+flat_map_option = "warn"
 implicit_clone = "warn"
 semicolon_if_nothing_returned = "warn"
 uninlined_format_args = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,8 @@ testutils = { path = "lib/testutils" }
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"
-
+uninlined_format_args = "warn"
+ 
 # Insta suggests compiling these packages in opt mode for faster testing.
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs.
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ testutils = { path = "lib/testutils" }
 explicit_iter_loop = "warn"
 flat_map_option = "warn"
 implicit_clone = "warn"
+needless_for_each = "warn"
 semicolon_if_nothing_returned = "warn"
 uninlined_format_args = "warn"
  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,8 @@ jj-lib = { path = "lib", version = "0.22.0" }
 jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.22.0" }
 testutils = { path = "lib/testutils" }
 
+[workspace.lints.clippy]
+
 # Insta suggests compiling these packages in opt mode for faster testing.
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs.
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ testutils = { path = "lib/testutils" }
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"
+semicolon_if_nothing_returned = "warn"
 uninlined_format_args = "warn"
  
 # Insta suggests compiling these packages in opt mode for faster testing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.22.0" }
 testutils = { path = "lib/testutils" }
 
 [workspace.lints.clippy]
+explicit_iter_loop = "warn"
 
 # Insta suggests compiling these packages in opt mode for faster testing.
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ testutils = { path = "lib/testutils" }
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"
+implicit_clone = "warn"
 semicolon_if_nothing_returned = "warn"
 uninlined_format_args = "warn"
  

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -117,3 +117,6 @@ watchman = ["jj-lib/watchman"]
 # The archive name is jj, not jj-cli. Also, `cargo binstall` gets
 # confused by the `v` before versions in archive name.
 pkg-url = "{ repo }/releases/download/v{ version }/jj-v{ version }-{ target }.{ archive-format }"
+
+[lints]
+workspace = true

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -33,9 +33,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=NIX_JJ_GIT_HASH");
 
     if let Some(git_hash) = get_git_hash() {
-        println!("cargo:rustc-env=JJ_VERSION={}-{}", version, git_hash);
+        println!("cargo:rustc-env=JJ_VERSION={version}-{git_hash}");
     } else {
-        println!("cargo:rustc-env=JJ_VERSION={}", version);
+        println!("cargo:rustc-env=JJ_VERSION={version}");
     }
 }
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -19,7 +19,7 @@ use std::str;
 const GIT_HEAD_PATH: &str = "../.git/HEAD";
 const JJ_OP_HEADS_PATH: &str = "../.jj/repo/op_heads/heads";
 
-fn main() -> std::io::Result<()> {
+fn main() {
     let version = std::env::var("CARGO_PKG_VERSION").unwrap();
 
     if Path::new(GIT_HEAD_PATH).exists() {
@@ -37,8 +37,6 @@ fn main() -> std::io::Result<()> {
     } else {
         println!("cargo:rustc-env=JJ_VERSION={}", version);
     }
-
-    Ok(())
 }
 
 fn get_git_hash() -> Option<String> {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -254,7 +254,7 @@ impl TracingSubscription {
             .modify(|filter| {
                 *filter = tracing_subscriber::EnvFilter::builder()
                     .with_default_directive(tracing::metadata::LevelFilter::DEBUG.into())
-                    .from_env_lossy()
+                    .from_env_lossy();
             })
             .map_err(|err| internal_error_with_message("failed to enable debug logging", err))?;
         tracing::info!("debug logging enabled");

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3311,7 +3311,7 @@ impl CliRunner {
                 .flatten()
                 .map(|path| format!("- {}", path.display()))
                 .join("\n");
-            e.hinted(format!("Check the following config files:\n{}", paths))
+            e.hinted(format!("Check the following config files:\n{paths}"))
         })?;
 
         let string_args = expand_args(ui, &self.app, env::args_os(), &config)?;

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -352,7 +352,7 @@ impl From<SnapshotError> for CommandError {
                         size_diff, max_size.0, max_size,
                     )
                 } else {
-                    format!("it is {}; the maximum size allowed is ~{}.", size, max_size,)
+                    format!("it is {size}; the maximum size allowed is ~{max_size}.")
                 };
 
                 user_error(format!(

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -92,7 +92,7 @@ pub fn cmd_bookmark_track(
         };
 
         let mut remote_per_bookmark: HashMap<&str, Vec<&str>> = HashMap::new();
-        for n in names.iter() {
+        for n in &names {
             remote_per_bookmark
                 .entry(&n.bookmark)
                 .or_default()

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -100,7 +100,7 @@ fn check_wc_author(
             AuthorChange::Email => &author.email,
         };
         if new_value.as_str() != Some(orig_value) {
-            warn_wc_author(ui, &author.name, &author.email)?
+            warn_wc_author(ui, &author.name, &author.email)?;
         }
     }
     Ok(())

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -173,7 +173,7 @@ pub(crate) fn cmd_fix(
     // reliably produce well formatted code anyway. Deduplicating inputs helps
     // to prevent quadratic growth in the number of tool executions required for
     // doing this in long chains of commits with disjoint sets of modified files.
-    let commits: Vec<_> = RevsetExpression::commits(root_commits.to_vec())
+    let commits: Vec<_> = RevsetExpression::commits(root_commits.clone())
         .descendants()
         .evaluate_programmatic(tx.base_repo().as_ref())?
         .iter()

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -123,7 +123,7 @@ pub struct GitPushArgs {
 
 fn make_bookmark_term(bookmark_names: &[impl fmt::Display]) -> String {
     match bookmark_names {
-        [bookmark_name] => format!("bookmark {}", bookmark_name),
+        [bookmark_name] => format!("bookmark {bookmark_name}"),
         bookmark_names => format!("bookmarks {}", bookmark_names.iter().join(", ")),
     }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -74,7 +74,7 @@ pub(crate) fn cmd_init(
             ui.warning_default(),
             "`--git` and `--git-repo` are deprecated.
 Use `jj git init` instead"
-        )?
+        )?;
     } else {
         if !command.settings().allow_native_backend() {
             return Err(user_error_with_hint(

--- a/cli/src/commands/operation/abandon.rs
+++ b/cli/src/commands/operation/abandon.rs
@@ -134,7 +134,7 @@ pub fn cmd_op_abandon(
         let mut locked_ws = workspace.start_working_copy_mutation()?;
         let old_op_id = locked_ws.locked_wc().old_operation_id();
         if let Some((_, new_id)) = reparented_head_ops().find(|(old, _)| old.id() == old_op_id) {
-            locked_ws.finish(new_id.clone())?
+            locked_ws.finish(new_id.clone())?;
         } else {
             writeln!(
                 ui.warning_default(),

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -383,13 +383,13 @@ fn write_modified_change_summary(
     modified_change: &ModifiedChange,
 ) -> Result<(), std::io::Error> {
     writeln!(formatter, "Change {}", short_change_hash(change_id))?;
-    for commit in modified_change.added_commits.iter() {
+    for commit in &modified_change.added_commits {
         formatter.with_label("diff", |formatter| write!(formatter.labeled("added"), "+"))?;
         write!(formatter, " ")?;
         commit_summary_template.format(commit, formatter)?;
         writeln!(formatter)?;
     }
-    for commit in modified_change.removed_commits.iter() {
+    for commit in &modified_change.removed_commits {
         formatter.with_label("diff", |formatter| {
             write!(formatter.labeled("removed"), "-")
         })?;

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -282,7 +282,7 @@ pub fn show_op_diff(
         })?;
         for (name, (from_target, to_target)) in changed_local_bookmarks {
             with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{}:", name)?;
+                writeln!(formatter, "{name}:")?;
                 write_ref_target_summary(
                     formatter,
                     current_repo,
@@ -310,7 +310,7 @@ pub fn show_op_diff(
         with_content_format.write(formatter, |formatter| writeln!(formatter, "Changed tags:"))?;
         for (name, (from_target, to_target)) in changed_tags {
             with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{}:", name)?;
+                writeln!(formatter, "{name}:")?;
                 write_ref_target_summary(
                     formatter,
                     current_repo,
@@ -351,7 +351,7 @@ pub fn show_op_diff(
         };
         for ((name, remote_name), (from_ref, to_ref)) in changed_remote_bookmarks {
             with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{}@{}:", name, remote_name)?;
+                writeln!(formatter, "{name}@{remote_name}:")?;
                 write_ref_target_summary(
                     formatter,
                     current_repo,
@@ -422,7 +422,7 @@ fn write_ref_target_summary(
         })?;
         write!(formatter, " ")?;
         if let Some(prefix) = prefix {
-            write!(formatter, "{} ", prefix)?;
+            write!(formatter, "{prefix} ")?;
         }
         Ok(())
     };

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -375,7 +375,7 @@ fn rebase_descendants(
     old_commits: &[impl Borrow<Commit>],
     rebase_options: RebaseOptions,
 ) -> Result<usize, CommandError> {
-    for old_commit in old_commits.iter() {
+    for old_commit in old_commits {
         let rewriter = CommitRewriter::new(
             tx.repo_mut(),
             old_commit.borrow().clone(),
@@ -414,7 +414,7 @@ fn rebase_descendants_transaction(
     if old_commits.is_empty() {
         return Ok(());
     }
-    for old_commit in old_commits.iter() {
+    for old_commit in &old_commits {
         check_rebase_destinations(workspace_command.repo(), &new_parents, old_commit)?;
     }
     let mut tx = workspace_command.start_transaction();
@@ -445,7 +445,7 @@ fn rebase_revisions(
     }
 
     workspace_command.check_rewritable(target_commits.iter().ids())?;
-    for commit in target_commits.iter() {
+    for commit in target_commits {
         if new_parents.contains(commit) {
             return Err(user_error(format!(
                 "Cannot rebase {} onto itself",

--- a/cli/src/commands/sparse.rs
+++ b/cli/src/commands/sparse.rs
@@ -177,7 +177,7 @@ fn edit_sparse(
                 workspace_relative_sparse_path.display()
             ))
         })?;
-        writeln!(&mut content, "{}", path_string).unwrap();
+        writeln!(&mut content, "{path_string}").unwrap();
     }
 
     let content = edit_temp_file(

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -93,7 +93,7 @@ pub(crate) fn cmd_status(
                 formatter.labeled("conflict"),
                 "There are unresolved conflicts at these paths:"
             )?;
-            print_conflicted_paths(&conflicts, formatter, &workspace_command)?
+            print_conflicted_paths(&conflicts, formatter, &workspace_command)?;
         }
 
         let template = workspace_command.commit_summary_template();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -715,7 +715,7 @@ impl fmt::Display for CommandNameAndArgs {
             // TODO: format with shell escapes
             CommandNameAndArgs::Vec(a) => write!(f, "{}", a.0.join(" ")),
             CommandNameAndArgs::Structured { env, command } => {
-                for (k, v) in env.iter() {
+                for (k, v) in env {
                     write!(f, "{k}={v} ")?;
                 }
                 write!(f, "{}", command.0.join(" "))

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -498,10 +498,10 @@ pub fn default_config() -> config::Config {
         .add_source(from_toml!("config/revsets.toml"))
         .add_source(from_toml!("config/templates.toml"));
     if cfg!(unix) {
-        builder = builder.add_source(from_toml!("config/unix.toml"))
+        builder = builder.add_source(from_toml!("config/unix.toml"));
     }
     if cfg!(windows) {
-        builder = builder.add_source(from_toml!("config/windows.toml"))
+        builder = builder.add_source(from_toml!("config/windows.toml"));
     }
     builder.build().unwrap()
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -323,7 +323,7 @@ impl LayeredConfigs {
                         config_vals.push(AnnotatedValue {
                             path,
                             value: value.to_owned(),
-                            source: source.to_owned(),
+                            source: source.clone(),
                             // Note: Value updated below.
                             is_overridden: false,
                         });
@@ -888,8 +888,8 @@ mod tests {
     fn test_layered_configs_resolved_config_values_empty() {
         let empty_config = config::Config::default();
         let layered_configs = LayeredConfigs {
-            default: empty_config.to_owned(),
-            env_base: empty_config.to_owned(),
+            default: empty_config.clone(),
+            env_base: empty_config.clone(),
             user: None,
             repo: None,
             env_overrides: empty_config,
@@ -919,7 +919,7 @@ mod tests {
             .build()
             .unwrap();
         let layered_configs = LayeredConfigs {
-            default: empty_config.to_owned(),
+            default: empty_config.clone(),
             env_base: env_base_config,
             user: None,
             repo: Some(repo_config),
@@ -1042,8 +1042,8 @@ mod tests {
             .build()
             .unwrap();
         let layered_configs = LayeredConfigs {
-            default: empty_config.to_owned(),
-            env_base: empty_config.to_owned(),
+            default: empty_config.clone(),
+            env_base: empty_config.clone(),
             user: Some(user_config),
             repo: Some(repo_config),
             env_overrides: empty_config,

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -73,7 +73,7 @@ pub fn edit_multiple_descriptions(
         JJ: - The syntax of the separator lines may change in the future.
 
     "#});
-    for (commit_id, temp_commit) in commits.iter() {
+    for (commit_id, temp_commit) in commits {
         let commit_hash = short_commit_hash(commit_id);
         bulk_message.push_str("JJ: describe ");
         bulk_message.push_str(&commit_hash);

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -39,10 +39,9 @@ pub fn edit_description(
     settings: &UserSettings,
 ) -> Result<String, CommandError> {
     let description = format!(
-        r#"{}
+        r#"{description}
 JJ: Lines starting with "JJ: " (like this one) will be removed.
-"#,
-        description
+"#
     );
 
     let description = edit_temp_file(

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1282,7 +1282,7 @@ fn show_diff_line_tokens(
         match token_type {
             DiffTokenType::Matching => formatter.write_all(content)?,
             DiffTokenType::Different => {
-                formatter.with_label("token", |formatter| formatter.write_all(content))?
+                formatter.with_label("token", |formatter| formatter.write_all(content))?;
             }
         }
     }
@@ -1402,7 +1402,7 @@ pub fn show_diff_summary(
                     CopyOperation::Rename => ("renamed", "R"),
                 };
                 let path = path_converter.format_copied_path(before_path, after_path);
-                writeln!(formatter.labeled(label), "{sigil} {path}")?
+                writeln!(formatter.labeled(label), "{sigil} {path}")?;
             } else {
                 let path = path_converter.format_file_path(after_path);
                 match (before.is_present(), after.is_present()) {

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -553,7 +553,7 @@ impl<W: Write> Formatter for ColorFormatter<W> {
     fn pop_label(&mut self) -> io::Result<()> {
         self.labels.pop();
         if self.labels.is_empty() {
-            self.write_new_style()?
+            self.write_new_style()?;
         }
         Ok(())
     }

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -395,7 +395,7 @@ impl<W: Write> ColorFormatter<W> {
         }
         if let Some(d) = new_debug {
             if !d.is_empty() {
-                write!(self.output, "<<{}::", d)?;
+                write!(self.output, "<<{d}::")?;
             }
             self.current_debug = Some(d);
         }
@@ -471,7 +471,7 @@ fn color_for_name_or_hex(name_or_hex: &str) -> Result<Color, config::ConfigError
         "bright cyan" => Ok(Color::Cyan),
         "bright white" => Ok(Color::White),
         _ => color_for_hex(name_or_hex)
-            .ok_or_else(|| config::ConfigError::Message(format!("invalid color: {}", name_or_hex))),
+            .ok_or_else(|| config::ConfigError::Message(format!("invalid color: {name_or_hex}"))),
     }
 }
 
@@ -786,7 +786,7 @@ mod tests {
         for [label, color] in labels_and_colors {
             // Use the color name as the label.
             config_builder = config_builder
-                .set_override(format!("colors.{}", label), color)
+                .set_override(format!("colors.{label}"), color)
                 .unwrap();
         }
         let mut output: Vec<u8> = vec![];

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -265,7 +265,7 @@ fn make_diff_sections(
                         .split_inclusive('\n')
                         .map(|line| Cow::Owned(line.to_owned()))
                         .collect(),
-                })
+                });
             }
             DiffHunk::Different(sides) => {
                 assert_eq!(sides.len(), 2, "only two inputs were provided to the diff");
@@ -285,7 +285,7 @@ fn make_diff_sections(
                         make_section_changed_lines(right_side, scm_record::ChangeType::Added),
                     ]
                     .concat(),
-                })
+                });
             }
         }
     }
@@ -361,7 +361,7 @@ pub fn make_diff_files(
                     is_checked: false,
                     old_description: None,
                     new_description: Some(Cow::Owned(describe_binary(hash.as_deref(), num_bytes))),
-                })
+                });
             }
 
             (
@@ -426,7 +426,7 @@ pub fn make_diff_files(
                     is_checked: false,
                     old_description: Some(Cow::Owned(describe_binary(hash.as_deref(), num_bytes))),
                     new_description: None,
-                })
+                });
             }
         }
 
@@ -507,7 +507,7 @@ pub fn apply_diff_builtin(
                         executable: file.get_file_mode()
                             == Some(scm_record::FileMode(mode::EXECUTABLE)),
                     }),
-                )
+                );
             }
         }
     }

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -800,7 +800,7 @@ mod tests {
         );
 
         let mut files = files;
-        for file in files.iter_mut() {
+        for file in &mut files {
             file.toggle_all();
         }
         let all_changes_tree_id =
@@ -864,7 +864,7 @@ mod tests {
         );
 
         let mut files = files;
-        for file in files.iter_mut() {
+        for file in &mut files {
             file.toggle_all();
         }
         let all_changes_tree_id =
@@ -928,7 +928,7 @@ mod tests {
         );
 
         let mut files = files;
-        for file in files.iter_mut() {
+        for file in &mut files {
             file.toggle_all();
         }
         let all_changes_tree_id =
@@ -993,7 +993,7 @@ mod tests {
         );
 
         let mut files = files;
-        for file in files.iter_mut() {
+        for file in &mut files {
             file.toggle_all();
         }
         let all_changes_tree_id =

--- a/cli/src/movement_util.rs
+++ b/cli/src/movement_util.rs
@@ -101,7 +101,7 @@ impl Direction {
 
         let template = workspace_command.commit_summary_template();
         let mut cmd_err = user_error(err_msg);
-        commits.iter().for_each(|commit| {
+        for commit in commits {
             cmd_err.add_formatted_hint_with(|formatter| {
                 if args.should_edit {
                     write!(formatter, "Working copy: ")?;
@@ -110,7 +110,7 @@ impl Direction {
                 }
                 template.format(commit, formatter)
             });
-        });
+        }
 
         cmd_err
     }

--- a/cli/src/movement_util.rs
+++ b/cli/src/movement_util.rs
@@ -109,7 +109,7 @@ impl Direction {
                     write!(formatter, "Working copy parent: ")?;
                 }
                 template.format(commit, formatter)
-            })
+            });
         });
 
         cmd_err

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -206,7 +206,7 @@ pub struct ConcatTemplate<T>(pub Vec<T>);
 impl<T: Template> Template for ConcatTemplate<T> {
     fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         for template in &self.0 {
-            template.format(formatter)?
+            template.format(formatter)?;
         }
         Ok(())
     }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -632,7 +632,7 @@ impl Ui {
         let default_choice = default.map(|c| if c { "Y" } else { "N" });
 
         let choice = self.prompt_choice(
-            &format!("{} {}", prompt, default_str),
+            &format!("{prompt} {default_str}"),
             &["y", "n", "yes", "no", "Yes", "No", "YES", "NO"],
             default_choice,
         )?;

--- a/cli/testing/fake-formatter.rs
+++ b/cli/testing/fake-formatter.rs
@@ -70,7 +70,7 @@ fn main() -> ExitCode {
     let args: Args = Args::parse();
     // Code formatters tend to print errors before printing the result.
     if let Some(data) = args.stderr {
-        eprint!("{}", data);
+        eprint!("{data}");
     }
     let stdout = if let Some(data) = args.stdout {
         // Other content-altering flags don't apply to --stdout.
@@ -106,14 +106,14 @@ fn main() -> ExitCode {
         }
         stdout
     };
-    print!("{}", stdout);
+    print!("{stdout}");
     if let Some(path) = args.tee {
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)
             .unwrap();
-        write!(file, "{}", stdout).unwrap();
+        write!(file, "{stdout}").unwrap();
     }
     if args.fail {
         ExitCode::FAILURE

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -183,7 +183,7 @@ fn test_config_list_layer() {
     let mut test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.to_owned());
+    test_env.set_config_path(user_config_path.clone());
     let repo_path = test_env.env_root().join("repo");
 
     // User
@@ -456,7 +456,7 @@ fn test_config_set_for_user() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     // Point to a config file since `config set` can't handle directories.
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.to_owned());
+    test_env.set_config_path(user_config_path.clone());
     let repo_path = test_env.env_root().join("repo");
 
     test_env.jj_cmd_ok(
@@ -840,7 +840,7 @@ fn test_config_show_paths() {
     let mut test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.to_owned());
+    test_env.set_config_path(user_config_path.clone());
     let repo_path = test_env.env_root().join("repo");
 
     test_env.jj_cmd_ok(

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -433,8 +433,8 @@ fn test_diff_types() {
             &[
                 "diff",
                 "--types",
-                &format!(r#"--from=description("{}")"#, from),
-                &format!(r#"--to=description("{}")"#, to),
+                &format!(r#"--from=description("{from}")"#),
+                &format!(r#"--to=description("{to}")"#),
             ],
         )
     };

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -618,7 +618,7 @@ fn test_git_colocated_external_checkout() {
     let git_check_out_ref = |name| {
         git_repo
             .set_head_detached(git_repo.find_reference(name).unwrap().target().unwrap())
-            .unwrap()
+            .unwrap();
     };
 
     test_env.jj_cmd_ok(&repo_path, &["git", "init", "--git-repo=."]);

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -328,7 +328,7 @@ fn test_log_null_terminate_multiline_descriptions() {
     insta::assert_debug_snapshot!(
         stdout,
         @r###""commit 3 line 1\n\ncommit 3 line 2\n\0commit 2 line 1\n\ncommit 2 line 2\n\0commit 1 line 1\n\ncommit 1 line 2\n\0""###
-    )
+    );
 }
 
 #[test]

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -610,7 +610,7 @@ fn test_prev_prompts_on_multiple_parents() {
     Hint: Working copy parent: mzvwutvl bc4f4fe3 (empty) third
     Hint: Working copy parent: kkmpptxz b0d21db3 (empty) second
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###)
+    "###);
 }
 
 #[test]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -738,7 +738,7 @@ fn test_op_recover_from_bad_gc() {
     let repo_path = test_env.env_root().join("repo");
     let git_object_path = |hex: &str| {
         let (shard, file_name) = hex.split_at(2);
-        let mut file_path = repo_path.to_owned();
+        let mut file_path = repo_path.clone();
         file_path.extend([".git", "objects", shard, file_name]);
         file_path
     };

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -628,7 +628,7 @@ fn test_parallelize_complex_nonlinear_target() {
     │ ○  14ca4df576b3 4 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###)
+    "###);
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -34,7 +34,7 @@ fn test_util_config_schema() {
                 [...]
             }
         }
-        "###)
+        "###);
     });
 }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -100,3 +100,6 @@ git = ["dep:git2", "dep:gix", "dep:gix-filter"]
 vendored-openssl = ["git2/vendored-openssl"]
 watchman = ["dep:tokio", "dep:watchman_client"]
 testing = ["git"]
+
+[lints]
+workspace = true

--- a/lib/benches/diff_bench.rs
+++ b/lib/benches/diff_bench.rs
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 }
 "##,
             ])
-        })
+        });
     });
 }
 

--- a/lib/gen-protos/Cargo.toml
+++ b/lib/gen-protos/Cargo.toml
@@ -9,3 +9,6 @@ license = { workspace = true }
 
 [dependencies]
 prost-build = { workspace = true }
+
+[lints]
+workspace = true

--- a/lib/proc-macros/Cargo.toml
+++ b/lib/proc-macros/Cargo.toml
@@ -20,3 +20,6 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+[lints]
+workspace = true

--- a/lib/proc-macros/src/content_hash.rs
+++ b/lib/proc-macros/src/content_hash.rs
@@ -138,7 +138,7 @@ fn hash_statements_for_enum_fields<'a>(
     let typed_bindings = enum_bindings_with_type(fields);
     let mut hash_statements = Vec::with_capacity(typed_bindings.len() + 1);
     hash_statements.push(quote! {::jj_lib::content_hash::ContentHash::hash(&#ix, state);});
-    for (ty, b) in typed_bindings.iter() {
+    for (ty, b) in &typed_bindings {
         hash_statements.push(quote_spanned! {b.span() =>
             <#ty as ::jj_lib::content_hash::ContentHash>::hash(#b, state);
         });

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -72,7 +72,7 @@ impl PartialOrd for Commit {
 
 impl Hash for Commit {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state)
+        self.id.hash(state);
     }
 }
 

--- a/lib/src/content_hash.rs
+++ b/lib/src/content_hash.rs
@@ -81,7 +81,7 @@ impl<T: ContentHash> ContentHash for [T] {
 
 impl<T: ContentHash> ContentHash for Vec<T> {
     fn hash(&self, state: &mut impl DigestUpdate) {
-        self.as_slice().hash(state)
+        self.as_slice().hash(state);
     }
 }
 
@@ -97,7 +97,7 @@ impl<T: ContentHash> ContentHash for Option<T> {
             None => state.update(&0u32.to_le_bytes()),
             Some(x) => {
                 state.update(&1u32.to_le_bytes());
-                x.hash(state)
+                x.hash(state);
             }
         }
     }

--- a/lib/src/content_hash.rs
+++ b/lib/src/content_hash.rs
@@ -138,7 +138,7 @@ where
 {
     fn hash(&self, state: &mut impl DigestUpdate) {
         state.update(&(self.len() as u64).to_le_bytes());
-        for (k, v) in self.iter() {
+        for (k, v) in self {
             k.hash(state);
             v.hash(state);
         }

--- a/lib/src/default_index/entry.rs
+++ b/lib/src/default_index/entry.rs
@@ -73,7 +73,7 @@ impl Eq for IndexEntry<'_> {}
 
 impl Hash for IndexEntry<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.pos.hash(state)
+        self.pos.hash(state);
     }
 }
 

--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -183,7 +183,7 @@ impl<'a> RevsetGraphWalk<'a> {
                         parent_edges
                             .iter()
                             .filter(|edge| known_ancestors.insert(edge.target)),
-                    )
+                    );
                 }
             }
         }

--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -233,7 +233,7 @@ impl DefaultIndexStore {
                     change_id_length,
                 )?;
                 maybe_parent_file = Some(parent_file.clone());
-                mutable_index = DefaultMutableIndex::incremental(parent_file)
+                mutable_index = DefaultMutableIndex::incremental(parent_file);
             }
         }
 

--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -354,10 +354,7 @@ impl IndexStore for DefaultIndexStore {
                         );
                     }
                     ReadonlyIndexLoadError::Other { name: _, error } => {
-                        eprintln!(
-                            "{err} (maybe the format has changed): {source}. Reindexing...",
-                            source = error
-                        );
+                        eprintln!("{err} (maybe the format has changed): {error}. Reindexing...");
                     }
                 }
                 self.reinit().map_err(|err| IndexReadError(err.into()))?;

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -559,7 +559,7 @@ impl<'input> Diff<'input> {
             others: vec![0..0; self.other_inputs.len()],
         };
         let mut new_unchanged_ranges = vec![];
-        for current in self.unchanged_regions.iter() {
+        for current in &self.unchanged_regions {
             // For the changed region between the previous region and the current one,
             // create a new Diff instance. Then adjust the start positions and
             // offsets to be valid in the context of the larger Diff instance
@@ -591,7 +591,7 @@ impl<'input> Diff<'input> {
     fn compact_unchanged_regions(&mut self) {
         let mut compacted = vec![];
         let mut maybe_previous: Option<UnchangedRange> = None;
-        for current in self.unchanged_regions.iter() {
+        for current in &self.unchanged_regions {
             if let Some(previous) = maybe_previous {
                 if previous.base.end == current.base.start
                     && iter::zip(&previous.others, &current.others)

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn test_find_word_ranges_multibyte() {
-        assert_eq!(find_word_ranges("⊢".as_bytes()), vec![0..3])
+        assert_eq!(find_word_ranges("⊢".as_bytes()), vec![0..3]);
     }
 
     #[test]

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -297,7 +297,7 @@ impl FilesetExpression {
     pub fn explicit_paths(&self) -> impl Iterator<Item = &RepoPath> {
         // pre/post-ordering doesn't matter so long as children are visited from
         // left to right.
-        self.dfs_pre().flat_map(|expr| match expr {
+        self.dfs_pre().filter_map(|expr| match expr {
             FilesetExpression::Pattern(pattern) => pattern.as_path(),
             _ => None,
         })

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -328,7 +328,7 @@ fn build_union_matcher(expressions: &[FilesetExpression]) -> Box<dyn Matcher> {
                     FilePattern::FilePath(path) => file_paths.push(path),
                     FilePattern::PrefixPath(path) => prefix_paths.push(path),
                     FilePattern::FileGlob { dir, pattern } => {
-                        file_globs.push((dir, pattern.clone()))
+                        file_globs.push((dir, pattern.clone()));
                     }
                 }
                 continue;

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1782,10 +1782,10 @@ pub fn parse_gitmodules(
             // TODO Git warns when a duplicate config entry is found, we should
             // consider doing the same.
             ("path", PartialSubmoduleConfig { path: None, .. }) => {
-                map_entry.path = Some(config_value.to_string())
+                map_entry.path = Some(config_value.to_string());
             }
             ("url", PartialSubmoduleConfig { url: None, .. }) => {
-                map_entry.url = Some(config_value.to_string())
+                map_entry.url = Some(config_value.to_string());
             }
             _ => (),
         };

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -956,8 +956,7 @@ impl Backend for GitBackend {
             .try_into_blob()
             .map_err(|err| to_read_object_err(err, id))?;
         let target = String::from_utf8(blob.take_data())
-            .map_err(|err| to_invalid_utf8_err(err.utf8_error(), id))?
-            .to_owned();
+            .map_err(|err| to_invalid_utf8_err(err.utf8_error(), id))?;
         Ok(target)
     }
 

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -85,7 +85,7 @@ where
                 reverse_edges.entry(target).or_default().push(GraphEdge {
                     target: node.clone(),
                     edge_type,
-                })
+                });
             }
             entries.push(node);
         }

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -388,7 +388,7 @@ fn commit_from_proto(mut proto: crate::protos::local_store::Commit) -> Commit {
         MergedTreeId::Merge(merge_builder.build())
     } else {
         assert_eq!(proto.root_tree.len(), 1);
-        MergedTreeId::Legacy(TreeId::new(proto.root_tree[0].to_vec()))
+        MergedTreeId::Legacy(TreeId::new(proto.root_tree[0].clone()))
     };
     let change_id = ChangeId::new(proto.change_id);
     Commit {

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -513,10 +513,10 @@ fn conflict_to_proto(conflict: &Conflict) -> crate::protos::local_store::Conflic
 fn conflict_from_proto(proto: crate::protos::local_store::Conflict) -> Conflict {
     let mut conflict = Conflict::default();
     for term in proto.removes {
-        conflict.removes.push(conflict_term_from_proto(term))
+        conflict.removes.push(conflict_term_from_proto(term));
     }
     for term in proto.adds {
-        conflict.adds.push(conflict_term_from_proto(term))
+        conflict.adds.push(conflict_term_from_proto(term));
     }
     conflict
 }

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -424,7 +424,7 @@ impl<T> FromIterator<T> for MergeBuilder<T> {
 
 impl<T> Extend<T> for MergeBuilder<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        self.values.extend(iter)
+        self.values.extend(iter);
     }
 }
 
@@ -512,7 +512,7 @@ impl<T> Merge<Merge<T>> {
 
 impl<T: ContentHash> ContentHash for Merge<T> {
     fn hash(&self, state: &mut impl DigestUpdate) {
-        self.values.hash(state)
+        self.values.hash(state);
     }
 }
 

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -67,7 +67,7 @@ impl PartialOrd for Operation {
 
 impl Hash for Operation {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state)
+        self.id.hash(state);
     }
 }
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -762,7 +762,7 @@ impl RepoLoader {
                 tx.repo_mut().rebase_descendants(settings)?;
             }
             let tx_description = tx_description.map_or_else(
-                || format!("merge {} operations", num_operations),
+                || format!("merge {num_operations} operations"),
                 |tx_description| tx_description.to_string(),
             );
             let merged_repo = tx.write(tx_description).leave_unpublished();

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1131,7 +1131,7 @@ impl MutableRepo {
                 let commit = self
                     .new_commit(
                         settings,
-                        new_commit_ids.to_vec(),
+                        new_commit_ids.clone(),
                         merged_parents_tree.id().clone(),
                     )
                     .write()?;

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -586,7 +586,7 @@ pub fn move_commits(
             HashMap::new();
         // Iterate through all descendants of the target set, going through children
         // before parents.
-        for commit in target_commits_descendants.iter() {
+        for commit in &target_commits_descendants {
             if !target_commit_external_descendants.contains_key(commit.id()) {
                 let children = if target_commit_ids.contains(commit.id()) {
                     IndexSet::new()

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -171,7 +171,7 @@ impl UserSettings {
     pub const USER_EMAIL_PLACEHOLDER: &'static str = "(no email configured)";
 
     pub fn commit_timestamp(&self) -> Option<Timestamp> {
-        self.timestamp.to_owned()
+        self.timestamp
     }
 
     pub fn operation_timestamp(&self) -> Option<Timestamp> {

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -87,7 +87,7 @@ impl OpHeadsStore for SimpleOpHeadsStore {
         assert!(!old_ids.contains(new_id));
         self.add_op_head(new_id);
         for old_id in old_ids {
-            self.remove_op_head(old_id)
+            self.remove_op_head(old_id);
         }
     }
 

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -609,8 +609,8 @@ impl WorkspaceLoader for DefaultWorkspaceLoader {
     ) -> Result<Box<dyn WorkingCopy>, WorkspaceLoadError> {
         Ok(working_copy_factory.load_working_copy(
             store.clone(),
-            self.workspace_root.to_owned(),
-            self.working_copy_state_path.to_owned(),
+            self.workspace_root.clone(),
+            self.working_copy_state_path.clone(),
         )?)
     }
 }

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -32,7 +32,7 @@ fn copy_directory(src: &Path, dst: &Path) {
         let base_name = child_src.file_name().unwrap();
         let child_dst = dst.join(base_name);
         if child_src.is_dir() {
-            copy_directory(&child_src, &child_dst)
+            copy_directory(&child_src, &child_dst);
         } else {
             std::fs::copy(&child_src, &child_dst).unwrap();
         }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -535,7 +535,7 @@ line 5
             2
         ),
         None
-    )
+    );
 }
 
 #[test]
@@ -631,7 +631,7 @@ fn test_parse_conflict_simple() {
             2
         ),
         @"None"
-    )
+    );
 }
 
 #[test]
@@ -746,7 +746,7 @@ fn test_parse_conflict_wrong_arity() {
             3
         ),
         None
-    )
+    );
 }
 
 #[test]
@@ -767,7 +767,7 @@ fn test_parse_conflict_malformed_missing_removes() {
             2
         ),
         None
-    )
+    );
 }
 
 #[test]
@@ -790,7 +790,7 @@ fn test_parse_conflict_malformed_marker() {
             2
         ),
         None
-    )
+    );
 }
 
 #[test]
@@ -814,7 +814,7 @@ fn test_parse_conflict_malformed_diff() {
             2
         ),
         None
-    )
+    );
 }
 
 #[test]

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -650,7 +650,7 @@ fn test_reindex_corrupt_segment_files() {
         // u32: number of local change ids
         // u32: number of overflow parent entries
         // u32: number of overflow change id positions
-        fs::write(entry.path(), b"\0".repeat(24)).unwrap()
+        fs::write(entry.path(), b"\0".repeat(24)).unwrap();
     }
 
     let repo = load_repo_at_head(&settings, test_repo.repo_path());

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -234,7 +234,7 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
             let path = RepoPathBuf::from_internal_string(format!("{left_kind:?}_{right_kind:?}"));
             write_path(&settings, repo, &mut left_tree_builder, *left_kind, &path);
             write_path(&settings, repo, &mut right_tree_builder, *right_kind, &path);
-            files.push((*left_kind, *right_kind, path.to_owned()));
+            files.push((*left_kind, *right_kind, path.clone()));
         }
     }
     let left_tree_id = left_tree_builder.write_tree(&store).unwrap();

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -541,7 +541,7 @@ fn test_resolve_with_conflict() {
             vec![expected_base1],
             vec![expected_side1, expected_side2]
         ))
-    )
+    );
 }
 
 #[test]

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -25,3 +25,6 @@ jj-lib = { workspace = true, features = ["testing"] }
 pollster = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Right now, we only use the basic Clippy lints. While many software opt to use `clippy::pedantic`, with sometimes individually disabled restrictions, this would be a bit extreme to do in one step (or to do at all, some lints might be intrusive or opiniated).

This PR proposes the activation of selected Clippy lints. Those I have tried so far are:
- `explicit_iter_loop`: prefer iterating over `&collection` rather than `collection.iter()`, this is more compact and idiomatic
- `flat_map_option`: using `.flat_map(f)` when `f` returns an `Option` is equivalent to using `.filter_map(f)`, except that the latter better underlines the filtering aspect
- `implicit_clone`: using `.to_vec()` on a `Vec`, or `.to_owned()` on an owned object can be replaced by `.clone()`, which makes it clearer that we already have something of the right type; at least one `.clone()` call is even superfluous after doing this transformation
- `needless_for_each`: for simple loops (one occurrence currently in the code), using an explicit `for` loop is clearer than using `.for_each()`
- ~~`redundant_else`: we learn very early that using `else` after a block which returns early is useless. This might be the most contentious lint in this list, as it changes the style a bit.~~ *(removed after discussion, see below)*
- `semicolon_if_nothing_returned`: using `;` at the end of expressions returning `()` when we do not explicitly need this unit value better expresses that we have a statement, not just an expression. It increases style consistency.
- `unlined_format_args`: inline variable names in `{}` when interpolating, also for consistency as this is done in 90%+ of the code.

Other lints might be of interest of course, but I gave it a first run in order to test the idea, and find some lints that other developers might feel comfortable with.

If I'm not wrong, all those lints are available in the stable compiler used to run Clippy in the CI.
