### PR TITLE
cli: use singular form when only 1 commit is abandoned after Git import

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -294,10 +294,16 @@ pub fn print_git_import_stats(
     }
 
     if !stats.abandoned_commits.is_empty() {
+        let num_abandoned_commits = stats.abandoned_commits.len();
         writeln!(
             formatter,
-            "Abandoned {} commits that are no longer reachable.",
-            stats.abandoned_commits.len()
+            "Abandoned {} {} no longer reachable.",
+            num_abandoned_commits,
+            if num_abandoned_commits == 1 {
+                "commit that is"
+            } else {
+                "commits that are"
+            }
         )?;
     }
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1046,7 +1046,7 @@ fn test_bookmark_track_untrack() {
     bookmark: feature2@origin [updated] untracked
     bookmark: feature3@origin [new] tracked
     bookmark: main@origin     [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     feature1: sptzoqmo 7b33f629 commit 1

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -299,7 +299,7 @@ fn test_git_colocated_rebase_on_import() {
     ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     Rebased 1 descendant commits off of commits rewritten from git
     Working copy now at: zsuskuln 15b1d70c (empty) (no description set)
     Parent commit      : qpvuntsm 47fe984d master | add a file
@@ -358,7 +358,7 @@ fn test_git_colocated_bookmarks() {
     ◆  0000000000000000000000000000000000000000
     "###);
     insta::assert_snapshot!(stderr, @r###"
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     Done importing changes from the underlying Git repo.

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -725,7 +725,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ○  01d115196c39 descr_for_b b?? b@origin
@@ -763,7 +763,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a2@origin [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ○  31c7d94b1f29 descr_for_a2 a2
@@ -1218,7 +1218,7 @@ fn test_git_fetch_removed_bookmark() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a2@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     ○  c7d4bdcbc215 descr_for_b b
@@ -1298,7 +1298,7 @@ fn test_git_fetch_removed_parent_bookmark() {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin     [deleted] untracked
     bookmark: trunk1@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     Warning: No branch matching `master` found on any specified/configured remote
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1004,7 +1004,7 @@ fn test_op_diff() {
     bookmark: bookmark-1@origin [updated] tracked
     bookmark: bookmark-2@origin [updated] untracked
     bookmark: bookmark-3@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     insta::assert_snapshot!(&stdout, @r#"
@@ -1690,7 +1690,7 @@ fn test_op_show() {
     bookmark: bookmark-1@origin [updated] tracked
     bookmark: bookmark-2@origin [updated] untracked
     bookmark: bookmark-3@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commit that is no longer reachable.
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
     insta::assert_snapshot!(&stdout, @r#"


### PR DESCRIPTION
# Checklist

If applicable:
~- [ ] I have updated `CHANGELOG.md`~
~- [ ] I have updated the documentation (README.md, docs/, demos/)~
~- [ ] I have updated the config schema (cli/src/config-schema.json)~
~- [ ] I have added tests to cover my changes~
