### PR TITLE
operation templates: use end time instead of start time 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Help command doesn't work recursively anymore, i.e. `jj workspace help root`
   doesn't work anymore.
 
+* Default operation log template now shows end times of operations instead of
+  start times.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -41,8 +41,6 @@ tag_list = '''
 label("tag", name) ++ format_ref_targets(self) ++ "\n"
 '''
 
-# TODO: Here and elsewhere, the end time for operations is more meaningful than
-# the start time. https://github.com/martinvonz/jj/pull/4602#discussion_r1791207491
 op_summary = '''
 separate(" ",
   self.id().short(),
@@ -51,7 +49,7 @@ separate(" ",
     surround(
        "(",
        ")",
-       format_timestamp(self.time().start())
+       format_timestamp(self.time().end())
     )
   ),
   self.description().first_line()
@@ -153,8 +151,12 @@ commit_summary_separator = 'label("separator", " | ")'
   coalesce(signature.name(), name_placeholder)
   ++ " <" ++ coalesce(signature.email(), email_placeholder) ++ ">"
   ++ " (" ++ format_timestamp(signature.timestamp()) ++ ")"'''
+# For operations, when it makes a difference whether to use the start time or
+# the end time, the latter is more meaningful. For mutating operations, this is
+# the moment when the repo was actually modified due to this operation. TODO:
+# This macro might need a better name, e.g. `format_operation_time_range`.
 'format_time_range(time_range)' = '''
-  time_range.start().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
+  time_range.end().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp.local().format("%Y-%m-%d %H:%M:%S")'
 
 'format_commit_summary_with_refs(commit, refs)' = '''

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -256,7 +256,7 @@ fn test_op_log_template() {
     test_env.add_config(
         r#"
 [template-aliases]
-'format_time_range(time_range)' = 'time_range.start().ago() ++ ", lasted " ++ time_range.duration()'
+'format_time_range(time_range)' = 'time_range.end().ago() ++ ", lasted " ++ time_range.duration()'
         "#,
     );
     let regex = Regex::new(r"\d\d years").unwrap();
@@ -820,7 +820,7 @@ fn test_op_summary_diff_template() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=debug"]);
     insta::assert_snapshot!(&stdout, @"");
     insta::assert_snapshot!(&stderr, @r#"
-    Undid operation: [38;5;4m<<op_log id short::2301f6e6ec31>>[39m<<op_log:: (>>[38;5;6m<<op_log time start local format::2001-02-03 08:05:11>>[39m<<op_log::) >><<op_log description first_line::new empty commit>>
+    Undid operation: [38;5;4m<<op_log id short::2301f6e6ec31>>[39m<<op_log:: (>>[38;5;6m<<op_log time end local format::2001-02-03 08:05:11>>[39m<<op_log::) >><<op_log description first_line::new empty commit>>
     "#);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -836,7 +836,7 @@ fn test_op_summary_diff_template() {
     );
     insta::assert_snapshot!(&stdout, @r#"
     From operation: [38;5;4m<<op_log id short::000000000000>>[39m<<op_log:: >>[38;5;2m<<op_log root::root()>>[39m
-      To operation: [38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: (>>[38;5;6m<<op_log time start local format::2001-02-03 08:05:12>>[39m<<op_log::) >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
+      To operation: [38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: (>>[38;5;6m<<op_log time end local format::2001-02-03 08:05:12>>[39m<<op_log::) >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
 
     Changed commits:
     ○  Change qpvuntsmwlqt


### PR DESCRIPTION
For a second, I thought about replacing the word "lasted" with "after" to make it clearer, but I think it's not necessary.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes (they are very minimal though)
