### PR TITLE
completion: suggest file paths incrementally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,7 @@ dependencies = [
  "futures 0.3.31",
  "git2",
  "gix",
+ "glob",
  "indexmap",
  "indoc",
  "insta",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,6 +64,7 @@ dunce = { workspace = true }
 futures = { workspace = true }
 git2 = { workspace = true }
 gix = { workspace = true }
+glob = { workspace = true }
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use jj_lib::backend::Signature;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
@@ -44,7 +44,7 @@ pub(crate) struct CommitArgs {
     /// Put these paths in the first commit
     #[arg(
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::modified_files),
+        add = ArgValueCompleter::new(complete::modified_files),
     )]
     paths: Vec<String>,
     /// Reset the author to the configured user

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use jj_lib::copies::CopyRecords;
 use jj_lib::repo::Repo;
@@ -59,7 +60,7 @@ pub(crate) struct DiffArgs {
     /// Restrict the diff to these paths
     #[arg(
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::modified_revision_or_range_files),
+        add = ArgValueCompleter::new(complete::modified_revision_or_range_files),
     )]
     paths: Vec<String>,
     #[command(flatten)]

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -16,6 +16,7 @@ use std::slice;
 
 use clap::ArgGroup;
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -44,7 +45,7 @@ pub(crate) struct InterdiffArgs {
     /// Restrict the diff to these paths
     #[arg(
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::interdiff_files),
+        add = ArgValueCompleter::new(complete::interdiff_files),
     )]
     paths: Vec<String>,
     #[command(flatten)]

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -15,6 +15,7 @@
 use std::io::Write;
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;
@@ -64,7 +65,7 @@ pub(crate) struct ResolveArgs {
     // TODO: Find the conflict we can resolve even if it's not the first one.
     #[arg(
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::revision_conflicted_files),
+        add = ArgValueCompleter::new(complete::revision_conflicted_files),
     )]
     paths: Vec<String>,
 }

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -15,6 +15,7 @@
 use std::io::Write;
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use jj_lib::object_id::ObjectId;
 use jj_lib::rewrite::restore_tree;
 use tracing::instrument;
@@ -47,7 +48,7 @@ pub(crate) struct RestoreArgs {
     /// Restore only these paths (instead of all paths)
     #[arg(
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::modified_range_files),
+        add = ArgValueCompleter::new(complete::modified_range_files),
     )]
     paths: Vec<String>,
     /// Revision to restore from (source)

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -14,6 +14,7 @@
 use std::io::Write;
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
 use tracing::instrument;
@@ -68,7 +69,7 @@ pub(crate) struct SplitArgs {
     /// Put these paths in the first commit
     #[arg(
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::modified_revision_files),
+        add = ArgValueCompleter::new(complete::modified_revision_files),
     )]
     paths: Vec<String>,
 }

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use itertools::Itertools as _;
 use jj_lib::commit::Commit;
 use jj_lib::commit::CommitIteratorExt;
@@ -93,7 +94,7 @@ pub(crate) struct SquashArgs {
     #[arg(
         conflicts_with_all = ["interactive", "tool"],
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCandidates::new(complete::squash_revision_files),
+        add = ArgValueCompleter::new(complete::squash_revision_files),
     )]
     paths: Vec<String>,
     /// The source revision will not be abandoned


### PR DESCRIPTION
stacked on #4887 (teach commands about files)

If there are multiple files in a subdirectory that are candidates for completion, only complete the common directory prefix to reduce the number of completion candidates shown at once.

This matches the normal shell completion of file paths.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
