### PR TITLE
revset: add error propagation path to other Revset methods

### DIFF
--- a/cli/src/commands/bookmark/forget.rs
+++ b/cli/src/commands/bookmark/forget.rs
@@ -73,6 +73,8 @@ fn find_forgettable_bookmarks<'a>(
     name_patterns: &[StringPattern],
 ) -> Result<Vec<(&'a str, BookmarkTarget<'a>)>, CommandError> {
     find_bookmarks_with(name_patterns, |pattern| {
-        view.bookmarks().filter(|(name, _)| pattern.matches(name))
+        view.bookmarks()
+            .filter(|(name, _)| pattern.matches(name))
+            .map(Ok)
     })
 }

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use itertools::Itertools as _;
-use jj_lib::backend::CommitId;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::RefTarget;
 use jj_lib::str_util::StringPattern;
@@ -77,26 +76,41 @@ pub fn cmd_bookmark_move(
 
     let target_commit = workspace_command.resolve_single_rev(ui, &args.to)?;
     let matched_bookmarks = {
-        let is_source_commit = if !args.from.is_empty() {
-            workspace_command
+        let is_source_ref: Box<dyn Fn(&RefTarget) -> _> = if !args.from.is_empty() {
+            let is_source_commit = workspace_command
                 .parse_union_revsets(ui, &args.from)?
                 .evaluate()?
-                .containing_fn()
+                .containing_fn();
+            Box::new(move |target: &RefTarget| {
+                for id in target.added_ids() {
+                    if is_source_commit(id)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            })
         } else {
-            Box::new(|_: &CommitId| true)
+            Box::new(|_| Ok(true))
         };
         let mut bookmarks = if !args.names.is_empty() {
             find_bookmarks_with(&args.names, |pattern| {
                 repo.view()
                     .local_bookmarks_matching(pattern)
-                    .filter(|(_, target)| target.added_ids().any(&is_source_commit))
-                    .map(Ok)
+                    .filter_map(|(name, target)| {
+                        is_source_ref(target)
+                            .map(|matched| matched.then_some((name, target)))
+                            .transpose()
+                    })
             })?
         } else {
             repo.view()
                 .local_bookmarks()
-                .filter(|(_, target)| target.added_ids().any(&is_source_commit))
-                .collect()
+                .filter_map(|(name, target)| {
+                    is_source_ref(target)
+                        .map(|matched| matched.then_some((name, target)))
+                        .transpose()
+                })
+                .try_collect()?
         };
         // Noop matches aren't error, but should be excluded from stats.
         bookmarks.retain(|(_, old_target)| old_target.as_normal() != Some(target_commit.id()));

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -90,6 +90,7 @@ pub fn cmd_bookmark_move(
                 repo.view()
                     .local_bookmarks_matching(pattern)
                     .filter(|(_, target)| target.added_ids().any(&is_source_commit))
+                    .map(Ok)
             })?
         } else {
             repo.view()

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -336,7 +336,7 @@ fn validate_commits_ready_to_push(
             .evaluate()?
             .containing_fn()
     } else {
-        Box::new(|_: &CommitId| false)
+        Box::new(|_: &CommitId| Ok(false))
     };
 
     for commit in workspace_helper
@@ -362,7 +362,7 @@ fn validate_commits_ready_to_push(
         if commit.has_conflict()? {
             reasons.push("it has conflicts");
         }
-        if !args.allow_private && is_private(commit.id()) {
+        if !args.allow_private && is_private(commit.id())? {
             reasons.push("it is private");
         }
         if !reasons.is_empty() {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -42,6 +42,7 @@ use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::revset;
 use jj_lib::revset::Revset;
+use jj_lib::revset::RevsetContainingFn;
 use jj_lib::revset::RevsetDiagnostics;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetModifier;
@@ -840,8 +841,6 @@ fn expect_fileset_literal(
         Ok(expression)
     })
 }
-
-type RevsetContainingFn<'repo> = dyn Fn(&CommitId) -> bool + 'repo;
 
 fn evaluate_revset_expression<'repo>(
     language: &CommitTemplateLanguage<'repo>,

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -743,7 +743,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 .keyword_cache
                 .is_immutable_fn(language, function.name_span)?
                 .clone();
-            let out_property = self_property.map(move |commit| is_immutable(commit.id()));
+            let out_property = self_property.and_then(move |commit| Ok(is_immutable(commit.id())?));
             Ok(L::wrap_boolean(out_property))
         },
     );
@@ -757,7 +757,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                     Ok(evaluate_user_revset(language, diagnostics, span, revset)?.containing_fn())
                 })?;
 
