### PR TITLE
workspace-update-stale: add a config knob to run automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [documentation](https://martinvonz.github.io/jj/latest/install-and-setup/#command-line-completion)
   to activate them.
 
+* Added the config setting `snapshot.auto-update-stale` for automatically
+  running `jj workspace update-stale` when applicable.
+
 ### Fixed bugs
 
 ## [0.23.0] - 2024-11-06

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -49,6 +49,7 @@ use jj_lib::revset::RevsetResolutionError;
 use jj_lib::signing::SignInitError;
 use jj_lib::str_util::StringPatternParseError;
 use jj_lib::view::RenameWorkspaceError;
+use jj_lib::working_copy::RecoverWorkspaceError;
 use jj_lib::working_copy::ResetError;
 use jj_lib::working_copy::SnapshotError;
 use jj_lib::working_copy::WorkingCopyStateError;
@@ -505,6 +506,18 @@ impl From<FilesetParseError> for CommandError {
             user_error_with_message(format!("Failed to parse fileset: {}", err.kind()), err);
         cmd_err.extend_hints(hint);
         cmd_err
+    }
+}
+
+impl From<RecoverWorkspaceError> for CommandError {
+    fn from(err: RecoverWorkspaceError) -> Self {
+        match err {
+            RecoverWorkspaceError::Backend(err) => err.into(),
+            RecoverWorkspaceError::OpHeadsStore(err) => err.into(),
+            RecoverWorkspaceError::Reset(err) => err.into(),
+            RecoverWorkspaceError::RewriteRootCommit(err) => err.into(),
+            err @ RecoverWorkspaceError::WorkspaceMissingWorkingCopy(_) => user_error(err),
+        }
     }
 }
 

--- a/cli/src/commands/workspace/update_stale.rs
+++ b/cli/src/commands/workspace/update_stale.rs
@@ -45,7 +45,7 @@ pub fn cmd_workspace_update_stale(
             // (since we just updated it), so we can return early.
             return Ok(());
         }
-        StaleWorkingCopy::Snapshotted((_workspace_command, commit)) => commit,
+        StaleWorkingCopy::Snapshotted((_repo, commit)) => commit,
     };
     let mut workspace_command = command.workspace_helper_no_snapshot(ui)?;
 

--- a/cli/src/commands/workspace/update_stale.rs
+++ b/cli/src/commands/workspace/update_stale.rs
@@ -18,13 +18,12 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::op_store::OpStoreError;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
+use jj_lib::working_copy::WorkingCopyFreshness;
 use tracing::instrument;
 
-use crate::cli_util::check_stale_working_copy;
 use crate::cli_util::print_checkout_stats;
 use crate::cli_util::short_commit_hash;
 use crate::cli_util::CommandHelper;
-use crate::cli_util::WorkingCopyFreshness;
 use crate::cli_util::WorkspaceCommandHelper;
 use crate::command_error::internal_error_with_message;
 use crate::command_error::user_error;
