### PR TITLE
Short first doc paragraph

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -522,13 +522,15 @@ impl ReadonlyUserRepo {
     }
 }
 
-/// A bookmark that should be advanced to satisfy the "advance-bookmarks"
-/// feature. This is a helper for `WorkspaceCommandTransaction`. It provides a
-/// type-safe way to separate the work of checking whether a bookmark can be
-/// advanced and actually advancing it. Advancing the bookmark never fails, but
-/// can't be done until the new `CommitId` is available. Splitting the work in
-/// this way also allows us to identify eligible bookmarks without actually
-/// moving them and return config errors to the user early.
+/// A advanceable bookmark to satisfy the "advance-bookmarks" feature.
+///
+/// This is a helper for `WorkspaceCommandTransaction`. It provides a
+/// type-safe way to separate the work of checking whether a bookmark
+/// can be advanced and actually advancing it. Advancing the bookmark
+/// never fails, but can't be done until the new `CommitId` is
+/// available. Splitting the work in this way also allows us to
+/// identify eligible bookmarks without actually moving them and
+/// return config errors to the user early.
 pub struct AdvanceableBookmark {
     name: String,
     old_commit_id: CommitId,
@@ -1999,7 +2001,8 @@ Then run `jj squash` to move the resolution into the conflicted commit."#,
     }
 }
 
-/// A [`Transaction`] tied to a particular workspace.
+/// An ongoing [`Transaction`] tied to a particular workspace.
+///
 /// `WorkspaceCommandTransaction`s are created with
 /// [`WorkspaceCommandHelper::start_transaction`] and committed with
 /// [`WorkspaceCommandTransaction::finish`]. The inner `Transaction` can also be

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -455,10 +455,11 @@ pub fn existing_config_path() -> Result<Option<PathBuf>, ConfigError> {
     ConfigEnv::new().existing_config_path()
 }
 
-/// Returns a path to the user-specific config file. If no config file is found,
-/// tries to guess a reasonable new location for it. If a path to a new config
-/// file is returned, the parent directory may be created as a result of this
-/// call.
+/// Returns a path to the user-specific config file.
+///
+/// If no config file is found, tries to guess a reasonable new
+/// location for it. If a path to a new config file is returned, the
+/// parent directory may be created as a result of this call.
 pub fn new_config_path() -> Result<Option<PathBuf>, ConfigError> {
     ConfigEnv::new().new_config_path()
 }

--- a/lib/proc-macros/src/lib.rs
+++ b/lib/proc-macros/src/lib.rs
@@ -6,6 +6,8 @@ use quote::quote;
 use syn::parse_macro_input;
 use syn::DeriveInput;
 
+/// Derive macro generating an impl of the trait `ContentHash`.
+///
 /// Derives the `ContentHash` trait for a struct by calling `ContentHash::hash`
 /// on each of the struct members in the order that they're declared. All
 /// members of the struct must implement the `ContentHash` trait.

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -367,10 +367,12 @@ pub fn materialized_diff_stream<'a>(
         .buffered((store.concurrency() / 2).max(1))
 }
 
-/// Parses conflict markers from a slice. Returns None if there were no valid
-/// conflict markers. The caller has to provide the expected number of merge
-/// sides (adds). Conflict markers that are otherwise valid will be considered
-/// invalid if they don't have the expected arity.
+/// Parses conflict markers from a slice.
+///
+/// Returns `None` if there were no valid conflict markers. The caller
+/// has to provide the expected number of merge sides (adds). Conflict
+/// markers that are otherwise valid will be considered invalid if
+/// they don't have the expected arity.
 // TODO: "parse" is not usually the opposite of "materialize", so maybe we
 // should rename them to "serialize" and "deserialize"?
 pub fn parse_conflict(input: &[u8], num_sides: usize) -> Option<Vec<Merge<BString>>> {

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -672,11 +672,13 @@ impl<'diff, 'input> Iterator for DiffHunkIterator<'diff, 'input> {
     }
 }
 
-/// Diffs slices of bytes. The returned diff hunks may be any length (may
-/// span many lines or may be only part of a line). This currently uses
-/// Histogram diff (or maybe something similar; I'm not sure I understood the
-/// algorithm correctly). It first diffs lines in the input and then refines
-/// the changed ranges at the word level.
+/// Diffs slices of bytes.
+///
+/// The returned diff hunks may be any length (may span many lines or
+/// may be only part of a line). This currently uses Histogram diff
+/// (or maybe something similar; I'm not sure I understood the
+/// algorithm correctly). It first diffs lines in the input and then
+/// refines the changed ranges at the word level.
 pub fn diff<'a, T: AsRef<[u8]> + ?Sized + 'a>(
     inputs: impl IntoIterator<Item = &'a T>,
 ) -> Vec<DiffHunk<'a>> {

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Filesystem monitor tool interface.
+//!
 //! Interfaces with a filesystem monitor tool to efficiently query for
 //! filesystem updates, without having to crawl the entire working copy. This is
 //! particularly useful for large working copies, or for working copies for

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -519,10 +519,12 @@ impl<T: ContentHash> ContentHash for Merge<T> {
 /// Borrowed `MergedTreeValue`.
 pub type MergedTreeVal<'a> = Merge<Option<&'a TreeValue>>;
 
-/// The value at a given path in a commit. It depends on the context whether it
-/// can be absent (`Merge::is_absent()`). For example, when getting the value at
-/// a specific path, it may be, but when iterating over entries in a tree, it
-/// shouldn't be.
+/// The value at a given path in a commit.
+///
+/// It depends on the context whether it can be absent
+/// (`Merge::is_absent()`). For example, when getting the value at a
+/// specific path, it may be, but when iterating over entries in a
+/// tree, it shouldn't be.
 pub type MergedTreeValue = Merge<Option<TreeValue>>;
 
 impl MergedTreeValue {

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -1101,10 +1101,13 @@ impl Stream for TreeDiffStreamImpl<'_> {
     }
 }
 
