### PR TITLE
cli: let "config set"/"unset" continue if file to edit can be disambiguated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   documentation](docs/config.md#dotted-style-headings-and-inline-tables) for
   details.
 
+* `jj config edit --user` now opens a file even if `$JJ_CONFIG` points to a
+  directory. If there are multiple config files, the command will fail.
+
 * The deprecated `[alias]` config section is no longer respected. Move command
   aliases to the `[aliases]` section.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed performance of progress bar rendering when fetching from Git remote.
   [#5057](https://github.com/martinvonz/jj/issues/5057)
 
+* `jj config path --user` no longer creates new file at the default config path.
+
 ## [0.24.0] - 2024-12-04
 
 ### Release highlights

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -36,6 +36,9 @@ pub fn cmd_config_edit(
     command: &CommandHelper,
     args: &ConfigEditArgs,
 ) -> Result<(), CommandError> {
-    let config_path = args.level.new_config_file_path(command.config_env())?;
-    run_ui_editor(command.settings(), config_path)
+    let file = args.level.edit_config_file(command)?;
+    if !file.path().exists() {
+        file.save()?;
+    }
+    run_ui_editor(command.settings(), file.path())
 }

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -67,25 +67,6 @@ impl ConfigLevelArgs {
         }
     }
 
-    fn new_config_file_path<'a>(
-        &self,
-        config_env: &'a ConfigEnv,
-    ) -> Result<&'a Path, CommandError> {
-        if self.user {
-            // TODO(#531): Special-case for editors that can't handle viewing
-            // directories?
-            config_env
-                .new_user_config_path()?
-                .ok_or_else(|| user_error("No user config path found to edit"))
-        } else if self.repo {
-            config_env
-                .repo_config_path()
-                .ok_or_else(|| user_error("No repo config path found to edit"))
-        } else {
-            panic!("No config_level provided")
-        }
-    }
-
     fn config_path<'a>(&self, config_env: &'a ConfigEnv) -> Result<&'a Path, CommandError> {
         if self.user {
             config_env

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -78,8 +78,22 @@ impl ConfigLevelArgs {
                 .ok_or_else(|| user_error("No user config path found to edit"))
         } else if self.repo {
             config_env
-                .new_repo_config_path()
+                .repo_config_path()
                 .ok_or_else(|| user_error("No repo config path found to edit"))
+        } else {
+            panic!("No config_level provided")
+        }
+    }
+
+    fn config_path<'a>(&self, config_env: &'a ConfigEnv) -> Result<&'a Path, CommandError> {
+        if self.user {
+            config_env
+                .user_config_path()
+                .ok_or_else(|| user_error("No user config path found"))
+        } else if self.repo {
+            config_env
+                .repo_config_path()
+                .ok_or_else(|| user_error("No repo config path found"))
         } else {
             panic!("No config_level provided")
         }

--- a/cli/src/commands/config/path.rs
+++ b/cli/src/commands/config/path.rs
@@ -39,7 +39,7 @@ pub fn cmd_config_path(
     command: &CommandHelper,
     args: &ConfigPathArgs,
 ) -> Result<(), CommandError> {
-    let config_path = args.level.new_config_file_path(command.config_env())?;
+    let config_path = args.level.config_path(command.config_env())?;
     writeln!(
         ui.stdout(),
         "{}",

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -52,7 +52,7 @@ pub fn cmd_config_set(
     command: &CommandHelper,
     args: &ConfigSetArgs,
 ) -> Result<(), CommandError> {
-    let mut file = args.level.edit_config_file(command.config_env())?;
+    let mut file = args.level.edit_config_file(command)?;
 
     // TODO(#531): Infer types based on schema (w/ --type arg to override).
     let value = parse_toml_value_or_bare_string(&args.value);

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -39,7 +39,7 @@ pub fn cmd_config_unset(
     command: &CommandHelper,
     args: &ConfigUnsetArgs,
 ) -> Result<(), CommandError> {
-    let mut file = args.level.edit_config_file(command.config_env())?;
+    let mut file = args.level.edit_config_file(command)?;
     let old_value = file
         .delete_value(&args.name)
         .map_err(|err| user_error_with_message(format!("Failed to unset {}", args.name), err))?;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -141,6 +141,13 @@ impl ConfigPath {
             None => ConfigPath::Unavailable,
         }
     }
+
+    fn as_path(&self) -> Option<&Path> {
+        match self {
+            ConfigPath::Existing(path) | ConfigPath::New(path) => Some(path),
+            ConfigPath::Unavailable => None,
+        }
+    }
 }
 
 /// Like std::fs::create_dir_all but creates new directories to be accessible to
@@ -225,8 +232,13 @@ impl ConfigEnv {
         })
     }
 
