### PR TITLE
docs: mention `snapshot.auto-track` in `config.md` too

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -954,6 +954,19 @@ using `jj debug watchman status`.
 
 ## Snapshot settings
 
+### Paths to automatically track
+
+All new files in the working copy that don't match the ignore patterns are
+tracked by default. You can set the `snapshot.auto-track` to set which paths
+get automatically tracked when they're added to the working copy. See the
+[fileset documentation](filesets.md) for the syntax. Files with paths matching
+[ignore files](working-copy.md#ignored-files) are never tracked automatically.
+
+You can use `jj file untrack` to untrack a file while keeping it in the working
+copy. However, first [ignore](working-copy.md#ignored-files) them or remove them
+from the `snapshot.auto-track` patterns; otherwise they will be immediately
+tracked again.
+
 ### Maximum size for new files
 
 By default, as an anti-footgun measure, `jj` will refuse to add new files to the

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -20,7 +20,7 @@ working copy, it will implicitly be untracked.
 The `snapshot.auto-track` config option controls which paths get automatically
 tracked when they're added to the working copy. See the
 [fileset documentation](filesets.md) for the syntax. Files with paths matching
-[ignore files](#ignored-files) are never tracked automatically
+[ignore files](#ignored-files) are never tracked automatically.
 
 You can use `jj file untrack` to untrack a file while keeping it in the working
 copy. However, first [ignore](#ignored-files) them or remove them from the


### PR DESCRIPTION
I forgot to add the `snapshot.auto-track` config option to `config.md` when I added it. This patch copies it from `working-copy.md` and modifies it slightly.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
