### PR TITLE
squash: move the core functionality to jj_lib

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -135,7 +135,11 @@ new working-copy commit.
         }
         let temp_commit = commit_builder.write_hidden()?;
         let template = description_template(ui, &tx, "", &temp_commit)?;
-        edit_description(tx.base_workspace_helper(), &template, command.settings())?
+        edit_description(
+            tx.base_workspace_helper().repo_path(),
+            &template,
+            command.settings(),
+        )?
     };
     commit_builder.set_description(description);
     let new_commit = commit_builder.write(tx.repo_mut())?;

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -166,8 +166,11 @@ pub(crate) fn cmd_describe(
 
         if let [(_, temp_commit)] = &*temp_commits {
             let template = description_template(ui, &tx, "", temp_commit)?;
-            let description =
-                edit_description(tx.base_workspace_helper(), &template, command.settings())?;
+            let description = edit_description(
+                tx.base_workspace_helper().repo_path(),
+                &template,
+                command.settings(),
+            )?;
 
             vec![(&commits[0], description)]
         } else {

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -140,8 +140,11 @@ The remainder will be in the second commit.
             "Enter a description for the first commit.",
             &temp_commit,
         )?;
-        let description =
-            edit_description(tx.base_workspace_helper(), &template, command.settings())?;
+        let description = edit_description(
+            tx.base_workspace_helper().repo_path(),
+            &template,
+            command.settings(),
+        )?;
         commit_builder.set_description(description);
         commit_builder.write(tx.repo_mut())?
     };
@@ -184,7 +187,11 @@ The remainder will be in the second commit.
                 "Enter a description for the second commit.",
                 &temp_commit,
             )?;
