### PR TITLE
diff_util: Add the short alias `S` for `--stat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* The `--stat` option for `jj log`, `jj show` and `jj diff` now has a
+  short alias `-S`
+
 ### Fixed bugs
 
 * The `$NO_COLOR` environment variable must now be non-empty to be respected.

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -92,7 +92,7 @@ pub struct DiffFormatArgs {
     #[arg(long, short)]
     pub summary: bool,
     /// Show a histogram of the changes
-    #[arg(long)]
+    #[arg(long, short_alias = 'S')]
     pub stat: bool,
     /// For each path, show only its type before and after
     ///


### PR DESCRIPTION
This was a suggestion from sm in the libera #jujutsu IRC chat.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
