### PR TITLE
bookmark: fix doc links

### DIFF
--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -35,7 +35,7 @@ use crate::ui::Ui;
 /// "+".
 ///
 /// For information about bookmarks, see
-/// https://martinvonz.github.io/jj/docs/bookmarks.md.
+/// https://martinvonz.github.io/jj/latest/bookmarks/.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkListArgs {
     /// Show all tracking and non-tracking remote bookmarks including the ones
@@ -71,7 +71,7 @@ pub struct BookmarkListArgs {
     ///
     /// All 0-argument methods of the `RefName` type are available as keywords.
     ///
-    /// For the syntax, see https://martinvonz.github.io/jj/latest/docs/templates.md
+    /// For the syntax, see https://martinvonz.github.io/jj/latest/templates/
     #[arg(long, short = 'T')]
     template: Option<String>,
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -305,7 +305,7 @@ List bookmarks and their targets
 
 By default, a tracking remote bookmark will be included only if its target is different from the local target. A non-tracking remote bookmark won't be listed. For a conflicted bookmark (both local and remote), old target revisions are preceded by a "-" and new target revisions are preceded by a "+".
 
-For information about bookmarks, see https://martinvonz.github.io/jj/docs/bookmarks.md.
+For information about bookmarks, see https://martinvonz.github.io/jj/latest/bookmarks/.
 
 **Usage:** `jj bookmark list [OPTIONS] [NAMES]...`
 
@@ -327,7 +327,7 @@ For information about bookmarks, see https://martinvonz.github.io/jj/docs/bookma
 
    All 0-argument methods of the `RefName` type are available as keywords.
 
-   For the syntax, see https://martinvonz.github.io/jj/latest/docs/templates.md
+   For the syntax, see https://martinvonz.github.io/jj/latest/templates/
 
 
 


### PR DESCRIPTION
The current links result in a 404. Replace them with the actual location of the respective pages.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
