### PR TITLE
squash: add -f/-t shorthands for --from/--[in]to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `at_operation(op, expr)` revset can be used in order to query revisions
   based on historical state.
 
+* `jj squash` now supports `-f/-t` shorthands for `--from/--[in]to`.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -60,10 +60,10 @@ pub(crate) struct SquashArgs {
     #[arg(long, short)]
     revision: Option<RevisionArg>,
     /// Revision(s) to squash from (default: @)
-    #[arg(long, conflicts_with = "revision")]
+    #[arg(long, short, conflicts_with = "revision")]
     from: Vec<RevisionArg>,
     /// Revision to squash into (default: @)
-    #[arg(long, conflicts_with = "revision", visible_alias = "to")]
+    #[arg(long, short = 't', conflicts_with = "revision", visible_alias = "to")]
     into: Option<RevisionArg>,
     /// The description to use for squashed revision (don't open editor)
     #[arg(long = "message", short, value_name = "MESSAGE")]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1972,8 +1972,8 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 ###### **Options:**
 
 * `-r`, `--revision <REVISION>` — Revision to squash into its parent (default: @)
-* `--from <FROM>` — Revision(s) to squash from (default: @)
-* `--into <INTO>` — Revision to squash into (default: @)
+* `-f`, `--from <FROM>` — Revision(s) to squash from (default: @)
+* `-t`, `--into <INTO>` — Revision to squash into (default: @)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
 * `-i`, `--interactive` — Interactively choose which parts to squash


### PR DESCRIPTION
I use these frequently and would like to type less :)

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes