### PR TITLE
tests: split cli/tests to separate crate, remove test-fakes feature (PoC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,7 +1823,6 @@ name = "jj-cli"
 version = "0.22.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "assert_matches",
  "async-trait",
  "bstr",
@@ -1846,7 +1845,6 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.13.0",
- "jj-cli",
  "jj-lib",
  "libc",
  "maplit",
@@ -1863,7 +1861,6 @@ dependencies = [
  "slab",
  "strsim",
  "tempfile",
- "test-case",
  "testutils",
  "textwrap",
  "thiserror",
@@ -1873,6 +1870,27 @@ dependencies = [
  "tracing-chrome",
  "tracing-subscriber",
  "unicode-width",
+]
+
+[[package]]
+name = "jj-cli-tests"
+version = "0.22.0"
+dependencies = [
+ "assert_cmd",
+ "chrono",
+ "clap",
+ "dunce",
+ "futures 0.3.31",
+ "git2",
+ "indoc",
+ "insta",
+ "itertools 0.13.0",
+ "jj-cli",
+ "jj-lib",
+ "regex",
+ "tempfile",
+ "test-case",
+ "testutils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,14 @@ cargo-features = []
 
 [workspace]
 resolver = "2"
-members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
+members = [
+    "cli",
+    "cli/tests",
+    "lib",
+    "lib/gen-protos",
+    "lib/proc-macros",
+    "lib/testutils",
+]
 
 [workspace.package]
 version = "0.22.0"
@@ -129,6 +136,7 @@ zstd = "0.12.4"
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in
 # their own (alphabetically sorted) block
 
+jj-cli = { path = "cli", version = "0.22.0" }
 jj-lib = { path = "lib", version = "0.22.0" }
 jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.22.0" }
 testutils = { path = "lib/testutils" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,8 +18,6 @@ include = [
     "/build.rs",
     "/examples/",
     "/src/",
-    "/testing/",
-    "/tests/",
     "!*.pending-snap",
     "!*.snap*",
     "/tests/cli-reference@.md.snap"
@@ -28,24 +26,6 @@ include = [
 [[bin]]
 name = "jj"
 path = "src/main.rs"
-
-[[bin]]
-name = "fake-editor"
-path = "testing/fake-editor.rs"
-required-features = ["test-fakes"]
-
-[[bin]]
-name = "fake-diff-editor"
-path = "testing/fake-diff-editor.rs"
-required-features = ["test-fakes"]
-
-[[bin]]
-name = "fake-formatter"
-path = "testing/fake-formatter.rs"
-required-features = ["test-fakes"]
-
-[[test]]
-name = "runner"
 
 [dependencies]
 bstr = { workspace = true }
@@ -96,20 +76,15 @@ libc = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-assert_cmd = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }
 insta = { workspace = true }
-test-case = { workspace = true }
 testutils = { workspace = true }
-# https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987
-jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 
 [features]
 default = ["watchman"]
 bench = ["dep:criterion"]
 packaging = []
-test-fakes = ["jj-lib/testing"]
 vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]
 

--- a/cli/tests/Cargo.toml
+++ b/cli/tests/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "jj-cli-tests"
+description = "Integration tests for the jj-cli crate"
+autotests = false
+publish = false
+
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+documentation = { workspace = true }
+readme = { workspace = true }
+
+# FIXME: switch to custom main.rs and remove build.rs
+build = "../build.rs"
+
+[[bin]]
+name = "jj"
+path = "../src/main.rs"
+
+# FIXME: move ../testing under .?
+[[bin]]
+name = "fake-editor"
+path = "../testing/fake-editor.rs"
+
+[[bin]]
+name = "fake-diff-editor"
+path = "../testing/fake-diff-editor.rs"
+
+[[bin]]
+name = "fake-formatter"
+path = "../testing/fake-formatter.rs"
+
+[[test]]
+name = "runner"
+path = "runner.rs"
+
+[dependencies]
+clap = { workspace = true }
+itertools = { workspace = true }
+jj-cli = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = { workspace = true }
+chrono = { workspace = true }
+dunce = { workspace = true }
+futures = { workspace = true }
+git2 = { workspace = true }
+indoc = { workspace = true }
+insta = { workspace = true }
+jj-lib = { workspace = true, features = ["testing"] }
+regex = { workspace = true }
+tempfile = { workspace = true }
+test-case = { workspace = true }
+testutils = { workspace = true }
+
+[lints]
+workspace = true

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 mod common;
 
 #[test]
 fn test_no_forgotten_test_files() {
-    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
-    testutils::assert_no_forgotten_test_files(&test_dir);
+    let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    testutils::assert_no_forgotten_test_files(test_dir);
 }
 
 mod test_abandon_command;


### PR DESCRIPTION


The goal is to remove the crate-cycle: `jj-cli --(dev)--> jj-cli`. Since there's no way to express binary dependency in Cargo.toml, all binaries which the tests depend on should have to be built within the same crate.

I put Cargo.toml in cli/tests so the directory structure looks familiar.

One big caveat: since we build a separate "jj" binary for tests, the production "jj" binary is no longer covered by these tests. We might want to leave a couple of tests in jj-cli to ensure that the real "jj" binary works.


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