-            let out_property = self_property.map(move |commit| is_contained(commit.id()));
+            let out_property = self_property.and_then(move |commit| Ok(is_contained(commit.id())?));
             Ok(L::wrap_boolean(out_property))
         },
     );
@@ -1020,7 +1020,7 @@ impl RefName {
             .get_or_try_init(|| {
                 let self_ids = self.target.added_ids().cloned().collect_vec();
                 let other_ids = tracking.target.added_ids().cloned().collect_vec();
-                Ok(revset::walk_revs(repo, &self_ids, &other_ids)?.count_estimate())
+                Ok(revset::walk_revs(repo, &self_ids, &other_ids)?.count_estimate()?)
             })
             .copied()
     }
@@ -1035,7 +1035,7 @@ impl RefName {
             .get_or_try_init(|| {
                 let self_ids = self.target.added_ids().cloned().collect_vec();
                 let other_ids = tracking.target.added_ids().cloned().collect_vec();
-                Ok(revset::walk_revs(repo, &other_ids, &self_ids)?.count_estimate())
+                Ok(revset::walk_revs(repo, &other_ids, &self_ids)?.count_estimate()?)
             })
             .copied()
     }

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -191,20 +191,21 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
         self.positions().next().is_none()
     }
 
-    fn count_estimate(&self) -> (usize, Option<usize>) {
+    fn count_estimate(&self) -> Result<(usize, Option<usize>), RevsetEvaluationError> {
         if cfg!(feature = "testing") {
             // Exercise the estimation feature in tests. (If we ever have a Revset
             // implementation in production code that returns estimates, we can probably
             // remove this and rewrite the associated tests.)
             let count = self.positions().take(10).count();
             if count < 10 {
-                (count, Some(count))
+                Ok((count, Some(count)))
             } else {
-                (10, None)
+                Ok((10, None))
             }
         } else {
+            // TODO: propagate error
             let count = self.positions().count();
-            (count, Some(count))
+            Ok((count, Some(count)))
         }
     }
 
@@ -213,7 +214,7 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
         Self: 'a,
     {
         let positions = PositionsAccumulator::new(self.index.clone(), self.inner.positions());
-        Box::new(move |commit_id| positions.contains(commit_id))
+        Box::new(move |commit_id| Ok(positions.contains(commit_id)))
     }
 }
 

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -57,6 +57,7 @@ use crate::repo_path::RepoPath;
 use crate::revset::ResolvedExpression;
 use crate::revset::ResolvedPredicateExpression;
 use crate::revset::Revset;
+use crate::revset::RevsetContainingFn;
 use crate::revset::RevsetEvaluationError;
 use crate::revset::RevsetFilterPredicate;
 use crate::revset::GENERATION_RANGE_FULL;
@@ -207,7 +208,7 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
         }
     }
 
