### PR TITLE
cli: warn if `trunk()` cannot be resolved after each transaction

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1909,6 +1909,7 @@ See https://martinvonz.github.io/jj/latest/working-copy/#stale-working-copy \
                     .collect(),
             )?;
         }
+        revset_util::warn_unresolvable_trunk(ui, new_repo, &self.env().revset_parse_context())?;
 
         Ok(())
     }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -546,7 +546,14 @@ fn test_git_clone_trunk_deleted() {
     Added 1 files, modified 0 files, removed 0 files
     "#);
 
-    test_env.jj_cmd_ok(&clone_path, &["bookmark", "forget", "main"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["bookmark", "forget", "main"]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r#"
+    Forgot 1 bookmarks.
+    Warning: Failed to resolve `revset-aliases.trunk()`: Revision "main@origin" doesn't exist
+    Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
+    "#);
+
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["log"]);
     insta::assert_snapshot!(stdout, @r#"
     @  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 cad212e1


### PR DESCRIPTION
Closes #4846.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
