### PR TITLE
tutorial: fix conflict formatting issue

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -343,8 +343,11 @@ Then run `jj squash` to move the resolution into the conflicted commit.
 $ cat file1
 <<<<<<< Conflict 1 of 1
 %%%%%%% Changes from base to side #1
--b1+a+++++++ Contents of side #2
-b2>>>>>>> Conflict 1 of 1 ends
+-b1
++a
++++++++ Contents of side #2
+b2
+>>>>>>> Conflict 1 of 1 ends
 
 $ echo resolved > file1
 


### PR DESCRIPTION
Fixes formatting issue from #4872. The current formatting is likely due to creating the files without a newline at the end of the file, which would result in the materialization issue described in #3968. Since the tutorial uses `echo`, which adds a newline automatically, this shouldn't be the output that users see when following the tutorial.