### PR TITLE
docs: fix a typo (-locked vs --locked) in Mac install section

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -128,7 +128,7 @@ or:
 
 ```shell
 # To install the latest release
-cargo install --features vendored-openssl -locked --bin jj jj-cli
+cargo install --features vendored-openssl --locked --bin jj jj-cli
 ```
 
 #### From Source, Homebrew OpenSSL


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
