### PR TITLE
docs: switch all toml examples to heading notation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -58,10 +58,10 @@ colors."commit_id prefix".bold = true
 "commit_id prefix" = { bold = true }
 ```
 
-Jujutsu favors the dotted style in these instructions, if only because it's
-easier to write down in an unconfusing way. If you are confident with TOML
+The docs below refer to keys in text using dotted notation, but example
+blocks will use heading notation to be unambiguous. If you are confident with TOML
 then use whichever suits you in your config. If you mix dotted keys and headings,
-**put the dotted keys before the first heading**.
+**you must put the dotted keys before the first heading**.
 
 That's probably enough TOML to keep you out of trouble but the [syntax guide] is
 very short if you ever need to check.
@@ -70,8 +70,9 @@ very short if you ever need to check.
 ## User settings
 
 ```toml
-user.name = "YOUR NAME"
-user.email = "YOUR_EMAIL@example.com"
+[user]
+name = "YOUR NAME"
+email = "YOUR_EMAIL@example.com"
 ```
 
 Don't forget to change these to your own details!
@@ -87,7 +88,8 @@ active labels alongside the regular colorized output.
 This setting overrides the `NO_COLOR` environment variable (if set).
 
 ```toml
-ui.color = "never" # Turn off color
+[ui]
+color = "never" # Turn off color
 ```
 
 ### Custom colors and styles
@@ -95,7 +97,8 @@ ui.color = "never" # Turn off color
 You can customize the colors used for various elements of the UI. For example:
 
 ```toml
-colors.commit_id = "green"
+[colors]
+commit_id = "green"
 ```
 
 The following colors are available:
@@ -117,7 +120,8 @@ All of them but "default" come in a bright version too, e.g. "bright red". The
 You can also use a 6-digit hex code for more control over the exact color used:
 
 ```toml
-colors.change_id = "#ff1525"
+[colors]
+change_id = "#ff1525"
 ```
 
 If you use a string value for a color, as in the examples above, it will be used
@@ -125,7 +129,8 @@ for the foreground color. You can also set the background color, or make the
 text bold or underlined. For that, you need to use a table:
 
 ```toml
-colors.commit_id = { fg = "green", bg = "#ff1525", bold = true, underline = true }
+[colors]
+commit_id = { fg = "green", bg = "#ff1525", bold = true, underline = true }
 ```
 
 The key names are called "labels". The above used `commit_id` as label. You can
@@ -135,8 +140,9 @@ make the commit ID of the working-copy commit also be underlined, you can do
 this:
 
 ```toml
-colors.commit_id = "green"
-colors."working_copy commit_id" = { underline = true }
+[colors]
+commit_id = "green"
+"working_copy commit_id" = { underline = true }
 ```
 
 Parts of the style that are not overridden - such as the foreground color in the
@@ -153,7 +159,8 @@ When `jj` is run with no explicit subcommand, the value of the
 subcommand name, subcommand alias, or user-defined alias (defaults to `"log"`).
 
 ```toml
-ui.default-command = ["log", "--reversed"]
+[ui]
+default-command = ["log", "--reversed"]
 ```
 
 ### Default description
@@ -178,7 +185,8 @@ The value of the `ui.default-description` setting can also be used in order to
 fill in things like BUG=, TESTED= etc.
 
 ```toml
-ui.default-description = "\n\nTESTED=TODO"
+[ui]
+default-description = "\n\nTESTED=TODO"
 ```
 
 ### Diff colors and styles
@@ -196,8 +204,9 @@ can override the default style with the following keys:
 ### Diff format
 
 ```toml
+[ui]
 # Possible values: "color-words" (default), "git", "summary"
-ui.diff.format = "git"
+diff.format = "git"
 ```
 
 #### Color-words diff options
@@ -285,7 +294,8 @@ You can configure the set of immutable commits via
 also consider the `release@origin` bookmark immutable:
 
 ```toml
-revset-aliases."immutable_heads()" = "builtin_immutable_heads() | release@origin"
+[revset-aliases]
+"immutable_heads()" = "builtin_immutable_heads() | release@origin"
 ```
 
 To prevent rewriting commits authored by other users:
@@ -293,7 +303,8 @@ To prevent rewriting commits authored by other users:
 ```toml
 # The `trunk().. &` bit is an optimization to scan for non-`mine()` commits
 # only among commits that are not in `trunk()`.
