### PR TITLE
bookmark: fix broken docs URLs that lead to 404 errors

### DIFF
--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -56,7 +56,7 @@ pub struct BookmarkListArgs {
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select bookmarks by wildcard pattern. For details, see
-    /// https://martinvonz.github.io/jj/docs/revsets.md#string-patterns.
+    /// https://martinvonz.github.io/jj/latest/revsets/#string-patterns.
     #[arg(value_parser = StringPattern::parse)]
     names: Vec<StringPattern>,
 

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -59,7 +59,7 @@ use crate::ui::Ui;
 /// Manage bookmarks
 ///
 /// For information about bookmarks, see
-/// https://martinvonz.github.io/jj/latest/docs/bookmarks.md.
+/// https://martinvonz.github.io/jj/latest/bookmarks.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BookmarkCommand {
     #[command(visible_alias("c"))]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -235,7 +235,7 @@ Apply the reverse of a revision on top of another revision
 
 Manage bookmarks
 
-For information about bookmarks, see https://martinvonz.github.io/jj/latest/docs/bookmarks.md.
+For information about bookmarks, see https://martinvonz.github.io/jj/latest/bookmarks.
 
 **Usage:** `jj bookmark <COMMAND>`
 
@@ -313,7 +313,7 @@ For information about bookmarks, see https://martinvonz.github.io/jj/latest/book
 
 * `<NAMES>` — Show bookmarks whose local name matches
 
-   By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by wildcard pattern. For details, see https://martinvonz.github.io/jj/docs/revsets.md#string-patterns.
+   By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by wildcard pattern. For details, see https://martinvonz.github.io/jj/latest/revsets/#string-patterns.
 
 ###### **Options:**
 


### PR DESCRIPTION
Found a few more broken links beyond those in 9b5cdf2.

# Checklist

If applicable:
- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (README.md, docs/, demos/)
- n/a I have updated the config schema (cli/src/config-schema.json)
- n/a I have added tests to cover my changes
