### PR TITLE
cli: diff: add `--exclude` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   "diff3" conflict style, meaning it is more likely to work with external tools,
   but it doesn't support conflicts with more than 2 sides.
 
+* `jj diff` now accepts a `-x` / `--exclude` flag (can be repeated), to remove
+  files from the view. Explicitly excluded files take precedence over included
+  files.
+
 ### Fixed bugs
 
 * `jj config unset <TABLE-NAME>` no longer removes a table (such as `[ui]`.)

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -692,6 +692,7 @@ With the `--from` and/or `--to` options, shows the difference from/to the given 
    If the revision is a merge commit, this shows changes *from* the automatic merge of the contents of all of its parents *to* the contents of the revision itself.
 * `-f`, `--from <FROM>` — Show changes from this revision
 * `-t`, `--to <TO>` — Show changes to this revision
+* `-x`, `--exclude <EXCLUDE>` — Exclude these paths from the diff
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
 * `--types` — For each path, show only its type before and after


### PR DESCRIPTION
First contribution, please let me know if this should be an issue / something else first.

Often, while iterating, I end up with a state where I've updated some dependencies (`cargo update`, etc) and some code. I want to inspect the diff, but `jj diff` (and `jj show`, etc) only accept an allowlist. This works ok when all the relevant changes are in a common directory, but is annoying when working in multiple (such as with workspaces).

This adds an `--exclude` flag to `jj diff`, which does what it says on the tin. `jj diff -x Cargo.lock`

Potential pitfalls: `jj diff -x *.lock` may not work as expected, as it could shell expand to something like `jj diff -x Cargo.lock flake.lock`, which would **ex**clude `Cargo.lock` but **in**clude `flake.lock`. Unsure if this motivates a section in the docs.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