-revset-aliases."immutable_heads()" = "builtin_immutable_heads() | (trunk().. & ~mine())"
+[revset-aliases]
+"immutable_heads()" = "builtin_immutable_heads() | (trunk().. & ~mine())"
 ```
 
 Ancestors of the configured set are also immutable. The root commit is always
@@ -306,8 +317,9 @@ immutable even if the set is empty.
 You can configure the revisions `jj log` would show when neither `-r` nor any paths are specified.
 
 ```toml
+[revsets]
 # Show commits that are not in `main@origin`
-revsets.log = "main@origin.."
+log = "main@origin.."
 ```
 
 The default value for `revsets.log` is
@@ -342,8 +354,9 @@ log = "builtin_log_compact_full_description"
 ### Graph style
 
 ```toml
+[ui]
 # Possible values: "curved" (default), "square", "ascii", "ascii-large"
-ui.graph.style = "square"
+graph.style = "square"
 ```
 
 #### Node style
@@ -374,7 +387,8 @@ If enabled, `log`/`evolog`/`op log` content will be wrapped based on
 the terminal width.
 
 ```toml
-ui.log-word-wrap = true
+[ui]
+log-word-wrap = true
 ```
 
 ### Display of commit and change ids
@@ -405,8 +419,9 @@ To customize these separately, use the `format_short_commit_id()` and
 To get shorter prefixes for certain revisions, set `revsets.short-prefixes`:
 
 ```toml
+[revsets]
 # Prioritize the current bookmark
-revsets.short-prefixes = "(main..@)::"
+short-prefixes = "(main..@)::"
 ```
 
 ### Relative timestamps
@@ -456,8 +471,9 @@ Another way you can override this check is by setting
 the revset arguments of such commands to expand to any number of revisions.
 
 ```toml
+[ui]
 # Assume `all:` prefix before revsets whenever it would make a difference
-ui.always-allow-large-revsets = true
+always-allow-large-revsets = true
 ```
 
 ## Pager
@@ -489,10 +505,11 @@ future.
 Additionally, paging behavior can be toggled via `ui.paginate` like so:
 
 ```toml
+[ui]
 # Enable pagination for commands that support it (default)
-ui.paginate = "auto"
+paginate = "auto"
 # Disable all pagination, equivalent to using --no-pager
-ui.paginate = "never"
+paginate = "never"
 ```
 
 ### Processing contents to be paged
@@ -503,7 +520,8 @@ through a pager you must do it using a subshell as, unlike `git` or `hg`, the
 command will be executed directly. For example:
 
 ```toml
-ui.pager = ["sh", "-c", "diff-so-fancy | less -RFX"]
+[ui]
+pager = ["sh", "-c", "diff-so-fancy | less -RFX"]
 ```
 
 Some formatters (like [`delta`](https://github.com/dandavison/delta)) require
@@ -523,9 +541,10 @@ format = "git"
 You can define aliases for commands, including their arguments. For example:
 
 ```toml
+[aliases]
 # `jj l` shows commits on the working-copy commit's (anonymous) bookmark
 # compared to the `main` bookmark
-aliases.l = ["log", "-r", "(main..@):: | (main..@)-"]
+l = ["log", "-r", "(main..@):: | (main..@)-"]
 ```
 
 This alias syntax can only run a single jj command. However, you may want to
@@ -575,26 +594,29 @@ Pico is the default editor (Notepad on Windows) in the absence of any other
 setting, but you could set it explicitly too.
 
 ```toml
-ui.editor = "pico"
+[ui]
+editor = "pico"
 ```
 
 To use NeoVim instead:
 
 ```toml
-ui.editor = "nvim"
+[ui]
+editor = "nvim"
 ```
 
 For GUI editors you possibly need to use a `-w` or `--wait`. Some examples:
 
 ```toml
-ui.editor = "code -w"       # VS Code
-ui.editor = "code.cmd -w"   # VS Code on Windows
-ui.editor = "bbedit -w"     # BBEdit
-ui.editor = "subl -n -w"    # Sublime Text
-ui.editor = "mate -w"       # TextMate
-ui.editor = ["C:/Program Files/Notepad++/notepad++.exe",
+[ui]
+editor = "code -w"       # VS Code
+editor = "code.cmd -w"   # VS Code on Windows
+editor = "bbedit -w"     # BBEdit
+editor = "subl -n -w"    # Sublime Text
+editor = "mate -w"       # TextMate
+editor = ["C:/Program Files/Notepad++/notepad++.exe",
     "-multiInst", "-notabbar", "-nosession", "-noPlugin"] # Notepad++
-ui.editor = "idea --temp-project --wait"   #IntelliJ
+editor = "idea --temp-project --wait"   #IntelliJ
 ```
 
 Obviously, you would only set one line, don't copy them all in!
@@ -626,9 +648,10 @@ If `ui.diff-editor` is a string, e.g. `"meld"`, the arguments will be read from
 the following config keys.
 
 ```toml
-# merge-tools.meld.program = "meld"      # Defaults to the name of the tool if not specified
-merge-tools.meld.program = "/path/to/meld" # May be necessary if `meld` is not in the PATH
-merge-tools.meld.edit-args = ["--newtab", "$left", "$right"]
+[merge-tools.meld]
+# program = "meld"      # Defaults to the name of the tool if not specified
+program = "/path/to/meld" # May be necessary if `meld` is not in the PATH
+edit-args = ["--newtab", "$left", "$right"]
 ```
 
 `jj` makes the following substitutions:
@@ -643,12 +666,13 @@ Finally, `ui.diff-editor` can be a list that specifies a command and its argumen
 Some examples:
 
 ```toml
+[ui]
 # Use merge-tools.meld.edit-args
-ui.diff-editor = "meld"  # Or `kdiff3`, or `diffedit3`, ...
+diff-editor = "meld"  # Or `kdiff3`, or `diffedit3`, ...
 # Specify edit-args inline
-ui.diff-editor = ["/path/to/binary", "--be-helpful", "$left", "$right"]
+diff-editor = ["/path/to/binary", "--be-helpful", "$left", "$right"]
 # Equivalent to ["binary", "$left", "$right"] arguments by default
-ui.diff-editor = "binary"
+diff-editor = "binary"
 ```
 
 
@@ -747,10 +771,11 @@ The `ui.merge-editor` key specifies the tool used for three-way merge tools
 by `jj resolve`. For example:
 
 ```toml
+[ui]
 # Use merge-tools.meld.merge-args
-ui.merge-editor = "meld"  # Or "vscode" or "vscodium" or "kdiff3" or "vimdiff"
+merge-editor = "meld"  # Or "vscode" or "vscodium" or "kdiff3" or "vimdiff"
 # Specify merge-args inline
-ui.merge-editor = ["meld", "$left", "$base", "$right", "-o", "$output"]
+merge-editor = ["meld", "$left", "$base", "$right", "-o", "$output"]
 ```
 
 The "vscode", "vscodium", "meld", "kdiff3", and "vimdiff" tools can be used out of the box,
@@ -769,16 +794,19 @@ the out-of-the-box configuration of the three default tools. (There is no need
 to copy it to your config file verbatim, but you are welcome to customize it.)
 
 ```toml
-# merge-tools.kdiff3.program  = "kdiff3"     # Defaults to the name of the tool if not specified
-merge-tools.kdiff3.merge-args = ["$base", "$left", "$right", "-o", "$output", "--auto"]
-merge-tools.meld.merge-args = ["$left", "$base", "$right", "-o", "$output", "--auto-merge"]
+[merge-tools.kdiff3]
+# program  = "kdiff3"     # Defaults to the name of the tool if not specified
+merge-args = ["$base", "$left", "$right", "-o", "$output", "--auto"]
+[merge-tools.meld]
+merge-args = ["$left", "$base", "$right", "-o", "$output", "--auto-merge"]
 
-merge-tools.vimdiff.merge-args = ["-f", "-d", "$output", "-M",
+[merge-tools.vimdiff]
+merge-args = ["-f", "-d", "$output", "-M",
     "$left", "$base", "$right",
     "-c", "wincmd J", "-c", "set modifiable",
     "-c", "set write"]
-merge-tools.vimdiff.program = "vim"
-merge-tools.vimdiff.merge-tool-edits-conflict-markers = true    # See below for an explanation
+program = "vim"
+merge-tool-edits-conflict-markers = true    # See below for an explanation
 ```
 
 `jj` makes the following substitutions:
@@ -895,14 +923,16 @@ By default the gpg backend will look for a `gpg` binary on your path. If you wan
 to change the program used or specify a path to `gpg` explicitly you can set:
 
 ```toml
-signing.backends.gpg.program = "gpg2"
+[signing]
+backends.gpg.program = "gpg2"
 ```
 
 Also by default the gpg backend will ignore key expiry when verifying commit signatures.
 To consider expired keys as invalid you can set:
 
 ```toml
-signing.backends.gpg.allow-expired-keys = false
+[signing]
+backends.gpg.allow-expired-keys = false
 ```
 
 ### SSH Signing
@@ -920,7 +950,8 @@ By default the ssh backend will look for a `ssh-keygen` binary on your path. If 
 to change the program used or specify a path to `ssh-keygen` explicitly you can set:
 
 ```toml
-signing.backends.ssh.program = "/path/to/ssh-keygen"
+[signing]
+backends.ssh.program = "/path/to/ssh-keygen"
 ```
 
 When verifying commit signatures the ssh backend needs to be provided with an allowed-signers
@@ -931,7 +962,8 @@ You can find the format for this file in the
 as follows:
 
 ```toml
-signing.backends.ssh.allowed-signers = "/path/to/allowed-signers"
+[signing]
+backends.ssh.allowed-signers = "/path/to/allowed-signers"
 ```
 
 ## Git settings
@@ -977,7 +1009,8 @@ may be undesirable in some repositories, e.g.:
 You can enable this behavior by setting `git.auto-local-bookmark` like so,
 
 ```toml
-git.auto-local-bookmark = true
+[git]
+auto-local-bookmark = true
 ```
 
 This setting is applied only to new remote bookmarks. Existing remote bookmarks
@@ -1000,7 +1033,8 @@ usual when commits are abandoned). You can disable this behavior and instead
 leave the Git-unreachable commits in your repo by setting:
 
 ```toml
-git.abandon-unreachable-commits = false
+[git]
+abandon-unreachable-commits = false
 ```
 
 [reachable]: https://git-scm.com/docs/gitglossary/#Documentation/gitglossary.txt-aiddefreachableareachable
@@ -1011,7 +1045,10 @@ git.abandon-unreachable-commits = false
 default. You can pick a different prefix by setting `git.push-bookmark-prefix`. For
 example:
 
-    git.push-bookmark-prefix = "martinvonz/push-"
+```toml
+[git]
+push-bookmark-prefix = "martinvonz/push-"
+```
 
 ### Set of private commits
 
@@ -1020,8 +1057,9 @@ a revset. The value is a revset of commits that Jujutsu will refuse to push. If
 unset, all commits are eligible to be pushed.
 
 ```toml
+[git]
 # Prevent pushing work in progress or anything explicitly labeled "private"
-git.private-commits = "description(glob:'wip:*') | description(glob:'private:*')"
+private-commits = "description(glob:'wip:*') | description(glob:'private:*')"
 ```
 
 If a commit is in `git.private-commits` but is already on the remote, then it is
@@ -1076,9 +1114,10 @@ changed by setting `snapshot.max-new-file-size` to a different value. For
 example:
 
 ```toml
-snapshot.max-new-file-size = "10MiB"
+[snapshot]
+max-new-file-size = "10MiB"
 # the following is equivalent
-snapshot.max-new-file-size = 10485760
+max-new-file-size = 10485760
 ```
 
 The value can be specified using a human readable string with typical suffixes;


### PR DESCRIPTION
I was a bit confused why adding this to the end of my config didn't do anything:

```toml
revset-aliases."immutable_heads()" = "..."
```

It turns out that I had a `[snapshot]` earlier in the file, so either I had to add that key at the beginning or it needs its own table header:

```toml
[revset-aliases]
"immutable_heads()" = "..."
```

IMO the config examples should all use that syntax to be unambiguous. If that sounds good I can go through all the examples in this file.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
