### PR TITLE
Doc: Fixed a doc mass-rename typo related to git branches.

### DIFF
--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -68,7 +68,7 @@ If you want to know the internals of bookmark tracking, consult the
   actual state only when it's actively communicating with the remote. However,
   `jj` does store the last-seen position of the remote bookmark; this is the
   commit `jj show <bookmark name>@<remote name>` would show. This notion is
-  completely analogous to Git's "remote-tracking bookmarks".
+  completely analogous to Git's "remote-tracking branches".
 - A **tracked (remote) bookmark** is defined above. You can make a remote bookmark
   tracked with the [`jj bookmark track` command](#manually-tracking-a-bookmark), for
   example.


### PR DESCRIPTION
I made this change through the github web tooling, I can remake this locally if needed, but it was easier to click the edit button on the web portal.