### PR TITLE
templates: add raw_escape_sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * String literals in filesets, revsets and templates now support hex bytes
   (with `\e` as escape / shorthand for `\x1b`).
 
+* New template function `raw_escape_sequence(...)` preserves escape sequences.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj squash` now supports `-f/-t` shorthands for `--from/--[in]to`.
 
+* String literals in filesets, revsets and templates now support hex bytes
+  (with `\e` as escape / shorthand for `\x1b`).
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -142,7 +142,8 @@ pub(crate) fn cmd_evolog(
         commits.truncate(n);
     }
     if !args.no_graph {
-        let mut graph = get_graphlog(graph_style, formatter.raw());
+        let mut raw_output = formatter.raw();
+        let mut graph = get_graphlog(graph_style, raw_output.as_mut());
         for commit in commits {
             let edges = commit
                 .predecessor_ids()

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -169,7 +169,8 @@ pub(crate) fn cmd_log(
         let limit = args.limit.or(args.deprecated_limit).unwrap_or(usize::MAX);
 
         if !args.no_graph {
-            let mut graph = get_graphlog(graph_style, formatter.raw());
+            let mut raw_output = formatter.raw();
+            let mut graph = get_graphlog(graph_style, raw_output.as_mut());
             let forward_iter = TopoGroupedGraphIterator::new(revset.iter_graph());
             let iter: Box<dyn Iterator<Item = _>> = if args.reversed {
                 Box::new(ReverseGraphIterator::new(forward_iter))

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -197,7 +197,8 @@ pub fn show_op_diff(
             writeln!(formatter, "Changed commits:")
         })?;
         if let Some(graph_style) = graph_style {
-            let mut graph = get_graphlog(graph_style, formatter.raw());
+            let mut raw_output = formatter.raw();
+            let mut graph = get_graphlog(graph_style, raw_output.as_mut());
 
             let graph_iter =
                 TopoGroupedGraphIterator::new(ordered_change_ids.iter().map(|change_id| {

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -197,7 +197,8 @@ fn do_op_log(
     let limit = args.limit.or(args.deprecated_limit).unwrap_or(usize::MAX);
     let iter = op_walk::walk_ancestors(slice::from_ref(current_op)).take(limit);
     if !args.no_graph {
-        let mut graph = get_graphlog(graph_style, formatter.raw());
+        let mut raw_output = formatter.raw();
+        let mut graph = get_graphlog(graph_style, raw_output.as_mut());
         for op in iter {
             let op = op?;
             let mut edges = vec![];

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -365,10 +365,15 @@ impl<'a> DiffRenderer<'a> {
                                 tool,
                             )
                         }
-                        DiffToolMode::Dir => {
-                            generate_diff(ui, formatter.raw(), from_tree, to_tree, matcher, tool)
-                                .map_err(DiffRenderError::DiffGenerate)
-                        }
+                        DiffToolMode::Dir => generate_diff(
+                            ui,
+                            formatter.raw().as_mut(),
+                            from_tree,
+                            to_tree,
+                            matcher,
+                            tool,
+                        )
+                        .map_err(DiffRenderError::DiffGenerate),
                     }?;
                 }
             }
@@ -1098,7 +1103,7 @@ pub fn show_file_by_file_diff(
 
             invoke_external_diff(
                 ui,
-                formatter.raw(),
+                formatter.raw().as_mut(),
                 tool,
                 &maplit::hashmap! {
                     "left" => left_path.to_str().expect("temp_dir should be valid utf-8"),

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -1,11 +1,11 @@
 // Copyright 2020 The Jujutsu Authors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,10 @@
 
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
-string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
+string_escape = @{
+  "\\"
+  ~ ("t" | "r" | "n" | "0" | "e" | ("x" ~ ASCII_HEX_DIGIT{2}) | "\"" | "\\")
+}
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -39,6 +39,7 @@ use crate::templater::ListTemplate;
 use crate::templater::Literal;
 use crate::templater::PlainTextFormattedProperty;
 use crate::templater::PropertyPlaceholder;
+use crate::templater::RawEscapeSequenceTemplate;
 use crate::templater::ReformatTemplate;
 use crate::templater::SeparateTemplate;
 use crate::templater::SizeHint;
@@ -1116,6 +1117,17 @@ fn builtin_functions<'a, L: TemplateLanguage<'a> + ?Sized>() -> TemplateBuildFun
             content, labels,
         ))))
     });
+    map.insert(
+        "raw_escape_sequence",
+        |language, diagnostics, build_ctx, function| {
+            let [content_node] = function.expect_exact_arguments()?;
+            let content =
+                expect_template_expression(language, diagnostics, build_ctx, content_node)?;
+            Ok(L::wrap_template(Box::new(RawEscapeSequenceTemplate(
+                content,
+            ))))
+        },
+    );
     map.insert("if", |language, diagnostics, build_ctx, function| {
         let ([condition_node, true_node], [false_node]) = function.expect_arguments()?;
         let condition =
@@ -2332,6 +2344,47 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(r#"label(if(empty, "error", "warning"), "text")"#),
             @"[38;5;1mtext[39m");
+    }
+
+    #[test]
+    fn test_raw_escape_sequence_function_strip_labels() {
+        let mut env = TestTemplateEnv::new();
+        env.add_color("error", crossterm::style::Color::DarkRed);
+        env.add_color("warning", crossterm::style::Color::DarkYellow);
+
+        insta::assert_snapshot!(
+            env.render_ok(r#"raw_escape_sequence(label("error warning", "text"))"#),
+            @"text",
+        );
+    }
+
+    #[test]
+    fn test_raw_escape_sequence_function_ansi_escape() {
+        let env = TestTemplateEnv::new();
+
+        // Sanitize ANSI escape without raw_escape_sequence
+        insta::assert_snapshot!(env.render_ok(r#""\e""#), @"␛");
+        insta::assert_snapshot!(env.render_ok(r#""\x1b""#), @"␛");
+        insta::assert_snapshot!(env.render_ok(r#""\x1B""#), @"␛");
+        insta::assert_snapshot!(
+            env.render_ok(r#""]8;;"
+                ++ "http://example.com"
+                ++ "\e\\"
+                ++ "Example"
+                ++ "\x1b]8;;\x1B\\""#),
+            @r#"␛]8;;http://example.com␛\Example␛]8;;␛\"#);
+
+        // Don't sanitize ANSI escape with raw_escape_sequence
+        insta::assert_snapshot!(env.render_ok(r#"raw_escape_sequence("\e")"#), @"");
+        insta::assert_snapshot!(env.render_ok(r#"raw_escape_sequence("\x1b")"#), @"");
+        insta::assert_snapshot!(env.render_ok(r#"raw_escape_sequence("\x1B")"#), @"");
+        insta::assert_snapshot!(
+            env.render_ok(r#"raw_escape_sequence("]8;;"
+                ++ "http://example.com"
+                ++ "\e\\"
+                ++ "Example"
+                ++ "\x1b]8;;\x1B\\")"#),
+            @r#"]8;;http://example.com\Example]8;;\"#);
     }
 
     #[test]

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -992,8 +992,8 @@ mod tests {
     fn test_string_literal() {
         // "\<char>" escapes
         assert_eq!(
-            parse_into_kind(r#" "\t\r\n\"\\\0" "#),
-            Ok(ExpressionKind::String("\t\r\n\"\\\0".to_owned())),
+            parse_into_kind(r#" "\t\r\n\"\\\0\e" "#),
+            Ok(ExpressionKind::String("\t\r\n\"\\\0\u{1b}".to_owned())),
         );
 
         // Invalid "\<char>" escape
@@ -1018,6 +1018,28 @@ mod tests {
         assert_eq!(
             parse_into_kind(r#" '"' "#),
             Ok(ExpressionKind::String(r#"""#.to_owned())),
+        );
+
+        // Hex bytes
+        assert_eq!(
+            parse_into_kind(r#""\x61\x65\x69\x6f\x75""#),
+            Ok(ExpressionKind::String("aeiou".to_owned())),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xe0\xe8\xec\xf0\xf9""#),
+            Ok(ExpressionKind::String("àèìðù".to_owned())),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\x""#),
+            Err(TemplateParseErrorKind::SyntaxError),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xf""#),
+            Err(TemplateParseErrorKind::SyntaxError),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xgg""#),
+            Err(TemplateParseErrorKind::SyntaxError),
         );
     }
 

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -709,7 +709,7 @@ impl<'a> TemplateFormatter<'a> {
         move |formatter| TemplateFormatter::new(formatter, error_handler)
     }
 
-    pub fn raw(&mut self) -> &mut dyn Write {
+    pub fn raw(&mut self) -> Box<dyn Write + '_> {
         self.formatter.raw()
     }
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -237,6 +237,8 @@ A double-quoted string literal supports the following escape sequences:
 * `\r`: carriage return
 * `\n`: new line
 * `\0`: null
+* `\e`: escape (i.e., `\x1b`)
+* `\xHH`: byte with hex value `HH`
 
 Other escape sequences are not supported. Any UTF-8 characters are allowed
 inside a string literal, with two exceptions: unescaped `"`-s and uses of `\`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -49,7 +49,9 @@ The following functions are defined.
   the content. The `label` is evaluated as a space-separated string.
 * `raw_escape_sequence(content: Template) -> Template`: Preserves any escape
   sequences in `content` (i.e., bypasses sanitization) and strips labels.