-            edit_description(tx.base_workspace_helper(), &template, command.settings())?
+            edit_description(
+                tx.base_workspace_helper().repo_path(),
+                &template,
+                command.settings(),
+            )?
         };
         commit_builder.set_description(description);
         commit_builder.write(tx.repo_mut())?

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -308,7 +308,7 @@ from the source will be moved into the destination.
                 .filter_map(|source| source.abandon.then_some(source.commit))
                 .collect_vec();
             combine_messages(
-                tx.base_workspace_helper(),
+                tx.base_workspace_helper().repo_path(),
                 &abandoned_commits,
                 destination,
                 settings,

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -16,9 +16,9 @@ use itertools::Itertools as _;
 use jj_lib::commit::Commit;
 use jj_lib::commit::CommitIteratorExt;
 use jj_lib::matchers::Matcher;
-use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
+use jj_lib::rewrite;
 use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
@@ -196,12 +196,6 @@ pub fn move_diff(
     tx.base_workspace_helper()
         .check_rewritable(sources.iter().chain(std::iter::once(destination)).ids())?;
 
-    struct SourceCommit<'a> {
-        commit: &'a Commit,
-        parent_tree: MergedTree,
-        selected_tree: MergedTree,
-        abandon: bool,
-    }
     let mut source_commits = vec![];
     for source in sources {
         let parent_tree = source.parent_tree(tx.repo())?;
@@ -227,105 +221,52 @@ from the source will be moved into the destination.
         let selected_tree_id =
             diff_selector.select(&parent_tree, &source_tree, matcher, format_instructions)?;
         let selected_tree = tx.repo().store().get_root_tree(&selected_tree_id)?;
-        let abandon = !keep_emptied && selected_tree.id() == source_tree.id();
-        if !abandon && selected_tree_id == parent_tree.id() {
-            // Nothing selected from this commit. If it's abandoned (i.e. already empty), we
-            // still include it so `jj squash` can be used for abandoning an empty commit in
-            // the middle of a stack.
-            continue;
-        }
-        // TODO: Do we want to optimize the case of moving to the parent commit (`jj
-        // squash -r`)? The source tree will be unchanged in that case.
-        source_commits.push(SourceCommit {
-            commit: source,
-            parent_tree,
+
+        source_commits.push(rewrite::CommitToSquash {
+            commit: source.clone(),
             selected_tree,
-            abandon,
+            parent_tree,
         });
     }
-    if source_commits.is_empty() {
-        if diff_selector.is_interactive() {
-            return Err(user_error("No changes selected"));
-        }
 
-        if let [only_path] = path_arg {
-            if no_rev_arg
-                && tx
-                    .base_workspace_helper()
-                    .parse_revset(ui, &RevisionArg::from(only_path.to_owned()))
-                    .is_ok()
-            {
-                writeln!(
-                    ui.warning_default(),
-                    "The argument {only_path:?} is being interpreted as a path. To specify a \
-                     revset, pass -r {only_path:?} instead."
-                )?;
+    let repo_path = tx.base_workspace_helper().repo_path().to_owned();
+    match rewrite::squash_commits(
+        settings,
+        tx.repo_mut(),
+        &source_commits,
+        destination,
+        keep_emptied,
+        |abandoned_commits| match description {
+            SquashedDescription::Exact(description) => Ok(description),
+            SquashedDescription::UseDestination => Ok(destination.description().to_owned()),
+            SquashedDescription::Combine => {
+                let abandoned_commits = abandoned_commits.iter().map(|c| &c.commit).collect_vec();
+                combine_messages(&repo_path, &abandoned_commits, destination, settings)
             }
-        }
+        },
+    )? {
+        rewrite::SquashResult::NoChanges => {
+            if diff_selector.is_interactive() {
+                return Err(user_error("No changes selected"));
+            }
 
-        return Ok(());
-    }
+            if let [only_path] = path_arg {
+                if no_rev_arg
+                    && tx
+                        .base_workspace_helper()
+                        .parse_revset(ui, &RevisionArg::from(only_path.to_owned()))
+                        .is_ok()
+                {
+                    writeln!(
+                        ui.warning_default(),
+                        "The argument {only_path:?} is being interpreted as a path. To specify a \
+                         revset, pass -r {only_path:?} instead."
+                    )?;
+                }
+            }
 
-    for source in &source_commits {
-        if source.abandon {
-            tx.repo_mut()
-                .record_abandoned_commit(source.commit.id().clone());
-        } else {
-            let source_tree = source.commit.tree()?;
-            // Apply the reverse of the selected changes onto the source
-            let new_source_tree = source_tree.merge(&source.selected_tree, &source.parent_tree)?;
-            tx.repo_mut()
-                .rewrite_commit(settings, source.commit)
-                .set_tree_id(new_source_tree.id().clone())
-                .write()?;
+            Ok(())
         }
+        rewrite::SquashResult::NewCommit(_) => Ok(()),
     }
-
-    let mut rewritten_destination = destination.clone();
-    if sources
-        .iter()
-        .any(|source| tx.repo().index().is_ancestor(source.id(), destination.id()))
-    {
-        // If we're moving changes to a descendant, first rebase descendants onto the
-        // rewritten sources. Otherwise it will likely already have the content
-        // changes we're moving, so applying them will have no effect and the
-        // changes will disappear.
-        let rebase_map = tx.repo_mut().rebase_descendants_return_map(settings)?;
-        let rebased_destination_id = rebase_map.get(destination.id()).unwrap().clone();
-        rewritten_destination = tx.repo().store().get_commit(&rebased_destination_id)?;
-    }
-    // Apply the selected changes onto the destination
-    let mut destination_tree = rewritten_destination.tree()?;
-    for source in &source_commits {
-        destination_tree = destination_tree.merge(&source.parent_tree, &source.selected_tree)?;
-    }
-    let description = match description {
-        SquashedDescription::Exact(description) => description,
-        SquashedDescription::UseDestination => destination.description().to_owned(),
-        SquashedDescription::Combine => {
-            let abandoned_commits = source_commits
-                .iter()
-                .filter_map(|source| source.abandon.then_some(source.commit))
-                .collect_vec();
-            combine_messages(
-                tx.base_workspace_helper().repo_path(),
-                &abandoned_commits,
-                destination,
-                settings,
-            )?
-        }
-    };
-    let mut predecessors = vec![destination.id().clone()];
-    predecessors.extend(
-        source_commits
-            .iter()
-            .map(|source| source.commit.id().clone()),
-    );
-    tx.repo_mut()
-        .rewrite_commit(settings, &rewritten_destination)
-        .set_tree_id(destination_tree.id().clone())
-        .set_predecessors(predecessors)
-        .set_description(description)
-        .write()?;
-    Ok(())
 }

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -117,7 +117,7 @@ aborted.
     if new_parent_tree_id == parent_base_tree.id() {
         tx.repo_mut().record_abandoned_commit(parent.id().clone());
         let description = combine_messages(
-            tx.base_workspace_helper(),
+            tx.base_workspace_helper().repo_path(),
             &[&parent],
             &commit,
             command.settings(),

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::Write as _;
+use std::path::Path;
 
 use bstr::ByteVec as _;
 use indexmap::IndexMap;
@@ -12,7 +13,6 @@ use thiserror::Error;
 
 use crate::cli_util::edit_temp_file;
 use crate::cli_util::short_commit_hash;
-use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::WorkspaceCommandTransaction;
 use crate::command_error::CommandError;
 use crate::formatter::PlainTextFormatter;
@@ -34,7 +34,7 @@ where
 }
 
 pub fn edit_description(
-    workspace_command: &WorkspaceCommandHelper,
+    repo_path: &Path,
     description: &str,
     settings: &UserSettings,
 ) -> Result<String, CommandError> {
@@ -47,7 +47,7 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
     let description = edit_temp_file(
         "description",
         ".jjdescription",
-        workspace_command.repo_path(),
+        repo_path,
         &description,
         settings,
     )?;
@@ -178,7 +178,7 @@ where
 /// then that one is used. Otherwise we concatenate the messages and ask the
 /// user to edit the result in their editor.
 pub fn combine_messages(
-    workspace_command: &WorkspaceCommandHelper,
+    repo_path: &Path,
     sources: &[&Commit],
     destination: &Commit,
     settings: &UserSettings,
@@ -208,7 +208,7 @@ pub fn combine_messages(
         combined.push_str("\nJJ: Description from source commit:\n");
         combined.push_str(commit.description());
     }
-    edit_description(workspace_command, &combined, settings)
+    edit_description(repo_path, &combined, settings)
 }
 
 /// Create a description from a list of paragraphs.


### PR DESCRIPTION
This allows 'squash' to be executed more easily from a programmatic context

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
