### PR TITLE
docs: Make the Roadmap a toplevel website entry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,4 +88,4 @@ future cloud-based server using the same model as [XetHub][xet-storage].
 [gg]: https://github.com/gulbanana/gg
 [jj-run]: https://github.com/martinvonz/jj/issues/1869
 [submodules]: https://github.com/martinvonz/jj/issues/494
-[xet-storage]: https://xethub.com/assets/docs/concepts/xet-storage
+[xet-storage]: https://web.archive.org/web/20240914200921/https://xethub.com/assets/docs/concepts/xet-storage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,10 +134,11 @@ nav:
       - 'Temporary Voting for Governance': 'governance/temporary-voting.md'
 
 - 'Design docs':
-    - 'Roadmap': "roadmap.md"
     - 'git-submodules': 'design/git-submodules.md'
     - 'git-submodule-storage': 'design/git-submodule-storage.md'
     - 'JJ run': 'design/run.md'
     - 'Sparse Patterns v2': 'design/sparse-v2.md'
     - 'Tracking branches': 'design/tracking-branches.md'
     - 'Copy tracking and tracing': 'design/copy-tracking.md'
+
+- 'Development Roadmap': "roadmap.md"


### PR DESCRIPTION
This also fixes the Xethub link, by pointing it to the web archive, which no longer is available.