-    fn containing_fn<'a>(&self) -> Box<dyn Fn(&CommitId) -> bool + 'a>
+    fn containing_fn<'a>(&self) -> Box<RevsetContainingFn<'a>>
     where
         Self: 'a,
     {

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -48,8 +48,7 @@ use crate::conflicts::MaterializedTreeValue;
 use crate::default_index::AsCompositeIndex;
 use crate::default_index::CompositeIndex;
 use crate::default_index::IndexPosition;
-use crate::graph::GraphEdge;
-use crate::graph::GraphNodeResult;
+use crate::graph::GraphNode;
 use crate::matchers::Matcher;
 use crate::matchers::Visit;
 use crate::merged_tree::resolve_file_values;
@@ -131,8 +130,7 @@ impl<I: AsCompositeIndex + Clone> RevsetImpl<I> {
     pub fn iter_graph_impl(
         &self,
         skip_transitive_edges: bool,
-    ) -> impl Iterator<Item = Result<(CommitId, Vec<GraphEdge<CommitId>>), RevsetEvaluationError>>
-    {
+    ) -> impl Iterator<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> {
         let index = self.index.clone();
         let walk = self.inner.positions();
         let mut graph_walk = RevsetGraphWalk::new(walk, skip_transitive_edges);
@@ -180,7 +178,7 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
 
     fn iter_graph<'a>(
         &self,
-    ) -> Box<dyn Iterator<Item = GraphNodeResult<CommitId, RevsetEvaluationError>> + 'a>
+    ) -> Box<dyn Iterator<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> + 'a>
     where
         Self: 'a,
     {

--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -28,6 +28,7 @@ use super::revset_engine::BoxedRevWalk;
 use crate::backend::CommitId;
 use crate::graph::GraphEdge;
 use crate::graph::GraphEdgeType;
+use crate::graph::GraphNode;
 
 // This can be cheaply allocated and hashed compared to `CommitId`-based type.
 type IndexGraphEdge = GraphEdge<IndexPosition>;
@@ -308,7 +309,7 @@ impl<'a> RevsetGraphWalk<'a> {
 }
 
 impl RevWalk<CompositeIndex> for RevsetGraphWalk<'_> {
-    type Item = (CommitId, Vec<GraphEdge<CommitId>>);
+    type Item = GraphNode<CommitId>;
 
     fn next(&mut self, index: &CompositeIndex) -> Option<Self::Item> {
         let position = self.next_index_position(index)?;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2207,13 +2207,14 @@ pub trait Revset: fmt::Debug {
     where
         Self: 'a;
 
+    /// Returns true if iterator will emit at least one commit or error.
     fn is_empty(&self) -> bool;
 
     /// Inclusive lower bound and, optionally, inclusive upper bound of how many
     /// commits are in the revset. The implementation can use its discretion as
     /// to how much effort should be put into the estimation, and how accurate
     /// the resulting estimate should be.
-    fn count_estimate(&self) -> (usize, Option<usize>);
+    fn count_estimate(&self) -> Result<(usize, Option<usize>), RevsetEvaluationError>;
 
     /// Returns a closure that checks if a commit is contained within the
     /// revset.
@@ -2226,7 +2227,7 @@ pub trait Revset: fmt::Debug {
 }
 
 /// Function that checks if a commit is contained within the revset.
-pub type RevsetContainingFn<'a> = dyn Fn(&CommitId) -> bool + 'a;
+pub type RevsetContainingFn<'a> = dyn Fn(&CommitId) -> Result<bool, RevsetEvaluationError> + 'a;
 
 pub trait RevsetIteratorExt<'index, I> {
     fn commits(self, store: &Arc<Store>) -> RevsetCommitIterator<I>;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2220,10 +2220,13 @@ pub trait Revset: fmt::Debug {
     ///
     /// The implementation may construct and maintain any necessary internal
     /// context to optimize the performance of the check.
-    fn containing_fn<'a>(&self) -> Box<dyn Fn(&CommitId) -> bool + 'a>
+    fn containing_fn<'a>(&self) -> Box<RevsetContainingFn<'a>>
     where
         Self: 'a;
 }
+
+/// Function that checks if a commit is contained within the revset.
+pub type RevsetContainingFn<'a> = dyn Fn(&CommitId) -> bool + 'a;
 
 pub trait RevsetIteratorExt<'index, I> {
     fn commits(self, store: &Arc<Store>) -> RevsetCommitIterator<I>;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -37,7 +37,7 @@ use crate::dsl_util::AliasExpandError as _;
 use crate::fileset;
 use crate::fileset::FilesetDiagnostics;
 use crate::fileset::FilesetExpression;
-use crate::graph::GraphNodeResult;
+use crate::graph::GraphNode;
 use crate::hex_util::to_forward_hex;
 use crate::id_prefix::IdPrefixContext;
 use crate::id_prefix::IdPrefixIndex;
@@ -2203,7 +2203,7 @@ pub trait Revset: fmt::Debug {
 
     fn iter_graph<'a>(
         &self,
-    ) -> Box<dyn Iterator<Item = GraphNodeResult<CommitId, RevsetEvaluationError>> + 'a>
+    ) -> Box<dyn Iterator<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> + 'a>
     where
         Self: 'a;
 

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3765,8 +3765,8 @@ fn test_revset_containing_fn() {
     let revset = revset_for_commits(repo.as_ref(), &[&commit_b, &commit_d]);
 
     let revset_has_commit = revset.containing_fn();
-    assert!(!revset_has_commit(commit_a.id()));
-    assert!(revset_has_commit(commit_b.id()));
-    assert!(!revset_has_commit(commit_c.id()));
-    assert!(revset_has_commit(commit_d.id()));
+    assert!(!revset_has_commit(commit_a.id()).unwrap());
+    assert!(revset_has_commit(commit_b.id()).unwrap());
+    assert!(!revset_has_commit(commit_c.id()).unwrap());
+    assert!(revset_has_commit(commit_d.id()).unwrap());
 }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
