### PR TITLE
bookmark list: add --remote to filter remote bookmarks listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New template functions `pad_start()`, `pad_end()`, `truncate_start()`, and
   `truncate_end()` are added.
 
+* `jj bookmark list` gained a `--remote REMOTE` option to display bookmarks
+   belonging to a remote. This option can be combined with `--tracked` or
+   `--conflicted`.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -318,6 +318,7 @@ For information about bookmarks, see https://martinvonz.github.io/jj/latest/book
 ###### **Options:**
 
 * `-a`, `--all-remotes` — Show all tracking and non-tracking remote bookmarks including the ones whose targets are synchronized with the local bookmarks
+* `--remote <REMOTE>` — Show all tracking and non-tracking remote bookmarks belonging to this remote. Can be combined with `--tracked` or `--conflicted` to filter the bookmarks shown (can be repeated)
 * `-t`, `--tracked` — Show remote tracked bookmarks only. Omits local Git-tracking bookmarks by default
 * `-c`, `--conflicted` — Show conflicted bookmarks only
 * `-r`, `--revisions <REVISIONS>` — Show bookmarks whose local targets are in the given revisions

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1533,6 +1533,47 @@ fn test_bookmark_list_filtered() {
     "###);
     insta::assert_snapshot!(stderr, @"");
 
+    // Select bookmarks with --remote
+    let (stdout, stderr) = query(&["--remote", "origin"]);
+    insta::assert_snapshot!(stdout, @r#"
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
+    remote-delete (deleted)
+      @origin: yxusvupt dad5f298 (empty) remote-delete
+    remote-keep: nlwprzpn 911e9120 (empty) remote-keep
+      @origin: nlwprzpn 911e9120 (empty) remote-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
+    "#);
+    insta::assert_snapshot!(stderr, @r#"
+    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
+    "#);
+    let (stdout, stderr) = query(&["--remote", "git"]);
+    insta::assert_snapshot!(stdout, @r#"
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
+      @git: kpqxywon c7b4c09c (empty) local-keep
+    remote-keep: nlwprzpn 911e9120 (empty) remote-keep
+      @git: nlwprzpn 911e9120 (empty) remote-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @git: xyxluytn e31634b6 (empty) rewritten
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+    let (stdout, stderr) = query(&["--remote", "origin", "--remote", "git"]);
+    insta::assert_snapshot!(stdout, @r#"
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
+      @git: kpqxywon c7b4c09c (empty) local-keep
+    remote-delete (deleted)
+      @origin: yxusvupt dad5f298 (empty) remote-delete
+    remote-keep: nlwprzpn 911e9120 (empty) remote-keep
+      @git: nlwprzpn 911e9120 (empty) remote-keep
+      @origin: nlwprzpn 911e9120 (empty) remote-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @git: xyxluytn e31634b6 (empty) rewritten
+      @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
+    "#);
+    insta::assert_snapshot!(stderr, @r#"
+    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
+    "#);
+
     // Can select deleted bookmark by name pattern, but not by revset.
     let (stdout, stderr) = query(&["remote-delete"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -1577,6 +1618,21 @@ fn test_bookmark_list_filtered() {
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
     "###);
+    insta::assert_snapshot!(stderr, @"");
+
+    // … but still filtered by --remote
+    let (stdout, stderr) = query(&[
+        "local-keep",
+        "-rbookmarks(remote-rewrite)",
+        "--remote",
+        "git",
+    ]);
+    insta::assert_snapshot!(stdout, @r#"
+    local-keep: kpqxywon c7b4c09c (empty) local-keep
+      @git: kpqxywon c7b4c09c (empty) local-keep
+    remote-rewrite: xyxluytn e31634b6 (empty) rewritten
+      @git: xyxluytn e31634b6 (empty) rewritten
+    "#);
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1747,6 +1803,24 @@ fn test_bookmark_list_tracked() {
     upstream-sync: lolpmnqw 32fa6da0 (empty) upstream-sync
       @upstream: lolpmnqw 32fa6da0 (empty) upstream-sync
     "###
+    );
+    insta::assert_snapshot!(stderr, @r###"
+    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
+    "###);
+
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &local_path,
+        &["bookmark", "list", "--tracked", "--remote", "origin"],
+    );
+    insta::assert_snapshot!(stdout, @r#"
+    remote-delete (deleted)
+      @origin: mnmymoky 203e60eb (empty) remote-delete
+    remote-sync: zwtyzrop c761c7ea (empty) remote-sync
+      @origin: zwtyzrop c761c7ea (empty) remote-sync
+    remote-unsync: nmzmmopx e1da745b (empty) local-only
+      @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
+    remote-untrack@origin: vmortlor 71a16b05 (empty) remote-untrack
+    "#
     );
     insta::assert_snapshot!(stderr, @r###"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.


### PR DESCRIPTION
I find myself quite often willing to run `jj bookmark list --remote upstream` to check the bookmarks belonging to one particular remote.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