-  Note: Doesn't yet work with wrapped output / `fill(...)` / `indent(...)`.
+  Note: This function is intended for escape sequences and as such, it's output
+  is expected to be invisible / of no display width. Outputting content with
+  nonzero display width may break wrapping, indentation etc.
 * `if(condition: Boolean, then: Template[, else: Template]) -> Template`:
   Conditionally evaluate `then`/`else` template content.
 * `coalesce(content: Template...) -> Template`: Returns the first **non-empty**

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -47,6 +47,9 @@ The following functions are defined.
   non-empty lines by the given `prefix`.
 * `label(label: Template, content: Template) -> Template`: Apply label to
   the content. The `label` is evaluated as a space-separated string.
+* `raw_escape_sequence(content: Template) -> Template`: Preserves any escape
+  sequences in `content` (i.e., bypasses sanitization) and strips labels.
+  Note: Doesn't yet work with wrapped output / `fill(...)` / `indent(...)`.
 * `if(condition: Boolean, then: Template[, else: Template]) -> Template`:
   Conditionally evaluate `then`/`else` template content.
 * `coalesce(content: Template...) -> Template`: Returns the first **non-empty**

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -412,6 +412,12 @@ impl<R: RuleType> StringLiteralParser<R> {
                     "r" => result.push('\r'),
                     "n" => result.push('\n'),
                     "0" => result.push('\0'),
+                    "e" => result.push('\x1b'),
+                    hex if hex.starts_with('x') => {
+                        result.push(char::from(
+                            u8::from_str_radix(&hex[1..], 16).expect("hex characters"),
+                        ));
+                    }
                     char => panic!("invalid escape: \\{char:?}"),
                 }
             } else {

--- a/lib/src/fileset.pest
+++ b/lib/src/fileset.pest
@@ -34,7 +34,10 @@ bare_string = @{
   | '\u{80}'..'\u{10ffff}' )+
 }
 
