### PR TITLE
Fix: Disallow revset names starting with a number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* Revset function names can no longer start with a number.
+
 ### Deprecations
 
 ### New features

--- a/lib/src/fileset.pest
+++ b/lib/src/fileset.pest
@@ -52,7 +52,7 @@ prefix_ops = _{ negate_op }
 infix_ops = _{ union_op | intersection_op | difference_op }
 
 function = { function_name ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")" }
-function_name = @{ (ASCII_ALPHANUMERIC | "_")+ }
+function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 function_arguments = {
   expression ~ (whitespace* ~ "," ~ whitespace* ~ expression)* ~ (whitespace* ~ ",")?
   | ""

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -439,6 +439,14 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_invalid_function_name() {
+        assert_eq!(
+            parse_into_kind("5foo(x)"),
+            Err(FilesetParseErrorKind::SyntaxError)
+        );
+    }
+
+    #[test]
     fn test_parse_whitespace() {
         let ascii_whitespaces: String = ('\x00'..='\x7f')
             .filter(char::is_ascii_whitespace)

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -64,7 +64,7 @@ compat_sub_op = { "-" }
 infix_op = _{ union_op | intersection_op | difference_op | compat_add_op | compat_sub_op }
 
 function = { function_name ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")" }
-function_name = @{ (ASCII_ALPHANUMERIC | "_")+ }
+function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 keyword_argument = { identifier ~ whitespace* ~ "=" ~ whitespace* ~ expression }
 argument = _{ keyword_argument | expression }
 function_arguments = {

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -1337,6 +1337,7 @@ mod tests {
     #[test]
     fn test_parse_revset_alias_func_decl() {
         let mut aliases_map = RevsetAliasesMap::new();
+        assert!(aliases_map.insert("5func()", r#""is function 0""#).is_err());
         aliases_map.insert("func()", r#""is function 0""#).unwrap();
         aliases_map
             .insert("func(a, b)", r#""is function 2""#)


### PR DESCRIPTION
Currently, `5` is a valid function name. This seems incorrect

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
