### PR TITLE
cli: make `jj desc` and `jj st` aliases visible again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates now support the `==` and `!=` logical operators for `Boolean`,
   `Integer`, and `String` types.
 
-* The `jj desc` and `jj st` aliases are now hidden to not interfere with shell
-  completion. They remain available.
-
 * New command `jj absorb` that moves changes to stack of mutable revisions.
 
 * New command `jj util exec` that can be used for arbitrary aliases.

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -36,12 +36,12 @@ use crate::description_util::ParsedBulkEditMessage;
 use crate::text_util::parse_author;
 use crate::ui::Ui;
 
-/// Update the change description or other metadata [aliases: desc]
+/// Update the change description or other metadata
 ///
 /// Starts an editor to let you edit the description of changes. The editor
 /// will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
 #[derive(clap::Args, Clone, Debug)]
-#[command(alias = "desc")]
+#[command(visible_aliases = &["desc"])]
 pub(crate) struct DescribeArgs {
     /// The revision(s) whose description to edit
     #[arg(default_value = "@", add = ArgValueCandidates::new(complete::mutable_revisions))]

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -26,7 +26,7 @@ use crate::diff_util::get_copy_records;
 use crate::diff_util::DiffFormat;
 use crate::ui::Ui;
 
-/// Show high-level repo status [aliases: st]
+/// Show high-level repo status
 ///
 /// This includes:
 ///
@@ -34,7 +34,7 @@ use crate::ui::Ui;
 ///    changes between them
 ///  * Conflicted bookmarks (see https://martinvonz.github.io/jj/latest/bookmarks/)
 #[derive(clap::Args, Clone, Debug)]
-#[command(alias = "st")]
+#[command(visible_alias = "st")]
 pub(crate) struct StatusArgs {
     /// Restrict the status display to these paths
     #[arg(value_hint = clap::ValueHint::AnyPath)]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -127,7 +127,7 @@ To get started, see the tutorial at https://martinvonz.github.io/jj/latest/tutor
 * `bookmark` — Manage bookmarks [default alias: b]
 * `commit` — Update the description and create a new change on top
 * `config` — Manage config options
-* `describe` — Update the change description or other metadata [aliases: desc]
+* `describe` — Update the change description or other metadata
 * `diff` — Compare file contents between two revisions
 * `diffedit` — Touch up the content changes in a revision with a diff editor
 * `duplicate` — Create new changes with the same content as existing ones
@@ -154,7 +154,7 @@ To get started, see the tutorial at https://martinvonz.github.io/jj/latest/tutor
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
 * `split` — Split a revision in two
 * `squash` — Move changes from a revision into another revision
-* `status` — Show high-level repo status [aliases: st]
+* `status` — Show high-level repo status
 * `tag` — Manage tags
 * `util` — Infrequently used commands such as for generating shell completions
 * `undo` — Undo an operation (shortcut for `jj op undo`)
@@ -635,7 +635,7 @@ Update config file to unset the given option
 
 ## `jj describe`
 
-Update the change description or other metadata [aliases: desc]
+Update the change description or other metadata
 
 Starts an editor to let you edit the description of changes. The editor will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
 
@@ -2107,7 +2107,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 ## `jj status`
 
-Show high-level repo status [aliases: st]
+Show high-level repo status
 
 This includes:
 


### PR DESCRIPTION
This backs out commit fd271d39ad54 "cli: make `jj desc` and `jj st` aliases hidden."

As we discussed in https://github.com/martinvonz/jj/pull/4811, completion of flags doesn't work for hidden aliases.


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
