### PR TITLE
diff: Allow setting the default level of context in config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
    belonging to a remote. This option can be combined with `--tracked` or
    `--conflicted`.
 
+* Added the config settings `diff.color-words.context` and `diff.git.context` to
+  control the default number of lines of context shown.
+
 ### Fixed bugs
 
 * Error on `trunk()` revset resolution is now handled gracefully.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -288,6 +288,22 @@
                             "type": "integer",
                             "description": "Maximum number of removed/added word alternation to inline",
                             "default": 3
+                        },
+                        "context": {
+                            "type": "integer",
+                            "description": "Number of lines of context to show",
+                            "default": 3
+                        }
+                    }
+                },
+                "git": {
+                    "type": "object",
+                    "description": "Options for git diffs",
+                    "properties": {
+                        "context": {
+                            "type": "integer",
+                            "description": "Number of lines of context to show",
+                            "default": 3
                         }
                     }
                 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -8,6 +8,10 @@ unamend = ["unsquash"]
 
 [diff.color-words]
 max-inline-alternation = 3
+context = 3
+
+[diff.git]
+context = 3
 
 [ui]
 # TODO: delete ui.allow-filesets in jj 0.26+

--- a/docs/config.md
+++ b/docs/config.md
@@ -204,7 +204,8 @@ ui.diff.format = "git"
 
 In color-words diffs, changed words are displayed inline by default. Because
 it's difficult to read a diff line with many removed/added words, there's a
-threshold to switch to traditional separate-line format.
+threshold to switch to traditional separate-line format. You can also change
+the default number of lines of context shown.
 
 * `max-inline-alternation`: Maximum number of removed/added word alternation to
   inline. For example, `<added> ... <added>` sequence has 1 alternation, so the
@@ -219,10 +220,23 @@ threshold to switch to traditional separate-line format.
   The default is `3`.
 
   **This parameter is experimental.** The definition is subject to change.
+* `context`: Number of lines of context to show in the diff. The default is `3`.
 
 ```toml
 [diff.color-words]
 max-inline-alternation = 3
+context = 3
+```
+
+#### Git diff options
+
+In git diffs you can change the default number of lines of context shown.
+
+* `context`: Number of lines of context to show in the diff. The default is `3`.
+
+```toml
+[diff.git]
+context = 3
 ```
 
 ### Generating diffs by external command


### PR DESCRIPTION
I'm used to more context by default.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
