### PR TITLE
revset: allow `tags()` to take a pattern for an argument

### DIFF
--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -309,6 +309,17 @@ impl View {
         self.data.tags.get(name).flatten()
     }
 
+    /// Iterates local tag `(name, target)`s matching the given pattern. Entries
+    /// are sorted by `name`.
+    pub fn local_tags_matching<'a: 'b, 'b>(
+        &'a self,
+        pattern: &'b StringPattern,
+    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + 'b {
+        pattern
+            .filter_btree_map(&self.data.tags)
+            .map(|(name, target)| (name.as_ref(), target))
+    }
+
     /// Sets tag to point to the given target. If the target is absent, the tag
     /// will be removed.
     pub fn set_tag_target(&mut self, name: &str, target: RefTarget) {


### PR DESCRIPTION
This makes it more consistent with `bookmarks()`, as noted by `@ldrndll` on Discord.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
