### PR TITLE
cli `util gc`: document the fact that evolution log limits gc

### DIFF
--- a/cli/src/commands/util/gc.rs
+++ b/cli/src/commands/util/gc.rs
@@ -27,6 +27,9 @@ use crate::ui::Ui;
 ///
 /// To garbage-collect old operations and the commits/objects referenced by
 /// then, run `jj op abandon ..<some old operation>` before `jj util gc`.
+///
+/// Previous versions of a change that are reachable via the evolution log are
+/// not garbage-collected.
 #[derive(clap::Args, Clone, Debug)]
 pub struct UtilGcArgs {
     /// Time threshold

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2268,6 +2268,8 @@ Run backend-dependent garbage collection.
 
 To garbage-collect old operations and the commits/objects referenced by then, run `jj op abandon ..<some old operation>` before `jj util gc`.
 
+Previous versions of a change that are reachable via the evolution log are not garbage-collected.
+
 **Usage:** `jj util gc [OPTIONS]`
 
 ###### **Options:**


### PR DESCRIPTION
This is a followup to the discussion in
https://github.com/martinvonz/jj/pull/4953#discussion_r1855328098
