### PR TITLE
revset: add `fork_point` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--insert-before` options to customize the location of the duplicated
   revisions.
 
+* New `fork_point()` revset function can be used to obtain the fork point
+  of multiple commits.
+
 ### Fixed bugs
 
 ## [0.23.0] - 2024-11-06

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -253,6 +253,12 @@ revsets (expressions) as arguments.
 * `latest(x[, count])`: Latest `count` commits in `x`, based on committer
   timestamp. The default `count` is 1.
 
+* `fork_point(x)`: The fork point of all commits in `x`. The fork point is the
+  common ancestor(s) of all commits in `x` which do not have any descendants
+  that are also common ancestors of all commits in `x`. It is equivalent to
+  the revset `heads(::x_1 & ::x_2 & ... & ::x_N)`, where `x_{1..N}` are commits
+  in `x`. If `x` resolves to a single commit, `fork_point(x)` resolves to `x`.
+
 * `merges()`: Merge commits.
 
 * `description(pattern)`: Commits that have a description matching the given
@@ -361,6 +367,18 @@ given [string pattern](#string-patterns).
     * `roots(E|B)` ⇒ `{B}`
     * `roots(E|A)` ⇒ `{A}`
     * `roots(A)` ⇒ `{A}`
+
+    **function** `fork_point()`
+
+    * `fork_point(E|D)` ⇒ `{A}`
+    * `fork_point(E|C)` ⇒ `{A}`
+    * `fork_point(E|B)` ⇒ `{B}`
+    * `fork_point(E|A)` ⇒ `{A}`
+    * `fork_point(D|C)` ⇒ `{C}`
+    * `fork_point(D|B)` ⇒ `{A}`
+    * `fork_point(B|C)` ⇒ `{A}`
+    * `fork_point(A)` ⇒ `{A}`
+    * `fork_point(none())` ⇒ `{}`
 
 ## String patterns
 


### PR DESCRIPTION
This can be used to find the best common ancestors of a revset with an arbitrary number of commits, which cannot be done currently.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
