### PR TITLE
feat: use `JJ_LOG` to specify log configuration

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -212,11 +212,14 @@ pub struct TracingSubscription {
 }
 
 impl TracingSubscription {
+    const ENV_VAR_NAME: &'static str = "JJ_LOG";
+
     /// Initializes tracing with the default configuration. This should be
     /// called as early as possible.
     pub fn init() -> Self {
         let filter = tracing_subscriber::EnvFilter::builder()
             .with_default_directive(tracing::metadata::LevelFilter::ERROR.into())
+            .with_env_var(Self::ENV_VAR_NAME)
             .from_env_lossy();
         let (filter, reload_log_filter) = tracing_subscriber::reload::Layer::new(filter);
 
@@ -267,6 +270,7 @@ impl TracingSubscription {
             .modify(|filter| {
                 *filter = tracing_subscriber::EnvFilter::builder()
                     .with_default_directive(tracing::metadata::LevelFilter::DEBUG.into())
+                    .with_env_var(Self::ENV_VAR_NAME)
                     .from_env_lossy();
             })
             .map_err(|err| internal_error_with_message("failed to enable debug logging", err))?;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -455,6 +455,16 @@ you can submit a PR based on the `gh-pages` bookmark of
  The `.rs` files generated from `.proto` files are included in the repository,
  and there is a GitHub CI check that will complain if they do not match.
 
+## Logging
+
+You can print internal jj logs using `JJ_LOG`. It acts like the `RUST_LOG`
+environment variable, frequent in Rust codebases, and accepts one or more
+[directives]. You can also use the `--debug` global option that sets
+`debug` log level for all targets by default. `JJ_LOG` is still respected when
+using `--debug`.
+
+[directives]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+
 ## Profiling
 
 One easy-to-use sampling profiler


### PR DESCRIPTION
Using the default `RUST_LOG` environment variable conflicts when working on unrelated Rust projects.

Supersedes #4350, which is stale.

Closes #4219 #4350

I am unsure whether this has to be listed as a breaking change in the CHANGELOG.

# Checklist

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
