### PR TITLE
conflicts: add "ui.conflict-marker-style" config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   materialized in the working copy. The default option ("diff") renders
   conflicts as a snapshot with a list of diffs to apply to the snapshot.
   The new "snapshot" option renders conflicts as a series of snapshots, showing
-  each side and base of the conflict.
+  each side and base of the conflict. The new "git" option replicates Git's
+  "diff3" conflict style, meaning it is more likely to work with external tools,
+  but it doesn't support conflicts with more than 2 sides.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `ui.conflict-marker-style` config option to change how conflicts are
   materialized in the working copy. The default option ("diff") renders
   conflicts as a snapshot with a list of diffs to apply to the snapshot.
+  The new "snapshot" option renders conflicts as a series of snapshots, showing
+  each side and base of the conflict.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `op diff`
   - `restore`
 
+* New `ui.conflict-marker-style` config option to change how conflicts are
+  materialized in the working copy. The default option ("diff") renders
+  conflicts as a snapshot with a list of diffs to apply to the snapshot.
+
 ### Fixed bugs
 
 * `jj config unset <TABLE-NAME>` no longer removes a table (such as `[ui]`.)

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -35,6 +35,7 @@ use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::store::Store;
 use jj_lib::working_copy::CheckoutError;
+use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
 use jj_lib::working_copy::ResetError;
@@ -240,14 +241,18 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
         self.inner.snapshot(&options)
     }
 
