### PR TITLE
cli: simplify-parents: add default `revsets.simplify-parents` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   "diff3" conflict style, meaning it is more likely to work with external tools,
   but it doesn't support conflicts with more than 2 sides.
 
+* `jj simplify-parents` now supports configuring the default revset when no
+   `--source` or `--revisions` arguments are provided with the
+   `revsets.simplify-parents` config.
+
 ### Fixed bugs
 
 * `jj config unset <TABLE-NAME>` no longer removes a table (such as `[ui]`.)

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -421,6 +421,11 @@
                     "type": "string",
                     "description": "Revisions to give shorter change and commit IDs to",
                     "default": "<revsets.log>"
+                },
+                "simplify-parents": {
+                    "type": "string",
+                    "description": "Default set of revisions to simplify when no explicit revset is given for jj simplify-parents",
+                    "default": "reachable(@, mutable())"
                 }
             },
             "additionalProperties": {

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -3,6 +3,7 @@
 
 [revsets]
 fix = "reachable(@, mutable())"
+simplify-parents = "reachable(@, mutable())"
 # log revset is also used as the default short-prefixes. If it failed to
 # evaluate, lengthy warning messages would be printed. Use present(expr) to
 # suppress symbol resolution error.
@@ -13,8 +14,8 @@ log = "present(@) | ancestors(immutable_heads().., 2) | present(trunk())"
 # symbol resolution error should be suppressed.
 'trunk()' = '''
 latest(
-  remote_bookmarks(exact:"main", exact:"origin") | 
-  remote_bookmarks(exact:"master", exact:"origin") | 
+  remote_bookmarks(exact:"main", exact:"origin") |
+  remote_bookmarks(exact:"master", exact:"origin") |
   remote_bookmarks(exact:"trunk", exact:"origin") |
   remote_bookmarks(exact:"main", exact:"upstream") |
   remote_bookmarks(exact:"master", exact:"upstream") |

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1975,12 +1975,14 @@ Removes all parents of each of the specified revisions that are also indirect an
 
 In other words, for all (A, B, C) where A has (B, C) as parents and C is an ancestor of B, A will be rewritten to have only B as a parent instead of B+C.
 
-**Usage:** `jj simplify-parents <--source <SOURCE>|--revisions <REVISIONS>>`
+**Usage:** `jj simplify-parents [OPTIONS]`
 
 ###### **Options:**
 
 * `-s`, `--source <SOURCE>` — Simplify specified revision(s) together with their trees of descendants (can be repeated)
 * `-r`, `--revisions <REVISIONS>` — Simplify specified revision(s) (can be repeated)
+
+   If both `--source` and `--revisions` are not provided, this defaults to the `revsets.simplify-parents` setting, or `reachable(@, mutable())` if it is not set.
 
 
 


### PR DESCRIPTION
This adds a new `revsets.simplify-parents` configuration option (similar to `revsets.fix`) which serves as the default revset for `jj simplify-parents` if no `--source` or `--revisions` arguments are provided.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [X] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
