### PR TITLE
style: remove unneeded lifetimes from trait implementations

### DIFF
--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -648,7 +648,7 @@ impl Write for FormatRecorder {
 
 struct RawEscapeSequenceRecorder<'a>(&'a mut FormatRecorder);
 
-impl<'a> Write for RawEscapeSequenceRecorder<'a> {
+impl Write for RawEscapeSequenceRecorder<'_> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         self.0.push_op(FormatOp::RawEscapeSequence(data.to_vec()));
         Ok(data.len())

--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -57,7 +57,7 @@ impl<K: Clone> From<&Edge<K>> for Ancestor<K> {
     }
 }
 
-impl<'writer, K, R> GraphLog<K> for SaplingGraphLog<'writer, R>
+impl<K, R> GraphLog<K> for SaplingGraphLog<'_, R>
 where
     K: Clone + Eq + Hash,
     R: Renderer<K, Output = String>,

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -752,7 +752,7 @@ fn to_u32_generation_range(range: &Range<u64>) -> Result<Range<u32>, RevsetEvalu
     Ok(start..end)
 }
 
-impl<'index> EvaluationContext<'index> {
+impl EvaluationContext<'_> {
     fn evaluate(
         &self,
         expression: &ResolvedExpression,

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -850,7 +850,7 @@ impl<'diff, 'input> DiffHunkIterator<'diff, 'input> {
     }
 }
 
-impl<'diff, 'input> Iterator for DiffHunkIterator<'diff, 'input> {
+impl<'input> Iterator for DiffHunkIterator<'_, 'input> {
     type Item = DiffHunk<'input>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl<'a, I> DiffLineIterator<'a, I> {
+impl<I> DiffLineIterator<'_, I> {
     /// Returns line number of the next hunk. After all hunks are consumed, this
     /// returns the next line number if the last hunk ends with newline.
     pub fn next_line_number(&self) -> DiffLineNumber {

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -448,7 +448,7 @@ pub struct IdIndexLookup<'i, 'q, K, P, S, const N: usize> {
     pos: usize, // may be index.len()
 }
 
-impl<'i, 'q, K, P, S, const N: usize> IdIndexLookup<'i, 'q, K, P, S, N>
+impl<K, P, S, const N: usize> IdIndexLookup<'_, '_, K, P, S, N>
 where
     K: ObjectId + Eq,
     S: IdIndexSource<P>,

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2225,7 +2225,7 @@ pub trait RevsetIteratorExt<'index, I> {
     fn reversed(self) -> ReverseRevsetIterator;
 }
 
-impl<'index, I: Iterator<Item = CommitId>> RevsetIteratorExt<'index, I> for I {
+impl<I: Iterator<Item = CommitId>> RevsetIteratorExt<'_, I> for I {
     fn commits(self, store: &Arc<Store>) -> RevsetCommitIterator<I> {
         RevsetCommitIterator {
             iter: self,

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -461,7 +461,7 @@ pub struct LockedWorkspace<'a> {
     locked_wc: Box<dyn LockedWorkingCopy>,
 }
 
-impl<'a> LockedWorkspace<'a> {
+impl LockedWorkspace<'_> {
     pub fn locked_wc(&mut self) -> &mut dyn LockedWorkingCopy {
         self.locked_wc.as_mut()
     }


### PR DESCRIPTION
Clippy 1.83 (currently in beta) detects more cases of unneeded lifetimes, namely in trait implementation declarations. Since this lint is warn by default (this is not something we opted in specifically), we will have to fix those instances to get a clean CI.