### PR TITLE
docs/git-compatibility.md: preserve working copy files when co-locating

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -174,15 +174,16 @@ technically possible (though not officially supported) to convert it into a
 co-located repo like so:
 
 ```bash
+# Ignore the .jj directory in Git
+echo '/*' > .jj/.gitignore
 # Move the Git repo
 mv .jj/repo/store/git .git
 # Tell jj where to find it
 echo -n '../../../.git' > .jj/repo/store/git_target
-# Ignore the .jj directory in Git
-echo '/*' > .jj/.gitignore
 # Make the Git repository non-bare and set HEAD
 git config --unset core.bare
-jj new @-
+# Convince jj to update .git/HEAD to point to the working-copy commit's parent
+jj new && jj undo
 ```
 
 We may officially support this in the future. If you try this, we would


### PR DESCRIPTION
Use `jj new` instead of `jj new @-` at the end of converting to a co-located repository, because the latter "stashes" newly added working copy changes into a sibling commit.

See also: https://github.com/martinvonz/jj/discussions/4945

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
