### PR TITLE
cli: insert dummy -h/--help flag when parsing early args

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2908,7 +2908,7 @@ fn resolve_default_command(
     app: &Command,
     mut string_args: Vec<String>,
 ) -> Result<Vec<String>, CommandError> {
-    const PRIORITY_FLAGS: &[&str] = &["help", "--help", "-h", "--version", "-V"];
+    const PRIORITY_FLAGS: &[&str] = &["--help", "-h", "--version", "-V"];
 
     let has_priority_flag = string_args
         .iter()
@@ -3033,7 +3033,6 @@ fn handle_early_args(
         .clone()
         .disable_version_flag(true)
         .disable_help_flag(true)
-        .disable_help_subcommand(true)
         .ignore_errors(true)
         .try_get_matches_from(args)?;
     let mut args: EarlyArgs = EarlyArgs::from_arg_matches(&early_matches).unwrap();

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3032,7 +3032,16 @@ fn handle_early_args(
     let early_matches = app
         .clone()
         .disable_version_flag(true)
+        // Do not emit DisplayHelp error
         .disable_help_flag(true)
+        // Do not stop parsing at -h/--help
+        .arg(
+            clap::Arg::new("help")
+                .short('h')
+                .long("help")
+                .global(true)
+                .action(ArgAction::Count),
+        )
         .ignore_errors(true)
         .try_get_matches_from(args)?;
     let mut args: EarlyArgs = EarlyArgs::from_arg_matches(&early_matches).unwrap();

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -559,6 +559,16 @@ fn test_early_args() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["help", "--color=always"]);
     insta::assert_snapshot!(stdout.lines().find(|l| l.contains("Commands:")).unwrap(), @"[1m[4mCommands:[0m");
 
+    // Check that early args are accepted after -h/--help
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["-h", "--color=always"]);
+    insta::assert_snapshot!(
+        stdout.lines().find(|l| l.contains("Usage:")).unwrap(),
+        @"[1m[4mUsage:[0m [1mjj[0m [OPTIONS] <COMMAND>");
+    let stdout = test_env.jj_cmd_success(test_env.env_root(), &["log", "--help", "--color=always"]);
+    insta::assert_snapshot!(
+        stdout.lines().find(|l| l.contains("Usage:")).unwrap(),
+        @"[1m[4mUsage:[0m [1mjj log[0m [OPTIONS] [PATHS]...");
+
     // Early args are parsed with clap's ignore_errors(), but there is a known
     // bug that causes defaults to be unpopulated. Test that the early args are
     // tolerant of this bug and don't cause a crash.


### PR DESCRIPTION
#4746

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
