### PR TITLE
backout: partial reversion of 3f0703ca2cf

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -117,6 +117,3 @@ watchman = ["jj-lib/watchman"]
 # The archive name is jj, not jj-cli. Also, `cargo binstall` gets
 # confused by the `v` before versions in archive name.
 pkg-url = "{ repo }/releases/download/v{ version }/jj-v{ version }-{ target }.{ archive-format }"
-
-[lints]
-workspace = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -101,6 +101,3 @@ git = ["dep:git2", "dep:gix", "dep:gix-filter"]
 vendored-openssl = ["git2/vendored-openssl"]
 watchman = ["dep:tokio", "dep:watchman_client"]
 testing = ["git"]
-
-[lints]
-workspace = true

--- a/lib/gen-protos/Cargo.toml
+++ b/lib/gen-protos/Cargo.toml
@@ -9,6 +9,3 @@ license = { workspace = true }
 
 [dependencies]
 prost-build = { workspace = true }
-
-[lints]
-workspace = true

--- a/lib/proc-macros/Cargo.toml
+++ b/lib/proc-macros/Cargo.toml
@@ -20,6 +20,3 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-
-[lints]
-workspace = true

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -25,6 +25,3 @@ jj-lib = { workspace = true, features = ["testing"] }
 pollster = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
-
-[lints]
-workspace = true


### PR DESCRIPTION
All of these toml files already have a `[lints]` key, it just exited earlier on in the file and were missed.

However, the occurrence of duplicate keys breaks TOML parsers that have stricter standard rules and reject these files (rather than merging the values). In particular, `tomllib` in Python 3.11 will reject these cargo files.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
