### PR TITLE
formatter: flush color escape sequence when raw() stream is requested

### DIFF
--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -142,7 +142,7 @@ pub(crate) fn cmd_evolog(
         commits.truncate(n);
     }
     if !args.no_graph {
-        let mut raw_output = formatter.raw();
+        let mut raw_output = formatter.raw()?;
         let mut graph = get_graphlog(graph_style, raw_output.as_mut());
         for commit in commits {
             let edges = commit

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -169,7 +169,7 @@ pub(crate) fn cmd_log(
         let limit = args.limit.or(args.deprecated_limit).unwrap_or(usize::MAX);
 
         if !args.no_graph {
-            let mut raw_output = formatter.raw();
+            let mut raw_output = formatter.raw()?;
             let mut graph = get_graphlog(graph_style, raw_output.as_mut());
             let forward_iter = TopoGroupedGraphIterator::new(revset.iter_graph());
             let iter: Box<dyn Iterator<Item = _>> = if args.reversed {

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -197,7 +197,7 @@ pub fn show_op_diff(
             writeln!(formatter, "Changed commits:")
         })?;
         if let Some(graph_style) = graph_style {
-            let mut raw_output = formatter.raw();
+            let mut raw_output = formatter.raw()?;
             let mut graph = get_graphlog(graph_style, raw_output.as_mut());
 
             let graph_iter =

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -197,7 +197,7 @@ fn do_op_log(
     let limit = args.limit.or(args.deprecated_limit).unwrap_or(usize::MAX);
     let iter = op_walk::walk_ancestors(slice::from_ref(current_op)).take(limit);
     if !args.no_graph {
-        let mut raw_output = formatter.raw();
+        let mut raw_output = formatter.raw()?;
         let mut graph = get_graphlog(graph_style, raw_output.as_mut());
         for op in iter {
             let op = op?;

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -365,15 +365,11 @@ impl<'a> DiffRenderer<'a> {
                                 tool,
                             )
                         }
-                        DiffToolMode::Dir => generate_diff(
-                            ui,
-                            formatter.raw().as_mut(),
-                            from_tree,
-                            to_tree,
-                            matcher,
-                            tool,
-                        )
-                        .map_err(DiffRenderError::DiffGenerate),
+                        DiffToolMode::Dir => {
+                            let mut writer = formatter.raw()?;
+                            generate_diff(ui, writer.as_mut(), from_tree, to_tree, matcher, tool)
+                                .map_err(DiffRenderError::DiffGenerate)
+                        }
                     }?;
                 }
             }
@@ -1101,9 +1097,10 @@ pub fn show_file_by_file_diff(
             let left_path = create_file(left_path, &left_wc_dir, left_value)?;
             let right_path = create_file(right_path, &right_wc_dir, right_value)?;
 
+            let mut writer = formatter.raw()?;
             invoke_external_diff(
                 ui,
-                formatter.raw().as_mut(),
+                writer.as_mut(),
                 tool,
                 &maplit::hashmap! {
                     "left" => left_path.to_str().expect("temp_dir should be valid utf-8"),

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -190,8 +190,7 @@ pub struct RawEscapeSequenceTemplate<T>(pub T);
 impl<T: Template> Template for RawEscapeSequenceTemplate<T> {
     fn format(&self, formatter: &mut TemplateFormatter) -> io::Result<()> {
         let rewrap = formatter.rewrap_fn();
-        let mut raw_formatter = PlainTextFormatter::new(formatter.raw());
-        // TODO(#4631): process "buffered" labels.
+        let mut raw_formatter = PlainTextFormatter::new(formatter.raw()?);
         self.0.format(&mut rewrap(&mut raw_formatter))
     }
 }
@@ -709,7 +708,7 @@ impl<'a> TemplateFormatter<'a> {
         move |formatter| TemplateFormatter::new(formatter, error_handler)
     }
 
-    pub fn raw(&mut self) -> Box<dyn Write + '_> {
+    pub fn raw(&mut self) -> io::Result<Box<dyn Write + '_>> {
         self.formatter.raw()
     }
 


### PR DESCRIPTION
#4631


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
