### PR TITLE
propagate `revsets.short-prefixes` evaluation error, prep for `at_operation()` revset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Revset function names can no longer start with a number.
 
+* Evaluation error of `revsets.short-prefixes` configuration is now reported.
+
 ### Deprecations
 
 ### New features

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -60,6 +60,8 @@ fn test_rewrite_immutable_generic() {
     // Error mutating the repo if immutable_heads() uses a ref that can't be
     // resolved
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmark_that_does_not_exist""#);
+    // Suppress warning in the commit summary template
+    test_env.add_config("template-aliases.'format_short_id(id)' = 'id.short(8)'");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "main"]);
     insta::assert_snapshot!(stderr, @r###"
     Config error: Invalid `revset-aliases.immutable_heads()`

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -789,6 +789,10 @@ fn test_op_diff() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "git-repo", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
+    // Suppress warning in the commit summary template. The configured "trunk()"
+    // can't be found in earlier operations.
+    test_env.add_config("template-aliases.'format_short_id(id)' = 'id.short(8)'");
+
     // Overview of op log.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
     insta::assert_snapshot!(&stdout, @r#"
@@ -1581,6 +1585,10 @@ fn test_op_show() {
     let git_repo = init_bare_git_repo(&git_repo_path);
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "git-repo", "repo"]);
     let repo_path = test_env.env_root().join("repo");
+
+    // Suppress warning in the commit summary template. The configured "trunk()"
+    // can't be found in earlier operations.
+    test_env.add_config("template-aliases.'format_short_id(id)' = 'id.short(8)'");
 
     // Overview of op log.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -161,7 +161,13 @@ impl IdPrefixIndex<'_> {
                 .commit_index
                 .resolve_prefix_to_key(&*indexes.commit_change_ids, prefix);
             if let PrefixResolution::SingleMatch(id) = resolution {
-                return PrefixResolution::SingleMatch(id);
+                // The disambiguation set may be loaded from a different repo,
+                // and contain a commit that doesn't exist in the current repo.
+                if repo.index().has_id(&id) {
+                    return PrefixResolution::SingleMatch(id);
+                } else {
+                    return PrefixResolution::NoMatch;
+                }
             }
         }
         repo.index().resolve_commit_id_prefix(prefix)

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -145,6 +145,11 @@ pub struct IdPrefixIndex<'a> {
 }
 
 impl IdPrefixIndex<'_> {
