### PR TITLE
docs: Don't hide the version selector when scrolling down

### DIFF
--- a/docs/extra.js
+++ b/docs/extra.js
@@ -1,0 +1,22 @@
+document$.subscribe(function () {
+  // Stop mkdocs-material from hiding the version selector when scrolling down;
+  // this is done by removing the --active class when mkdocs-material adds it.
+  // (--active = scrolled down)
+
+  const title = document.querySelector('*[data-md-component="header-title"]');
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.attributeName === "class") {
+        const classList = title.className.split(" ");
+        classList.forEach((className) => {
+          if (className.endsWith("--active")) {
+            title.classList.remove(className);
+          }
+        });
+      }
+    });
+  });
+
+  observer.observe(title, { attributes: true });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,9 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
+extra_javascript:
+  - extra.js
+
 # This lists all the files that become part of the documentation
 nav:
 - 'Home': 'index.md'


### PR DESCRIPTION
by popular request (@arxanas)

NB: this also means the header will always say "Jujutsu docs", but maybe it's good because the user will be reminded that they are in the presence of mighty Jujutsu and will behave accordingly

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
