### PR TITLE
formatter & colors.toml: replace `op_log` color label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Help command doesn't work recursively anymore, i.e. `jj workspace help root`
   doesn't work anymore.
 
+* The color label `op_log` from the `[colors]` config section now **only**
+  applies to the op log and not to the other places operations are displayed. In
+  almost all cases, if you configured `op_log` before, you should use the new
+  `operation` label instead.
+
 * Default operation log template now shows end times of operations instead of
   start times.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1492,12 +1492,7 @@ impl WorkspaceCommandHelper {
             &self.op_summary_template_text,
             OperationTemplateLanguage::wrap_operation,
         )
-        // TODO: "op_log" is not a great label name for op_summary. We could
-        // replace it with `operation summary` and use `operation` in
-        // colors.toml. TODO: It would be better to put labels like these
-        // consistently in the same place, e.g. `templates.toml` instead of the
-        // rust code.
-        .labeled("op_log")
+        .labeled("operation")
     }
 
     pub fn short_change_id_template(&self) -> TemplateRenderer<'_, Commit> {

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -130,6 +130,7 @@ fn do_op_log(
                 &text,
                 OperationTemplateLanguage::wrap_operation,
             )?
+            .labeled("operation")
             .labeled("op_log");
         op_node_template = workspace_env
             .parse_template(

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -82,7 +82,7 @@ pub fn cmd_op_show(
         let text = command.settings().config().get_string("templates.op_log")?;
         workspace_command
             .parse_operation_template(ui, &text)?
-            .labeled("op_log")
+            .labeled("operation")
     };
 
     ui.request_pager();

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -97,13 +97,13 @@
 "diff copied" = "green"
 "diff access-denied" = { bg = "red" }
 
-"op_log id" = "blue"
-"op_log user" = "yellow"
-"op_log time" = "cyan"
-"op_log current_operation" = { bold = true }
-"op_log current_operation id" = "bright blue"
-"op_log current_operation user" = "yellow"                    # No bright yellow, see comment above
-"op_log current_operation time" = "bright cyan"
+"operation id" = "blue"
+"operation user" = "yellow"
+"operation time" = "cyan"
+"operation current_operation" = { bold = true }
+"operation current_operation id" = "bright blue"
+"operation current_operation user" = "yellow"                    # No bright yellow, see comment above
+"operation current_operation time" = "bright cyan"
 
 "node elided" = { fg = "bright black" }
 "node working_copy" = { fg = "green", bold = true }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -820,7 +820,7 @@ fn test_op_summary_diff_template() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=debug"]);
     insta::assert_snapshot!(&stdout, @"");
     insta::assert_snapshot!(&stderr, @r#"
-    Undid operation: [38;5;4m<<op_log id short::2301f6e6ec31>>[39m<<op_log:: (>>[38;5;6m<<op_log time end local format::2001-02-03 08:05:11>>[39m<<op_log::) >><<op_log description first_line::new empty commit>>
+    Undid operation: [38;5;4m<<operation id short::2301f6e6ec31>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
     "#);
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -835,8 +835,8 @@ fn test_op_summary_diff_template() {
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
-    From operation: [38;5;4m<<op_log id short::000000000000>>[39m<<op_log:: >>[38;5;2m<<op_log root::root()>>[39m
-      To operation: [38;5;4m<<op_log id short::d208ae1b4e3c>>[39m<<op_log:: (>>[38;5;6m<<op_log time end local format::2001-02-03 08:05:12>>[39m<<op_log::) >><<op_log description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
+    From operation: [38;5;4m<<operation id short::000000000000>>[39m<<operation:: >>[38;5;2m<<operation root::root()>>[39m
+      To operation: [38;5;4m<<operation id short::d208ae1b4e3c>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:12>>[39m<<operation::) >><<operation description first_line::undo operation 2301f6e6ec31931a9b0a594742d6035a44c05250d1707f7f8678e888b11a98773ef07bf0e8008a5bccddf7114da4a35d1a1b1f7efa37c1e6c80d6bdb8f0d7a90>>
 
     Changed commits:
     ○  Change qpvuntsmwlqt


### PR DESCRIPTION
Cleans up after 7051effa8f

It's split into "operation log" and "operation summary". The color labels use "operation".

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [?] It doesn't seem to be mentioned in the docs
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
