### PR TITLE
cli: duplicate: parse -rREV option properly

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -755,9 +755,7 @@ When any of the `--destination`, `--insert-after`, or `--insert-before` argument
 
 ###### **Arguments:**
 
-* `<REVISIONS>` — The revision(s) to duplicate
-
-  Default value: `@`
+* `<REVISIONS>` — The revision(s) to duplicate (default: @)
 
 ###### **Options:**
 

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -344,7 +344,8 @@ fn test_duplicate_destination() {
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // Duplicate multiple commits without a direct ancestry relationship onto a
     // single destination.
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "b", "-d", "c"]);
+    let (stdout, stderr) =
+        test_env.jj_cmd_ok(&repo_path, &["duplicate", "-r=a1", "-r=b", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as xlzxqlsl da0996fd a1
@@ -369,8 +370,10 @@ fn test_duplicate_destination() {
 
     // Duplicate multiple commits without a direct ancestry relationship onto
     // multiple destinations.
-    let (stdout, stderr) =
-        test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "b", "-d", "c", "-d", "d"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &repo_path,
+        &["duplicate", "-r=a1", "b", "-d", "c", "-d", "d"],
+    );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as oupztwtk 2f519daa a1


### PR DESCRIPTION
I'm thinking of deprecating `jj duplicate REV` (without `-r`), but that might be controversial.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
