### PR TITLE
cli: allow (and ignore) `-d` flag for `jj new`

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -51,9 +51,10 @@ pub(crate) struct NewArgs {
     /// Parent(s) of the new change
     #[arg(default_value = "@")]
     pub(crate) revisions: Vec<RevisionArg>,
-    /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
-    unused_revision: u8,
+    /// Ignored (but lets you pass `-d`/`-r` for consistency with other
+    /// commands)
+    #[arg(short = 'd', hide = true, short_alias = 'r',  action = clap::ArgAction::Count)]
+    unused_destination: u8,
     /// The change description to use
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,


### PR DESCRIPTION
We were discussing whether `jj backout` and `jj duplicate` should support `-d/-A/-B` just like `jj rebase` does. `jj new` already accepts `-A/-B` but it does not accept `-d`. It does support `-r`, however. It seems like `-d` is a better match for `jj new` since it creates a commit on top. So this patch adds support for that flag too. I now think `-r` sounds misleading for `jj new`, but I left it in for now.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
