### PR TITLE
cli: make command aliases not interfere with completion

### DIFF
--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -23,7 +23,7 @@ use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Create a new bookmark
+/// Create a new bookmark [aliases: c]
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkCreateArgs {
     /// The bookmark's target revision

--- a/cli/src/commands/bookmark/delete.rs
+++ b/cli/src/commands/bookmark/delete.rs
@@ -22,7 +22,7 @@ use crate::command_error::CommandError;
 use crate::ui::Ui;
 
 /// Delete an existing bookmark and propagate the deletion to remotes on the
-/// next push
+/// next push [aliases: d]
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkDeleteArgs {
     /// The bookmarks to delete

--- a/cli/src/commands/bookmark/forget.rs
+++ b/cli/src/commands/bookmark/forget.rs
@@ -25,7 +25,7 @@ use crate::command_error::CommandError;
 use crate::ui::Ui;
 
 /// Forget everything about a bookmark, including its local and remote
-/// targets
+/// targets [aliases: f]
 ///
 /// A forgotten bookmark will not impact remotes on future pushes. It will be
 /// recreated on future pulls if it still exists in the remote.

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -26,7 +26,7 @@ use crate::commit_templater::CommitTemplateLanguage;
 use crate::commit_templater::RefName;
 use crate::ui::Ui;
 
-/// List bookmarks and their targets
+/// List bookmarks and their targets [aliases: l]
 ///
 /// By default, a tracking remote bookmark will be included only if its target
 /// is different from the local target. A non-tracking remote bookmark won't be

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -62,21 +62,21 @@ use crate::ui::Ui;
 /// https://martinvonz.github.io/jj/latest/bookmarks.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BookmarkCommand {
-    #[command(visible_alias("c"))]
+    #[command(alias("c"))]
     Create(BookmarkCreateArgs),
-    #[command(visible_alias("d"))]
+    #[command(alias("d"))]
     Delete(BookmarkDeleteArgs),
-    #[command(visible_alias("f"))]
+    #[command(alias("f"))]
     Forget(BookmarkForgetArgs),
-    #[command(visible_alias("l"))]
+    #[command(alias("l"))]
     List(BookmarkListArgs),
-    #[command(visible_alias("m"))]
+    #[command(alias("m"))]
     Move(BookmarkMoveArgs),
-    #[command(visible_alias("r"))]
+    #[command(alias("r"))]
     Rename(BookmarkRenameArgs),
-    #[command(visible_alias("s"))]
+    #[command(alias("s"))]
     Set(BookmarkSetArgs),
-    #[command(visible_alias("t"))]
+    #[command(alias("t"))]
     Track(BookmarkTrackArgs),
     Untrack(BookmarkUntrackArgs),
 }

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -25,7 +25,7 @@ use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Move existing bookmarks to target revision
+/// Move existing bookmarks to target revision [aliases: m]
 ///
 /// If bookmark names are given, the specified bookmarks will be updated to
 /// point to the target revision.

--- a/cli/src/commands/bookmark/rename.rs
+++ b/cli/src/commands/bookmark/rename.rs
@@ -20,7 +20,7 @@ use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Rename `old` bookmark name to `new` bookmark name
+/// Rename `old` bookmark name to `new` bookmark name [aliases: r]
 ///
 /// The new bookmark name points at the same commit as the old bookmark name.
 #[derive(clap::Args, Clone, Debug)]

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -24,7 +24,7 @@ use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Create or update a bookmark to point to a certain commit
+/// Create or update a bookmark to point to a certain commit [aliases: s]
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkSetArgs {
     /// The bookmark's target revision

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -24,7 +24,7 @@ use crate::commit_templater::CommitTemplateLanguage;
 use crate::commit_templater::RefName;
 use crate::ui::Ui;
 
-/// Start tracking given remote bookmarks
+/// Start tracking given remote bookmarks [aliases: t]
 ///
 /// A tracking remote bookmark will be imported as a local bookmark of the same
 /// name. Changes to it will propagate to the existing local bookmark on future

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -26,9 +26,9 @@ use crate::description_util::join_message_paragraphs;
 use crate::text_util::parse_author;
 use crate::ui::Ui;
 
-/// Update the description and create a new change on top.
+/// Update the description and create a new change on top [aliases: ci]
 #[derive(clap::Args, Clone, Debug)]
-#[command(visible_aliases=&["ci"])]
+#[command(alias = "ci")]
 pub(crate) struct CommitArgs {
     /// Interactively choose which changes to include in the first commit
     #[arg(short, long)]

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -21,7 +21,7 @@ use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Start an editor on a jj config file.
+/// Start an editor on a jj config file [aliases: e]
 ///
 /// Creates the file if it doesn't already exist regardless of what the editor
 /// does.

--- a/cli/src/commands/config/get.rs
+++ b/cli/src/commands/config/get.rs
@@ -22,7 +22,7 @@ use crate::command_error::CommandError;
 use crate::config::ConfigNamePathBuf;
 use crate::ui::Ui;
 
-/// Get the value of a given config option.
+/// Get the value of a given config option [aliases: g]
 ///
 /// Unlike `jj config list`, the result of `jj config get` is printed without
 /// extra formatting and therefore is usable in scripting. For example:

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -26,7 +26,7 @@ use crate::template_builder::TemplateLanguage as _;
 use crate::templater::TemplatePropertyExt as _;
 use crate::ui::Ui;
 
-/// List variables set in config file, along with their values.
+/// List variables set in config file, along with their values [aliases: l]
 #[derive(clap::Args, Clone, Debug)]
 #[command(mut_group("config_level", |g| g.required(false)))]
 pub struct ConfigListArgs {

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -75,17 +75,17 @@ impl ConfigLevelArgs {
 /// config, see https://martinvonz.github.io/jj/latest/config/.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub(crate) enum ConfigCommand {
-    #[command(visible_alias("e"))]
+    #[command(alias("e"))]
     Edit(ConfigEditArgs),
-    #[command(visible_alias("g"))]
+    #[command(alias("g"))]
     Get(ConfigGetArgs),
-    #[command(visible_alias("l"))]
+    #[command(alias("l"))]
     List(ConfigListArgs),
-    #[command(visible_alias("p"))]
+    #[command(alias("p"))]
     Path(ConfigPathArgs),
-    #[command(visible_alias("s"))]
+    #[command(alias("s"))]
     Set(ConfigSetArgs),
-    #[command(visible_alias("u"))]
+    #[command(alias("u"))]
     Unset(ConfigUnsetArgs),
 }
 

--- a/cli/src/commands/config/path.rs
+++ b/cli/src/commands/config/path.rs
@@ -23,7 +23,7 @@ use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Print the path to the config file
+/// Print the path to the config file [aliases: p]
 ///
 /// A config file at that path may or may not exist.
 ///

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -29,7 +29,7 @@ use crate::config::write_config_value_to_file;
 use crate::config::ConfigNamePathBuf;
 use crate::ui::Ui;
 
-/// Update config file to set the given option to a given value.
+/// Update config file to set the given option to a given value [aliases: s]
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigSetArgs {
     #[arg(required = true)]

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -23,7 +23,7 @@ use crate::config::remove_config_value_from_file;
 use crate::config::ConfigNamePathBuf;
 use crate::ui::Ui;
 
-/// Update config file to unset the given option.
+/// Update config file to unset the given option [aliases: u]
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigUnsetArgs {
     #[arg(required = true)]

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -133,7 +133,7 @@ enum Command {
     New(new::NewArgs),
     Next(next::NextArgs),
     #[command(subcommand)]
-    #[command(visible_alias = "op")]
+    #[command(alias = "op")]
     Operation(operation::OperationCommand),
     Parallelize(parallelize::ParallelizeArgs),
     Prev(prev::PrevArgs),

--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -37,7 +37,7 @@ use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Commands for working with the operation log
+/// Commands for working with the operation log [aliases: op]
 ///
 /// For information about the operation log, see
 /// https://martinvonz.github.io/jj/latest/operation-log/.

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -23,14 +23,14 @@ use crate::ui::Ui;
 /// Manage tags.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum TagCommand {
-    #[command(visible_alias("l"))]
+    #[command(alias("l"))]
     List(TagListArgs),
 }
 
 /// List tags.
 #[derive(clap::Args, Clone, Debug)]
 pub struct TagListArgs {
-    /// Show tags whose local name matches
+    /// Show tags whose local name matches [aliases: l]
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
     /// select tags by wildcard pattern. For details, see

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -121,7 +121,7 @@ To get started, see the tutorial at https://martinvonz.github.io/jj/latest/tutor
 * `abandon` — Abandon a revision
 * `backout` — Apply the reverse of a revision on top of another revision
 * `bookmark` — Manage bookmarks
-* `commit` — Update the description and create a new change on top
+* `commit` — Update the description and create a new change on top [aliases: ci]
 * `config` — Manage config options
 * `describe` — Update the change description or other metadata [aliases: desc]
 * `diff` — Compare file contents between two revisions
@@ -138,7 +138,7 @@ To get started, see the tutorial at https://martinvonz.github.io/jj/latest/tutor
 * `log` — Show revision history
 * `new` — Create a new, empty change and (by default) edit it in the working copy
 * `next` — Move the working-copy commit to the child revision
-* `operation` — Commands for working with the operation log
+* `operation` — Commands for working with the operation log [aliases: op]
 * `parallelize` — Parallelize revisions by making them siblings
 * `prev` — Change the working copy revision relative to the parent revision
 * `rebase` — Move revisions to different parent(s)
@@ -245,21 +245,21 @@ For information about bookmarks, see https://martinvonz.github.io/jj/latest/book
 
 ###### **Subcommands:**
 
-* `create` — Create a new bookmark
-* `delete` — Delete an existing bookmark and propagate the deletion to remotes on the next push
-* `forget` — Forget everything about a bookmark, including its local and remote targets
-* `list` — List bookmarks and their targets
-* `move` — Move existing bookmarks to target revision
-* `rename` — Rename `old` bookmark name to `new` bookmark name
-* `set` — Create or update a bookmark to point to a certain commit
-* `track` — Start tracking given remote bookmarks
+* `create` — Create a new bookmark [aliases: c]
+* `delete` — Delete an existing bookmark and propagate the deletion to remotes on the next push [aliases: d]
+* `forget` — Forget everything about a bookmark, including its local and remote targets [aliases: f]
+* `list` — List bookmarks and their targets [aliases: l]
+* `move` — Move existing bookmarks to target revision [aliases: m]
+* `rename` — Rename `old` bookmark name to `new` bookmark name [aliases: r]
+* `set` — Create or update a bookmark to point to a certain commit [aliases: s]
+* `track` — Start tracking given remote bookmarks [aliases: t]
 * `untrack` — Stop tracking given remote bookmarks
 
 
 
 ## `jj bookmark create`
 
-Create a new bookmark
+Create a new bookmark [aliases: c]
 
 **Usage:** `jj bookmark create [OPTIONS] <NAMES>...`
 
@@ -275,7 +275,7 @@ Create a new bookmark
 
 ## `jj bookmark delete`
 
-Delete an existing bookmark and propagate the deletion to remotes on the next push
+Delete an existing bookmark and propagate the deletion to remotes on the next push [aliases: d]
 
 **Usage:** `jj bookmark delete <NAMES>...`
 
@@ -289,7 +289,7 @@ Delete an existing bookmark and propagate the deletion to remotes on the next pu
 
 ## `jj bookmark forget`
 
-Forget everything about a bookmark, including its local and remote targets
+Forget everything about a bookmark, including its local and remote targets [aliases: f]
 
 A forgotten bookmark will not impact remotes on future pushes. It will be recreated on future pulls if it still exists in the remote.
 
@@ -305,7 +305,7 @@ A forgotten bookmark will not impact remotes on future pushes. It will be recrea
 
 ## `jj bookmark list`
 
-List bookmarks and their targets
+List bookmarks and their targets [aliases: l]
 
 By default, a tracking remote bookmark will be included only if its target is different from the local target. A non-tracking remote bookmark won't be listed. For a conflicted bookmark (both local and remote), old target revisions are preceded by a "-" and new target revisions are preceded by a "+".
 
@@ -342,7 +342,7 @@ For information about bookmarks, see https://martinvonz.github.io/jj/latest/book
 
 ## `jj bookmark move`
 
-Move existing bookmarks to target revision
+Move existing bookmarks to target revision [aliases: m]
 
 If bookmark names are given, the specified bookmarks will be updated to point to the target revision.
 
@@ -372,7 +372,7 @@ $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
 ## `jj bookmark rename`
 
-Rename `old` bookmark name to `new` bookmark name
+Rename `old` bookmark name to `new` bookmark name [aliases: r]
 
 The new bookmark name points at the same commit as the old bookmark name.
 
@@ -387,7 +387,7 @@ The new bookmark name points at the same commit as the old bookmark name.
 
 ## `jj bookmark set`
 
-Create or update a bookmark to point to a certain commit
+Create or update a bookmark to point to a certain commit [aliases: s]
 
 **Usage:** `jj bookmark set [OPTIONS] <NAMES>...`
 
@@ -404,7 +404,7 @@ Create or update a bookmark to point to a certain commit
 
 ## `jj bookmark track`
 
-Start tracking given remote bookmarks
+Start tracking given remote bookmarks [aliases: t]
 
 A tracking remote bookmark will be imported as a local bookmark of the same name. Changes to it will propagate to the existing local bookmark on future pulls.
 
@@ -440,7 +440,7 @@ A non-tracking remote bookmark is just a pointer to the last-fetched remote book
 
 ## `jj commit`
 
-Update the description and create a new change on top
+Update the description and create a new change on top [aliases: ci]
 
 **Usage:** `jj commit [OPTIONS] [PATHS]...`
 
@@ -478,18 +478,18 @@ For file locations, supported config options, and other details about jj config,
 
 ###### **Subcommands:**
 
-* `edit` — Start an editor on a jj config file
-* `get` — Get the value of a given config option.
-* `list` — List variables set in config file, along with their values
-* `path` — Print the path to the config file
-* `set` — Update config file to set the given option to a given value
-* `unset` — Update config file to unset the given option
+* `edit` — Start an editor on a jj config file [aliases: e]
+* `get` — Get the value of a given config option [aliases: g]
+* `list` — List variables set in config file, along with their values [aliases: l]
+* `path` — Print the path to the config file [aliases: p]
+* `set` — Update config file to set the given option to a given value [aliases: s]
+* `unset` — Update config file to unset the given option [aliases: u]
 
 
 
 ## `jj config edit`
 
-Start an editor on a jj config file.
+Start an editor on a jj config file [aliases: e]
 
 Creates the file if it doesn't already exist regardless of what the editor does.
 
@@ -504,7 +504,7 @@ Creates the file if it doesn't already exist regardless of what the editor does.
 
 ## `jj config get`
 
-Get the value of a given config option.
+Get the value of a given config option [aliases: g]
 
 Unlike `jj config list`, the result of `jj config get` is printed without
 extra formatting and therefore is usable in scripting. For example:
@@ -524,7 +524,7 @@ Martin von Zweigbergk
 
 ## `jj config list`
 
-List variables set in config file, along with their values
+List variables set in config file, along with their values [aliases: l]
 
 **Usage:** `jj config list [OPTIONS] [NAME]`
 
@@ -552,7 +552,7 @@ List variables set in config file, along with their values
 
 ## `jj config path`
 
-Print the path to the config file
+Print the path to the config file [aliases: p]
 
 A config file at that path may or may not exist.
 
@@ -569,7 +569,7 @@ See `jj config edit` if you'd like to immediately edit the file.
 
 ## `jj config set`
 
-Update config file to set the given option to a given value
+Update config file to set the given option to a given value [aliases: s]
 
 **Usage:** `jj config set <--user|--repo> <NAME> <VALUE>`
 
@@ -587,7 +587,7 @@ Update config file to set the given option to a given value
 
 ## `jj config unset`
 
-Update config file to unset the given option
+Update config file to unset the given option [aliases: u]
 
 **Usage:** `jj config unset <--user|--repo> <NAME>`
 
@@ -1417,7 +1417,7 @@ B   =>   @
 
 ## `jj operation`
 
-Commands for working with the operation log
+Commands for working with the operation log [aliases: op]
 
 For information about the operation log, see https://martinvonz.github.io/jj/latest/operation-log/.
 
@@ -2093,7 +2093,7 @@ List tags
 
 ###### **Arguments:**
 
-* `<NAMES>` — Show tags whose local name matches
+* `<NAMES>` — Show tags whose local name matches [aliases: l]
 
    By default, the specified name matches exactly. Use `glob:` prefix to select tags by wildcard pattern. For details, see https://martinvonz.github.io/jj/latest/revsets/#string-patterns.
 


### PR DESCRIPTION
Follows up on #4740

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
