### PR TITLE
templates: make `op_summary` in e.g. `jj undo` output more readable and colorful

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1492,6 +1492,12 @@ impl WorkspaceCommandHelper {
             &self.op_summary_template_text,
             OperationTemplateLanguage::wrap_operation,
         )
+        // TODO: "op_log" is not a great label name for op_summary. We could
+        // replace it with `operation summary` and use `operation` in
+        // colors.toml. TODO: It would be better to put labels like these
+        // consistently in the same place, e.g. `templates.toml` instead of the
+        // rust code.
+        .labeled("op_log")
     }
 
     pub fn short_change_id_template(&self) -> TemplateRenderer<'_, Commit> {

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -125,14 +125,12 @@ pub fn cmd_op_diff(
     let op_summary_template = workspace_command.operation_summary_template();
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
-    formatter.with_label("op_log", |formatter| {
-        write!(formatter, "From operation ")?;
-        op_summary_template.format(&from_op, &mut *formatter)?;
-        writeln!(formatter)?;
-        write!(formatter, "  To operation ")?;
-        op_summary_template.format(&to_op, &mut *formatter)?;
-        writeln!(formatter)
-    })?;
+    write!(formatter, "From operation ")?;
+    op_summary_template.format(&from_op, &mut *formatter)?;
+    writeln!(formatter)?;
+    write!(formatter, "  To operation ")?;
+    op_summary_template.format(&to_op, &mut *formatter)?;
+    writeln!(formatter)?;
 
     show_op_diff(
         ui,

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -125,10 +125,10 @@ pub fn cmd_op_diff(
     let op_summary_template = workspace_command.operation_summary_template();
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
-    write!(formatter, "From operation ")?;
+    write!(formatter, "From operation: ")?;
     op_summary_template.format(&from_op, &mut *formatter)?;
     writeln!(formatter)?;
-    write!(formatter, "  To operation ")?;
+    write!(formatter, "  To operation: ")?;
     op_summary_template.format(&to_op, &mut *formatter)?;
     writeln!(formatter)?;
 

--- a/cli/src/commands/operation/restore.rs
+++ b/cli/src/commands/operation/restore.rs
@@ -56,7 +56,7 @@ pub fn cmd_op_restore(
     );
     tx.repo_mut().set_view(new_view);
     if let Some(mut formatter) = ui.status_formatter() {
-        write!(formatter, "Restored to operation ")?;
+        write!(formatter, "Restored to operation: ")?;
         let template = tx.base_workspace_helper().operation_summary_template();
         template.format(&target_op, formatter.as_mut())?;
         writeln!(formatter)?;

--- a/cli/src/commands/operation/undo.rs
+++ b/cli/src/commands/operation/undo.rs
@@ -69,7 +69,7 @@ pub fn cmd_op_undo(
     );
     tx.repo_mut().set_view(new_view);
     if let Some(mut formatter) = ui.status_formatter() {
-        write!(formatter, "Undid operation ")?;
+        write!(formatter, "Undid operation: ")?;
         let template = tx.base_workspace_helper().operation_summary_template();
         template.format(&bad_op, formatter.as_mut())?;
         writeln!(formatter)?;

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -41,10 +41,20 @@ tag_list = '''
 label("tag", name) ++ format_ref_targets(self) ++ "\n"
 '''
 
+# TODO: Here and elsewhere, the end time for operations is more meaningful than
+# the start time. https://github.com/martinvonz/jj/pull/4602#discussion_r1791207491
 op_summary = '''
-if(root,
-  separate(" ", self.id().short(), label("root", "root()")),
-  separate(" ", self.id().short(), format_time_range(self.time()), self.description().first_line())
+separate(" ",
+  self.id().short(),
+  if(root,
+    label("root", "root()"),
+    surround(
+       "(",
+       ")",
+       format_timestamp(self.time().start())
+    )
+  ),
+  self.description().first_line()
 )
 '''
 

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -76,7 +76,7 @@ fn test_duplicate() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Undid operation b5bdbb51ab28 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00 duplicate 1 commit(s)
+    Undid operation: b5bdbb51ab28 (2001-02-03 08:05:17) duplicate 1 commit(s)
     "#);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @"");
@@ -280,7 +280,7 @@ fn test_undo_after_duplicate() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Undid operation e3dbefa46ed5 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00 duplicate 1 commit(s)
+    Undid operation: e3dbefa46ed5 (2001-02-03 08:05:11) duplicate 1 commit(s)
     "#);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -757,7 +757,7 @@ fn test_git_colocated_undo_head_move() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Undid operation b50ec983d1c1 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00 new empty commit
+    Undid operation: b50ec983d1c1 (2001-02-03 08:05:13) new empty commit
     Working copy now at: royxmykx eb08b363 (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     "#);

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -932,7 +932,7 @@ fn test_git_fetch_undo() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Undid operation eb2029853b02 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00 fetch from git remote(s) origin
+    Undid operation: eb2029853b02 (2001-02-03 08:05:18) fetch from git remote(s) origin
     "#);
     // The undo works as expected
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
@@ -1018,7 +1018,7 @@ fn test_fetch_undo_what() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Restored to operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     "#);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     b (deleted)
@@ -1047,7 +1047,7 @@ fn test_fetch_undo_what() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Restored to operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     "#);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -101,7 +101,7 @@ fn test_git_export_undo() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Undid operation b27a68390bea 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00 export git refs
+    Undid operation: b27a68390bea (2001-02-03 08:05:10) export git refs
     "#);
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
     [
@@ -162,7 +162,7 @@ fn test_git_import_undo() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Restored to operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     "#);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
     // Try "git import" again, which should re-import the bookmark "a".
@@ -228,7 +228,7 @@ fn test_git_import_move_export_with_default_undo() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Restored to operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     Working copy now at: qpvuntsm 230dd059 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     "#);

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -791,9 +791,8 @@ fn test_op_summary_diff_template() {
     test_env.jj_cmd_ok(&repo_path, &["new", "--no-edit", "-m=scratch"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=always"]);
     insta::assert_snapshot!(&stdout, @"");
-    // BUG!! (Fixed in next commit)
     insta::assert_snapshot!(&stderr, @r#"
-    Undid operation ac20a4ff4791 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 new empty commit
+    Undid operation [38;5;4mac20a4ff4791[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m - [38;5;6m2001-02-03 04:05:08.000 +07:00[39m new empty commit
     "#);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -821,7 +820,7 @@ fn test_op_summary_diff_template() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=debug"]);
     insta::assert_snapshot!(&stdout, @"");
     insta::assert_snapshot!(&stderr, @r#"
-    Undid operation <<id short::2301f6e6ec31>> <<time start::2001-02-03 04:05:11.000 +07:00>> - <<time end::2001-02-03 04:05:11.000 +07:00>> <<description first_line::new empty commit>>
+    Undid operation [38;5;4m<<op_log id short::2301f6e6ec31>>[39m<<op_log:: >>[38;5;6m<<op_log time start::2001-02-03 04:05:11.000 +07:00>>[39m<<op_log:: - >>[38;5;6m<<op_log time end::2001-02-03 04:05:11.000 +07:00>>[39m<<op_log:: >><<op_log description first_line::new empty commit>>
     "#);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -836,8 +835,8 @@ fn test_op_summary_diff_template() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    <<op_log::From operation >>[38;5;4m<<op_log id short::000000000000>>[39m<<op_log:: >>[38;5;2m<<op_log root::root()>>[39m<<op_log::>>
-    <<op_log::  To operation >>[38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: >>[38;5;6m<<op_log time start::2001-02-03 04:05:12.000 +07:00>>[39m<<op_log:: - >>[38;5;6m<<op_log time end::2001-02-03 04:05:12.000 +07:00>>[39m<<op_log:: >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>><<op_log::>>
+    From operation [38;5;4m<<op_log id short::000000000000>>[39m<<op_log:: >>[38;5;2m<<op_log root::root()>>[39m
+      To operation [38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: >>[38;5;6m<<op_log time start::2001-02-03 04:05:12.000 +07:00>>[39m<<op_log:: - >>[38;5;6m<<op_log time end::2001-02-03 04:05:12.000 +07:00>>[39m<<op_log:: >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
 
     Changed commits:
     ○  Change qpvuntsmwlqt

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -792,7 +792,7 @@ fn test_op_summary_diff_template() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=always"]);
     insta::assert_snapshot!(&stdout, @"");
     insta::assert_snapshot!(&stderr, @r#"
-    Undid operation [38;5;4mac20a4ff4791[39m [38;5;6m2001-02-03 04:05:08.000 +07:00[39m - [38;5;6m2001-02-03 04:05:08.000 +07:00[39m new empty commit
+    Undid operation: [38;5;4mac20a4ff4791[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
     "#);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -807,8 +807,8 @@ fn test_op_summary_diff_template() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation [38;5;4m000000000000[39m [38;5;2mroot()[39m
-      To operation [38;5;4me3792fce5b1f[39m [38;5;6m2001-02-03 04:05:09.000 +07:00[39m - [38;5;6m2001-02-03 04:05:09.000 +07:00[39m undo operation ac20a4ff47914da9a2e43677b94455b86383bfb9227374d6531ecee85b9ff9230eeb96416a24bb27e7477aa18d50c01810e97c6a008b5c584224650846f4c05b
+    From operation: [38;5;4m000000000000[39m [38;5;2mroot()[39m
+      To operation: [38;5;4me3792fce5b1f[39m ([38;5;6m2001-02-03 08:05:09[39m) undo operation ac20a4ff47914da9a2e43677b94455b86383bfb9227374d6531ecee85b9ff9230eeb96416a24bb27e7477aa18d50c01810e97c6a008b5c584224650846f4c05b
 
     Changed commits:
     ○  Change qpvuntsmwlqt
@@ -820,7 +820,7 @@ fn test_op_summary_diff_template() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=debug"]);
     insta::assert_snapshot!(&stdout, @"");
     insta::assert_snapshot!(&stderr, @r#"
-    Undid operation [38;5;4m<<op_log id short::2301f6e6ec31>>[39m<<op_log:: >>[38;5;6m<<op_log time start::2001-02-03 04:05:11.000 +07:00>>[39m<<op_log:: - >>[38;5;6m<<op_log time end::2001-02-03 04:05:11.000 +07:00>>[39m<<op_log:: >><<op_log description first_line::new empty commit>>
+    Undid operation: [38;5;4m<<op_log id short::2301f6e6ec31>>[39m<<op_log:: (>>[38;5;6m<<op_log time start local format::2001-02-03 08:05:11>>[39m<<op_log::) >><<op_log description first_line::new empty commit>>
     "#);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -835,8 +835,8 @@ fn test_op_summary_diff_template() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation [38;5;4m<<op_log id short::000000000000>>[39m<<op_log:: >>[38;5;2m<<op_log root::root()>>[39m
-      To operation [38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: >>[38;5;6m<<op_log time start::2001-02-03 04:05:12.000 +07:00>>[39m<<op_log:: - >>[38;5;6m<<op_log time end::2001-02-03 04:05:12.000 +07:00>>[39m<<op_log:: >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
+    From operation: [38;5;4m<<op_log id short::000000000000>>[39m<<op_log:: >>[38;5;2m<<op_log root::root()>>[39m
+      To operation: [38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: (>>[38;5;6m<<op_log time start local format::2001-02-03 08:05:12>>[39m<<op_log::) >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
 
     Changed commits:
     ○  Change qpvuntsmwlqt
@@ -872,13 +872,13 @@ fn test_op_diff() {
         &["op", "diff", "--from", "0000000", "--to", "0000000"],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 000000000000 root()
-      To operation 000000000000 root()
+    From operation: 000000000000 root()
+      To operation: 000000000000 root()
     "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--from", "@", "--to", "@"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 4d05b146ac44 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 check out git remote's default branch
-      To operation 4d05b146ac44 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 check out git remote's default branch
+    From operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
+      To operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
     "#);
 
     // Diff from parent operation to latest operation.
@@ -886,8 +886,8 @@ fn test_op_diff() {
     // @- --to @` (if `@` is not a merge commit).
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--from", "@-", "--to", "@"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 85a54acdbc88 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 fetch from git remote into empty repo
-      To operation 4d05b146ac44 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 check out git remote's default branch
+    From operation: 85a54acdbc88 (2001-02-03 08:05:07) fetch from git remote into empty repo
+      To operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
 
     Changed commits:
     ○  Change sqpuoqvxutmz
@@ -911,8 +911,8 @@ fn test_op_diff() {
     // Diff from root operation to latest operation
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--from", "0000000"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 000000000000 root()
-      To operation 4d05b146ac44 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 check out git remote's default branch
+    From operation: 000000000000 root()
+      To operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
 
     Changed commits:
     ○  Change sqpuoqvxutmz
@@ -944,8 +944,8 @@ fn test_op_diff() {
     // Diff from latest operation to root operation
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--to", "0000000"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 4d05b146ac44 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 check out git remote's default branch
-      To operation 000000000000 root()
+    From operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
+      To operation: 000000000000 root()
 
     Changed commits:
     ○  Change sqpuoqvxutmz
@@ -1020,8 +1020,8 @@ fn test_op_diff() {
         &["op", "diff", "--from", first_parent_id, "--to", op_id],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 4d05b146ac44 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 check out git remote's default branch
-      To operation cd3fc3ddbdd9 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00 reconcile divergent operations
+    From operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
+      To operation: cd3fc3ddbdd9 (2001-02-03 08:05:16) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1037,8 +1037,8 @@ fn test_op_diff() {
         &["op", "diff", "--from", second_parent_id, "--to", op_id],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 484785c371e5 2001-02-03 04:05:15.000 +07:00 - 2001-02-03 04:05:15.000 +07:00 point bookmark bookmark-1 to commit 3d9189bc56a1972729350456eb95ec5bf90be2a8
-      To operation cd3fc3ddbdd9 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00 reconcile divergent operations
+    From operation: 484785c371e5 (2001-02-03 08:05:15) point bookmark bookmark-1 to commit 3d9189bc56a1972729350456eb95ec5bf90be2a8
+      To operation: cd3fc3ddbdd9 (2001-02-03 08:05:16) reconcile divergent operations
 
     Changed commits:
     ○  Change sqpuoqvxutmz
@@ -1071,8 +1071,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation cd3fc3ddbdd9 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00 reconcile divergent operations
-      To operation 894f1f54aabe 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00 fetch from git remote(s) origin
+    From operation: cd3fc3ddbdd9 (2001-02-03 08:05:16) reconcile divergent operations
+      To operation: 894f1f54aabe (2001-02-03 08:05:20) fetch from git remote(s) origin
 
     Changed commits:
     ○  Change qzxslznxxpoz
@@ -1119,8 +1119,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 894f1f54aabe 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00 fetch from git remote(s) origin
-      To operation ed134e3dc5c6 2001-02-03 04:05:22.000 +07:00 - 2001-02-03 04:05:22.000 +07:00 create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
+    From operation: 894f1f54aabe (2001-02-03 08:05:20) fetch from git remote(s) origin
+      To operation: ed134e3dc5c6 (2001-02-03 08:05:22) create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
 
     Changed local bookmarks:
     bookmark-2:
@@ -1138,8 +1138,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation ed134e3dc5c6 2001-02-03 04:05:22.000 +07:00 - 2001-02-03 04:05:22.000 +07:00 create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
-      To operation 871bda1a359f 2001-02-03 04:05:24.000 +07:00 - 2001-02-03 04:05:24.000 +07:00 track remote bookmark bookmark-2@origin
+    From operation: ed134e3dc5c6 (2001-02-03 08:05:22) create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
+      To operation: 871bda1a359f (2001-02-03 08:05:24) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1159,8 +1159,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation ed134e3dc5c6 2001-02-03 04:05:22.000 +07:00 - 2001-02-03 04:05:22.000 +07:00 create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
-      To operation 871bda1a359f 2001-02-03 04:05:24.000 +07:00 - 2001-02-03 04:05:24.000 +07:00 track remote bookmark bookmark-2@origin
+    From operation: ed134e3dc5c6 (2001-02-03 08:05:22) create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
+      To operation: 871bda1a359f (2001-02-03 08:05:24) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1182,8 +1182,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 871bda1a359f 2001-02-03 04:05:24.000 +07:00 - 2001-02-03 04:05:24.000 +07:00 track remote bookmark bookmark-2@origin
-      To operation 2604b8b3b9e5 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00 new empty commit
+    From operation: 871bda1a359f (2001-02-03 08:05:24) track remote bookmark bookmark-2@origin
+      To operation: 2604b8b3b9e5 (2001-02-03 08:05:28) new empty commit
 
     Changed commits:
     ○  Change wvuyspvkupzz
@@ -1202,8 +1202,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 2604b8b3b9e5 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00 new empty commit
-      To operation e64617a51cdb 2001-02-03 04:05:30.000 +07:00 - 2001-02-03 04:05:30.000 +07:00 point bookmark bookmark-1 to commit 358b82d6be53fa9b062325abb8bc820a8b34c68d
+    From operation: 2604b8b3b9e5 (2001-02-03 08:05:28) new empty commit
+      To operation: e64617a51cdb (2001-02-03 08:05:30) point bookmark bookmark-1 to commit 358b82d6be53fa9b062325abb8bc820a8b34c68d
 
     Changed local bookmarks:
     bookmark-1:
@@ -1221,8 +1221,8 @@ fn test_op_diff() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation e64617a51cdb 2001-02-03 04:05:30.000 +07:00 - 2001-02-03 04:05:30.000 +07:00 point bookmark bookmark-1 to commit 358b82d6be53fa9b062325abb8bc820a8b34c68d
-      To operation e07e94fbdd09 2001-02-03 04:05:32.000 +07:00 - 2001-02-03 04:05:32.000 +07:00 delete bookmark bookmark-2
+    From operation: e64617a51cdb (2001-02-03 08:05:30) point bookmark bookmark-1 to commit 358b82d6be53fa9b062325abb8bc820a8b34c68d
+      To operation: e07e94fbdd09 (2001-02-03 08:05:32) delete bookmark bookmark-2
 
     Changed local bookmarks:
     bookmark-2:
@@ -1244,8 +1244,8 @@ fn test_op_diff() {
     "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation e07e94fbdd09 2001-02-03 04:05:32.000 +07:00 - 2001-02-03 04:05:32.000 +07:00 delete bookmark bookmark-2
-      To operation 203fe2a7ed9e 2001-02-03 04:05:34.000 +07:00 - 2001-02-03 04:05:34.000 +07:00 push all tracked bookmarks to git remote origin
+    From operation: e07e94fbdd09 (2001-02-03 08:05:32) delete bookmark bookmark-2
+      To operation: 203fe2a7ed9e (2001-02-03 08:05:34) push all tracked bookmarks to git remote origin
 
     Changed commits:
     ○  Change oupztwtkortx
@@ -1277,8 +1277,8 @@ fn test_op_diff_patch() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--op", "@-", "-p", "--git"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
-      To operation 187a5a9d8a22 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 snapshot working copy
+    From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: 187a5a9d8a22 (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  Change qpvuntsmwlqt
@@ -1294,8 +1294,8 @@ fn test_op_diff_patch() {
     "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--op", "@", "-p", "--git"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 187a5a9d8a22 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 snapshot working copy
-      To operation a7e535e73c4b 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 new empty commit
+    From operation: 187a5a9d8a22 (2001-02-03 08:05:08) snapshot working copy
+      To operation: a7e535e73c4b (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
     ○  Change rlvkpnrzqnoo
@@ -1312,8 +1312,8 @@ fn test_op_diff_patch() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 15c3c5d0baf0 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00 snapshot working copy
-      To operation 894c12d90345 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00 squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
+    From operation: 15c3c5d0baf0 (2001-02-03 08:05:11) snapshot working copy
+      To operation: 894c12d90345 (2001-02-03 08:05:11) squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
 
     Changed commits:
     ○  Change mzvwutvlkqwt
@@ -1349,8 +1349,8 @@ fn test_op_diff_patch() {
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 894c12d90345 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00 squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
-      To operation e5505aa79d31 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00 abandon commit 9f4fb57fba25a7b47ce5980a5d9a4766778331e8
+    From operation: 894c12d90345 (2001-02-03 08:05:11) squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
+      To operation: e5505aa79d31 (2001-02-03 08:05:13) abandon commit 9f4fb57fba25a7b47ce5980a5d9a4766778331e8
 
     Changed commits:
     ○  Change yqosqzytrlsw
@@ -1440,8 +1440,8 @@ fn test_op_diff_sibling() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation d700dc16fded 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00 new empty commit
-      To operation 13b143e1f4f9 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00 describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+    From operation: d700dc16fded (2001-02-03 08:05:11) new empty commit
+      To operation: 13b143e1f4f9 (2001-02-03 08:05:12) describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
 
     Changed commits:
     ○  Change qpvuntsmwlqt
@@ -1470,8 +1470,8 @@ fn test_op_diff_sibling() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation 13b143e1f4f9 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00 describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
-      To operation d700dc16fded 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00 new empty commit
+    From operation: 13b143e1f4f9 (2001-02-03 08:05:12) describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
+      To operation: d700dc16fded (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     ○    Change mzvwutvlkqwt
@@ -1514,8 +1514,8 @@ fn test_op_diff_word_wrap() {
 
     // ui.log-word-wrap option works, and diff stat respects content width
     insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @r#"
-    From operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
-      To operation f3052392e08c 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 snapshot working copy
+    From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: f3052392e08c (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  Change sqpuoqvxutmz
@@ -1568,8 +1568,8 @@ fn test_op_diff_word_wrap() {
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
         render(&["op", "diff", "--from=@---", "--config-toml", config], 10, true), @r#"
-    From operation eac759b9ab75 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
-      To operation f3052392e08c 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 snapshot working copy
+    From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: f3052392e08c (2001-02-03 08:05:08) snapshot working copy
 
     Changed
     commits:

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -681,7 +681,7 @@ fn test_rebase_revision_onto_descendant() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r#"
-    Restored to operation cc1a7e3419ad 2001-02-03 04:05:15.000 +07:00 - 2001-02-03 04:05:15.000 +07:00 create bookmark merge pointing to commit b05964d109522cd06e48f1a2661e1a0f58be0984
+    Restored to operation: cc1a7e3419ad (2001-02-03 08:05:15) create bookmark merge pointing to commit b05964d109522cd06e48f1a2661e1a0f58be0984
     Working copy now at: vruxwmqv b05964d1 merge | merge
     Parent commit      : royxmykx cea87a87 b | b
     Parent commit      : zsuskuln 2c5b7858 a | a


### PR DESCRIPTION
This is meant to be a quick fix before I update the demos in the README. The primary reason to update them is the branch -> bookmark transition, but I noticed that `jj undo`'s output is currently not very pretty.

I believe printing both the start and end times is excessive for a summary. For a long-running operation like `jj describe` with the editor open for a long time, the ending time seems more meaningful.

I was a bit torn on whether to use `format_timestamp(self.time().end())` or `self.time().end().ago()`. The latter looks better (`finished 2 seconds ago` instead of `finished 2024-10-07 15:46:03`), but is less configurable and worse for dates long ago. In the future, we could add a `format_op_summary_timestamp` function and/or a template function that uses `.ago()` for recent dates and absolute dates for old dates.

Previous look:
<img width="544" alt="Pasted image 20241006191123" src="https://github.com/user-attachments/assets/f4f9736f-6ba0-4df4-b6da-ae1d83926170">

Or in the demo:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/7cd251d6-ac9d-41a5-aa94-e9aa25783767">


**New look**:

<img width="505" alt="image" src="https://github.com/user-attachments/assets/60d5ef29-8a88-4c95-a8aa-2bf4e8fd8224">


<details><summary>Previous version</summary>

<img width="535" alt="image" src="https://github.com/user-attachments/assets/9ef78cd3-ced6-4b8e-81c5-669f58f9e446">


<img width="550" alt="Pasted image 20241007143128" src="https://github.com/user-attachments/assets/f2665b44-d35f-407d-8610-f1f5079d3eea">

</details>


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