+    /// Returns an empty index that just falls back to a provided `repo`.
+    pub const fn empty() -> IdPrefixIndex<'static> {
+        IdPrefixIndex { indexes: None }
+    }
+
     /// Resolve an unambiguous commit ID prefix.
     pub fn resolve_commit_prefix(
         &self,

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1634,9 +1634,12 @@ impl PartialSymbolResolver for CommitPrefixResolver<'_> {
         symbol: &str,
     ) -> Result<Option<Vec<CommitId>>, RevsetResolutionError> {
         if let Some(prefix) = HexPrefix::new(symbol) {
-            let index = self.context.map_or(IdPrefixIndex::empty(), |ctx| {
-                ctx.populate(self.context_repo)
-            });
+            let index = self
+                .context
+                .map(|ctx| ctx.populate(self.context_repo))
+                .transpose()
+                .map_err(|err| RevsetResolutionError::Other(err.into()))?
+                .unwrap_or(IdPrefixIndex::empty());
             match index.resolve_commit_prefix(repo, &prefix) {
                 PrefixResolution::AmbiguousMatch => Err(
                     RevsetResolutionError::AmbiguousCommitIdPrefix(symbol.to_owned()),
@@ -1662,9 +1665,12 @@ impl PartialSymbolResolver for ChangePrefixResolver<'_> {
         symbol: &str,
     ) -> Result<Option<Vec<CommitId>>, RevsetResolutionError> {
         if let Some(prefix) = to_forward_hex(symbol).as_deref().and_then(HexPrefix::new) {
-            let index = self.context.map_or(IdPrefixIndex::empty(), |ctx| {
-                ctx.populate(self.context_repo)
-            });
+            let index = self
+                .context
+                .map(|ctx| ctx.populate(self.context_repo))
+                .transpose()
+                .map_err(|err| RevsetResolutionError::Other(err.into()))?
+                .unwrap_or(IdPrefixIndex::empty());
             match index.resolve_change_prefix(repo, &prefix) {
                 PrefixResolution::AmbiguousMatch => Err(
                     RevsetResolutionError::AmbiguousChangeIdPrefix(symbol.to_owned()),

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -139,7 +139,7 @@ fn test_id_prefix() {
     // Without a disambiguation revset
     // ---------------------------------------------------------------------------------------------
     let context = IdPrefixContext::default();
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     assert_eq!(
         index.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
         2
@@ -194,7 +194,7 @@ fn test_id_prefix() {
     let expression =
         RevsetExpression::commits(vec![commits[0].id().clone(), commits[2].id().clone()]);
     let context = context.disambiguate_within(expression);
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     // The prefix is now shorter
     assert_eq!(
         index.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
@@ -224,7 +224,7 @@ fn test_id_prefix() {
     // ---------------------------------------------------------------------------------------------
     let expression = RevsetExpression::commit(root_commit_id.clone());
     let context = context.disambiguate_within(expression);
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     assert_eq!(
         index.shortest_commit_prefix_len(repo.as_ref(), root_commit_id),
         1
@@ -252,18 +252,9 @@ fn test_id_prefix() {
 
     // Disambiguate within revset that fails to evaluate
     // ---------------------------------------------------------------------------------------------
-    // TODO: Should be an error
     let expression = RevsetExpression::symbol("nonexistent".to_string());
     let context = context.disambiguate_within(expression);
-    let index = context.populate(repo.as_ref());
-    assert_eq!(
-        index.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
-        2
-    );
-    assert_eq!(
-        index.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
-        AmbiguousMatch
-    );
+    assert!(context.populate(repo.as_ref()).is_err());
 }
 
 #[test]
@@ -340,7 +331,7 @@ fn test_id_prefix_divergent() {
     // Without a disambiguation revset
     // --------------------------------
     let context = IdPrefixContext::default();
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     assert_eq!(
         index.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
         3
@@ -373,7 +364,7 @@ fn test_id_prefix_divergent() {
     // ----------------------------------------------------------------------
     let expression = RevsetExpression::commits(vec![second_commit.id().clone()]);
     let context = context.disambiguate_within(expression);
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     // The prefix is now shorter
     assert_eq!(
         index.shortest_change_prefix_len(repo.as_ref(), second_commit.change_id()),
@@ -486,7 +477,7 @@ fn test_id_prefix_hidden() {
     // Without a disambiguation revset
     // --------------------------------
     let context = IdPrefixContext::default();
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     assert_eq!(
         index.shortest_commit_prefix_len(repo.as_ref(), hidden_commit.id()),
         2
@@ -522,7 +513,7 @@ fn test_id_prefix_hidden() {
     // --------------------------
     let expression = RevsetExpression::commit(hidden_commit.id().clone());
     let context = context.disambiguate_within(expression);
-    let index = context.populate(repo.as_ref());
+    let index = context.populate(repo.as_ref()).unwrap();
     assert_eq!(
         index.shortest_commit_prefix_len(repo.as_ref(), hidden_commit.id()),
         1

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -138,53 +138,54 @@ fn test_id_prefix() {
 
     // Without a disambiguation revset
     // ---------------------------------------------------------------------------------------------
-    let c = IdPrefixContext::default();
+    let context = IdPrefixContext::default();
+    let index = context.populate(repo.as_ref());
     assert_eq!(
-        c.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
+        index.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
         2
     );
     assert_eq!(
-        c.shortest_commit_prefix_len(repo.as_ref(), commits[5].id()),
+        index.shortest_commit_prefix_len(repo.as_ref(), commits[5].id()),
         1
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("2a")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("2a")),
         SingleMatch(commits[2].id().clone())
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("20")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("20")),
         NoMatch
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("2a0")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("2a0")),
         NoMatch
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
         2
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), commits[6].change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), commits[6].change_id()),
         1
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("7")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("7")),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("78")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("78")),
         SingleMatch(vec![commits[0].id().clone()])
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("70")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("70")),
         NoMatch
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("780")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("780")),
         NoMatch
     );
 
@@ -192,28 +193,29 @@ fn test_id_prefix() {
     // ---------------------------------------------------------------------------------------------
     let expression =
         RevsetExpression::commits(vec![commits[0].id().clone(), commits[2].id().clone()]);
-    let c = c.disambiguate_within(expression);
+    let context = context.disambiguate_within(expression);
+    let index = context.populate(repo.as_ref());
     // The prefix is now shorter
     assert_eq!(
-        c.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
+        index.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
         1
     );
     // Shorter prefix within the set can be used
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
         SingleMatch(commits[2].id().clone())
     );
     // Can still resolve commits outside the set
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("21")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("21")),
         SingleMatch(commits[24].id().clone())
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
         1
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("7")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("7")),
         SingleMatch(vec![commits[0].id().clone()])
     );
 
@@ -221,29 +223,30 @@ fn test_id_prefix() {
     // needed.
     // ---------------------------------------------------------------------------------------------
     let expression = RevsetExpression::commit(root_commit_id.clone());
-    let c = c.disambiguate_within(expression);
+    let context = context.disambiguate_within(expression);
+    let index = context.populate(repo.as_ref());
     assert_eq!(
-        c.shortest_commit_prefix_len(repo.as_ref(), root_commit_id),
+        index.shortest_commit_prefix_len(repo.as_ref(), root_commit_id),
         1
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("")),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix("0")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("0")),
         SingleMatch(root_commit_id.clone())
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), root_change_id),
+        index.shortest_change_prefix_len(repo.as_ref(), root_change_id),
         1
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("")),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("0")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("0")),
         SingleMatch(vec![root_commit_id.clone()])
     );
 
@@ -251,13 +254,14 @@ fn test_id_prefix() {
     // ---------------------------------------------------------------------------------------------
     // TODO: Should be an error
     let expression = RevsetExpression::symbol("nonexistent".to_string());
-    let context = c.disambiguate_within(expression);
+    let context = context.disambiguate_within(expression);
+    let index = context.populate(repo.as_ref());
     assert_eq!(
-        context.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
+        index.shortest_commit_prefix_len(repo.as_ref(), commits[2].id()),
         2
     );
     assert_eq!(
-        context.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix("2")),
         AmbiguousMatch
     );
 }
@@ -335,29 +339,30 @@ fn test_id_prefix_divergent() {
 
     // Without a disambiguation revset
     // --------------------------------
-    let c = IdPrefixContext::default();
+    let context = IdPrefixContext::default();
+    let index = context.populate(repo.as_ref());
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), commits[0].change_id()),
         3
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), commits[1].change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), commits[1].change_id()),
         3
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), commits[2].change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), commits[2].change_id()),
         3
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("a5")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("a5")),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("a53")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("a53")),
         SingleMatch(vec![first_commit.id().clone()])
     );
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("a50")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("a50")),
         SingleMatch(vec![
             second_commit.id().clone(),
             third_commit_divergent_with_second.id().clone()
@@ -367,10 +372,11 @@ fn test_id_prefix_divergent() {
     // Now, disambiguate within the revset containing only the second commit
     // ----------------------------------------------------------------------
     let expression = RevsetExpression::commits(vec![second_commit.id().clone()]);
-    let c = c.disambiguate_within(expression);
+    let context = context.disambiguate_within(expression);
+    let index = context.populate(repo.as_ref());
     // The prefix is now shorter
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), second_commit.change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), second_commit.change_id()),
         1
     );
     // This tests two issues, both important:
