### PR TITLE
templates: Timestamp: add `after`, `before` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `coalesce(revsets...)` revset which returns commits in the first revset
   in the `revsets` list that does not evaluate to `none()`.
 
+* Timestamp objects in templates now have `after(date) -> Boolean` and
+  `before(date) -> Boolean` methods for comparing timestamps to other dates.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -265,6 +265,8 @@ The following methods are defined.
   format string](https://docs.rs/chrono/latest/chrono/format/strftime/).
 * `.utc() -> Timestamp`: Convert timestamp into UTC timezone.
 * `.local() -> Timestamp`: Convert timestamp into local timezone.
+* `.after(date: String) -> Boolean`: True if the timestamp is exactly at or after the given date.
+* `.before(date: String) -> Boolean`: True if the timestamp is before, but not including, the given date.
 
 ### TimestampRange type
 


### PR DESCRIPTION
This allows for more fine-grained control of timestamp formatting, for example:

```
[template-aliases]
'format_timestamp(timestamp)' = '''
if(timestamp.before("1 week ago"),
  timestamp.format("%b %d %Y %H:%M"),
  timestamp.ago()
)
'''
```

Closes #3782.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
