### PR TITLE
Back out 89d57ffb: "build: add `rust-toolchain.toml`"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
 [workspace.package]
 version = "0.24.0"
 license = "Apache-2.0"
-rust-version = "1.76" # NOTE: remember to update CI, rust-toolchain.toml, contributing.md, changelog.md, install-and-setup.md, and flake.nix
+rust-version = "1.76" # NOTE: remember to update CI, contributing.md, changelog.md, install-and-setup.md, and flake.nix
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/martinvonz/jj"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -133,13 +133,16 @@ recommended steps.
 One-time setup:
 
     rustup toolchain add nightly  # wanted for 'rustfmt'
-    cargo install cargo-insta cargo-watch cargo-nextest
+    rustup toolchain add 1.76     # also specified in Cargo.toml
+    cargo install cargo-insta
+    cargo install cargo-watch
+    cargo install cargo-nextest
 
 During development (adapt according to your preference):
 
     cargo watch --ignore '.jj/**' -s \
       'cargo clippy --workspace --all-targets \
-       && cargo check --workspace --all-targets'
+       && cargo +1.76 check --workspace --all-targets'
     cargo +nightly fmt # Occasionally
     cargo nextest run --workspace # Occasionally
     cargo insta test --workspace --test-runner nextest # Occasionally
@@ -185,17 +188,6 @@ These are listed roughly in order of decreasing importance.
 
    On Linux, you may be able to speed up `nextest` even further by using
    the `mold` linker, as explained below.
-
-### Using an alternative Rust compiler version
-
-To use a different version of the Rust compiler/toolchain for development, you
-can run:
-
-    rustup override set 1.80  # or any other version
-
-Or manually set it in individual `cargo` commands:
-
-    cargo +1.80 clippy --workspace --all-targets  # or any other version
 
 ### Using `mold` for faster tests on Linux
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.76"
-profile = "default"
-components = ["rust-analyzer"]


### PR DESCRIPTION
This backs out commit 89d57ffb29577c99f0f5187b76bff369f19c5886.

This is causing a CI failure because we can't build musl binaries, presumably because the rust-toolchain file overriding the chosen musl toolchain for some reason. Backout until we can reapply a proper fix.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
