### PR TITLE
add rust-toolchain.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
 [workspace.package]
 version = "0.22.0"
 license = "Apache-2.0"
-rust-version = "1.76" # NOTE: remember to update CI, contributing.md, changelog.md, install-and-setup.md, and flake.nix
+rust-version = "1.76" # NOTE: remember to update CI, contributing.md, changelog.md, install-and-setup.md, and rust-toolchain.toml
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/martinvonz/jj"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.76.0"


### PR DESCRIPTION
CI is pinned to our MSRV. This file makes rustup automatically select that same version for people developing locally with rustup. MSRV violations can therefore be caught earilier during development, instead of in CI.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

I had some MSRV related broken CI [here](https://github.com/martinvonz/jj/pull/4737), which I didn't notice locally. I don't think this is extremely important, just nice to have if there are no downsides. I don't know of any downsides, but maybe someone else does.