-/// Helps with writing trees with conflicts. You start by creating an instance
-/// of this type with one or more base trees. You then add overrides on top. The
-/// overrides may be conflicts. Then you can write the result as a legacy tree
-/// (allowing path-level conflicts) or as multiple conflict-free trees.
+/// Helper for writing trees with conflicts.
+///
+/// You start by creating an instance of this type with one or more
+/// base trees. You then add overrides on top. The overrides may be
+/// conflicts. Then you can write the result as a legacy tree
+/// (allowing path-level conflicts) or as multiple conflict-free
+/// trees.
 pub struct MergedTreeBuilder {
     base_tree_id: MergedTreeId,
     overrides: BTreeMap<RepoPathBuf, MergedTreeValue>,

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -463,12 +463,14 @@ pub struct MoveCommitsStats {
 }
 
 /// Moves `target_commits` from their current location to a new location in the
-/// graph, given by the set of `new_parent_ids` and `new_children`.
-/// The roots of `target_commits` are rebased onto the new parents, while the
-/// new children are rebased onto the heads of `target_commits`.
-/// This assumes that `target_commits` and `new_children` can be rewritten, and
-/// there will be no cycles in the resulting graph.
-/// `target_commits` should be in reverse topological order.
+/// graph.
+///
+/// The roots of `target_commits` are rebased onto the new parents
+/// given by `new_parent_ids`, while the `new_children` commits are
+/// rebased onto the heads of `target_commits`. This assumes that
+/// `target_commits` and `new_children` can be rewritten, and there
+/// will be no cycles in the resulting graph. `target_commits` should
+/// be in reverse topological order.
 pub fn move_commits(
     settings: &UserSettings,
     mut_repo: &mut MutableRepo,

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A persistent table of fixed-size keys to variable-size values. The keys are
-//! stored in sorted order, with each key followed by an integer offset into the
-//! list of values. The values are concatenated after the keys. A file may have
-//! a parent file, and the parent may have its own parent, and so on. The child
-//! file then represents the union of the entries.
+//! A persistent table of fixed-size keys to variable-size values.
+//!
+//! The keys are stored in sorted order, with each key followed by an
+//! integer offset into the list of values. The values are
+//! concatenated after the keys. A file may have a parent file, and
+//! the parent may have its own parent, and so on. The child file then
+//! represents the union of the entries.
 
 #![allow(missing_docs)]
 

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -164,6 +164,8 @@ pub fn create_op_metadata(
     }
 }
 
+/// An unpublished operation in the store.
+///
 /// An Operation which has been written to the operation store but not
 /// published. The repo can be loaded at an unpublished Operation, but the
 /// Operation will not be visible in the op log if the repo is loaded at head.

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -93,6 +93,8 @@ pub enum WorkspaceLoadError {
     Path(#[from] PathError),
 }
 
+/// The combination of a repo and a working copy.
+///
 /// Represents the combination of a repo and working copy, i.e. what's typically
 /// the .jj/ directory and its parent. See
 /// <https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#workspaces>

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -531,6 +531,8 @@ pub fn assert_rebased_onto(
     new_commit
 }
 
+/// Maps children of an abandoned commit to a new rebase target.
+///
 /// If `expected_old_commit` was abandoned, the `rebased` map indicates the
 /// commit the children of `expected_old_commit` should be rebased to, which
 /// would have a different change id. This happens when the EmptyBehavior in

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -78,11 +78,14 @@ fn get_hash(content: &(impl jj_lib::content_hash::ContentHash + ?Sized)) -> Vec<
     jj_lib::content_hash::blake2b_hash(content).as_slice()[..HASH_LENGTH].to_vec()
 }
 
-/// A commit backend for use in tests. It's meant to be strict, in order to
-/// catch bugs where we make the wrong assumptions. For example, unlike both
-/// `GitBackend` and `LocalBackend`, this backend doesn't share objects written
-/// to different paths (writing a file with contents X to path A will not make
-/// it possible to read that contents from path B given the same `FileId`).
+/// A commit backend for use in tests.
+///
+/// It's meant to be strict, in order to catch bugs where we make the
+/// wrong assumptions. For example, unlike both `GitBackend` and
+/// `LocalBackend`, this backend doesn't share objects written to
+/// different paths (writing a file with contents X to path A will not
+/// make it possible to read that contents from path B given the same
+/// `FileId`).
 pub struct TestBackend {
     root_commit_id: CommitId,
     root_change_id: ChangeId,


### PR DESCRIPTION
This removes the need for ignoring the `too_long_first_doc_paragraph` lint.
