### PR TITLE
nix: Add meta field to package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -129,11 +129,6 @@
         default = self.packages.${system}.jujutsu;
       };
 
-      apps.default = {
-        type = "app";
-        program = pkgs.lib.getExe self.packages.${system}.jujutsu;
-      };
-
       formatter = pkgs.nixpkgs-fmt;
 
       checks.jujutsu = self.packages.${system}.jujutsu.overrideAttrs ({ ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -118,13 +118,20 @@
               --fish <($out/bin/jj util completion fish) \
               --zsh <($out/bin/jj util completion zsh)
           '';
+
+          meta = {
+            description = "Git-compatible DVCS that is both simple and powerful";
+            homepage = "https://github.com/martinvonz/jj";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "jj";
+          };
         };
         default = self.packages.${system}.jujutsu;
       };
 
       apps.default = {
         type = "app";
-        program = "${self.packages.${system}.jujutsu}/bin/jj";
+        program = pkgs.lib.getExe self.packages.${system}.jujutsu;
       };
 
       formatter = pkgs.nixpkgs-fmt;


### PR DESCRIPTION
The most relevant part (and the motivation for this change) is the addition of the `mainProgram` attribute. This allows getting the executable name from inside nix expressions with ease:

```nix
# before
lib.getExe' jujutsu "jj"
# or
"${jujutsu}/bin/jj"
#or (when using it as a flake input)
inputs.jj.apps.${system}.default.program
```

```nix
# now
lib.getExe jujutsu
```

Everything is copied verbatim from the `nixpkgs` expression (without the maintainer list and changelog link, which depends on the version).

I also deleted the `apps` output. Its only use was to provide an easy way to get the path to the executable AFAICT, but it's redundant now.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
