### PR TITLE
cli: document `b` as a "default alias"

### DIFF
--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -56,7 +56,10 @@ use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Manage bookmarks
+// Unlike most other aliases, `b` is defined in the config and can be overridden
+// by the user.
+
+/// Manage bookmarks [default alias: b]
 ///
 /// For information about bookmarks, see
 /// https://martinvonz.github.io/jj/latest/bookmarks.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -122,7 +122,7 @@ To get started, see the tutorial at https://martinvonz.github.io/jj/latest/tutor
 
 * `abandon` — Abandon a revision
 * `backout` — Apply the reverse of a revision on top of another revision
-* `bookmark` — Manage bookmarks
+* `bookmark` — Manage bookmarks [default alias: b]
 * `commit` — Update the description and create a new change on top
 * `config` — Manage config options
 * `describe` — Update the change description or other metadata [aliases: desc]
@@ -239,7 +239,7 @@ Apply the reverse of a revision on top of another revision
 
 ## `jj bookmark`
 
-Manage bookmarks
+Manage bookmarks [default alias: b]
 
 For information about bookmarks, see https://martinvonz.github.io/jj/latest/bookmarks.
 


### PR DESCRIPTION
Unlike other documented aliases, it can be redefined by the user. However, I think it's important for people to be informed that `b` exists.

I left `amend`, `unamend`, and `ci` undocumented, since I think we were considering removing or at least discouraging them.

We could also instead make b a normal built-in alias, now that it won't interfere with completion if we define them as in the previous commit (**Update:** This is no longer the case). I am not sure if letting people redefine it is worth the special case.