@@ -67,7 +66,7 @@ pub fn cmd_workspace_update_stale(
     let repo = workspace_command.repo().clone();
     let (mut locked_ws, desired_wc_commit) =
         workspace_command.unchecked_start_working_copy_mutation()?;
-    match check_stale_working_copy(locked_ws.locked_wc(), &desired_wc_commit, &repo)? {
+    match WorkingCopyFreshness::check_stale(locked_ws.locked_wc(), &desired_wc_commit, &repo)? {
         WorkingCopyFreshness::Fresh | WorkingCopyFreshness::Updated(_) => {
             writeln!(
                 ui.status(),

--- a/cli/src/commands/workspace/update_stale.rs
+++ b/cli/src/commands/workspace/update_stale.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jj_lib::working_copy::WorkingCopyFreshness;
 use tracing::instrument;
 
-use crate::cli_util::update_stale_working_copy;
 use crate::cli_util::CommandHelper;
-use crate::cli_util::StaleWorkingCopy;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -34,41 +31,7 @@ pub fn cmd_workspace_update_stale(
     command: &CommandHelper,
     _args: &WorkspaceUpdateStaleArgs,
 ) -> Result<(), CommandError> {
-    // Snapshot the current working copy on top of the last known working-copy
-    // operation, then merge the divergent operations. The wc_commit_id of the
-    // merged repo wouldn't change because the old one wins, but it's probably
-    // fine if we picked the new wc_commit_id.
-    let known_wc_commit = match command.load_stale_working_copy_commit(ui)? {
-        StaleWorkingCopy::Recovered(_) => {
-            // We have already recovered from the situation that prompted the user to run
-            // this command, and it is known that the workspace is not stale
-            // (since we just updated it), so we can return early.
-            return Ok(());
-        }
-        StaleWorkingCopy::Snapshotted((_repo, commit)) => commit,
-    };
-    let mut workspace_command = command.workspace_helper_no_snapshot(ui)?;
+    command.recover_stale_working_copy(ui)?;
 
-    let repo = workspace_command.repo().clone();
-    let (mut locked_ws, desired_wc_commit) =
-        workspace_command.unchecked_start_working_copy_mutation()?;
-    match WorkingCopyFreshness::check_stale(locked_ws.locked_wc(), &desired_wc_commit, &repo)? {
-        WorkingCopyFreshness::Fresh | WorkingCopyFreshness::Updated(_) => {
-            writeln!(
-                ui.status(),
-                "Nothing to do (the working copy is not stale)."
-            )?;
-        }
-        WorkingCopyFreshness::WorkingCopyStale | WorkingCopyFreshness::SiblingOperation => {
-            let stats = update_stale_working_copy(
-                locked_ws,
-                repo.op_id().clone(),
-                &known_wc_commit,
-                &desired_wc_commit,
-            )?;
-
-            workspace_command.write_stale_commit_stats(ui, &desired_wc_commit, stats)?;
-        }
-    }
     Ok(())
 }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -457,6 +457,11 @@
                     "description": "Fileset pattern describing what new files to automatically track on snapshotting. By default all new files are tracked.",
                     "default": "all()"
                 },
+                "auto-update-stale": {
+                    "type": "boolean",
+                    "description": "Whether to automatically update the working copy if it is stale. See https://martinvonz.github.io/jj/latest/working-copy/#stale-working-copy",
+                    "default": "false"
+                },
                 "max-new-file-size": {
                     "type": [
                         "integer",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -30,3 +30,4 @@ edit = false
 [snapshot]
 max-new-file-size = "1MiB"
 auto-track = "all()"
+auto-update-stale = false

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -523,6 +523,7 @@ fn test_workspaces_conflicting_edits() {
     Rebased 1 descendant commits onto commits rewritten by other operation
     Working copy now at: pmmvwywv?? e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    Updated working copy to fresh commit e82cd4ee8faa
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
@@ -600,6 +601,7 @@ fn test_workspaces_updated_by_other() {
     insta::assert_snapshot!(stderr, @r###"
     Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    Updated working copy to fresh commit e82cd4ee8faa
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r###"
@@ -657,13 +659,13 @@ fn test_workspaces_updated_by_other_automatic() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
     insta::assert_snapshot!(stdout, @r###"
     The working copy is clean
-    Working copy : pmmvwywv 3224de8a (empty) (no description set)
-    Parent commit: qpvuntsm 506f4ec3 (no description set)
+    Working copy : pmmvwywv e82cd4ee (empty) (no description set)
+    Parent commit: qpvuntsm d4124476 (no description set)
     "###);
     insta::assert_snapshot!(stderr, @r###"
-    Warning: Automatically updated to fresh commit 3224de8ae048
     Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    Updated working copy to fresh commit e82cd4ee8faa
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
@@ -848,9 +850,7 @@ fn test_workspaces_update_stale_noop() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "update-stale"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing to do (the working copy is not stale).
-    "###);
+    insta::assert_snapshot!(stderr, @"Attempted recovery, but the working copy is not stale");
 
     let stderr = test_env.jj_cmd_failure(
         &main_path,
@@ -890,7 +890,7 @@ fn test_workspaces_update_stale_snapshot() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Concurrent modification detected, resolving automatically.
-    Nothing to do (the working copy is not stale).
+    Attempted recovery, but the working copy is not stale
     "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
