### PR TITLE
git sync: Rebase commits onto new branch heads.

### DIFF
--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -155,6 +155,11 @@ impl<'repo> CommitRewriter<'repo> {
         self.mut_repo
     }
 
+    /// Returns an immutable reference to `MutableRepo`.
+    pub fn repo(&mut self) -> &MutableRepo {
+        self.mut_repo
+    }
+
     /// The commit we're rewriting.
     pub fn old_commit(&self) -> &Commit {
         &self.old_commit


### PR DESCRIPTION
## Summary
* [X] Get branch pre-fetch heads
* [X] Build candidates from prefetch heads
* [X] Fetch from remotes
* [X] Get branch post-fetch heads
* [X] Rebase
  * [X] Build old -> new map
  * [X] transform descendants


## Details
* implement CommitRewritter::repo() to return an immutable reference.
* transform_descendants() roots are candidates with parents in update_record.
* simplify parent merge
* drop newly emptied commits
* update new parents from the updated heads set if the old parents are ancestors.

Issue: #1039