### PR TITLE
gitignore: add more detail to errors on invalid pattern

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -239,7 +239,11 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
         options: &SnapshotOptions,
     ) -> Result<(MergedTreeId, SnapshotStats), SnapshotError> {
         let options = SnapshotOptions {
-            base_ignores: options.base_ignores.chain("", "/.conflicts".as_bytes())?,
+            base_ignores: options.base_ignores.chain(
+                "",
+                Path::new(""),
+                "/.conflicts".as_bytes(),
+            )?,
             ..options.clone()
         };
         self.inner.snapshot(&options)

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -239,7 +239,9 @@ fn test_snapshot_invalid_ignore_pattern() {
     std::fs::write(&gitignore_path, " []\n").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r#"
     Internal error: Failed to snapshot the working copy
-    Caused by: error parsing glob ' []': unclosed character class; missing ']'
+    Caused by:
+    1: Failed to parse ignore patterns from file $TEST_ENV/repo/.gitignore
+    2: error parsing glob ' []': unclosed character class; missing ']'
     "#);
 
     // Test invalid UTF-8 in .gitignore
@@ -247,7 +249,7 @@ fn test_snapshot_invalid_ignore_pattern() {
     insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r##"
     Internal error: Failed to snapshot the working copy
     Caused by:
-    1: invalid UTF-8 for ignore pattern in  on line #1: �
+    1: Invalid UTF-8 for ignore pattern in $TEST_ENV/repo/.gitignore on line #1: �
     2: invalid utf-8 sequence of 1 bytes from index 0
     "##);
 }


### PR DESCRIPTION
From Discord question: https://discord.com/channels/968932220549103686/1317492522712436826

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
