### PR TITLE
revset: refactor as a prep for introducing type-safe resolution state

### DIFF
--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -27,7 +27,6 @@ use jj_lib::revset;
 use jj_lib::revset::DefaultSymbolResolver;
 use jj_lib::revset::Revset;
 use jj_lib::revset::RevsetAliasesMap;
-use jj_lib::revset::RevsetCommitRef;
 use jj_lib::revset::RevsetDiagnostics;
 use jj_lib::revset::RevsetEvaluationError;
 use jj_lib::revset::RevsetExpression;
@@ -313,7 +312,7 @@ fn format_multiple_revisions_error(
             "Some of these commits have the same change id. Abandon one of them with `jj abandon \
              -r <REVISION>`.",
         );
-    } else if let RevsetExpression::CommitRef(RevsetCommitRef::Symbol(bookmark_name)) = expression {
+    } else if let Some(bookmark_name) = expression.as_symbol() {
         // Separate hint if there's a conflicted bookmark
         cmd_err.add_formatted_hint_with(|formatter| {
             writeln!(

--- a/cli/tests/test_debug_command.rs
+++ b/cli/tests/test_debug_command.rs
@@ -57,16 +57,12 @@ fn test_debug_revset() {
     insta::with_settings!({filters => vec![
         (r"(?m)(^    .*\n)+", "    ..\n"),
     ]}, {
-        assert_snapshot!(stdout, @r###"
+        assert_snapshot!(stdout, @r"
         -- Parsed:
-        CommitRef(
-            ..
-        )
+        Root
 
         -- Optimized:
-        CommitRef(
-            ..
-        )
+        Root
 
         -- Resolved:
         Commits(
@@ -80,7 +76,7 @@ fn test_debug_revset() {
 
         -- Commit IDs:
         0000000000000000000000000000000000000000
-        "###);
+        ");
     });
 }
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -466,6 +466,14 @@ impl RevsetExpression {
         }
     }
 
+    /// Returns symbol string if this expression is of that type.
+    pub fn as_symbol(&self) -> Option<&str> {
+        match self {
+            RevsetExpression::CommitRef(RevsetCommitRef::Symbol(name)) => Some(name),
+            _ => None,
+        }
+    }
+
     /// Resolve a programmatically created revset expression.
     ///
     /// In particular, the expression must not contain any symbols (bookmarks,

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -419,6 +419,11 @@ impl RevsetExpression {
         })
     }
 
+    /// Suppresses name resolution error within `self`.
+    pub fn present(self: &Rc<Self>) -> Rc<Self> {
+        Rc::new(Self::Present(self.clone()))
+    }
+
     /// Commits that are not in `self`, i.e. the complement of `self`.
     pub fn negated(self: &Rc<Self>) -> Rc<Self> {
         Rc::new(Self::NotIn(self.clone()))
@@ -873,7 +878,7 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
     map.insert("present", |diagnostics, function, context| {
         let [arg] = function.expect_exact_arguments()?;
         let expression = lower_expression(diagnostics, arg, context)?;
-        Ok(Rc::new(RevsetExpression::Present(expression)))
+        Ok(expression.present())
     });
     map.insert("at_operation", |diagnostics, function, context| {
         let [op_arg, cand_arg] = function.expect_exact_arguments()?;

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -14,7 +14,6 @@
 
 use std::iter;
 use std::path::Path;
-use std::rc::Rc;
 
 use assert_matches::assert_matches;
 use chrono::DateTime;
@@ -456,14 +455,13 @@ fn test_resolve_working_copy() {
 
     // The error can be suppressed by present()
     assert_eq!(
-        Rc::new(RevsetExpression::Present(RevsetExpression::working_copy(
-            ws1.clone()
-        )))
-        .evaluate_programmatic(mut_repo)
-        .unwrap()
-        .iter()
-        .map(Result::unwrap)
-        .collect_vec(),
+        RevsetExpression::working_copy(ws1.clone())
+            .present()
+            .evaluate_programmatic(mut_repo)
+            .unwrap()
+            .iter()
+            .map(Result::unwrap)
+            .collect_vec(),
         vec![]
     );
 


### PR DESCRIPTION


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
