### PR TITLE
docs: fix typos in `immutable_heads()` example

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -268,10 +268,10 @@ You can configure the set of immutable commits via
 `revset-aliases."immutable_heads()"`. The default set of immutable heads is
 `builtin_immutable_heads()`, which in turn is defined as
 `present(trunk()) | tags() | untracked_remote_bookmarks()`. For example, to
-also consider the `maint@origin` bookmark immutable:
+also consider the `main@origin` bookmark immutable:
 
 ```toml
-revset-aliases."immutable_heads()" = "builtin_immutable_heads() | maint@origin"
+revset-aliases."immutable_heads()" = "builtin_immutable_heads() | main@origin"
 ```
 
 To prevent rewriting commits authored by other users:


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