-string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
+string_escape = @{
+  "\\"
+  ~ ("t" | "r" | "n" | "0" | "e" | ("x" ~ ASCII_HEX_DIGIT{2}) | "\"" | "\\")
+}
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -485,14 +485,14 @@ mod tests {
     fn test_parse_string_literal() {
         // "\<char>" escapes
         assert_eq!(
-            parse_into_kind(r#" "\t\r\n\"\\\0" "#),
-            Ok(ExpressionKind::String("\t\r\n\"\\\0".to_owned()))
+            parse_into_kind(r#" "\t\r\n\"\\\0\e" "#),
+            Ok(ExpressionKind::String("\t\r\n\"\\\0\u{1b}".to_owned())),
         );
 
         // Invalid "\<char>" escape
         assert_eq!(
             parse_into_kind(r#" "\y" "#),
-            Err(FilesetParseErrorKind::SyntaxError)
+            Err(FilesetParseErrorKind::SyntaxError),
         );
 
         // Single-quoted raw string
@@ -511,6 +511,28 @@ mod tests {
         assert_eq!(
             parse_into_kind(r#" '"' "#),
             Ok(ExpressionKind::String(r#"""#.to_owned())),
+        );
+
+        // Hex bytes
+        assert_eq!(
+            parse_into_kind(r#""\x61\x65\x69\x6f\x75""#),
+            Ok(ExpressionKind::String("aeiou".to_owned())),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xe0\xe8\xec\xf0\xf9""#),
+            Ok(ExpressionKind::String("àèìðù".to_owned())),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\x""#),
+            Err(FilesetParseErrorKind::SyntaxError),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xf""#),
+            Err(FilesetParseErrorKind::SyntaxError),
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xgg""#),
+            Err(FilesetParseErrorKind::SyntaxError),
         );
     }
 

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -1,11 +1,11 @@
 // Copyright 2021 The Jujutsu Authors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,10 @@ symbol = _{
   | raw_string_literal
 }
 
-string_escape = @{ "\\" ~ ("t" | "r" | "n" | "0" | "\"" | "\\") }
+string_escape = @{
+  "\\"
+  ~ ("t" | "r" | "n" | "0" | "e" | ("x" ~ ASCII_HEX_DIGIT{2}) | "\"" | "\\")
+}
 string_content_char = @{ !("\"" | "\\") ~ ANY }
 string_content = @{ string_content_char+ }
 string_literal = ${ "\"" ~ (string_content | string_escape)* ~ "\"" }

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -1266,8 +1266,8 @@ mod tests {
     fn test_parse_string_literal() {
         // "\<char>" escapes
         assert_eq!(
-            parse_into_kind(r#" "\t\r\n\"\\\0" "#),
-            Ok(ExpressionKind::String("\t\r\n\"\\\0".to_owned()))
+            parse_into_kind(r#" "\t\r\n\"\\\0\e" "#),
+            Ok(ExpressionKind::String("\t\r\n\"\\\0\u{1b}".to_owned()))
         );
 
         // Invalid "\<char>" escape
@@ -1292,6 +1292,28 @@ mod tests {
         assert_eq!(
             parse_into_kind(r#" '"' "#),
             Ok(ExpressionKind::String(r#"""#.to_owned()))
+        );
+
+        // Hex bytes
+        assert_eq!(
+            parse_into_kind(r#""\x61\x65\x69\x6f\x75""#),
+            Ok(ExpressionKind::String("aeiou".to_owned()))
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xe0\xe8\xec\xf0\xf9""#),
+            Ok(ExpressionKind::String("àèìðù".to_owned()))
+        );
+        assert_eq!(
+            parse_into_kind(r#""\x""#),
+            Err(RevsetParseErrorKind::SyntaxError)
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xf""#),
+            Err(RevsetParseErrorKind::SyntaxError)
+        );
+        assert_eq!(
+            parse_into_kind(r#""\xgg""#),
+            Err(RevsetParseErrorKind::SyntaxError)
         );
     }
 


### PR DESCRIPTION
Templates can be formatted (using labels) and are usually sanitized
(unless for plain text output).
`raw_escape_sequence(content)` bypasses both.

```toml
	'hyperlink(url, text)' = '''
		raw_escape_sequence("\e]8;;" ++ url ++ "\e\\") ++
		text ++
		raw_escape_sequence("\e]8;;\e\\")
	'''
```

In this example, `raw_escape_sequence` not only outputs the intended
escape codes, it also strips away any escape codes that might otherwise
be part of the `url` (from any labels attached to the `url` content).

---

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes