### PR TITLE
cli: deprecate --config-toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* `--config-toml=TOML` is deprecated in favor of `--config=NAME=VALUE` and
+  `--config-file=PATH`.
+
 * The `Signature.username()` template method is deprecated for
   `Signature().email().local()`.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3109,8 +3109,9 @@ pub struct EarlyArgs {
     /// constructs (such as array notation), quotes can be omitted.
     #[arg(long, value_name = "NAME=VALUE", global = true)]
     pub config: Vec<String>,
-    /// Additional configuration options (can be repeated)
-    #[arg(long, value_name = "TOML", global = true)]
+    /// Additional configuration options (can be repeated) (DEPRECATED)
+    // TODO: delete --config-toml in jj 0.31+
+    #[arg(long, value_name = "TOML", global = true, hide = true)]
     pub config_toml: Vec<String>,
     /// Additional configuration files (can be repeated)
     #[arg(long, value_name = "PATH", global = true, value_hint = clap::ValueHint::FilePath)]
@@ -3334,6 +3335,12 @@ fn handle_early_args(
     let args = EarlyArgs::from_arg_matches(&early_matches).unwrap();
 
     let old_layers_len = config.layers().len();
+    if !args.config_toml.is_empty() {
+        writeln!(
+            ui.warning_default(),
+            "--config-toml is deprecated; use --config or --config-file instead."
+        )?;
+    }
     config.extend_layers(parse_config_args(&args.merged_config_args(&early_matches))?);
 
     // Command arguments overrides any other configuration including the

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2609,7 +2609,7 @@ pub fn print_snapshot_stats(
               - Adding the file to `.gitignore`
               - Run `jj config set --repo snapshot.max-new-file-size {size}`
                 This will increase the maximum file size allowed for new files, in this repository only.
-              - Run `jj --config-toml 'snapshot.max-new-file-size={size}' st`
+              - Run `jj --config snapshot.max-new-file-size={size} st`
                 This will increase the maximum file size allowed for new files, for this command only.
             "
         )?;
@@ -3682,11 +3682,11 @@ impl CliRunner {
             maybe_cwd_workspace_loader
         };
 
-        // Apply workspace configs and --config-toml arguments.
+        // Apply workspace configs and --config arguments.
         ui.reset(&config)?;
 
         // If -R is specified, check if the expanded arguments differ. Aliases
-        // can also be injected by --config-toml, but that's obviously wrong.
+        // can also be injected by --config, but that's obviously wrong.
         if args.global_args.repository.is_some() {
             let new_string_args = expand_args(ui, &self.app, env::args_os(), &config).ok();
             if new_string_args.as_ref() != Some(&string_args) {

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -35,9 +35,7 @@ use crate::config::ConfigEnv;
 use crate::config::CONFIG_SCHEMA;
 use crate::ui::Ui;
 
-const BOOKMARK_HELP_TEMPLATE: &str = r#"
-[template-aliases]
-"bookmark_help()" = """
+const BOOKMARK_HELP_TEMPLATE: &str = r#"template-aliases.'bookmark_help()'='''
 " " ++
 if(normal_target,
     if(normal_target.description(),
@@ -46,8 +44,7 @@ if(normal_target,
     ),
     "(conflicted bookmark)",
 )
-"""
-"#;
+'''"#;
 
 /// A helper function for various completer functions. It returns
 /// (candidate, help) assuming they are separated by a space.
@@ -64,7 +61,7 @@ pub fn local_bookmarks() -> Vec<CompletionCandidate> {
             .build()
             .arg("bookmark")
             .arg("list")
-            .arg("--config-toml")
+            .arg("--config")
             .arg(BOOKMARK_HELP_TEMPLATE)
             .arg("--template")
             .arg(r#"if(!remote, name ++ bookmark_help()) ++ "\n""#)
@@ -86,7 +83,7 @@ pub fn tracked_bookmarks() -> Vec<CompletionCandidate> {
             .arg("bookmark")
             .arg("list")
             .arg("--tracked")
-            .arg("--config-toml")
+            .arg("--config")
             .arg(BOOKMARK_HELP_TEMPLATE)
             .arg("--template")
             .arg(r#"if(remote, name ++ '@' ++ remote ++ bookmark_help() ++ "\n")"#)
@@ -108,7 +105,7 @@ pub fn untracked_bookmarks() -> Vec<CompletionCandidate> {
             .arg("bookmark")
             .arg("list")
             .arg("--all-remotes")
-            .arg("--config-toml")
+            .arg("--config")
             .arg(BOOKMARK_HELP_TEMPLATE)
             .arg("--template")
             .arg(
@@ -146,7 +143,7 @@ pub fn bookmarks() -> Vec<CompletionCandidate> {
             .arg("bookmark")
             .arg("list")
             .arg("--all-remotes")
-            .arg("--config-toml")
+            .arg("--config")
             .arg(BOOKMARK_HELP_TEMPLATE)
             .arg("--template")
             .arg(
@@ -238,7 +235,7 @@ fn revisions(revisions: Option<&str>) -> Vec<CompletionCandidate> {
         cmd.arg("bookmark")
             .arg("list")
             .arg("--all-remotes")
-            .arg("--config-toml")
+            .arg("--config")
             .arg(BOOKMARK_HELP_TEMPLATE)
             .arg("--template")
             .arg(
@@ -278,7 +275,7 @@ fn revisions(revisions: Option<&str>) -> Vec<CompletionCandidate> {
                 .build()
                 .arg("tag")
                 .arg("list")
-                .arg("--config-toml")
+                .arg("--config")
                 .arg(BOOKMARK_HELP_TEMPLATE)
                 .arg("--template")
                 .arg(r#"name ++ bookmark_help() ++ "\n""#)
@@ -370,8 +367,8 @@ pub fn workspaces() -> Vec<CompletionCandidate> {
     with_jj(|jj, _| {
         let output = jj
             .build()
-            .arg("--config-toml")
-            .arg(r#"templates.commit_summary = 'if(description, description.first_line(), "(no description set)")'"#)
+            .arg("--config")
+            .arg(r#"templates.commit_summary='if(description, description.first_line(), "(no description set)")'"#)
             .arg("workspace")
             .arg("list")
             .output()
@@ -472,8 +469,7 @@ fn all_files_from_rev(rev: String, current: &std::ffi::OsStr) -> Vec<CompletionC
             .arg("list")
             .arg("--revision")
             .arg(rev)
-            .arg("--config-toml")
-            .arg("ui.allow-filesets = true")
+            .arg("--config=ui.allow-filesets=true")
             .arg(current_prefix_to_fileset(current))
             .stdout(std::process::Stdio::piped())
             .spawn()
@@ -505,8 +501,7 @@ fn modified_files_from_rev_with_jj_cmd(
     };
     cmd.arg("diff")
         .arg("--summary")
-        .arg("--config-toml")
-        .arg("ui.allow-filesets = true")
+        .arg("--config=ui.allow-filesets=true")
         .arg(current_prefix_to_fileset(current));
     match rev {
         (rev, None) => cmd.arg("--revision").arg(rev),
@@ -558,8 +553,7 @@ fn conflicted_files_from_rev(rev: &str, current: &std::ffi::OsStr) -> Vec<Comple
             .arg("--list")
             .arg("--revision")
             .arg(rev)
-            .arg("--config-toml")
-            .arg("ui.allow-filesets = true")
+            .arg("--config=ui.allow-filesets=true")
             .arg(current_prefix_to_fileset(current))
             .output()
             .map_err(user_error)?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -197,7 +197,6 @@ To get started, see the tutorial at https://martinvonz.github.io/jj/latest/tutor
 * `--config <NAME=VALUE>` — Additional configuration options (can be repeated)
 
    The name should be specified as TOML dotted keys. The value should be specified as a TOML expression. If string value doesn't contain any TOML constructs (such as array notation), quotes can be omitted.
-* `--config-toml <TOML>` — Additional configuration options (can be repeated)
 * `--config-file <PATH>` — Additional configuration files (can be repeated)
 
 

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -37,7 +37,7 @@ fn set_up(trunk_name: &str) -> (TestEnvironment, PathBuf) {
         &[
             "git",
             "clone",
-            "--config-toml=git.auto-local-bookmark=true",
+            "--config=git.auto-local-bookmark=true",
             origin_git_repo_path.to_str().unwrap(),
             "local",
         ],

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -136,7 +136,7 @@ fn test_commit_interactive() {
         &workspace_path,
         &[
             "commit",
-            "--config-toml=ui.diff-editor='false'",
+            "--config=ui.diff-editor='false'",
             "--tool=fake-diff-editor",
         ],
     );
@@ -357,9 +357,8 @@ fn test_commit_reset_author() {
         &repo_path,
         &[
             "commit",
-            "--config-toml",
-            r#"user.name = "Ove Ridder"
-            user.email = "ove.ridder@example.com""#,
+            "--config=user.name=Ove Ridder",
+            "--config=user.email=ove.ridder@example.com",
             "--reset-author",
             "-m1",
         ],

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -192,8 +192,8 @@ fn test_mine_is_true_when_author_is_user() {
     test_env.jj_cmd_ok(
         &repo_path,
         &[
-            "--config-toml=user.email='johndoe@example.com'",
-            "--config-toml=user.name='John Doe'",
+            "--config=user.email=johndoe@example.com",
+            "--config=user.name=John Doe",
             "new",
         ],
     );
@@ -280,11 +280,7 @@ fn test_log_builtin_templates() {
 
     test_env.jj_cmd_ok(
         &repo_path,
-        &[
-            "--config-toml=user.email=''",
-            "--config-toml=user.name=''",
-            "new",
-        ],
+        &["--config=user.email=''", "--config=user.name=''", "new"],
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
 
@@ -353,11 +349,7 @@ fn test_log_builtin_templates_colored() {
 
     test_env.jj_cmd_ok(
         &repo_path,
-        &[
-            "--config-toml=user.email=''",
-            "--config-toml=user.name=''",
-            "new",
-        ],
+        &["--config=user.email=''", "--config=user.name=''", "new"],
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
 
@@ -421,11 +413,7 @@ fn test_log_builtin_templates_colored_debug() {
 
     test_env.jj_cmd_ok(
         &repo_path,
-        &[
-            "--config-toml=user.email=''",
-            "--config-toml=user.name=''",
-            "new",
-        ],
+        &["--config=user.email=''", "--config=user.name=''", "new"],
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
 
@@ -751,7 +739,7 @@ fn test_log_customize_short_id() {
         &repo_path,
         &[
             "log",
-            "--config-toml",
+            "--config",
             &format!(r#"{decl}='id.shortest(5).prefix().upper() ++ "_" ++ id.shortest(5).rest()'"#),
         ],
     );
@@ -766,11 +754,7 @@ fn test_log_customize_short_id() {
         &repo_path,
         &[
             "log",
-            "--config-toml",
-            r#"
-                [template-aliases]
-                'format_short_change_id(id)'='format_short_id(id).upper()'
-            "#,
+            "--config=template-aliases.'format_short_change_id(id)'='format_short_id(id).upper()'",
         ],
     );
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -337,14 +337,13 @@ fn test_aliases_are_completed() {
     );
     insta::assert_snapshot!(stdout, @"repo-alias");
 
-    // cannot load aliases from --config-toml flag
+    // cannot load aliases from --config flag
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &[
             "--",
             "jj",
-            "--config-toml",
-            "aliases.cli-alias = ['bookmark']",
+            "--config=aliases.cli-alias=['bookmark']",
             "cli-al",
         ],
     );

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -83,7 +83,6 @@ fn test_bookmark_names() {
     --quiet	Silence non-primary command output
     --no-pager	Disable the pager
     --config	Additional configuration options (can be repeated)
-    --config-toml	Additional configuration options (can be repeated)
     --config-file	Additional configuration files (can be repeated)
     --help	Print help (see more with '--help')
     ");

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -185,7 +185,7 @@ bar
             "list",
             "multiline",
             "--include-overridden",
-            "--config-toml=multiline='single'",
+            "--config=multiline='single'",
         ],
     );
     insta::assert_snapshot!(stdout, @r"
@@ -293,7 +293,7 @@ fn test_config_layer_override_default() {
             "config",
             "list",
             config_key,
-            "--config-toml",
+            "--config",
             &format!("{config_key}={value:?}", value = "command-arg"),
         ],
     );
@@ -309,7 +309,7 @@ fn test_config_layer_override_default() {
             "list",
             config_key,
             "--include-overridden",
-            "--config-toml",
+            "--config",
             &format!("{config_key}={value:?}", value = "command-arg"),
         ],
     );
@@ -381,7 +381,7 @@ fn test_config_layer_override_env() {
             "config",
             "list",
             config_key,
-            "--config-toml",
+            "--config",
             &format!("{config_key}={value:?}", value = "command-arg"),
         ],
     );
@@ -397,7 +397,7 @@ fn test_config_layer_override_env() {
             "list",
             config_key,
             "--include-overridden",
-            "--config-toml",
+            "--config",
             &format!("{config_key}={value:?}", value = "command-arg"),
         ],
     );

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -602,9 +602,8 @@ fn test_describe_author() {
         &repo_path,
         &[
             "describe",
-            "--config-toml",
-            r#"user.name = "Ove Ridder"
-            user.email = "ove.ridder@example.com""#,
+            "--config=user.name=Ove Ridder",
+            "--config=user.email=ove.ridder@example.com",
             "--no-edit",
             "--reset-author",
         ],
@@ -628,9 +627,8 @@ fn test_describe_author() {
             "describe",
             "@---",
             "@-",
-            "--config-toml",
-            r#"user.name = "Ove Ridder"
-            user.email = "ove.ridder@example.com""#,
+            "--config=user.name=Ove Ridder",
+            "--config=user.email=ove.ridder@example.com",
             "--reset-author",
         ],
     );

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -68,7 +68,7 @@ fn test_diffedit() {
     std::fs::write(&edit_script, "files-before file1 file2\0files-after file2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
-        &["diffedit", "--config-toml=ui.diff-instructions=false"],
+        &["diffedit", "--config=ui.diff-instructions=false"],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -90,7 +90,7 @@ fn test_diffedit() {
         &repo_path,
         &[
             "diffedit",
-            "--config-toml=ui.diff-editor='false'",
+            "--config=ui.diff-editor='false'",
             "--tool=fake-diff-editor",
         ],
     );
@@ -456,7 +456,7 @@ fn test_diffedit_3pane() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
-        &["diffedit", "--config-toml", &config_with_output_as_after],
+        &["diffedit", "--config", &config_with_output_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -470,7 +470,7 @@ fn test_diffedit_3pane() {
     // Nothing happens if we make no changes, `config_with_right_as_after` version
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
-        &["diffedit", "--config-toml", &config_with_right_as_after],
+        &["diffedit", "--config", &config_with_right_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -486,7 +486,7 @@ fn test_diffedit_3pane() {
     std::fs::write(&edit_script, "reset file2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
-        &["diffedit", "--config-toml", &config_with_output_as_after],
+        &["diffedit", "--config", &config_with_output_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -505,7 +505,7 @@ fn test_diffedit_3pane() {
     std::fs::write(&edit_script, "write file1\nnew content").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
-        &["diffedit", "--config-toml", &config_with_output_as_after],
+        &["diffedit", "--config", &config_with_output_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -525,7 +525,7 @@ fn test_diffedit_3pane() {
     std::fs::write(&edit_script, "write file1\nnew content").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
-        &["diffedit", "--config-toml", &config_with_right_as_after],
+        &["diffedit", "--config", &config_with_right_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -156,9 +156,8 @@ fn test_evolog_with_custom_symbols() {
     test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "@", "-d", "root()"]);
     std::fs::write(repo_path.join("file1"), "resolved\n").unwrap();
 
-    let toml = concat!("templates.log_node = 'if(current_working_copy, \"$\", \"┝\")'\n",);
-
-    let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--config-toml", toml]);
+    let config = "templates.log_node='if(current_working_copy, \"$\", \"┝\")'";
+    let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--config", config]);
 
     insta::assert_snapshot!(stdout, @r###"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
@@ -180,7 +179,7 @@ fn test_evolog_word_wrap() {
     let render = |args: &[&str], columns: u32, word_wrap: bool| {
         let mut args = args.to_vec();
         if word_wrap {
-            args.push("--config-toml=ui.log-word-wrap=true");
+            args.push("--config=ui.log-word-wrap=true");
         }
         let assert = test_env
             .jj_cmd(&repo_path, &args)

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -37,7 +37,7 @@ fn set_up() -> (TestEnvironment, PathBuf) {
         &[
             "git",
             "clone",
-            "--config-toml=git.auto-local-bookmark=true",
+            "--config=git.auto-local-bookmark=true",
             origin_git_repo_path.to_str().unwrap(),
             "local",
         ],

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -38,7 +38,7 @@ fn set_up() -> (TestEnvironment, PathBuf) {
         &[
             "git",
             "clone",
-            "--config-toml=git.auto-local-bookmark=true",
+            "--config=git.auto-local-bookmark=true",
             origin_git_repo_path.to_str().unwrap(),
             "local",
         ],
@@ -688,8 +688,7 @@ fn test_git_push_changes() {
         &[
             "git",
             "push",
-            "--config-toml",
-            r"git.push-bookmark-prefix='test-'",
+            "--config=git.push-bookmark-prefix=test-",
             "--change=@",
         ],
     );
@@ -706,8 +705,7 @@ fn test_git_push_changes() {
         &[
             "git",
             "push",
-            "--config-toml",
-            r"git.push-branch-prefix='branch-'",
+            "--config=git.push-branch-prefix=branch-",
             "--change=@",
         ],
     );

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -404,30 +404,23 @@ fn test_color_config() {
     ◆  0000000000000000000000000000000000000000
     "###);
 
-    // Test that --config-toml 'ui.color="never"' overrides the config.
+    // Test that --config 'ui.color=never' overrides the config.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
-        &[
-            "--config-toml",
-            "ui.color=\"never\"",
-            "log",
-            "-T",
-            "commit_id",
-        ],
+        &["--config=ui.color=never", "log", "-T", "commit_id"],
     );
     insta::assert_snapshot!(stdout, @r###"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
     "###);
 
-    // --color overrides --config-toml 'ui.color=...'.
+    // --color overrides --config 'ui.color=...'.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
             "--color",
             "never",
-            "--config-toml",
-            "ui.color=\"always\"",
+            "--config=ui.color=always",
             "log",
             "-T",
             "commit_id",
@@ -466,7 +459,7 @@ fn test_color_config() {
     For more information, try '--help'.
     ");
     // Invalid ui.color
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "--config-toml=ui.color=true"]);
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "--config=ui.color=true"]);
     insta::assert_snapshot!(stderr, @r"
     Config error: Invalid type or value for ui.color
     Caused by: wanted string or table
@@ -518,7 +511,7 @@ fn test_color_ui_messages() {
         &[
             "log",
             "-r@|@--",
-            "--config-toml=templates.log_node='commit_id'",
+            "--config=templates.log_node=commit_id",
             "-Tdescription",
         ],
     );
@@ -591,10 +584,7 @@ fn test_early_args() {
     // bug that causes defaults to be unpopulated. Test that the early args are
     // tolerant of this bug and don't cause a crash.
     test_env.jj_cmd_success(test_env.env_root(), &["--no-pager", "help"]);
-    test_env.jj_cmd_success(
-        test_env.env_root(),
-        &["--config-toml", "ui.color = 'always'", "help"],
-    );
+    test_env.jj_cmd_success(test_env.env_root(), &["--config=ui.color=always", "help"]);
 }
 
 #[test]
@@ -710,10 +700,8 @@ fn test_invalid_config_value() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    let stderr = test_env.jj_cmd_failure(
-        &repo_path,
-        &["status", "--config-toml=snapshot.auto-track=[0]"],
-    );
+    let stderr =
+        test_env.jj_cmd_failure(&repo_path, &["status", "--config=snapshot.auto-track=[0]"]);
     insta::assert_snapshot!(stderr, @r"
     Config error: Invalid type or value for snapshot.auto-track
     Caused by: invalid type: sequence, expected a string

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -143,7 +143,7 @@ fn test_log_with_or_without_diff() {
             "description",
             "-p",
             "-s",
-            "--config-toml=ui.diff.format='summary'",
+            "--config=ui.diff.format=summary",
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
@@ -740,7 +740,7 @@ fn test_log_author_format() {
         test_env.jj_cmd_success(
             &repo_path,
             &[
-                "--config-toml",
+                "--config",
                 &format!("{decl}='signature.email().local()'"),
                 "log",
                 "--revisions=@",
@@ -863,7 +863,7 @@ fn test_log_filtered_by_path() {
         test_env.env_root(),
         &[
             "log",
-            "--config-toml=ui.allow-filesets=false",
+            "--config=ui.allow-filesets=false",
             "-R",
             repo_path.to_str().unwrap(),
             "all()",
@@ -1320,10 +1320,7 @@ fn test_graph_styles() {
     "###);
 
     // Invalid style name
-    let stderr = test_env.jj_cmd_failure(
-        &repo_path,
-        &["log", "--config-toml=ui.graph.style='unknown'"],
-    );
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "--config=ui.graph.style=unknown"]);
     insta::assert_snapshot!(stderr, @r"
     Config error: Invalid type or value for ui.graph.style
     Caused by: unknown variant `unknown`, expected one of `ascii`, `ascii-large`, `curved`, `square`
@@ -1340,7 +1337,7 @@ fn test_log_word_wrap() {
     let render = |args: &[&str], columns: u32, word_wrap: bool| {
         let mut args = args.to_vec();
         if word_wrap {
-            args.push("--config-toml=ui.log-word-wrap=true");
+            args.push("--config=ui.log-word-wrap=true");
         }
         let assert = test_env
             .jj_cmd(&repo_path, &args)

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -33,8 +33,7 @@ fn test_op_log() {
         &[
             "op",
             "log",
-            "--config-toml",
-            "template-aliases.'format_time_range(x)' = 'x'",
+            "--config=template-aliases.'format_time_range(x)'=x",
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
@@ -121,11 +120,8 @@ fn test_op_log_with_custom_symbols() {
         &[
             "op",
             "log",
-            "--config-toml",
-            concat!(
-                "template-aliases.'format_time_range(x)' = 'x'\n",
-                "templates.op_log_node = 'if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
-            ),
+            "--config=template-aliases.'format_time_range(x)'=x",
+            "--config=templates.op_log_node='if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
         ],
     );
     insta::assert_snapshot!(&stdout, @r#"
@@ -316,7 +312,7 @@ fn test_op_log_word_wrap() {
     let render = |args: &[&str], columns: u32, word_wrap: bool| {
         let mut args = args.to_vec();
         if word_wrap {
-            args.push("--config-toml=ui.log-word-wrap=true");
+            args.push("--config=ui.log-word-wrap=true");
         }
         let assert = test_env
             .jj_cmd(&repo_path, &args)
@@ -417,7 +413,7 @@ fn test_op_log_word_wrap() {
     // Nested graph widths should be subtracted from the term width
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
-        render(&["op", "log", "-T''", "--op-diff", "-n1", "--config-toml", config], 15, true), @r#"
+        render(&["op", "log", "-T''", "--op-diff", "-n1", "--config", config], 15, true), @r#"
     @
     │
     │  Changed
@@ -1498,7 +1494,7 @@ fn test_op_diff_word_wrap() {
     let render = |args: &[&str], columns: u32, word_wrap: bool| {
         let mut args = args.to_vec();
         if word_wrap {
-            args.push("--config-toml=ui.log-word-wrap=true");
+            args.push("--config=ui.log-word-wrap=true");
         }
         let assert = test_env
             .jj_cmd(&repo_path, &args)
@@ -1568,7 +1564,7 @@ fn test_op_diff_word_wrap() {
     // Graph width should be subtracted from the term width
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
-        render(&["op", "diff", "--from=@---", "--config-toml", config], 10, true), @r#"
+        render(&["op", "diff", "--from=@---", "--config", config], 10, true), @r#"
     From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
       To operation: f3052392e08c (2001-02-03 08:05:08) snapshot working copy
 

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -743,7 +743,7 @@ fn test_rebase_multiple_destinations() {
         &repo_path,
         &[
             "rebase",
-            "--config-toml=ui.always-allow-large-revsets=true",
+            "--config=ui.always-allow-large-revsets=true",
             "-r=a",
             "-d=b|c",
         ],

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -125,7 +125,7 @@ fn test_resolution() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml=ui.merge-editor='false'",
+            "--config=ui.merge-editor='false'",
             "--tool=fake-editor",
         ],
     );
@@ -172,8 +172,7 @@ fn test_resolution() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml",
-            "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
+            "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         ],
     );
     insta::assert_snapshot!(
@@ -230,8 +229,7 @@ fn test_resolution() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml",
-            "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
+            "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         ],
     );
     insta::assert_snapshot!(stdout, @"");
@@ -375,12 +373,8 @@ fn test_resolution() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml",
-            r#"
-            [merge-tools.fake-editor]
-            merge-tool-edits-conflict-markers = true
-            conflict-marker-style = "git"
-            "#,
+            "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
+            "--config=merge-tools.fake-editor.conflict-marker-style=git",
         ],
     );
     insta::assert_snapshot!(stdout, @"");
@@ -461,8 +455,7 @@ fn test_resolution() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml",
-            "merge-tools.fake-editor.merge-conflict-exit-codes = [1]",
+            "--config=merge-tools.fake-editor.merge-conflict-exit-codes=[1]",
         ],
     );
     insta::assert_snapshot!(stdout, @"");
@@ -531,8 +524,7 @@ fn test_resolution() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml",
-            "merge-tools.fake-editor.merge-conflict-exit-codes = [1]",
+            "--config=merge-tools.fake-editor.merge-conflict-exit-codes=[1]",
         ],
     );
     // On Windows, the ExitStatus struct prints "exit code" instead of "exit status"
@@ -556,7 +548,7 @@ fn check_resolve_produces_input_file(
     let editor_script = test_env.set_up_fake_editor();
     std::fs::write(editor_script, format!("expect\n{expected_content}")).unwrap();
 
-    let merge_arg_config = format!(r#"merge-tools.fake-editor.merge-args = ["${role}"]"#);
+    let merge_arg_config = format!(r#"merge-tools.fake-editor.merge-args=["${role}"]"#);
     // This error means that fake-editor exited successfully but did not modify the
     // output file.
     // We cannot use `insta::assert_snapshot!` here after insta 1.22 due to
@@ -565,7 +557,7 @@ fn check_resolve_produces_input_file(
     assert_eq!(
         test_env.jj_cmd_failure(
             repo_path,
-            &["resolve", "--config-toml", &merge_arg_config, filename]
+            &["resolve", "--config", &merge_arg_config, filename]
         ),
         format!(
             "Resolving conflicts in: {filename}\nError: Failed to resolve conflicts\nCaused by: \
@@ -778,8 +770,7 @@ fn test_simplify_conflict_sides() {
         &repo_path,
         &[
             "resolve",
-            "--config-toml",
-            "merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
+            "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
             "fileB",
         ],
     );

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -570,17 +570,11 @@ fn test_alias_override() {
     "###,
     );
 
-    // 'f(x)' should be overridden by --config-toml 'f(a)'. If aliases were sorted
+    // 'f(x)' should be overridden by --config 'f(a)'. If aliases were sorted
     // purely by name, 'f(a)' would come first.
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
-        &[
-            "log",
-            "-r",
-            "f(_)",
-            "--config-toml",
-            "revset-aliases.'f(a)' = 'arg'",
-        ],
+        &["log", "-r", "f(_)", "--config=revset-aliases.'f(a)'=arg"],
     );
     insta::assert_snapshot!(stderr, @r###"
     Error: Revision "arg" doesn't exist
@@ -686,7 +680,7 @@ fn test_all_modifier() {
     // Modifier shouldn't be allowed in sub expression
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
-        &["new", "x..", "--config-toml=revset-aliases.x='all:@'"],
+        &["new", "x..", "--config=revset-aliases.x='all:@'"],
     );
     insta::assert_snapshot!(stderr, @r#"
     Error: Failed to parse revset: In alias "x"
@@ -711,8 +705,8 @@ fn test_all_modifier() {
         &repo_path,
         &[
             "new",
-            "--config-toml=revset-aliases.'immutable_heads()'='all:@'",
-            "--config-toml=revsets.short-prefixes='none()'",
+            "--config=revset-aliases.'immutable_heads()'='all:@'",
+            "--config=revsets.short-prefixes='none()'",
         ],
     );
     insta::assert_snapshot!(stderr, @r###"
@@ -746,8 +740,7 @@ fn test_revset_committer_date_with_time_zone() {
     test_env.jj_cmd_ok(
         &repo_path,
         &[
-            "--config-toml",
-            "debug.commit-timestamp='2023-01-25T11:30:00-05:00'",
+            "--config=debug.commit-timestamp='2023-01-25T11:30:00-05:00'",
             "describe",
             "-m",
             "first",
@@ -756,8 +749,7 @@ fn test_revset_committer_date_with_time_zone() {
     test_env.jj_cmd_ok(
         &repo_path,
         &[
-            "--config-toml",
-            "debug.commit-timestamp='2023-01-25T12:30:00-05:00'",
+            "--config=debug.commit-timestamp='2023-01-25T12:30:00-05:00'",
             "new",
             "-m",
             "second",
@@ -766,8 +758,7 @@ fn test_revset_committer_date_with_time_zone() {
     test_env.jj_cmd_ok(
         &repo_path,
         &[
-            "--config-toml",
-            "debug.commit-timestamp='2023-01-25T13:30:00-05:00'",
+            "--config=debug.commit-timestamp='2023-01-25T13:30:00-05:00'",
             "new",
             "-m",
             "third",
@@ -781,7 +772,7 @@ fn test_revset_committer_date_with_time_zone() {
             let before_log = test_env.jj_cmd_success(
                 &repo_path,
                 &[
-                    "--config-toml",
+                    "--config",
                     config.as_str(),
                     "log",
                     "--no-graph",
@@ -794,7 +785,7 @@ fn test_revset_committer_date_with_time_zone() {
             let after_log = test_env.jj_cmd_success(
                 &repo_path,
                 &[
-                    "--config-toml",
+                    "--config",
                     config.as_str(),
                     "log",
                     "--no-graph",

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -437,7 +437,7 @@ fn test_templater_alias_override() {
     "#,
     );
 
-    // 'f(x)' should be overridden by --config-toml 'f(a)'. If aliases were sorted
+    // 'f(x)' should be overridden by --config 'f(a)'. If aliases were sorted
     // purely by name, 'f(a)' would come first.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -447,8 +447,7 @@ fn test_templater_alias_override() {
             "-r@",
             "-T",
             r#"f(_)"#,
-            "--config-toml",
-            r#"template-aliases.'f(a)' = '"arg"'"#,
+            r#"--config=template-aliases.'f(a)'='"arg"'"#,
         ],
     );
     insta::assert_snapshot!(stdout, @"arg");

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -240,7 +240,7 @@ fn test_unsquash_partial() {
         &repo_path,
         &[
             "unsquash",
-            "--config-toml=ui.diff-editor='false'",
+            "--config=ui.diff-editor='false'",
             "--tool=fake-diff-editor",
         ],
     );

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -45,7 +45,7 @@ fn test_gc_args() {
     // Use the local backend because GitBackend::gc() depends on the git CLI.
     test_env.jj_cmd_ok(
         test_env.env_root(),
-        &["init", "repo", "--config-toml=ui.allow-init-native=true"],
+        &["init", "repo", "--config=ui.allow-init-native=true"],
     );
     let repo_path = test_env.env_root().join("repo");
 
@@ -69,7 +69,7 @@ fn test_gc_operation_log() {
     // Use the local backend because GitBackend::gc() depends on the git CLI.
     test_env.jj_cmd_ok(
         test_env.env_root(),
-        &["init", "repo", "--config-toml=ui.allow-init-native=true"],
+        &["init", "repo", "--config=ui.allow-init-native=true"],
     );
     let repo_path = test_env.env_root().join("repo");
 

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -36,7 +36,7 @@ fn test_snapshot_large_file() {
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 13`
         This will increase the maximum file size allowed for new files, in this repository only.
-      - Run `jj --config-toml 'snapshot.max-new-file-size=13' st`
+      - Run `jj --config snapshot.max-new-file-size=13 st`
         This will increase the maximum file size allowed for new files, for this command only.
     ");
 
@@ -53,18 +53,14 @@ fn test_snapshot_large_file() {
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 11264`
         This will increase the maximum file size allowed for new files, in this repository only.
-      - Run `jj --config-toml 'snapshot.max-new-file-size=11264' st`
+      - Run `jj --config snapshot.max-new-file-size=11264 st`
         This will increase the maximum file size allowed for new files, for this command only.
     ");
 
     // test invalid configuration
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
-        &[
-            "file",
-            "list",
-            "--config-toml=snapshot.max-new-file-size = []",
-        ],
+        &["file", "list", "--config=snapshot.max-new-file-size=[]"],
     );
     insta::assert_snapshot!(stderr, @r"
     Config error: Invalid type or value for snapshot.max-new-file-size
@@ -102,7 +98,7 @@ fn test_snapshot_large_file_restore() {
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 13`
         This will increase the maximum file size allowed for new files, in this repository only.
-      - Run `jj --config-toml 'snapshot.max-new-file-size=13' st`
+      - Run `jj --config snapshot.max-new-file-size=13 st`
         This will increase the maximum file size allowed for new files, for this command only.
     Created kkmpptxz e3eb7e81 (no description set)
     Working copy now at: kkmpptxz e3eb7e81 (no description set)

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -689,7 +689,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     // Use the local backend because GitBackend::gc() depends on the git CLI.
     test_env.jj_cmd_ok(
         test_env.env_root(),
-        &["init", "main", "--config-toml=ui.allow-init-native=true"],
+        &["init", "main", "--config=ui.allow-init-native=true"],
     );
     let main_path = test_env.env_root().join("main");
     let secondary_path = test_env.env_root().join("secondary");

--- a/demos/demo_juggle_conflicts.sh
+++ b/demos/demo_juggle_conflicts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 new_tmp_dir
 (
-    jj init --config-toml ui.allow-init-native=true
+    jj init --config ui.allow-init-native=true
     echo "first" > file
     jj bookmark create first
     jj commit -m 'first'

--- a/docs/config.md
+++ b/docs/config.md
@@ -1203,27 +1203,18 @@ env JJ_CONFIG=/dev/null jj log       # Ignores any settings specified in the con
 
 ### Specifying config on the command-line
 
-You can use one or more `--config`/`--config-toml`/`--config-file` options on
-the command line to specify additional configuration settings. This overrides
-settings defined in config files or environment variables. For example,
+You can use one or more `--config`/`--config-file` options on the command line
+to specify additional configuration settings. This overrides settings defined in
+config files or environment variables. For example,
 
 ```shell
-jj --config=ui.color=always --config-toml='ui.diff-editor="kdiff3"' split
+jj --config=ui.color=always --config=ui.diff-editor=kdiff3 split
 ```
 
-Config specified by `--config-toml` must be valid TOML. In particular, string
-values must be surrounded by quotes. To pass these quotes to `jj`, most shells
-require surrounding those quotes with single quotes as shown above. On the other
-hand, `--config` can accept a bare string value.
+Config value should be specified as a TOML expression. If string value doesn't
+contain any TOML constructs (such as array notation), quotes can be omitted.
 
-In `sh`-compatible shells, `--config-toml` can be used to merge entire TOML
-files with the config specified in `.jjconfig.toml`:
-
-```shell
-jj --config-toml="$(cat extra-config.toml)" log
-```
-
-This is equivalent to
+To load an entire TOML document, use `--config-file`:
 
 ```shell
 jj --config-file=extra-config.toml log

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -50,9 +50,8 @@ pub enum FsmonitorSettings {
 
     /// No filesystem monitor. This is the default if nothing is configured, but
     /// also makes it possible to turn off the monitor on a case-by-case basis
-    /// when the user gives an option like
-    /// `--config-toml='core.fsmonitor="none"'`; useful when e.g. when doing
-    /// analysis of snapshot performance.
+    /// when the user gives an option like `--config=core.fsmonitor=none`;
+    /// useful when e.g. when doing analysis of snapshot performance.
     None,
 }
 


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
