### PR TITLE
completion: teach config about keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "sapling-renderdag",
  "scm-record",
  "serde",
+ "serde_json",
  "slab",
  "strsim",
  "tempfile",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -80,6 +80,7 @@ rpassword = { workspace = true }
 sapling-renderdag = { workspace = true }
 scm-record = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 slab = { workspace = true }
 strsim = { workspace = true }
 tempfile = { workspace = true }

--- a/cli/src/commands/config/get.rs
+++ b/cli/src/commands/config/get.rs
@@ -14,11 +14,13 @@
 
 use std::io::Write as _;
 
+use clap_complete::ArgValueCandidates;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::config_error;
 use crate::command_error::CommandError;
+use crate::complete;
 use crate::config::ConfigNamePathBuf;
 use crate::ui::Ui;
 
@@ -34,7 +36,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]
 pub struct ConfigGetArgs {
-    #[arg(required = true)]
+    #[arg(required = true, add = ArgValueCandidates::new(complete::leaf_config_keys))]
     name: ConfigNamePathBuf,
 }
 

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap_complete::ArgValueCandidates;
 use tracing::instrument;
 
 use super::ConfigLevelArgs;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
+use crate::complete;
 use crate::config::to_toml_value;
 use crate::config::AnnotatedValue;
 use crate::config::ConfigNamePathBuf;
@@ -31,6 +33,7 @@ use crate::ui::Ui;
 #[command(mut_group("config_level", |g| g.required(false)))]
 pub struct ConfigListArgs {
     /// An optional name of a specific config option to look up.
+    #[arg(add = ArgValueCandidates::new(complete::config_keys))]
     pub name: Option<ConfigNamePathBuf>,
     /// Whether to explicitly include built-in default values in the list.
     #[arg(long, conflicts_with = "config_level")]

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -14,6 +14,7 @@
 
 use std::io;
 
+use clap_complete::ArgValueCandidates;
 use jj_lib::commit::Commit;
 use jj_lib::repo::Repo;
 use tracing::instrument;
@@ -24,6 +25,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::WorkspaceCommandHelper;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
+use crate::complete;
 use crate::config::parse_toml_value_or_bare_string;
 use crate::config::write_config_value_to_file;
 use crate::config::ConfigNamePathBuf;
@@ -32,7 +34,7 @@ use crate::ui::Ui;
 /// Update config file to set the given option to a given value.
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigSetArgs {
-    #[arg(required = true)]
+    #[arg(required = true, add = ArgValueCandidates::new(complete::leaf_config_keys))]
     name: ConfigNamePathBuf,
     #[arg(required = true)]
     value: String,

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap_complete::ArgValueCandidates;
 use tracing::instrument;
 
 use super::ConfigLevelArgs;
@@ -19,6 +20,7 @@ use crate::cli_util::get_new_config_file_path;
 use crate::cli_util::CommandHelper;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
+use crate::complete;
 use crate::config::remove_config_value_from_file;
 use crate::config::ConfigNamePathBuf;
 use crate::ui::Ui;
@@ -26,7 +28,7 @@ use crate::ui::Ui;
 /// Update config file to unset the given option.
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigUnsetArgs {
-    #[arg(required = true)]
+    #[arg(required = true, add = ArgValueCandidates::new(complete::leaf_config_keys))]
     name: ConfigNamePathBuf,
     #[command(flatten)]
     level: ConfigLevelArgs,

--- a/cli/src/commands/util/config_schema.rs
+++ b/cli/src/commands/util/config_schema.rs
@@ -16,6 +16,7 @@ use std::io::Write as _;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
+use crate::config::CONFIG_SCHEMA;
 use crate::ui::Ui;
 
 /// Print the JSON schema for the jj TOML config format.
@@ -27,8 +28,6 @@ pub fn cmd_util_config_schema(
     _command: &CommandHelper,
     _args: &UtilConfigSchemaArgs,
 ) -> Result<(), CommandError> {
-    // TODO(#879): Consider generating entire schema dynamically vs. static file.
-    let buf = include_bytes!("../../config-schema.json");
-    ui.stdout().write_all(buf)?;
+    ui.stdout().write_all(CONFIG_SCHEMA.as_bytes())?;
     Ok(())
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -35,6 +35,9 @@ use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 
+// TODO(#879): Consider generating entire schema dynamically vs. static file.
+pub const CONFIG_SCHEMA: &str = include_str!("config-schema.json");
+
 /// Parses a TOML value expression. Interprets the given value as string if it
 /// can't be parsed.
 pub fn parse_toml_value_or_bare_string(value_str: &str) -> toml_edit::Value {

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -472,3 +472,25 @@ fn test_workspaces() {
     default	initial
     ");
 }
+
+#[test]
+fn test_config() {
+    let mut test_env = TestEnvironment::default();
+    test_env.add_env_var("COMPLETE", "fish");
+    let dir = test_env.env_root();
+
+    let stdout = test_env.jj_cmd_success(dir, &["--", "jj", "config", "get", "c"]);
+    insta::assert_snapshot!(stdout, @r"
+    core.fsmonitor	Whether to use an external filesystem monitor, useful for large repos
+    core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
+    ");
+
+    let stdout = test_env.jj_cmd_success(dir, &["--", "jj", "config", "list", "c"]);
+    insta::assert_snapshot!(stdout, @r"
+    colors	Mapping from jj formatter labels to colors
+    core
+    core.fsmonitor	Whether to use an external filesystem monitor, useful for large repos
+    core.watchman
+    core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
+    ");
+}


### PR DESCRIPTION
There are two known limitations right now:

- Only statically known keys are suggested.

- Keys that the user did not set are still suggested for `jj config get`. Running that suggestion may result in an error. The error message will be appropriate though and there is some value in letting the user know that this config value theoretically exists. Some users may try to explore what configurations are available via the completions.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
