### PR TITLE
cli: reference config settings for 'jj log -T' and 'jj git push -c'

### DIFF
--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -114,6 +114,9 @@ pub struct GitPushArgs {
     revisions: Vec<RevisionArg>,
     /// Push this commit by creating a bookmark based on its change ID (can be
     /// repeated)
+    ///
+    /// Use the `git.push-bookmark-prefix` setting to change the prefix for
+    /// generated names.
     #[arg(long, short)]
     change: Vec<RevisionArg>,
     /// Only display what will change on the remote

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -77,7 +77,12 @@ pub(crate) struct LogArgs {
     no_graph: bool,
     /// Render each revision using the given template
     ///
-    /// For the syntax, see https://martinvonz.github.io/jj/latest/templates/
+    /// Run `jj log -T` to list the built-in templates.
+    ///
+    /// You can also specify arbitrary template expressions. For the syntax,
+    /// see https://martinvonz.github.io/jj/latest/templates/.
+    ///
+    /// If not specified, this defaults to the `templates.log` setting.
     #[arg(long, short = 'T')]
     template: Option<String>,
     /// Show patch

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1134,6 +1134,8 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `--allow-private` — Allow pushing commits that are private
 * `-r`, `--revisions <REVISIONS>` — Push bookmarks pointing to these commits (can be repeated)
 * `-c`, `--change <CHANGE>` — Push this commit by creating a bookmark based on its change ID (can be repeated)
+
+   Use the `git.push-bookmark-prefix` setting to change the prefix for generated names.
 * `--dry-run` — Only display what will change on the remote
 
 
@@ -1313,7 +1315,11 @@ Spans of revisions that are not included in the graph per `--revisions` are rend
 * `--no-graph` — Don't show the graph, show a flat list of revisions
 * `-T`, `--template <TEMPLATE>` — Render each revision using the given template
 
-   For the syntax, see https://martinvonz.github.io/jj/latest/templates/
+   Run `jj log -T` to list the built-in templates.
+
+   You can also specify arbitrary template expressions. For the syntax, see https://martinvonz.github.io/jj/latest/templates/.
+
+   If not specified, this defaults to the `templates.log` setting.
 * `-p`, `--patch` — Show patch
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

---

Initially I wanted to have a uniform way to reference settings, eg. like this

![image](https://github.com/user-attachments/assets/25aab459-23c2-45fb-81e2-74f6a684c9af)

but it turned out that `clap` mangles lists unless you use `verbatim_doc_comment` -- see https://github.com/clap-rs/clap/issues/2389. So I just went with prose.