-    fn check_out(&mut self, commit: &Commit) -> Result<CheckoutStats, CheckoutError> {
+    fn check_out(
+        &mut self,
+        commit: &Commit,
+        options: &CheckoutOptions,
+    ) -> Result<CheckoutStats, CheckoutError> {
         let conflicts = commit
             .tree()?
             .conflicts()
             .map(|(path, _value)| format!("{}\n", path.as_internal_file_string()))
             .join("");
         std::fs::write(self.wc_path.join(".conflicts"), conflicts).unwrap();
-        self.inner.check_out(commit)
+        self.inner.check_out(commit, options)
     }
 
     fn rename_workspace(&mut self, new_workspace_id: WorkspaceId) {
@@ -269,8 +274,9 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
     fn set_sparse_patterns(
         &mut self,
         new_sparse_patterns: Vec<RepoPathBuf>,
+        options: &CheckoutOptions,
     ) -> Result<CheckoutStats, CheckoutError> {
-        self.inner.set_sparse_patterns(new_sparse_patterns)
+        self.inner.set_sparse_patterns(new_sparse_patterns, options)
     }
 
     fn finish(

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -127,7 +127,11 @@ fn write_tree_entries<P: AsRef<RepoPath>>(
                 io::copy(&mut reader, &mut ui.stdout_formatter().as_mut())?;
             }
             MaterializedTreeValue::FileConflict { contents, .. } => {
-                materialize_merge_result(&contents, &mut ui.stdout_formatter())?;
+                materialize_merge_result(
+                    &contents,
+                    workspace_command.env().conflict_marker_style(),
+                    &mut ui.stdout_formatter(),
+                )?;
             }
             MaterializedTreeValue::OtherConflict { id } => {
                 ui.stdout_formatter().write_all(id.describe().as_bytes())?;

--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -44,6 +44,7 @@ pub(crate) fn cmd_file_track(
     args: &FileTrackArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
+    let conflict_marker_style = workspace_command.env().conflict_marker_style();
     let matcher = workspace_command
         .parse_file_patterns(ui, &args.paths)?
         .to_matcher();
@@ -57,6 +58,7 @@ pub(crate) fn cmd_file_track(
         progress: None,
         start_tracking_matcher: &matcher,
         max_new_file_size: command.settings().max_new_file_size()?,
+        conflict_marker_style,
     })?;
     let num_rebased = tx.repo_mut().rebase_descendants(command.settings())?;
     if num_rebased > 0 {

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -44,6 +44,7 @@ pub(crate) fn cmd_file_untrack(
     args: &FileUntrackArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
+    let conflict_marker_style = workspace_command.env().conflict_marker_style();
     let store = workspace_command.repo().store().clone();
     let matcher = workspace_command
         .parse_file_patterns(ui, &args.paths)?
@@ -75,6 +76,7 @@ pub(crate) fn cmd_file_untrack(
         progress: None,
         start_tracking_matcher: &auto_tracking_matcher,
         max_new_file_size: command.settings().max_new_file_size()?,
+        conflict_marker_style,
     })?;
     if wc_tree_id != *new_commit.tree_id() {
         let wc_tree = store.get_root_tree(&wc_tree_id)?;

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -125,7 +125,9 @@ pub fn cmd_op_diff(
     let diff_renderer = {
         let formats = diff_formats_for_log(command.settings(), &args.diff_format, args.patch)?;
         let path_converter = workspace_env.path_converter();
-        (!formats.is_empty()).then(|| DiffRenderer::new(merged_repo, path_converter, formats))
+        let conflict_marker_style = workspace_env.conflict_marker_style();
+        (!formats.is_empty())
+            .then(|| DiffRenderer::new(merged_repo, path_converter, conflict_marker_style, formats))
     };
     let id_prefix_context = workspace_env.new_id_prefix_context();
     let commit_summary_template = {

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -167,8 +167,15 @@ fn do_op_log(
                 )?
             };
             let path_converter = workspace_env.path_converter();
-            let diff_renderer = (!diff_formats.is_empty())
-                .then(|| DiffRenderer::new(repo.as_ref(), path_converter, diff_formats.clone()));
+            let conflict_marker_style = workspace_env.conflict_marker_style();
+            let diff_renderer = (!diff_formats.is_empty()).then(|| {
+                DiffRenderer::new(
+                    repo.as_ref(),
+                    path_converter,
+                    conflict_marker_style,
+                    diff_formats.clone(),
+                )
+            });
 
             show_op_diff(
                 ui,

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -73,7 +73,15 @@ pub fn cmd_op_show(
     let diff_renderer = {
         let formats = diff_formats_for_log(command.settings(), &args.diff_format, args.patch)?;
         let path_converter = workspace_env.path_converter();
-        (!formats.is_empty()).then(|| DiffRenderer::new(repo.as_ref(), path_converter, formats))
+        let conflict_marker_style = workspace_env.conflict_marker_style();
+        (!formats.is_empty()).then(|| {
+            DiffRenderer::new(
+                repo.as_ref(),
+                path_converter,
+                conflict_marker_style,
+                formats,
+            )
+        })
     };
 
     // TODO: Should we make this customizable via clap arg?

--- a/cli/src/commands/sparse.rs
+++ b/cli/src/commands/sparse.rs
@@ -211,11 +211,12 @@ fn update_sparse_patterns_with(
     workspace_command: &mut WorkspaceCommandHelper,
     f: impl FnOnce(&mut Ui, &[RepoPathBuf]) -> Result<Vec<RepoPathBuf>, CommandError>,
 ) -> Result<(), CommandError> {
+    let checkout_options = workspace_command.checkout_options();
     let (mut locked_ws, wc_commit) = workspace_command.start_working_copy_mutation()?;
     let new_patterns = f(ui, locked_ws.locked_wc().sparse_patterns()?)?;
     let stats = locked_ws
         .locked_wc()
-        .set_sparse_patterns(new_patterns)
+        .set_sparse_patterns(new_patterns, &checkout_options)
         .map_err(|err| internal_error_with_message("Failed to update working copy paths", err))?;
     let operation_id = locked_ws.locked_wc().old_operation_id().clone();
     locked_ws.finish(operation_id)?;

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -146,10 +146,11 @@ pub fn cmd_workspace_add(
     };
 
     if let Some(sparse_patterns) = sparsity {
+        let checkout_options = new_workspace_command.checkout_options();
         let (mut locked_ws, _wc_commit) = new_workspace_command.start_working_copy_mutation()?;
         locked_ws
             .locked_wc()
-            .set_sparse_patterns(sparse_patterns)
+            .set_sparse_patterns(sparse_patterns, &checkout_options)
             .map_err(|err| internal_error_with_message("Failed to set sparse patterns", err))?;
         let operation_id = locked_ws.locked_wc().old_operation_id().clone();
         locked_ws.finish(operation_id)?;

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -158,6 +158,14 @@
                 "merge-editor": {
                     "type": "string",
                     "description": "Tool to use for resolving three-way merges. Behavior for a given tool name can be configured in merge-tools.TOOL tables"
+                },
+                "conflict-marker-style": {
+                    "type": "string",
+                    "description": "Conflict marker style to use when materializing conflicts in the working copy",
+                    "enum": [
+                        "diff"
+                    ],
+                    "default": "diff"
                 }
             }
         },

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -163,7 +163,8 @@
                     "type": "string",
                     "description": "Conflict marker style to use when materializing conflicts in the working copy",
                     "enum": [
-                        "diff"
+                        "diff",
+                        "snapshot"
                     ],
                     "default": "diff"
                 }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -164,7 +164,8 @@
                     "description": "Conflict marker style to use when materializing conflicts in the working copy",
                     "enum": [
                         "diff",
-                        "snapshot"
+                        "snapshot",
+                        "git"
                     ],
                     "default": "diff"
                 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -22,6 +22,7 @@ paginate = "auto"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 log-word-wrap = false
 log-synthetic-elided-nodes = true
+conflict-marker-style = "diff"
 
 [ui.movement]
 edit = false

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use indoc::indoc;
+
 use crate::common::TestEnvironment;
 
 #[test]
@@ -56,4 +58,104 @@ fn test_snapshot_large_file() {
     test_env.add_config(r#"snapshot.auto-track = 'none()'"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
     insta::assert_snapshot!(stdout, @"");
+}
+
+#[test]
+fn test_materialize_and_snapshot_different_conflict_markers() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    // Configure to use Git-style conflict markers
+    test_env.add_config(r#"ui.conflict-marker-style = "git""#);
+
+    // Create a conflict in the working copy
+    let conflict_file = repo_path.join("file");
+    std::fs::write(
+        &conflict_file,
+        indoc! {"
+            line 1
+            line 2
+            line 3
+        "},
+    )
+    .unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "base"]);
+    std::fs::write(
+        &conflict_file,
+        indoc! {"
+            line 1
+            line 2 - a
+            line 3
+        "},
+    )
+    .unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "side-a"]);
+    test_env.jj_cmd_ok(&repo_path, &["new", "description(base)", "-m", "side-b"]);
+    std::fs::write(
+        &conflict_file,
+        indoc! {"
+            line 1
+            line 2 - b
+            line 3 - b
+        "},
+    )
+    .unwrap();
+    test_env.jj_cmd_ok(
+        &repo_path,
+        &["new", "description(side-a)", "description(side-b)"],
+    );
+
+    // File should have Git-style conflict markers
+    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r##"
+    line 1
+    <<<<<<< Side #1 (Conflict 1 of 1)
+    line 2 - a
+    line 3
+    ||||||| Base
+    line 2
+    line 3
+    =======
+    line 2 - b
+    line 3 - b
+    >>>>>>> Side #2 (Conflict 1 of 1 ends)
+    "##);
+
+    // Configure to use JJ-style "snapshot" conflict markers
+    test_env.add_config(r#"ui.conflict-marker-style = "snapshot""#);
+
+    // Update the conflict, still using Git-style conflict markers
+    std::fs::write(
+        &conflict_file,
+        indoc! {"
+            line 1
+            <<<<<<<
+            line 2 - a
+            line 3 - a
+            |||||||
+            line 2
+            line 3
+            =======
+            line 2 - b
+            line 3 - b
+            >>>>>>>
+        "},
+    )
+    .unwrap();
+
+    // Git-style markers should be parsed, then rendered with new config
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r##"
+    diff --git a/file b/file
+    --- a/file
+    +++ b/file
+    @@ -2,7 +2,7 @@
+     <<<<<<< Conflict 1 of 1
+     +++++++ Contents of side #1
+     line 2 - a
+    -line 3
+    +line 3 - a
+     ------- Contents of base
+     line 2
+     line 3
+    "##);
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -285,6 +285,24 @@ diff.tool = "vimdiff"
 diff-invocation-mode = "file-by-file"
 ```
 
+### Conflict marker style
+
+You can configure which style of conflict markers to use when materializing
+conflicts:
+
+```toml
+[ui]
+# Shows a single snapshot and one or more diffs to apply to it
+conflict-marker-style = "diff"
+# Shows a snapshot for each side and base of the conflict
+conflict-marker-style = "snapshot"
+# Uses Git's "diff3" conflict markers to support tools that depend on it
+conflict-marker-style = "git"
+```
+
+For more details about these conflict marker styles, see the [conflicts
+page](conflicts.md#conflict-markers).
+
 ### Set of immutable commits
 
 You can configure the set of immutable commits via

--- a/lib/src/annotate.rs
+++ b/lib/src/annotate.rs
@@ -34,6 +34,7 @@ use crate::backend::CommitId;
 use crate::commit::Commit;
 use crate::conflicts::materialize_merge_result_to_bytes;
 use crate::conflicts::materialize_tree_value;
+use crate::conflicts::ConflictMarkerStyle;
 use crate::conflicts::MaterializedTreeValue;
 use crate::diff::Diff;
 use crate::diff::DiffHunkKind;
@@ -358,9 +359,9 @@ fn get_file_contents(
                 })?;
             Ok(file_contents.into())
         }
-        MaterializedTreeValue::FileConflict { contents, .. } => {
-            Ok(materialize_merge_result_to_bytes(&contents))
-        }
+        MaterializedTreeValue::FileConflict { contents, .. } => Ok(
+            materialize_merge_result_to_bytes(&contents, ConflictMarkerStyle::default()),
+        ),
         _ => Ok(BString::default()),
     }
 }

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -300,9 +300,7 @@ fn materialize_conflict_hunks(
                     format!("base #{}", base_index + 1)
                 };
 
-                let right1 = if let Some(right1) = hunk.get_add(add_index) {
-                    right1
-                } else {
+                let Some(right1) = hunk.get_add(add_index) else {
                     // If we have no more positive terms, emit the remaining negative
                     // terms as snapshots.
                     output.write_all(CONFLICT_MINUS_LINE)?;

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -44,6 +44,7 @@ use crate::backend::MillisSinceEpoch;
 use crate::commit::Commit;
 use crate::conflicts::materialize_merge_result_to_bytes;
 use crate::conflicts::materialize_tree_value;
+use crate::conflicts::ConflictMarkerStyle;
 use crate::conflicts::MaterializedTreeValue;
 use crate::default_index::AsCompositeIndex;
 use crate::default_index::CompositeIndex;
@@ -1346,7 +1347,7 @@ fn to_file_content(path: &RepoPath, value: MaterializedTreeValue) -> BackendResu
         MaterializedTreeValue::Symlink { id: _, target } => Ok(target.into_bytes()),
         MaterializedTreeValue::GitSubmodule(_) => Ok(vec![]),
         MaterializedTreeValue::FileConflict { contents, .. } => {
-            Ok(materialize_merge_result_to_bytes(&contents).into())
+            Ok(materialize_merge_result_to_bytes(&contents, ConflictMarkerStyle::default()).into())
         }
         MaterializedTreeValue::OtherConflict { .. } => Ok(vec![]),
         MaterializedTreeValue::Tree(id) => {

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -339,6 +339,13 @@ impl<T> Merge<T> {
         self.values.resize(num_sides * 2 - 1, value.clone());
     }
 
+    /// Returns a slice containing the terms. The items will alternate between
+    /// positive and negative terms, starting with positive (since there's one
+    /// more of those).
+    pub fn as_slice(&self) -> &[T] {
+        &self.values
+    }
+
     /// Returns an iterator over references to the terms. The items will
     /// alternate between positive and negative terms, starting with
     /// positive (since there's one more of those).

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -28,6 +28,7 @@ use crate::backend::Commit;
 use crate::backend::Signature;
 use crate::backend::Timestamp;
 use crate::config::ConfigError;
+use crate::conflicts::ConflictMarkerStyle;
 use crate::fmt_util::binary_prefix;
 use crate::fsmonitor::FsmonitorSettings;
 use crate::signing::SignBehavior;
@@ -253,6 +254,13 @@ impl UserSettings {
 
     pub fn sign_settings(&self) -> SignSettings {
         SignSettings::from_settings(self)
+    }
+
+    pub fn conflict_marker_style(&self) -> Result<ConflictMarkerStyle, ConfigError> {
+        Ok(self
+            .get("ui.conflict-marker-style")
+            .optional()?
+            .unwrap_or_default())
     }
 }
 

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -54,6 +54,7 @@ use crate::signing::SignInitError;
 use crate::signing::Signer;
 use crate::store::Store;
 use crate::working_copy::CheckoutError;
+use crate::working_copy::CheckoutOptions;
 use crate::working_copy::CheckoutStats;
 use crate::working_copy::LockedWorkingCopy;
 use crate::working_copy::WorkingCopy;
@@ -433,6 +434,7 @@ impl Workspace {
         operation_id: OperationId,
         old_tree_id: Option<&MergedTreeId>,
         commit: &Commit,
+        options: &CheckoutOptions,
     ) -> Result<CheckoutStats, CheckoutError> {
         let mut locked_ws =
             self.start_working_copy_mutation()
@@ -449,7 +451,7 @@ impl Workspace {
                 return Err(CheckoutError::ConcurrentCheckout);
             }
         }
-        let stats = locked_ws.locked_wc().check_out(commit)?;
+        let stats = locked_ws.locked_wc().check_out(commit, options)?;
         locked_ws
             .finish(operation_id)
             .map_err(|err| CheckoutError::Other {

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -19,6 +19,7 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
+use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::WorkingCopy;
 use pollster::FutureExt as _;
@@ -62,7 +63,12 @@ fn test_sparse_checkout() {
 
     test_workspace
         .workspace
-        .check_out(repo.op_id().clone(), None, &commit)
+        .check_out(
+            repo.op_id().clone(),
+            None,
+            &commit,
+            &CheckoutOptions::empty_for_test(),
+        )
         .unwrap();
     let ws = &mut test_workspace.workspace;
 
@@ -71,7 +77,7 @@ fn test_sparse_checkout() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     let stats = locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns.clone())
+        .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())
         .unwrap();
     assert_eq!(
         stats,
@@ -130,7 +136,7 @@ fn test_sparse_checkout() {
     let mut locked_wc = wc.start_mutation().unwrap();
     let sparse_patterns = to_owned_path_vec(&[root_file1_path, dir1_subdir1_path, dir2_path]);
     let stats = locked_wc
-        .set_sparse_patterns(sparse_patterns.clone())
+        .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())
         .unwrap();
     assert_eq!(
         stats,
@@ -195,7 +201,12 @@ fn test_sparse_commit() {
     let commit = commit_with_tree(repo.store(), tree.id());
     test_workspace
         .workspace
-        .check_out(repo.op_id().clone(), None, &commit)
+        .check_out(
+            repo.op_id().clone(),
+            None,
+            &commit,
+            &CheckoutOptions::empty_for_test(),
+        )
         .unwrap();
 
     // Set sparse patterns to only dir1/
@@ -206,7 +217,7 @@ fn test_sparse_commit() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns)
+        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
         .unwrap();
     locked_ws.finish(repo.op_id().clone()).unwrap();
 
@@ -247,7 +258,7 @@ fn test_sparse_commit() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path, dir2_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns)
+        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
         .unwrap();
     locked_ws.finish(op_id).unwrap();
 
@@ -283,7 +294,7 @@ fn test_sparse_commit_gitignore() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns)
+        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
         .unwrap();
     locked_ws.finish(repo.op_id().clone()).unwrap();
 


### PR DESCRIPTION
Resolves #823.

Adds support for "diff" (current default), "snapshot", and "git-diff3" (falls back to "diff" if more than 2 sides) options.

**Example of "diff"**

```
<<<<<<< Conflict 1 of 1
+++++++ Contents of side #1
fn example(word: String) {
    println!("word is {word}");
%%%%%%% Changes from base to side #2
-fn example(w: String) {
+fn example(w: &str) {
     println!("word is {w}");
>>>>>>> Conflict 1 of 1 ends
}
```

**Example of "snapshot"**

```
<<<<<<< Conflict 1 of 1
+++++++ Contents of side #1
fn example(word: String) {
    println!("word is {word}");
------- Contents of base
fn example(w: String) {
    println!("word is {w}");
+++++++ Contents of side #2
fn example(w: &str) {
    println!("word is {w}");
>>>>>>> Conflict 1 of 1 ends
}
```

**Example of "git"**

```
<<<<<<< Side #1 (Conflict 1 of 1)
fn example(word: String) {
    println!("word is {word}");
||||||| Base
fn example(w: String) {
    println!("word is {w}");
=======
fn example(w: &str) {
    println!("word is {w}");
>>>>>>> Side #2 (Conflict 1 of 1 ends)
}
```

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
