### PR TITLE
cli: do not stringify git2::Error too early

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -62,7 +62,7 @@ pub fn map_git_error(err: git2::Error) -> CommandError {
 
         user_error_with_hint(err, hint)
     } else {
-        user_error(err.to_string())
+        user_error(err)
     }
 }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
