### PR TITLE
Docs: swap order of `@` and `main` in `jj new` doc comment

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -44,8 +44,8 @@ use crate::ui::Ui;
 /// the new commit. This can be avoided with `--no-edit`.
 ///
 /// Note that you can create a merge commit by specifying multiple revisions as
-/// argument. For example, `jj new main @` will create a new commit with the
-/// `main` bookmark and the working copy as parents.
+/// argument. For example, `jj new @ main` will create a new commit with the
+/// working copy and the `main` bookmark as parents.
 ///
 /// For more information, see
 /// https://martinvonz.github.io/jj/latest/working-copy/.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1392,7 +1392,7 @@ Create a new, empty change and (by default) edit it in the working copy
 
 By default, `jj` will edit the new change, making the working copy represent the new commit. This can be avoided with `--no-edit`.
 
-Note that you can create a merge commit by specifying multiple revisions as argument. For example, `jj new main @` will create a new commit with the `main` bookmark and the working copy as parents.
+Note that you can create a merge commit by specifying multiple revisions as argument. For example, `jj new @ main` will create a new commit with the working copy and the `main` bookmark as parents.
 
 For more information, see https://martinvonz.github.io/jj/latest/working-copy/.
 


### PR DESCRIPTION
I followed the recommendation in the `jj new` doc to use `jj new main @` to make a merge commit and ended up with a merge commit that GitHub did not like. The PR diff included both the relevant changes from that branch plus everything I merged in. @papertigers pointed out that swapping the two args produces a merge commit GitHub understands better. Happy to add a line explaining that the order matters, but it might be too much detail for this spot. The linked doc https://martinvonz.github.io/jj/latest/working-copy/ also does not explain this.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
