### PR TITLE
RFC: `branch move`: document that we don't want to support `-f` for `--from`

### DIFF
--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -42,10 +42,15 @@ use crate::ui::Ui;
 #[command(group(clap::ArgGroup::new("source").multiple(true).required(true)))]
 pub struct BookmarkMoveArgs {
     /// Move bookmarks from the given revisions
+    // We intentionally do not support the short `-f` for `--from` since it
+    // could be confused with a shorthand for `--force`, and people might not
+    // realize they need `-B`/`--allow-backwards` instead.
     #[arg(long, group = "source", value_name = "REVISIONS")]
     from: Vec<RevisionArg>,
 
     /// Move bookmarks to this revision
+    // We intentionally do not support the short `-t` for `--to` since we don't
+    // support `-f` for `--from`.
     #[arg(long, default_value = "@", value_name = "REVISION")]
     to: RevisionArg,
 


### PR DESCRIPTION
Reasoning TLDR: we don't want it confused with --force. This follows up on #4612, which *did* add these shortcuts for `jj move`.

I was initially going to add them, but people imagining `jj branch move --force` (as people were worried in #4612) is a real possibility, since `jj branch move --allow-backwards` is a thing.

The reason I would like us to think about this is that I was looking at adding some shorthands like `jj b m` to git-comparison.md (just a few, where the `jj` version looks especially long), and I'm not sure whether to use `-t` or `--to` there.
