### PR TITLE
gitignore: remove FIXME comment about passing path

### DIFF
--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -76,8 +76,9 @@ impl GitIgnoreFile {
                     line: String::from_utf8_lossy(input_line).to_string(),
                     source: err,
                 })?;
-            // FIXME: do we need to provide the `from` argument? Is it for providing
-            // diagnostics or correctness?
+            // The `from` argument doesn't provide any diagnostics or correctness, so it is
+            // not required. It only allows retrieving the path from the `Glob` later, which
+            // we never do.
             builder
                 .add_line(None, line)
                 .map_err(|err| GitIgnoreError::Underlying {


### PR DESCRIPTION
I looked through the code for the `ignore` crate, and this optional path is not used anywhere. The only reason to pass it would be to be able to get the path from the `Glob` when we call `Gitignore::matched` or `Gitignore::matched_path_or_any_parents`, but we ignore the returned `Glob` completely anyway. Passing the path would require an unnecessary clone of the path for each line in every .gitignore file, so it's better not to pass it since we don't need it.

https://github.com/martinvonz/jj/pull/5113#discussion_r1887769952

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
