### PR TITLE
completion: teach commands about files

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap_complete::ArgValueCandidates;
 use jj_lib::backend::Signature;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
@@ -20,6 +21,7 @@ use tracing::instrument;
 use crate::cli_util::CommandHelper;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
+use crate::complete;
 use crate::description_util::description_template;
 use crate::description_util::edit_description;
 use crate::description_util::join_message_paragraphs;
@@ -40,7 +42,10 @@ pub(crate) struct CommitArgs {
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,
     /// Put these paths in the first commit
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::modified_files),
+    )]
     paths: Vec<String>,
     /// Reset the author to the configured user
     ///

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -57,7 +57,10 @@ pub(crate) struct DiffArgs {
     #[arg(long, short, conflicts_with = "revision", add = ArgValueCandidates::new(complete::all_revisions))]
     to: Option<RevisionArg>,
     /// Restrict the diff to these paths
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::modified_revision_or_range_files),
+    )]
     paths: Vec<String>,
     #[command(flatten)]
     format: DiffFormatArgs,

--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use jj_lib::annotate::get_annotation_for_file;
 use jj_lib::annotate::FileAnnotation;
 use jj_lib::commit::Commit;
@@ -37,7 +38,10 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct FileAnnotateArgs {
     /// the file to annotate
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCompleter::new(complete::all_revision_files),
+    )]
     path: String,
     /// an optional revision to start at
     #[arg(long, short, add = ArgValueCandidates::new(complete::all_revisions))]

--- a/cli/src/commands/file/chmod.rs
+++ b/cli/src/commands/file/chmod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use jj_lib::backend::TreeValue;
 use jj_lib::merged_tree::MergedTreeBuilder;
 use jj_lib::object_id::ObjectId;
@@ -52,7 +53,11 @@ pub(crate) struct FileChmodArgs {
     )]
     revision: RevisionArg,
     /// Paths to change the executable bit for
-    #[arg(required = true, value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        required = true,
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCompleter::new(complete::all_revision_files),
+    )]
     paths: Vec<String>,
 }
 

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -16,6 +16,7 @@ use std::io;
 use std::io::Write;
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use jj_lib::backend::BackendResult;
 use jj_lib::conflicts::materialize_merge_result;
 use jj_lib::conflicts::materialize_tree_value;
@@ -51,7 +52,11 @@ pub(crate) struct FileShowArgs {
     )]
     revision: RevisionArg,
     /// Paths to print
-    #[arg(required = true, value_hint = clap::ValueHint::FilePath)]
+    #[arg(
+        required = true,
+        value_hint = clap::ValueHint::FilePath,
+        add = ArgValueCompleter::new(complete::all_revision_files),
+    )]
     paths: Vec<String>,
 }
 

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -14,6 +14,7 @@
 
 use std::io::Write;
 
+use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTreeBuilder;
@@ -24,6 +25,7 @@ use tracing::instrument;
 use crate::cli_util::CommandHelper;
 use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
+use crate::complete;
 use crate::ui::Ui;
 
 /// Stop tracking specified paths in the working copy
@@ -33,7 +35,11 @@ pub(crate) struct FileUntrackArgs {
     ///
     /// The paths could be ignored via a .gitignore or .git/info/exclude (in
     /// colocated repos).
-    #[arg(required = true, value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        required = true,
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCompleter::new(complete::all_revision_files),
+    )]
     paths: Vec<String>,
 }
 

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -42,7 +42,10 @@ pub(crate) struct InterdiffArgs {
     #[arg(long, short, add = ArgValueCandidates::new(complete::all_revisions))]
     to: Option<RevisionArg>,
     /// Restrict the diff to these paths
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::interdiff_files),
+    )]
     paths: Vec<String>,
     #[command(flatten)]
     format: DiffFormatArgs,

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -62,7 +62,10 @@ pub(crate) struct ResolveArgs {
     /// will attempt to resolve the first conflict we can find. You can use
     /// the `--list` argument to find paths to use here.
     // TODO: Find the conflict we can resolve even if it's not the first one.
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::revision_conflicted_files),
+    )]
     paths: Vec<String>,
 }
 

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -45,7 +45,10 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct RestoreArgs {
     /// Restore only these paths (instead of all paths)
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::modified_range_files),
+    )]
     paths: Vec<String>,
     /// Revision to restore from (source)
     #[arg(long, short, add = ArgValueCandidates::new(complete::all_revisions))]

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -66,7 +66,10 @@ pub(crate) struct SplitArgs {
     #[arg(long, short, alias = "siblings")]
     parallel: bool,
     /// Put these paths in the first commit
-    #[arg(value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::modified_revision_files),
+    )]
     paths: Vec<String>,
 }
 

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -90,7 +90,11 @@ pub(crate) struct SquashArgs {
     #[arg(long, value_name = "NAME")]
     tool: Option<String>,
     /// Move only changes to these paths (instead of all paths)
-    #[arg(conflicts_with_all = ["interactive", "tool"], value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        conflicts_with_all = ["interactive", "tool"],
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCandidates::new(complete::squash_revision_files),
+    )]
     paths: Vec<String>,
     /// The source revision will not be abandoned
     #[arg(long, short)]


### PR DESCRIPTION
This is heavily based on Benjamin Tan's fish completions:
https://gist.github.com/bnjmnt4n/9f47082b8b6e6ed2b2a805a1516090c8

Some differences include:
- The end of a `--from`, `--to` range is also considered.
- `jj log` is not completed (yet). It has a different `--revisions` argument
  that requires some special handling.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
