### PR TITLE
README: add Contributing bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 **[Homepage] &nbsp;&nbsp;&bull;&nbsp;&nbsp;**
 **[Installation] &nbsp;&nbsp;&bull;&nbsp;&nbsp;**
 **[Getting Started] &nbsp;&nbsp;&bull;&nbsp;&nbsp;**
-**[Development Roadmap]**
+**[Development Roadmap] &nbsp;&nbsp;&bull;&nbsp;&nbsp;**
+**[Contributing](#contributing)**
 
 [Homepage]: https://martinvonz.github.io/jj
 [Installation]: https://martinvonz.github.io/jj/latest/install-and-setup


### PR DESCRIPTION
People will often look for contributing instructions from https://github.com/martinvonz/jj, this makes it easier to find.

It will also lead more people to read the contributing docs on the website as opposed to GitHub. This is becoming desireable, see the discussion at
https://github.com/martinvonz/jj/pull/4822#discussion_r1844611306
