### PR TITLE
faq: add an entry about why merge commits are often empty

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -285,6 +285,24 @@ your edits, then use `jj squash` to update the earlier revision with those edits
 For when you would use git stashing, use `jj edit <rev>` for expected behaviour.
 Other workflows may prefer `jj edit` as well.
 
+### Why are most merge commits marked as "(empty)"?
+
+Jujutsu, like Git, is a snapshot-based VCS. That means that each commit
+logically records the state of all current files in the repo. The changes in a
+commit are not recorded but are instead calculated when needed by comparing the
+commit's state to the parent commit's state. Jujutsu defines the changes in a
+commit to be relative to the auto-merged parents (if there's only one parent,
+then that merge is trivial - it's the parent commit's state). As a result, a
+merge commit that was a clean merge (no conflict resolution, no additional
+changes) is considered empty. Conversely, if the merge commit contains conflict
+resolutions or additional changes, then it will be considered non-empty.
+
+This definition of the changes in a commit is used throughout Jujutsu. It's
+used by `jj diff -r` and `jj log -p` to show the changes in a commit. It's used
+by `jj rebase` to rebase the changes in a commit. It's used in `jj log` to
+indicate which commits are empty. It's used in the `files()` revset function
+(and by `jj log <path>`) to find commits that modify a certain path. And so on.
+
 ### How do I deal with divergent changes ('??' after the [change ID])?
 
 A [divergent change][glossary_divergent_change] represents a change that has two


### PR DESCRIPTION
I think the user in #4965 was wondering about this. And if they weren't, I know I've heard the question many times before anyway.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
