### PR TITLE
nix: fix usage of new parallel linker in Darwin devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,14 @@
         if pkgs.stdenv.isLinux then
           [ "-fuse-ld=mold" "-Wl,--compress-debug-sections=zstd" ]
         else if pkgs.stdenv.isDarwin then
-          [ "-fuse-ld=/usr/bin/ld" "-ld_new" ]
+          # on darwin, /usr/bin/ld actually looks at the environment variable
+          # $DEVELOPER_DIR, which is set by the nix stdenv, and if set,
+          # automatically uses it to route the `ld` invocation to the binary
+          # within. in the devShell though, that isn't what we want; it's
+          # functional, but Xcode's linker as of ~v15 (not yet open source)
+          # is ultra-fast and very shiny; it is enabled via -ld_new, and on by
+          # default as of v16+
+          [ "--ld-path=$(unset DEVELOPER_DIR; /usr/bin/xcrun --find ld)" "-ld_new" ]
         else
           [ ];
 


### PR DESCRIPTION
As reported by @lilyball on Discord, the recent nixpkgs update this week brought with it an entirely new Darwin stdenv, which had a behavioral change versus the prior one, causing builds inside the developer shell to fail, as the new super-duper parallel linker could not be used.

However, rather than giving up and throwing away *billions* of precious CPU cycles, @emilazy and @lilyball instead doubled down and diagnosed the issue. The result is a new impenetrable line of Nix code, which is fully explained by the comments within.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
