### PR TITLE
docs: Replace "first make sure that nothing is staged" comment with equivalent `--only` flag

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -239,8 +239,7 @@ parent.
     <tr>
       <td>Edit description (commit message) of the previous change</td>
       <td><code>jj describe @-</code></td>
-      <td><code>git commit --amend</code> (first make sure that nothing is
-          staged)</td>
+      <td><code>git commit --amend --only</code></td>
     </tr>
     <tr>
       <td>Temporarily put away the current change</td>


### PR DESCRIPTION
This part of the git-comparison table was implying you need to manually check and clear staged changes in order to only update the previous commit's message. That isn't the case, though. As mentioned in the [`git-commit` documentation][1], this can be directly achieved by using the `--only` flag with `--amend`:

> If this option is specified together with --amend, then no paths need
> to be specified, which can be used to amend the last commit without
> committing changes that have already been staged.

[1]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--o