### PR TITLE
nix: Pin nixpkgs input to current registry definition, automate lock updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,8 +28,10 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,8 @@
     # For listing and iterating nix systems
     flake-utils.url = "github:numtide/flake-utils";
 
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
     # For installing non-standard rustc versions
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
This was highlighted in @necauqua in Discord [here](https://discord.com/channels/968932220549103686/969291218347524238/1313984464447344661) and I agreed with the concern. The first commit enacts the pinning, the second one automated updates. I arbitrarily chose the same weekly cron schedule as the scorecards workflow.

Anecdotally a number of Rust-adjacent Nix libraries (such as Crane) also use this GHA. I myself used it for a long time as well:
https://github.com/shanesveller/nix-flake-lock-targets/blob/0ce982a5d1c115d8ba0683da3cd4af131309c26e/.github/workflows/update.yml

Feedback very welcome about further adjusting or populating the action arguments as lightly documented [here](https://github.com/DeterminateSystems/update-flake-lock/tree/a2bbe0274e3a0c4194390a1e445f734c597ebc37?tab=readme-ov-file#add-assignees-or-reviewers) and defined [here](https://github.com/DeterminateSystems/update-flake-lock/blob/0ba11186640dde09ade3e5599aabb2a57f28d8aa/action.yml#L26-L65).

Some callouts:
- pr-title
- pr-body
- pr-labels
- pr-assignees
- pr-reviewers
- git-author-name
- git-author-email
- git-committer-name
- git-committer-email
- sign-commits

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