+    /// Returns a path to the user-specific config file or directory.
+    pub fn user_config_path(&self) -> Option<&Path> {
+        self.user_config_path.as_path()
+    }
+
     /// Returns a path to the existing user-specific config file or directory.
-    pub fn existing_user_config_path(&self) -> Option<&Path> {
+    fn existing_user_config_path(&self) -> Option<&Path> {
         match &self.user_config_path {
             ConfigPath::Existing(path) => Some(path),
             _ => None,
@@ -243,8 +255,7 @@ impl ConfigEnv {
             ConfigPath::Existing(path) => Ok(Some(path)),
             ConfigPath::New(path) => {
                 // TODO: Maybe we shouldn't create new file here. Not all
-                // callers need an empty file. For example, "jj config path"
-                // should be a readonly operation. "jj config set" doesn't have
+                // callers need an empty file. "jj config set" doesn't have
                 // to create an empty file to be overwritten. Since it's unclear
                 // who and when to update ConfigPath::New(_) to ::Existing(_),
                 // it's probably better to not cache the path existence.
@@ -276,20 +287,16 @@ impl ConfigEnv {
         self.repo_config_path = ConfigPath::new(Some(path.join("config.toml")));
     }
 
+    /// Returns a path to the repo-specific config file.
+    pub fn repo_config_path(&self) -> Option<&Path> {
+        self.repo_config_path.as_path()
+    }
+
     /// Returns a path to the existing repo-specific config file.
-    pub fn existing_repo_config_path(&self) -> Option<&Path> {
+    fn existing_repo_config_path(&self) -> Option<&Path> {
         match &self.repo_config_path {
             ConfigPath::Existing(path) => Some(path),
             _ => None,
-        }
-    }
-
-    /// Returns a path to the repo-specific config file.
-    pub fn new_repo_config_path(&self) -> Option<&Path> {
-        match &self.repo_config_path {
-            ConfigPath::Existing(path) => Some(path),
-            ConfigPath::New(path) => Some(path),
-            ConfigPath::Unavailable => None,
         }
     }
 

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -248,6 +248,12 @@ impl TestEnvironment {
         &self.config_path
     }
 
+    pub fn last_config_file_path(&self) -> PathBuf {
+        let config_file_number = self.config_file_number.borrow();
+        self.config_path
+            .join(format!("config{config_file_number:04}.toml"))
+    }
+
     pub fn set_config_path(&mut self, config_path: PathBuf) {
         self.config_path = config_path;
     }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -503,6 +503,17 @@ impl ConfigFile {
         Ok(ConfigFile { layer })
     }
 
+    /// Wraps file-based [`ConfigLayer`] for modification. Returns `Err(layer)`
+    /// if the source `path` is unknown.
+    #[allow(clippy::result_large_err)] // Ok-variant is as large as Err anyway
+    pub fn from_layer(layer: ConfigLayer) -> Result<Self, ConfigLayer> {
+        if layer.path.is_some() {
+            Ok(ConfigFile { layer })
+        } else {
+            Err(layer)
+        }
+    }
+
     /// Writes serialized data to the source file.
     pub fn save(&self) -> Result<(), ConfigFileSaveError> {
         fs::write(self.path(), self.layer.data.to_string())
@@ -654,6 +665,11 @@ impl StackedConfig {
     /// Layers sorted by precedence.
     pub fn layers(&self) -> &[ConfigLayer] {
         &self.layers
+    }
+
+    /// Layers of the specified `source`.
+    pub fn layers_for(&self, source: ConfigSource) -> &[ConfigLayer] {
+        &self.layers[self.layer_range(source)]
     }
 
     /// Looks up value of the specified type `T` from all layers, merges sub


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
