### PR TITLE
nix: skip `test_shallow_commits_lack_parents` under Nix builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729304879,
-        "narHash": "sha256-H7KGGJUU9BcDNnfXiATBGgs6FJKWQdfftNJS+/v2aMU=",
+        "lastModified": 1731292155,
+        "narHash": "sha256-fYVoUUtSadbOrH0z0epVQDsStBDS/S/fAK//0ECQAAI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b259ef799b5ac014604da71ecd92d4a52603ed2d",
+        "rev": "7c4cd99ed7604b79e8cb721099ac99c66f656b3a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,14 @@
           buildFeatures = [ "packaging" ];
           cargoBuildFlags = [ "--bin" "jj" ]; # don't build and install the fake editors
           useNextest = true;
+
+          checkFlags = [
+            # https://github.com/martinvonz/jj/issues/4784
+            # seems to fail reliably under Nix/nix-shell only, but otherwise
+            # is an unknown anomaly?
+            "--skip" "test_shallow_commits_lack_parents"
+          ];
+          
           src = filterSrc ./. [
             ".*\\.nix$"
             "^.jj/"


### PR DESCRIPTION
While this isn't a real solution to #4784 it does stem the bleeding for anyone like Mitchell (or myself) who have to install the flake from the Git repository. This patch also probably needs to be backported to upstream nixpkgs, too.

The `flake.lock` update is so that we can get a newer version of `cargo-nextest` that supports the `--skip` flag (there is a range of nextest versions that don't support `--skip` after the migration to use 'filtersets' was introduced.)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