@@ -381,7 +387,7 @@ fn test_id_prefix_divergent() {
     //   match is not ambiguous, even though the first commit's change id would also
     //   match the prefix.
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("a")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("a")),
         SingleMatch(vec![
             second_commit.id().clone(),
             third_commit_divergent_with_second.id().clone()
@@ -390,11 +396,11 @@ fn test_id_prefix_divergent() {
 
     // We can still resolve commits outside the set
     assert_eq!(
-        c.resolve_change_prefix(repo.as_ref(), &prefix("a53")),
+        index.resolve_change_prefix(repo.as_ref(), &prefix("a53")),
         SingleMatch(vec![first_commit.id().clone()])
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), first_commit.change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), first_commit.change_id()),
         3
     );
 }
@@ -479,32 +485,33 @@ fn test_id_prefix_hidden() {
 
     // Without a disambiguation revset
     // --------------------------------
-    let c = IdPrefixContext::default();
+    let context = IdPrefixContext::default();
+    let index = context.populate(repo.as_ref());
     assert_eq!(
-        c.shortest_commit_prefix_len(repo.as_ref(), hidden_commit.id()),
+        index.shortest_commit_prefix_len(repo.as_ref(), hidden_commit.id()),
         2
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), hidden_commit.change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), hidden_commit.change_id()),
         3
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix(&hidden_commit.id().hex()[..1])),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix(&hidden_commit.id().hex()[..1])),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix(&hidden_commit.id().hex()[..2])),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix(&hidden_commit.id().hex()[..2])),
         SingleMatch(hidden_commit.id().clone())
     );
     assert_eq!(
-        c.resolve_change_prefix(
+        index.resolve_change_prefix(
             repo.as_ref(),
             &prefix(&hidden_commit.change_id().hex()[..2])
         ),
         AmbiguousMatch
     );
     assert_eq!(
-        c.resolve_change_prefix(
+        index.resolve_change_prefix(
             repo.as_ref(),
             &prefix(&hidden_commit.change_id().hex()[..3])
         ),
@@ -514,32 +521,33 @@ fn test_id_prefix_hidden() {
     // Disambiguate within hidden
     // --------------------------
     let expression = RevsetExpression::commit(hidden_commit.id().clone());
-    let c = c.disambiguate_within(expression);
+    let context = context.disambiguate_within(expression);
+    let index = context.populate(repo.as_ref());
     assert_eq!(
-        c.shortest_commit_prefix_len(repo.as_ref(), hidden_commit.id()),
+        index.shortest_commit_prefix_len(repo.as_ref(), hidden_commit.id()),
         1
     );
     assert_eq!(
-        c.shortest_change_prefix_len(repo.as_ref(), hidden_commit.change_id()),
+        index.shortest_change_prefix_len(repo.as_ref(), hidden_commit.change_id()),
         1
     );
     // Short commit id can be resolved even if it's hidden.
     assert_eq!(
-        c.resolve_commit_prefix(repo.as_ref(), &prefix(&hidden_commit.id().hex()[..1])),
+        index.resolve_commit_prefix(repo.as_ref(), &prefix(&hidden_commit.id().hex()[..1])),
         SingleMatch(hidden_commit.id().clone())
     );
     // OTOH, hidden change id should never be found. The resolution might be
     // ambiguous if hidden commits were excluded from the disambiguation set.
     // In that case, shortest_change_prefix_len() shouldn't be 1.
     assert_eq!(
-        c.resolve_change_prefix(
+        index.resolve_change_prefix(
             repo.as_ref(),
             &prefix(&hidden_commit.change_id().hex()[..1])
         ),
         NoMatch
     );
     assert_eq!(
-        c.resolve_change_prefix(
+        index.resolve_change_prefix(
             repo.as_ref(),
             &prefix(&hidden_commit.change_id().hex()[..2])
         ),


### PR DESCRIPTION


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
