### PR TITLE
changelog: move shallow clone support to unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New template function `raw_escape_sequence(...)` preserves escape sequences.
 
+* Initial support for shallow git repositories has been implemented. However
+  deepening the history of a shallow repository is not yet supported.
+
+* `jj git clone` now accepts a `--depth <DEPTH>` option, which
+  allows to clone the repository with a given depth.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.
@@ -132,12 +138,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   description for the second commit (the newly created empty one).
 
 * Author and committer names are now yellow by default.
-
-* Initial support for shallow git repositories has been implemented. However
-  deepening the history of a shallow repository is not yet supported.
-
-* `jj git clone` now accepts a `--depth <DEPTH>` option, which
-  allows to clone the repository with a given depth.
 
 ### Fixed bugs
 


### PR DESCRIPTION
The change was originally made during the last release cycle, so the hunks were based and rebased on top of the previous release section.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
